### PR TITLE
Added ca-certificates to validator image

### DIFF
--- a/neurons/validators/Dockerfile
+++ b/neurons/validators/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE=python:3.11-slim
 FROM $BASE_IMAGE
 
 RUN apt-get update \
-  && apt-get install -y make wget gcc ccache patchelf openssh-client g++ \
+  && apt-get install -y make wget gcc ccache patchelf ca-certificates openssh-client g++ \
   && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Describe your changes
- Added `ca-certificates` as dependency to the validator container
- Fixes this error on the connector service on `dev.lium.io`

```bash
aiohttp.client_exceptions.ClientConnectorCertificateError: Cannot connect to host dev.lium.io:443 ssl:True [SSLCertVerificationError: (1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1006)')]
```

## Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?
