### PR TITLE
feat(miner/validator): Multiple Collateral Contract Versions Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ testing/
 .env
 
 **/.python-version
+notebooks/

--- a/neurons/miners/src/core/config.py
+++ b/neurons/miners/src/core/config.py
@@ -45,6 +45,21 @@ class Settings(BaseSettings):
     OLD_COLLATERAL_CONTRACT_ADDRESS: str | None = Field(
         env='OLD_COLLATERAL_CONTRACT_ADDRESS', default='0x999F9A49A85e9D6E981cad42f197349f50172bEB'
     )
+    CONTRACT_VERSIONS: dict = {
+        "1.0.0": {
+            "address": "0x999F9A49A85e9D6E981cad42f197349f50172bEB",
+            "info": "1st Version of the collateral contract",
+        },
+        "1.0.1": {
+            "address": "0xfB0FEAf1aB5d3788B40F97076ae0104bFbbdC124",
+            "info": "2nd version: Implemented partial slashing",
+        },
+        "1.0.2": {
+            "address": "0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6",
+            "info": "3rd version: Fixed 'ExecutorNotOwned' error",
+        },
+    }
+
     COLLATERAL_DAYS: int = 7
 
     MINER_PORTAL_URI: str = Field(env="MINER_PORTAL_URI", default="wss://provider-api.lium.io")

--- a/neurons/miners/src/core/utils.py
+++ b/neurons/miners/src/core/utils.py
@@ -92,22 +92,25 @@ _m = StructuredMessage
 
 def get_collateral_contract(
     miner_key: str = None,
-    require_old_contract: bool = False,
+    version: str = "1.0.1",
 ) -> CollateralContract:
     """
     Initializes and returns a CollateralContract instance.
 
     Args:
-        contract_address (str): Address of the collateral contract.
+        version (str): Contract version to use (defaults to 1.0.1).
         miner_key (str): Optional miner key required for contract operations.
 
     Returns:
         CollateralContract: The initialized contract instance.
     """
     network = settings.BITTENSOR_NETWORK
