### PR TITLE
fix: reset job_score to 0 when collateral is not deposited

### DIFF
--- a/neurons/validators/src/services/task_service.py
+++ b/neurons/validators/src/services/task_service.py
@@ -1124,6 +1124,7 @@ class TaskService:
 
                 if not collateral_deposited and not settings.DEBUG_COLLATERAL_CONTRACT:
                     actual_score = 0
+                    job_score = 0
                     log_msg = "Train task is finished. But not eligible from collateral contract."
                 elif len(port_maps) < MIN_PORT_COUNT:
                     actual_score = 0


### PR DESCRIPTION
## Issue

Still give job score to non-deposited executors. This lead to make this executor visible in the website which is wrong. 

## Updates

- Set `job_score` to 0 when collateral is not deposited. 