### PR TITLE
feat(validator): Give Half Score to Executors on Old Contracts

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -100,6 +100,9 @@ class Settings(BaseSettings):
         wallet.hotkey_file.get_keypair()  # this raises errors if the keys are inaccessible
         return wallet
 
+    def get_latest_contract_version(self) -> str:
+        return max(self.CONTRACT_VERSIONS.keys())
+
     def get_bittensor_config(self) -> bittensor.config:
         parser = argparse.ArgumentParser()
         # bittensor.wallet.add_args(parser)


### PR DESCRIPTION
# Summary 

Give only half score to the executors which have collaterals in old contracts during synthetic job. 

## Context

We deployed two new versions of collateral contracts last week. Latest one is for partial slashing and fixed one from a vulnerability in depositing. 

## Problem 

A week is pased, but still major of executors have collaterals in v1 contract. This happens because there's no incentivize for miners to move collateral to new contract. 

## Solution 

For seamless integration, we'll give portion of the score for the executors which have collaterals in old contracts. For now, it'll be half of original score but this will be decreased from time to time to incentivize more miners. 

