### PR TITLE
fix: if too low amount of ports in DB - use redis as fallback

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -80,11 +80,9 @@ class DockerService:
 
             # Get successful ports from database as dict {external_port: PortMapping}
             available_ports = await self.port_mapping_dao.get_successful_ports(UUID(executor_id))
-
-
-            if not available_ports:
-                logger.warning(f"No successful ports found in database for executor {executor_id}")
-                raise Exception("No successful ports found in database")
+            MIN_PORTS = 3
+            if len(available_ports) < MIN_PORTS:
+                raise Exception(f"Not enough successful ports found in database for executor {executor_id}")
 
             mappings = []
 

--- a/neurons/validators/src/services/executor_connectivity_service.py
+++ b/neurons/validators/src/services/executor_connectivity_service.py
@@ -312,6 +312,16 @@ class ExecutorConnectivityService:
                 ) as response:
                     if response.status == 200:
                         data = await response.json()
+                        if len(data.get("success_count", 0)) <= 2:
+                            logger.warning(
+                                _m(
+                                    f"Port check request returned only {len(data.get('success_count'))} successful",
+                                    {
+                                        **extra,
+                                        "data": data,
+                                    },
+                                )
+                            )
                         return data.get("results", {})
                     else:
                         logger.error(_m(f"Port check request failed with status {response.status}", extra))


### PR DESCRIPTION
If only 1 available port in the database - take redis ports. + increase logs to understand the issue reason better