### PR TITLE
feat: handle switch validator request from miner portal

### DIFF
--- a/neurons/miners/src/clients/miner_portal_client.py
+++ b/neurons/miners/src/clients/miner_portal_client.py
@@ -23,6 +23,7 @@ from protocol.miner_request import (
 from protocol.miner_portal_request import (
     BaseMinerPortalRequest,
     AddExecutorRequest,
+    SwitchValidatorRequest,
     ExecutorAdded,
     AddExecutorFailed,
     SyncExecutorMinerPortalRequest,
@@ -31,6 +32,8 @@ from protocol.miner_portal_request import (
     SyncExecutorCentralMinerRequest,
     SyncExecutorCentralMinerSuccess,
     SyncExecutorCentralMinerFailed,
+    ValidatorSwitched,
+    ValidatorSwitchFailed,
 )
 
 logger = logging.getLogger(__name__)
@@ -184,6 +187,12 @@ class MinerPortalClient:
                     port=request.payload.port,
                     validator=request.payload.validator_hotkey,
                 )
+            )
+            self.message_queue.append(result)
+
+        if isinstance(request, SwitchValidatorRequest):
+            result: Union[ValidatorSwitched, ValidatorSwitchFailed] = self.executor_service.switch_validator(
+                request,
             )
             self.message_queue.append(result)
 

--- a/neurons/miners/src/protocol/miner_portal_request.py
+++ b/neurons/miners/src/protocol/miner_portal_request.py
@@ -10,6 +10,7 @@ from models.executor import Executor
 
 class RequestType(enum.Enum):
     AddExecutorRequest = "AddExecutorRequest"
+    SwitchValidatorRequest = "SwitchValidatorRequest"
     ExecutorAdded = "ExecutorAdded"
     AddExecutorFailed = "AddExecutorFailed"
     SyncExecutorMinerPortalRequest = "SyncExecutorMinerPortalRequest"
@@ -18,6 +19,8 @@ class RequestType(enum.Enum):
     SyncExecutorCentralMinerRequest = "SyncExecutorCentralMinerRequest"
     SyncExecutorCentralMinerSuccess = "SyncExecutorCentralMinerSuccess"
     SyncExecutorCentralMinerFailed = "SyncExecutorCentralMinerFailed"
+    ValidatorSwitched = "ValidatorSwitched"
+    ValidatorSwitchFailed = "ValidatorSwitchFailed"
 
 
 class BaseMinerPortalRequest(BaseRequest):
@@ -40,6 +43,10 @@ class AddExecutorPayload(BaseModel):
         return self
 
 
+class SwitchValidatorPayload(BaseModel):
+    validator_hotkey: str
+
+
 class SyncExecutorPayload(BaseModel):
     uuid: UUID
     validator: str
@@ -52,6 +59,12 @@ class AddExecutorRequest(BaseMinerPortalRequest):
     executor_id: UUID
     validator_hotkey: str
     payload: AddExecutorPayload
+
+
+class SwitchValidatorRequest(BaseMinerPortalRequest):
+    message_type: RequestType = RequestType.SwitchValidatorRequest
+    executor_id: UUID
+    payload: SwitchValidatorPayload
 
 
 class ExecutorAdded(BaseMinerPortalRequest):
@@ -91,4 +104,15 @@ class SyncExecutorCentralMinerSuccess(BaseMinerPortalRequest):
 
 class SyncExecutorCentralMinerFailed(BaseMinerPortalRequest):
     message_type: RequestType = RequestType.SyncExecutorCentralMinerFailed
+    error: str
+
+
+class ValidatorSwitched(BaseMinerPortalRequest):
+    message_type: RequestType = RequestType.ValidatorSwitched
+    executor_id: UUID
+
+
+class ValidatorSwitchFailed(BaseMinerPortalRequest):
+    message_type: RequestType = RequestType.ValidatorSwitchFailed
+    executor_id: UUID
     error: str


### PR DESCRIPTION
## Summary

  Implements the ability for miners to switch validators through the miner portal interface. This feature allows executors to be reassigned to different validators via a new API endpoint.

## Describe your changes
  - New request types: Added SwitchValidatorRequest, ValidatorSwitched, and ValidatorSwitchFailed message types to the miner portal protocol
  - Service layer: Implemented switch_validator() method in ExecutorService that updates the validator assignment for a given executor
  - Client integration: Added request handling in MinerPortalClient to process switch validator requests
  

 ## Test Plan

  - Verify switch validator request properly updates executor's validator assignment
  - Test error handling for invalid executor IDs
  - Confirm proper success/failure response messages
  - Validate database persistence of validator changes
  