-    contract_address =  settings.COLLATERAL_CONTRACT_ADDRESS
-    if require_old_contract and settings.OLD_COLLATERAL_CONTRACT_ADDRESS:
-        contract_address = settings.OLD_COLLATERAL_CONTRACT_ADDRESS
+    contract_address = settings.COLLATERAL_CONTRACT_ADDRESS  # Default address
+    
+    # Use version-specific address if available
+    if version and settings.CONTRACT_VERSIONS.get(version):
+        contract_address = settings.CONTRACT_VERSIONS.get(version)["address"]
+    
     rpc_url = settings.SUBTENSOR_EVM_RPC_URL
 
     return CollateralContract(

--- a/neurons/miners/src/services/cli_service.py
+++ b/neurons/miners/src/services/cli_service.py
@@ -28,7 +28,7 @@ def require_executor_dao(func):
 
 
 class CliService:
-    def __init__(self, private_key: Optional[str] = None, with_executor_db: bool = False, require_old_contract: bool = False):
+    def __init__(self, private_key: Optional[str] = None, with_executor_db: bool = False, version: str = "1.0.0"):
         """
         Initialize the CLI service.
         :param private_key: Ethereum private key for signing (optional).
@@ -40,8 +40,8 @@ class CliService:
         self.hotkey = self.wallet.get_hotkey().ss58_address
         self.private_key = private_key
         self.collateral_contract = (
-            get_collateral_contract(miner_key=private_key, require_old_contract=require_old_contract)
-            if private_key else get_collateral_contract(require_old_contract=require_old_contract)
+            get_collateral_contract(miner_key=private_key, version=version)
+            if private_key else get_collateral_contract(version=version)
         )
         self.executor_dao = ExecutorDao(session=next(get_db())) if with_executor_db else None
         self.logger = logging.getLogger()

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -68,6 +68,20 @@ class Settings(BaseSettings):
     OLD_COLLATERAL_CONTRACT_ADDRESS: str | None = Field(
         env='OLD_COLLATERAL_CONTRACT_ADDRESS', default='0x999F9A49A85e9D6E981cad42f197349f50172bEB'
     )
+    CONTRACT_VERSIONS: dict = {
+        "1.0.0": {
+            "address": "0x999F9A49A85e9D6E981cad42f197349f50172bEB",
+            "info": "1st Version of the collateral contract",
+        },
+        "1.0.1": {
+            "address": "0xfB0FEAf1aB5d3788B40F97076ae0104bFbbdC124",
+            "info": "2nd version: Implemented partial slashing",
+        },
+        "1.0.2": {
+            "address": "0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6",
+            "info": "3rd version: Fixed 'ExecutorNotOwned' error",
+        },
+    }
 
     # GPU types that will be excluded in collateral checks
     COLLATERAL_EXCLUDED_GPU_TYPES: list[str] = [

--- a/neurons/validators/src/core/utils.py
+++ b/neurons/validators/src/core/utils.py
@@ -193,7 +193,7 @@ async def retry_ssh_command(
     await execute_command()
 
 
-def get_collateral_contract(require_old_contract: bool = False) -> CollateralContract:
+def get_collateral_contract(version: str = "1.0.2") -> CollateralContract:
     """
     Initializes and returns a CollateralContract instance.
 
@@ -208,8 +208,9 @@ def get_collateral_contract(require_old_contract: bool = False) -> CollateralCon
     """
     network = settings.BITTENSOR_NETWORK
     contract_address = settings.COLLATERAL_CONTRACT_ADDRESS
-    if require_old_contract and settings.OLD_COLLATERAL_CONTRACT_ADDRESS:
-        contract_address = settings.OLD_COLLATERAL_CONTRACT_ADDRESS
+    if version and settings.CONTRACT_VERSIONS.get(version):
+        contract_address = settings.CONTRACT_VERSIONS.get(version)["address"]
+
     rpc_url = settings.SUBTENSOR_EVM_RPC_URL
 
     return CollateralContract(


### PR DESCRIPTION
# Overview 

This PR covers the updates in validator and miner to support multiple collateral contracts (3 versions) so far. 

## Key Features

### Validator 

Implemented fallback solutions for all collateral contracts - 3 versions in checking eligibility with collateral for executors. 

### Miner 

Enhance CLIs to show all available collaterals with metadata, and select the version in all collateral-relating clis. 
- Get rid of `require-old-contract` argument 
- Added a prompt that requests `version` with showing all available contracts as table. 

## All Collateral Contracts 

| Version | Address                         | Explanation                                             |
| :------- | :---------------------: | ------------------------------------- |
| 1.0.0 |   0x999F9A49A85e9D6E981cad42f197349f50172bEB   | 1st Version of the collateral contract |
| 1.0.1 |   0xfB0FEAf1aB5d3788B40F97076ae0104bFbbdC124   | 2nd version: Implemented partial slashing    |
| 1.0.2 ⭐ |  0x8A4023FdD1eaA7b242F3723a7d096B6CC693c7C6   | 2nd version: Implemented partial slashing |

## How to Use CLIs ( Miners )

**How to see all collaterals**
```sh
docker exec -it miners-miner-1 \
pdm run /root/app/src/cli.py show-contract-versions 
```
<img width="766" height="119" alt="image" src="https://github.com/user-attachments/assets/304e46f4-990b-489e-99c9-91b8f279b8b3" />

**Get executor collateral**
```sh
docker exec -it miners-miner-1 \
pdm run /root/app/src/cli.py get-executor-collateral --address <address> --port<port> 
```

<img width="795" height="146" alt="image" src="https://github.com/user-attachments/assets/13770bac-9b2f-4cc8-bea9-d20235127fcf" />

If you put `1`, it'll be `1.0.0`. if you put `2`, it'll be `1.0.1`, etc. 

> **Note**: Other commands relating to collateral will work as same as described in the above commands. For `deposit-collateral`, it won't ask version because we don't want you to deposit to older contracts. It'll automatically deposit to new contract. 

## Best Practices 

If you deposited collateral for your executor to either version `1.0.0` or `1.0.1`, 
- Please deposit to new collateral first and request reclaim from older contracts if your executor is ***rented***
- You can reclaim from older contracts if your executor isn't ***rented***

## Additional Resources 

- [Migration Guideline](https://github.com/Datura-ai/lium-io/pull/574)
