### PR TITLE
DAH-1866 chutes

### DIFF
--- a/neurons/executor/.env.template
+++ b/neurons/executor/.env.template
@@ -23,3 +23,17 @@ SSH_PUBLIC_PORT=2200 # Optional. in case you are using proxy and public port is 
 # RENTING_PORT_MAPPINGS="[[46681, 56681], [46682, 56682]]"
 
 MINER_HOTKEY_SS58_ADDRESS=
+
+# Chutes bridge relay (staging only)
+CHUTES_BRIDGE_ENABLED=false
+CHUTES_BRIDGE_SSH_HOST=
+CHUTES_BRIDGE_SSH_PORT=22
+CHUTES_BRIDGE_SSH_USER=lium-bridge
+CHUTES_BRIDGE_SSH_KEY_PATH=/run/secrets/chutes_bridge_key
+CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC=10
+CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC=300
+CHUTES_STAGING_AUTH_BYPASS=false
+
+# Optional compose-only host paths used by docker-compose.chutes-stage.override.yml
+# CHUTES_BRIDGE_SSH_KEY_HOST_PATH=./stage-secrets/chutes_bridge_key
+# CHUTES_BRIDGE_SSH_KNOWN_HOSTS_HOST_PATH=./stage-secrets/chutes_bridge_known_hosts

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -148,3 +148,47 @@ The above command should show the `nvidia-smi` result if sysbox is installed cor
 sudo systemctl restart docker
 ```
 
+## chutes-install
+
+Staging Chutes activation on executor currently has two separate steps:
+
+1. One-time host bootstrap on the same GPU machine:
+```shell
+cd /path/to/chutes/lium-bridge
+sudo ./install_chutes_bridge.sh
+```
+This installs `/opt/lium-bridge/`, the restricted `lium-bridge` SSH user, `ForceCommand`, sudoers allowlist, and bridge state. It does not write executor env values and does not add the executor relay key to `authorized_keys`.
+
+2. Executor relay activation in this checkout:
+```shell
+cd neurons/executor
+./chutes-install.sh --bridge-host host.docker.internal
+```
+
+`chutes-install.sh` prepares `.env` and `stage-secrets/` for the staging relay path. It writes:
+- `CHUTES_BRIDGE_ENABLED=true`
+- `CHUTES_BRIDGE_SSH_HOST`
+- `CHUTES_BRIDGE_SSH_PORT`
+- `CHUTES_BRIDGE_SSH_USER`
+- `CHUTES_BRIDGE_SSH_KEY_PATH=/run/secrets/chutes_bridge_key`
+- `CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC`
+- `CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC`
+- `CHUTES_STAGING_AUTH_BYPASS`
+- `CHUTES_BRIDGE_SSH_KEY_HOST_PATH`
+- `CHUTES_BRIDGE_SSH_KNOWN_HOSTS_HOST_PATH`
+
+Before the relay can work, you still need to:
+- add the dedicated executor relay public key to `/var/lib/lium-bridge/.ssh/authorized_keys` on the GPU host
+- put the matching private key at `./stage-secrets/chutes_bridge_key`
+- put the bridge host fingerprint at `./stage-secrets/chutes_bridge_known_hosts`
+
+Then restart executor with the staging override:
+```shell
+docker compose -f docker-compose.app.yml -f docker-compose.chutes-stage.override.yml up -d --force-recreate executor
+```
+
+After that, the staging-only Chutes relay endpoints can call the host bridge:
+- `POST /chutes/install` -> `bridgectl setup`
+- `POST /chutes/start` -> `bridgectl start`
+- `POST /chutes/stop` -> `bridgectl stop`
+- `GET /chutes/status` -> `bridgectl status`

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -173,7 +173,6 @@ cd neurons/executor
 - `CHUTES_BRIDGE_SSH_KEY_PATH=/run/secrets/chutes_bridge_key`
 - `CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC`
 - `CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC`
-- `CHUTES_STAGING_AUTH_BYPASS`
 - `CHUTES_BRIDGE_SSH_KEY_HOST_PATH`
 - `CHUTES_BRIDGE_SSH_KNOWN_HOSTS_HOST_PATH`
 
@@ -192,3 +191,11 @@ After that, the staging-only Chutes relay endpoints can call the host bridge:
 - `POST /chutes/start` -> `bridgectl start`
 - `POST /chutes/stop` -> `bridgectl stop`
 - `GET /chutes/status` -> `bridgectl status`
+
+Relay contract:
+- `POST /chutes/install`, `POST /chutes/start`, and `POST /chutes/stop` require validator-signed headers: `X-Validator-Hotkey`, `X-Miner-Hotkey`, `X-Timestamp`, and `X-Signature`
+- The signed blob must match the canonical validator/miner REST auth payload (`validator_hotkey`, `miner_hotkey`, `timestamp` with sorted JSON keys)
+- The executor only trusts the configured validator hotkey and requires `X-Miner-Hotkey` to match the executor miner hotkey
+- `POST /chutes/install` validates `validator_hotkey` and `hotkey_ss58` as SS58, `hotkey_seed` as 64 hex chars with optional `0x`, and `node_name` against the bridge hostname pattern
+- `POST /chutes/start` is fail-closed: if the agent pod does not become healthy within the bridge timeout window, the API returns `500` instead of a degraded `200`
+- `GET /chutes/status` can report `bridge.state=error` together with `last_error` after a failed `start`

--- a/neurons/executor/docker-compose.chutes-stage.override.yml
+++ b/neurons/executor/docker-compose.chutes-stage.override.yml
@@ -2,6 +2,14 @@ services:
   executor:
     extra_hosts:
       - "host.docker.internal:host-gateway"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:8001/version || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    deploy:
+      resources:
+        reservations: {}
     volumes:
       - ./src/core/config.py:/root/app/src/core/config.py:ro
       - ./src/middlewares/miner.py:/root/app/src/middlewares/miner.py:ro

--- a/neurons/executor/docker-compose.chutes-stage.override.yml
+++ b/neurons/executor/docker-compose.chutes-stage.override.yml
@@ -14,6 +14,7 @@ services:
       - ./src/core/config.py:/root/app/src/core/config.py:ro
       - ./src/middlewares/miner.py:/root/app/src/middlewares/miner.py:ro
       - ./src/routes/apis.py:/root/app/src/routes/apis.py:ro
+      - ./src/dependencies/auth.py:/root/app/src/dependencies/auth.py:ro
       - ./src/payloads/chutes.py:/root/app/src/payloads/chutes.py:ro
       - ./src/services/chutes_relay_service.py:/root/app/src/services/chutes_relay_service.py:ro
       - ${CHUTES_BRIDGE_SSH_KEY_HOST_PATH:-./stage-secrets/chutes_bridge_key}:/run/secrets/chutes_bridge_key:ro

--- a/neurons/executor/docker-compose.chutes-stage.override.yml
+++ b/neurons/executor/docker-compose.chutes-stage.override.yml
@@ -1,0 +1,12 @@
+services:
+  executor:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - ./src/core/config.py:/root/app/src/core/config.py:ro
+      - ./src/middlewares/miner.py:/root/app/src/middlewares/miner.py:ro
+      - ./src/routes/apis.py:/root/app/src/routes/apis.py:ro
+      - ./src/payloads/chutes.py:/root/app/src/payloads/chutes.py:ro
+      - ./src/services/chutes_relay_service.py:/root/app/src/services/chutes_relay_service.py:ro
+      - ${CHUTES_BRIDGE_SSH_KEY_HOST_PATH:-./stage-secrets/chutes_bridge_key}:/run/secrets/chutes_bridge_key:ro
+      - ${CHUTES_BRIDGE_SSH_KNOWN_HOSTS_HOST_PATH:-./stage-secrets/chutes_bridge_known_hosts}:/root/.ssh/known_hosts:ro

--- a/neurons/executor/docker-compose.local-image.override.yml
+++ b/neurons/executor/docker-compose.local-image.override.yml
@@ -1,0 +1,5 @@
+services:
+  executor:
+    image: daturaai/compute-subnet-executor:latest
+  monitor:
+    image: daturaai/compute-subnet-executor:latest

--- a/neurons/executor/lium-bridge/README.md
+++ b/neurons/executor/lium-bridge/README.md
@@ -1,0 +1,59 @@
+# lium-bridge
+
+Bridgectl — a set of scripts to manage the Chutes (K3s) stack on Lium GPU machines. Allows switching a GPU machine between Lium executor mode and Chutes mining mode.
+
+## Installation
+
+```bash
+sudo ./install_chutes_bridge.sh
+```
+
+This creates `/opt/lium-bridge/`, copies scripts, sets up a restricted `lium-bridge` SSH user with `ForceCommand`, and configures sudoers.
+
+## Usage
+
+All commands return JSON on stdout and log to `/var/log/lium-bridge.log`.
+
+```bash
+bridgectl setup --validator-hotkey <ss58> --hotkey-ss58 <ss58> --hotkey-seed <hex>
+bridgectl start    # Start K3s + Chutes
+bridgectl stop     # Stop K3s + Chutes
+bridgectl status   # Health check (read-only)
+bridgectl uninstall  # Tear down K3s + Chutes, restore host to not_installed
+```
+
+## Current behavior
+
+- `setup` installs K3s, GPU Operator, Chutes GPU charts, and leaves the host in `installed_stopped`
+- `start` starts K3s, waits for node Ready (up to 2 min) and agent pod healthy (up to 3 min), then saves `state=running`
+- `stop` deletes Chutes-managed workload pods with 60s grace, stops K3s, then saves `state=stopped`
+- `status` is read-only and no longer treats `stopped` without a running executor as an error
+- `uninstall` removes Helm releases when possible, runs `k3s-uninstall.sh`, cleans K3s paths, restarts Docker, and saves `state=not_installed`
+
+Validated on H100 host `64.34.82.167`: repeated `start -> stop` cycles, plus idempotent `start` and `stop`.
+
+## State machine
+
+```
+not_installed → [setup] → installed_stopped → [start] → running
+                                  ↑              ↑          |
+                                  |              +--- [stop] -+
+                                  |                          |
+                                  +------ [stop] ------------+
+                                          (state: stopped)
+```
+
+State is persisted in `/opt/lium-bridge/state.json`.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `install_chutes_bridge.sh` | One-shot installer: creates dirs, users, SSH config, sudoers |
+| `bin/bridgectl` | Dispatcher — parses command verb, delegates to the right script. Supports SSH `ForceCommand` |
+| `bin/setup-chutes` | Installs K3s, Helm, GPU Operator, Chutes Helm charts, generates miner kubeconfig |
+| `bin/start-chutes` | Starts K3s, waits for node Ready + agent pod healthy, saves state → `running` |
+| `bin/stop-chutes` | Deletes chute workload pods (grace period 60s), stops K3s, saves state → `stopped` |
+| `bin/status` | Read-only health check: K3s active, agent healthy, pod count, disk free; `stopped` without executor is valid |
+| `bin/uninstall-chutes` | Removes Helm releases, uninstalls K3s, restarts Docker, saves state → `not_installed` |
+| `bin/miner-rbac.yml` | K8s RBAC manifest for miner service account (used by Helm chart, not applied directly) |

--- a/neurons/executor/lium-bridge/README.md
+++ b/neurons/executor/lium-bridge/README.md
@@ -25,9 +25,9 @@ bridgectl uninstall  # Tear down K3s + Chutes, restore host to not_installed
 ## Current behavior
 
 - `setup` installs K3s, GPU Operator, Chutes GPU charts, and leaves the host in `installed_stopped`
-- `start` starts K3s, waits for node Ready (up to 2 min) and agent pod healthy (up to 3 min), then saves `state=running`
+- `start` starts K3s, waits for node Ready (up to 2 min) and agent pod healthy (up to 3 min); if the agent pod never becomes healthy it returns `ok=false`, saves `state=error`, and records `last_error`
 - `stop` deletes Chutes-managed workload pods with 60s grace, stops K3s, then saves `state=stopped`
-- `status` is read-only and no longer treats `stopped` without a running executor as an error
+- `status` is read-only and surfaces persisted `state=error` and `last_error` from the previous bridge action
 - `uninstall` removes Helm releases when possible, runs `k3s-uninstall.sh`, cleans K3s paths, restarts Docker, and saves `state=not_installed`
 
 Validated on H100 host `64.34.82.167`: repeated `start -> stop` cycles, plus idempotent `start` and `stop`.
@@ -38,6 +38,8 @@ Validated on H100 host `64.34.82.167`: repeated `start -> stop` cycles, plus ide
 not_installed → [setup] → installed_stopped → [start] → running
                                   ↑              ↑          |
                                   |              +--- [stop] -+
+                                  |                          |
+                                  +-- [start fails] → error -+
                                   |                          |
                                   +------ [stop] ------------+
                                           (state: stopped)
@@ -50,10 +52,10 @@ State is persisted in `/opt/lium-bridge/state.json`.
 | File | Description |
 |------|-------------|
 | `install_chutes_bridge.sh` | One-shot installer: creates dirs, users, SSH config, sudoers |
-| `bin/bridgectl` | Dispatcher — parses command verb, delegates to the right script. Supports SSH `ForceCommand` |
+| `bin/bridgectl` | Dispatcher — parses command verb, delegates to the right script, and logs only the verb to avoid leaking setup secrets |
 | `bin/setup-chutes` | Installs K3s, Helm, GPU Operator, Chutes Helm charts, generates miner kubeconfig |
-| `bin/start-chutes` | Starts K3s, waits for node Ready + agent pod healthy, saves state → `running` |
+| `bin/start-chutes` | Starts K3s, waits for node Ready + agent pod healthy, and fails closed into `state=error` if the agent never becomes healthy |
 | `bin/stop-chutes` | Deletes chute workload pods (grace period 60s), stops K3s, saves state → `stopped` |
-| `bin/status` | Read-only health check: K3s active, agent healthy, pod count, disk free; `stopped` without executor is valid |
+| `bin/status` | Read-only health check: K3s active, agent healthy, pod count, disk free, and persisted `last_error` |
 | `bin/uninstall-chutes` | Removes Helm releases, uninstalls K3s, restarts Docker, saves state → `not_installed` |
 | `bin/miner-rbac.yml` | K8s RBAC manifest for miner service account (used by Helm chart, not applied directly) |

--- a/neurons/executor/lium-bridge/bin/bridgectl
+++ b/neurons/executor/lium-bridge/bin/bridgectl
@@ -65,7 +65,7 @@ case "${VERB}" in
             fail_json "Script not found: ${SCRIPT}"
         fi
         shift
-        log "INFO" "Running: ${VERB} $*"
+        log "INFO" "Running verb=${VERB}"
         exec sudo "${SCRIPT}" "$@"
         ;;
     "")

--- a/neurons/executor/lium-bridge/bin/bridgectl
+++ b/neurons/executor/lium-bridge/bin/bridgectl
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# bridgectl — dispatcher for lium-bridge commands
+# All commands return JSON. No arbitrary shell access.
+
+set -euo pipefail
+
+BRIDGE_DIR="/opt/lium-bridge"
+BIN_DIR="${BRIDGE_DIR}/bin"
+STATE_FILE="${BRIDGE_DIR}/state.json"
+LOG_FILE="/var/log/lium-bridge.log"
+
+# --- Helpers ---
+
+log() {
+    local level="$1"; shift
+    echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${level}] $*" >> "${LOG_FILE}" 2>/dev/null || true
+}
+
+json_output() {
+    # Usage: json_output '{"ok": true, ...}'
+    echo "$1"
+}
+
+fail_json() {
+    local msg="$1"
+    local state
+    state=$(read_state)
+    log "ERROR" "${msg}"
+    python3 -c "import json,sys; json.dump({'ok':False,'state':sys.argv[1],'error':sys.argv[2]}, sys.stdout)" "${state}" "${msg}"
+    echo ""
+    exit 1
+}
+
+read_state() {
+    if [[ -f "${STATE_FILE}" ]]; then
+        python3 -c "import json; print(json.load(open('${STATE_FILE}'))['state'])" 2>/dev/null || echo "unknown"
+    else
+        echo "not_installed"
+    fi
+}
+
+# --- SSH ForceCommand support ---
+# When called via SSH ForceCommand, the original command is in SSH_ORIGINAL_COMMAND
+if [[ -n "${SSH_ORIGINAL_COMMAND:-}" ]]; then
+    # Parse safely: read -ra prevents glob expansion and honours quoting
+    read -ra _args <<< "${SSH_ORIGINAL_COMMAND}"
+    set -- "${_args[@]}"
+    # Strip "bridgectl" prefix if present
+    if [[ "${1:-}" == "bridgectl" ]]; then
+        shift
+    fi
+fi
+
+# --- Dispatch ---
+
+VERB="${1:-}"
+
+case "${VERB}" in
+    setup|start|stop|status|uninstall)
+        SCRIPT="${BIN_DIR}/${VERB}-chutes"
+        if [[ "${VERB}" == "status" ]]; then
+            SCRIPT="${BIN_DIR}/status"
+        fi
+        if [[ ! -x "${SCRIPT}" ]]; then
+            fail_json "Script not found: ${SCRIPT}"
+        fi
+        shift
+        log "INFO" "Running: ${VERB} $*"
+        exec sudo "${SCRIPT}" "$@"
+        ;;
+    "")
+        fail_json "No command specified. Usage: bridgectl {setup|start|stop|status|uninstall}"
+        ;;
+    *)
+        fail_json "Unknown command: ${VERB}. Usage: bridgectl {setup|start|stop|status|uninstall}"
+        ;;
+esac

--- a/neurons/executor/lium-bridge/bin/miner-rbac.yml
+++ b/neurons/executor/lium-bridge/bin/miner-rbac.yml
@@ -1,0 +1,59 @@
+---
+# ClusterRole for read-only access to all resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: miner
+rules:
+  - apiGroups: ["*"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["patch"]
+
+---
+# ClusterRoleBinding for read-only access
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: miner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: miner
+subjects:
+  - kind: User
+    name: miner
+    apiGroup: rbac.authorization.k8s.io
+
+---
+# Role for write access to specific resources in chutes namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: miner
+  namespace: chutes
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services", "configmaps"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+
+---
+# RoleBinding for write access in chutes namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: miner
+  namespace: chutes
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: miner
+subjects:
+  - kind: User
+    name: miner
+    apiGroup: rbac.authorization.k8s.io

--- a/neurons/executor/lium-bridge/bin/setup-chutes
+++ b/neurons/executor/lium-bridge/bin/setup-chutes
@@ -28,11 +28,13 @@ log() {
 fail() {
     local msg="$1"
     log "FATAL" "${msg}"
-    # Reset state to not_installed so retries are possible
-    save_state "not_installed"
     python3 -c "
 import json, sys
-json.dump({'ok': False, 'state': 'not_installed', 'error': sys.argv[1]}, sys.stdout)
+state = 'error'
+try:
+    state = json.load(open('${STATE_FILE}'))['state']
+except: pass
+json.dump({'ok': False, 'state': state, 'error': sys.argv[1]}, sys.stdout)
 " "${msg}"
     echo ""
     exit 1
@@ -57,12 +59,14 @@ json.dump(s, open('${STATE_FILE}', 'w'))
 VALIDATOR_HOTKEY=""
 HOTKEY_SS58=""
 HOTKEY_SEED=""
+NODE_NAME=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --validator-hotkey) VALIDATOR_HOTKEY="$2"; shift 2 ;;
         --hotkey-ss58)      HOTKEY_SS58="$2"; shift 2 ;;
         --hotkey-seed)      HOTKEY_SEED="$2"; shift 2 ;;
+        --node-name)        NODE_NAME="$2"; shift 2 ;;
         *) fail "Unknown argument: $1" ;;
     esac
 done
@@ -70,11 +74,20 @@ done
 [[ -z "${VALIDATOR_HOTKEY}" ]] && fail "Missing --validator-hotkey"
 [[ -z "${HOTKEY_SS58}" ]]      && fail "Missing --hotkey-ss58"
 [[ -z "${HOTKEY_SEED}" ]]      && fail "Missing --hotkey-seed"
+[[ -z "${NODE_NAME}" ]]        && fail "Missing --node-name"
 
 # Strip 0x prefix from seed if present
 HOTKEY_SEED="${HOTKEY_SEED#0x}"
 
 save_state "installing"
+
+# =============================================================================
+# STEP 0: SET HOSTNAME
+# =============================================================================
+log "INFO" "Step 0: Setting hostname to '${NODE_NAME}'..."
+hostnamectl set-hostname "${NODE_NAME}" 2>/dev/null || true
+echo "${NODE_NAME}" > /etc/hostname
+log "INFO" "Hostname set to '${NODE_NAME}'"
 
 # =============================================================================
 # STEP 1: PREREQUISITES CHECK
@@ -104,21 +117,20 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -y -qq jq curl socat conntrack openssl &>/dev/null
 
-# Install or upgrade nvidia-container-toolkit (>=1.17 required for containerd config v3)
-_nctk_need_install=false
-if ! command -v nvidia-ctk &>/dev/null; then
-    _nctk_need_install=true
-else
-    _nctk_major=$(nvidia-ctk --version 2>/dev/null | grep -oP 'version \K[0-9]+' || echo "0")
-    _nctk_minor=$(nvidia-ctk --version 2>/dev/null | grep -oP 'version [0-9]+\.\K[0-9]+' || echo "0")
-    if [[ "${_nctk_major}" -lt 1 ]] || [[ "${_nctk_major}" -eq 1 && "${_nctk_minor}" -lt 17 ]]; then
-        _nctk_need_install=true
-    fi
+# Install/upgrade nvidia-container-toolkit (>= 1.18 required for GPU Operator CDI support)
+NCTK_MIN="1.18.0"
+NCTK_CUR="0.0.0"
+if command -v nvidia-ctk &>/dev/null; then
+    NCTK_CUR=$(nvidia-container-cli --version 2>/dev/null | awk '/^cli-version:/{print $2}' || echo "0.0.0")
 fi
-if [[ "${_nctk_need_install}" == "true" ]]; then
-    log "INFO" "Installing/upgrading nvidia-container-toolkit..."
+if printf '%s\n' "${NCTK_MIN}" "${NCTK_CUR}" | sort -V | head -1 | grep -qx "${NCTK_MIN}"; then
+    log "INFO" "nvidia-container-toolkit ${NCTK_CUR} >= ${NCTK_MIN}, OK"
+else
+    log "INFO" "Installing/upgrading nvidia-container-toolkit (current: ${NCTK_CUR}, need >= ${NCTK_MIN})..."
     apt-get install -y -qq nvidia-container-toolkit &>/dev/null \
         || fail "Failed to install nvidia-container-toolkit"
+    NCTK_CUR=$(nvidia-container-cli --version 2>/dev/null | awk '/^cli-version:/{print $2}' || echo "unknown")
+    log "INFO" "nvidia-container-toolkit upgraded to ${NCTK_CUR}"
 fi
 
 log "INFO" "Prerequisites OK"
@@ -460,7 +472,7 @@ CSRYAML
 
     CERT_B64=$(base64 -w 0 < "${TEMP_DIR}/${CERT_NAME}.crt")
     KEY_B64=$(base64 -w 0 < "${TEMP_DIR}/${CERT_NAME}.key")
-    HOSTNAME=$(hostname)
+    HOSTNAME="${NODE_NAME}"
 
     # Build kubeconfig
     MINER_KUBECONFIG=$(cat <<KUBECFG

--- a/neurons/executor/lium-bridge/bin/setup-chutes
+++ b/neurons/executor/lium-bridge/bin/setup-chutes
@@ -44,10 +44,10 @@ save_state() {
     local state="$1"
     python3 -c "
 import json, sys
-s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None}
+s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None, 'gpu_name': None}
 try:
     old = json.load(open('${STATE_FILE}'))
-    for k in ('gpu_verified', 'node_name'):
+    for k in ('gpu_verified', 'node_name', 'gpu_name'):
         if k in old: s[k] = old[k]
 except: pass
 json.dump(s, open('${STATE_FILE}', 'w'))
@@ -77,6 +77,18 @@ done
 HOTKEY_SEED="${HOTKEY_SEED#0x}"
 
 save_state "installing"
+
+# Detect GPU name early (before K3s takes over GPUs) and persist to state.json
+GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 | xargs || echo "")
+if [[ -n "${GPU_NAME}" ]]; then
+    log "INFO" "Detected GPU: ${GPU_NAME}"
+    python3 -c "
+import json
+s = json.load(open('${STATE_FILE}'))
+s['gpu_name'] = '${GPU_NAME}'
+json.dump(s, open('${STATE_FILE}', 'w'))
+"
+fi
 
 # =============================================================================
 # STEP 1: PREREQUISITES CHECK

--- a/neurons/executor/lium-bridge/bin/setup-chutes
+++ b/neurons/executor/lium-bridge/bin/setup-chutes
@@ -1,0 +1,524 @@
+#!/usr/bin/env bash
+# bridgectl setup — install K3s + Chutes stack on a GPU machine
+# Expects: NVIDIA drivers + Docker already installed (from Lium executor)
+# Usage: setup-chutes --validator-hotkey <ss58> --hotkey-ss58 <ss58> --hotkey-seed <hex>
+set -euo pipefail
+
+# --- Constants ---
+
+BRIDGE_DIR="/opt/lium-bridge"
+STATE_FILE="${BRIDGE_DIR}/state.json"
+LOG_FILE="/var/log/lium-bridge.log"
+KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+
+K3S_VERSION="v1.33.1+k3s1"
+HELM_VERSION="v3.17.3"
+REGISTRY_PORT="30500"
+AGENT_PORT="32000"
+
+# --- Logging ---
+
+log() {
+    local level="$1"; shift
+    local msg="[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${level}] $*"
+    echo "${msg}" >> "${LOG_FILE}" 2>/dev/null || true
+    echo "${msg}" >&2
+}
+
+fail() {
+    local msg="$1"
+    log "FATAL" "${msg}"
+    python3 -c "
+import json, sys
+state = 'error'
+try:
+    state = json.load(open('${STATE_FILE}'))['state']
+except: pass
+json.dump({'ok': False, 'state': state, 'error': sys.argv[1]}, sys.stdout)
+" "${msg}"
+    echo ""
+    exit 1
+}
+
+save_state() {
+    local state="$1"
+    python3 -c "
+import json, sys
+s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None}
+try:
+    old = json.load(open('${STATE_FILE}'))
+    for k in ('gpu_verified', 'node_name'):
+        if k in old: s[k] = old[k]
+except: pass
+json.dump(s, open('${STATE_FILE}', 'w'))
+" "${state}"
+}
+
+# --- Parse args ---
+
+VALIDATOR_HOTKEY=""
+HOTKEY_SS58=""
+HOTKEY_SEED=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --validator-hotkey) VALIDATOR_HOTKEY="$2"; shift 2 ;;
+        --hotkey-ss58)      HOTKEY_SS58="$2"; shift 2 ;;
+        --hotkey-seed)      HOTKEY_SEED="$2"; shift 2 ;;
+        *) fail "Unknown argument: $1" ;;
+    esac
+done
+
+[[ -z "${VALIDATOR_HOTKEY}" ]] && fail "Missing --validator-hotkey"
+[[ -z "${HOTKEY_SS58}" ]]      && fail "Missing --hotkey-ss58"
+[[ -z "${HOTKEY_SEED}" ]]      && fail "Missing --hotkey-seed"
+
+# Strip 0x prefix from seed if present
+HOTKEY_SEED="${HOTKEY_SEED#0x}"
+
+save_state "installing"
+
+# =============================================================================
+# STEP 1: PREREQUISITES CHECK
+# =============================================================================
+log "INFO" "Step 1: Checking prerequisites..."
+
+command -v nvidia-smi &>/dev/null || fail "nvidia-smi not found"
+nvidia-smi &>/dev/null           || fail "nvidia-smi failed — GPU driver not working"
+
+systemctl is-active docker &>/dev/null || fail "Docker is not running"
+
+DISK_FREE=$(df -BG / | tail -1 | awk '{print $4}' | tr -d 'G')
+[[ "${DISK_FREE}" -lt 100 ]] && log "WARN" "Only ${DISK_FREE}GB free (recommended: 200GB+)"
+
+# Check ports not already in use (skip if K3s is already installed — idempotent re-run)
+if ! command -v k3s &>/dev/null; then
+    for port in 6443 ${AGENT_PORT}; do
+        if ss -tlnp 2>/dev/null | grep -q ":${port} "; then
+            fail "Port ${port} is already in use"
+        fi
+    done
+fi
+
+# Install missing packages
+log "INFO" "Installing required packages..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y -qq jq curl socat conntrack openssl &>/dev/null
+
+# Install nvidia-container-toolkit if missing
+if ! command -v nvidia-ctk &>/dev/null; then
+    log "INFO" "Installing nvidia-container-toolkit..."
+    apt-get install -y -qq nvidia-container-toolkit &>/dev/null \
+        || fail "Failed to install nvidia-container-toolkit"
+fi
+
+log "INFO" "Prerequisites OK"
+
+# =============================================================================
+# STEP 2: INSTALL HELM
+# =============================================================================
+if ! command -v helm &>/dev/null; then
+    log "INFO" "Step 2: Installing Helm ${HELM_VERSION}..."
+    ARCH=$(uname -m)
+    HELM_ARCH="amd64"
+    [[ "${ARCH}" == "aarch64" || "${ARCH}" == "arm64" ]] && HELM_ARCH="arm64"
+
+    curl -sfL "https://get.helm.sh/helm-${HELM_VERSION}-linux-${HELM_ARCH}.tar.gz" -o /tmp/helm.tar.gz
+    tar -xzf /tmp/helm.tar.gz -C /tmp
+    mv /tmp/linux-${HELM_ARCH}/helm /usr/local/bin/helm
+    chmod 755 /usr/local/bin/helm
+    rm -rf /tmp/helm.tar.gz /tmp/linux-${HELM_ARCH}
+
+    helm version --short >> "${LOG_FILE}" 2>&1 || fail "Helm install failed"
+    log "INFO" "Helm installed"
+else
+    log "INFO" "Step 2: Helm already installed, skipping"
+fi
+
+# =============================================================================
+# STEP 3: INSTALL K3S (without starting)
+# =============================================================================
+log "INFO" "Step 3: Installing K3s ${K3S_VERSION}..."
+
+# Detect the local node IP (for K3s binding)
+NODE_IP=$(ip route get 1.1.1.1 2>/dev/null | awk '{for(i=1;i<=NF;i++) if ($i=="src") print $(i+1)}' | head -1)
+[[ -z "${NODE_IP}" ]] && NODE_IP=$(hostname -I | awk '{print $1}')
+[[ -z "${NODE_IP}" ]] && fail "Could not detect node IP"
+log "INFO" "Detected local node IP: ${NODE_IP}"
+
+# Detect the public IP (for external access: kubeconfig, TLS SAN, node label)
+PUBLIC_IP=$(curl -sf --max-time 5 https://api.ipify.org 2>/dev/null || true)
+if [[ -z "${PUBLIC_IP}" ]]; then
+    PUBLIC_IP=$(curl -sf --max-time 5 https://ifconfig.me 2>/dev/null || true)
+fi
+if [[ -n "${PUBLIC_IP}" && "${PUBLIC_IP}" != "${NODE_IP}" ]]; then
+    log "INFO" "Detected public IP: ${PUBLIC_IP}"
+    EXTERNAL_IP="${PUBLIC_IP}"
+    TLS_SAN_EXTRA=("--tls-san" "${PUBLIC_IP}")
+else
+    log "WARN" "Could not detect public IP or same as local, using local IP for external access"
+    EXTERNAL_IP="${NODE_IP}"
+    TLS_SAN_EXTRA=()
+fi
+
+curl -sfL https://get.k3s.io | \
+    INSTALL_K3S_SKIP_START=true \
+    INSTALL_K3S_VERSION="${K3S_VERSION}" \
+    sh -s - \
+        --write-kubeconfig-mode 644 \
+        --disable servicelb \
+        --disable traefik \
+        --node-ip "${NODE_IP}" \
+        --advertise-address "${NODE_IP}" \
+        --tls-san "${NODE_IP}" \
+        "${TLS_SAN_EXTRA[@]}" \
+    || fail "K3s install failed"
+
+log "INFO" "K3s binary installed"
+
+# =============================================================================
+# STEP 4: CONFIGURE K3S (registries, sysctl, kernel modules)
+# =============================================================================
+log "INFO" "Step 4: Configuring K3s..."
+
+REGISTRY_HOSTNAME="$(echo "${VALIDATOR_HOTKEY}" | tr '[:upper:]' '[:lower:]').localregistry.chutes.ai"
+
+mkdir -p /etc/rancher/k3s
+cat > /etc/rancher/k3s/registries.yaml <<REGISTRIES
+mirrors:
+  "${REGISTRY_HOSTNAME}:${REGISTRY_PORT}":
+    endpoint:
+      - "http://${REGISTRY_HOSTNAME}:${REGISTRY_PORT}"
+
+configs:
+  "${REGISTRY_HOSTNAME}:${REGISTRY_PORT}":
+    tls:
+      insecure_skip_verify: true
+REGISTRIES
+
+# Load kernel modules
+modprobe br_netfilter  2>/dev/null || true
+modprobe overlay       2>/dev/null || true
+
+cat > /etc/modules-load.d/kubernetes.conf <<'EOF'
+br_netfilter
+overlay
+EOF
+
+# Sysctl
+sysctl -w net.bridge.bridge-nf-call-iptables=1  2>/dev/null || true
+sysctl -w net.bridge.bridge-nf-call-ip6tables=1 2>/dev/null || true
+sysctl -w net.ipv4.ip_forward=1                 2>/dev/null || true
+
+cat > /etc/sysctl.d/99-kubernetes.conf <<'EOF'
+net.bridge.bridge-nf-call-iptables = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+net.ipv4.ip_forward = 1
+EOF
+
+# Disable swap (K3s requirement)
+swapoff -a 2>/dev/null || true
+sed -i '/\sswap\s/s/^/#/' /etc/fstab 2>/dev/null || true
+
+log "INFO" "K3s configured"
+
+# =============================================================================
+# STEP 5: START K3S
+# =============================================================================
+log "INFO" "Step 5: Starting K3s..."
+
+systemctl daemon-reload
+systemctl start k3s
+systemctl enable k3s
+
+# Wait for kubeconfig
+log "INFO" "Waiting for kubeconfig..."
+for i in $(seq 1 60); do
+    [[ -f "${KUBECONFIG}" ]] && break
+    sleep 2
+done
+[[ -f "${KUBECONFIG}" ]] || fail "Timeout waiting for ${KUBECONFIG}"
+
+# Wait for node Ready
+log "INFO" "Waiting for node Ready..."
+for i in $(seq 1 60); do
+    if k3s kubectl get nodes 2>/dev/null | grep -q " Ready"; then
+        break
+    fi
+    sleep 5
+done
+k3s kubectl get nodes 2>/dev/null | grep -q " Ready" || fail "Node did not become Ready"
+
+# Label node with external IP (required for GraVal verification and control node access)
+NODE_NAME=$(k3s kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+k3s kubectl label nodes "${NODE_NAME}" "chutes/external-ip=${EXTERNAL_IP}" --overwrite
+log "INFO" "K3s node is Ready (labeled with external-ip=${NODE_IP})"
+
+# =============================================================================
+# STEP 6: CONFIGURE NVIDIA RUNTIME FOR K3S CONTAINERD
+# =============================================================================
+log "INFO" "Step 6: Configuring NVIDIA runtime for K3s containerd..."
+
+CONTAINERD_CONFIG="/var/lib/rancher/k3s/agent/etc/containerd/config.toml"
+CONTAINERD_TMPL="${CONTAINERD_CONFIG}.tmpl"
+
+# Wait for containerd config to appear
+for i in $(seq 1 30); do
+    [[ -f "${CONTAINERD_CONFIG}" ]] && break
+    sleep 2
+done
+[[ -f "${CONTAINERD_CONFIG}" ]] || fail "K3s containerd config not found"
+
+# Create template from config if not exists
+if [[ ! -f "${CONTAINERD_TMPL}" ]]; then
+    cp "${CONTAINERD_CONFIG}" "${CONTAINERD_TMPL}"
+fi
+
+# Configure both docker and k3s containerd
+nvidia-ctk runtime configure --runtime=docker --set-as-default 2>/dev/null || true
+nvidia-ctk runtime configure --runtime=containerd \
+    --config="${CONTAINERD_TMPL}" \
+    || fail "nvidia-ctk containerd configure failed"
+
+# Restart K3s to pick up NVIDIA runtime
+log "INFO" "Restarting K3s with NVIDIA runtime..."
+systemctl restart k3s
+
+# Wait for node Ready again
+for i in $(seq 1 60); do
+    if k3s kubectl get nodes 2>/dev/null | grep -q " Ready"; then
+        break
+    fi
+    sleep 5
+done
+k3s kubectl get nodes 2>/dev/null | grep -q " Ready" || fail "Node not Ready after NVIDIA runtime config"
+log "INFO" "NVIDIA runtime configured"
+
+# =============================================================================
+# STEP 7: CREATE NAMESPACES + HOST MOUNTS + DEVICE PERMISSIONS
+# =============================================================================
+log "INFO" "Step 7: Creating namespaces and host mounts..."
+
+k3s kubectl create namespace chutes      2>/dev/null || true
+k3s kubectl create namespace monitoring  2>/dev/null || true
+k3s kubectl create namespace gpu-operator 2>/dev/null || true
+
+# Host mount directories (pods run as UID 1000)
+mkdir -p /var/snap/cache
+chown 1000:1000 /var/snap/cache
+chmod 0755 /var/snap/cache
+
+mkdir -p /var/lib/chutes/agent
+chown -R 1000:1000 /var/lib/chutes
+chmod -R 0755 /var/lib/chutes
+
+# NVIDIA device permissions
+chmod 0666 /dev/nvidia* 2>/dev/null || true
+chmod 0666 /dev/nvidiactl 2>/dev/null || true
+chmod 0666 /dev/nvidia-uvm 2>/dev/null || true
+chmod 0666 /dev/nvidia-uvm-tools 2>/dev/null || true
+
+# Create /dev/char symlinks for nvidia devices
+ls /dev/nvidia? 2>/dev/null | grep -E 'nvidia[0-9]' | while read -r dev; do
+    MAJ=$(stat -c '%t' "${dev}" 2>/dev/null | xargs printf '%d' 2>/dev/null) || continue
+    MIN=$(stat -c '%T' "${dev}" 2>/dev/null | xargs printf '%d' 2>/dev/null) || continue
+    ln -sf "${dev}" "/dev/char/${MAJ}:${MIN}" 2>/dev/null || true
+done
+
+log "INFO" "Namespaces and host mounts created"
+
+# =============================================================================
+# STEP 8: GPU OPERATOR (Helm)
+# =============================================================================
+log "INFO" "Step 8: Installing GPU Operator..."
+
+helm repo add nvidia https://helm.ngc.nvidia.com/nvidia 2>/dev/null || true
+helm repo update
+
+helm upgrade --install gpu-operator nvidia/gpu-operator \
+    --namespace gpu-operator \
+    --kubeconfig "${KUBECONFIG}" \
+    --create-namespace \
+    --set driver.enabled=false \
+    --set toolkit.enabled=false \
+    --set operator.upgradeCRD=false \
+    --wait --timeout 5m \
+    || fail "GPU Operator helm install failed"
+
+log "INFO" "GPU Operator installed"
+
+# =============================================================================
+# STEP 9: DEPLOY CHUTES GPU CHARTS (Helm)
+# =============================================================================
+# NOTE: RBAC (miner ClusterRole/RoleBinding) is included in the chutes-miner-gpu chart,
+# so we do NOT apply miner-rbac.yml separately — it would conflict with Helm ownership.
+log "INFO" "Step 9: Deploying Chutes GPU charts..."
+
+helm repo add chutes https://chutesai.github.io/chutes-miner 2>/dev/null || true
+helm repo update
+
+helm upgrade --install chutes chutes/chutes-miner-gpu \
+    --namespace chutes \
+    --kubeconfig "${KUBECONFIG}" \
+    --create-namespace \
+    --set multiCluster=true \
+    --set-string minerCredentials.ss58Address="${HOTKEY_SS58}" \
+    --set-string minerCredentials.secretSeed="${HOTKEY_SEED}" \
+    --wait --timeout 10m \
+    || fail "Chutes GPU charts helm install failed"
+
+# Wait for agent pod to be running
+log "INFO" "Waiting for chutes-agent pod..."
+for i in $(seq 1 60); do
+    if k3s kubectl get pods -n chutes 2>/dev/null | grep -E "agent.*Running"; then
+        break
+    fi
+    sleep 5
+done
+
+# Check agent API is responding
+for i in $(seq 1 30); do
+    if curl -sf "http://localhost:${AGENT_PORT}" &>/dev/null || \
+       curl -sf "http://localhost:${AGENT_PORT}/health" &>/dev/null; then
+        break
+    fi
+    sleep 2
+done
+
+log "INFO" "Chutes GPU charts deployed"
+
+# =============================================================================
+# STEP 10: SETUP MINER KUBECONFIG (for control node access via add-node)
+# =============================================================================
+log "INFO" "Step 10: Generating miner kubeconfig..."
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TEMP_DIR}"' EXIT
+
+CERT_NAME="miner"
+CERT_ORG="chutes"
+NAMESPACE="default"
+
+# Check if kubeconfig secret already exists
+if k3s kubectl get secret "${CERT_NAME}-kubeconfig" -n "${NAMESPACE}" &>/dev/null; then
+    log "INFO" "Miner kubeconfig secret already exists, skipping"
+else
+    # Generate RSA key
+    openssl genrsa -out "${TEMP_DIR}/${CERT_NAME}.key" 2048 2>/dev/null
+
+    # Generate CSR
+    openssl req -new \
+        -key "${TEMP_DIR}/${CERT_NAME}.key" \
+        -out "${TEMP_DIR}/${CERT_NAME}.csr" \
+        -subj "/CN=${CERT_NAME}/O=${CERT_ORG}" \
+        2>/dev/null
+
+    CSR_B64=$(base64 -w 0 < "${TEMP_DIR}/${CERT_NAME}.csr")
+
+    # Delete old CSR if exists
+    k3s kubectl delete csr "${CERT_NAME}-csr" 2>/dev/null || true
+
+    # Submit CSR to K8s
+    k3s kubectl apply -f - <<CSRYAML
+apiVersion: certificates.k8s.io/v1
+kind: CertificateSigningRequest
+metadata:
+  name: ${CERT_NAME}-csr
+spec:
+  request: ${CSR_B64}
+  signerName: kubernetes.io/kube-apiserver-client
+  usages:
+    - client auth
+CSRYAML
+
+    # Approve CSR
+    k3s kubectl certificate approve "${CERT_NAME}-csr"
+
+    # Wait for certificate to be issued
+    for i in $(seq 1 30); do
+        CERT_DATA=$(k3s kubectl get csr "${CERT_NAME}-csr" -o jsonpath='{.status.certificate}' 2>/dev/null)
+        [[ -n "${CERT_DATA}" ]] && break
+        sleep 2
+    done
+    [[ -z "${CERT_DATA}" ]] && fail "Timeout waiting for certificate to be issued"
+
+    # Save cert
+    echo "${CERT_DATA}" | base64 -d > "${TEMP_DIR}/${CERT_NAME}.crt"
+
+    # Get cluster CA and API server from admin kubeconfig
+    CLUSTER_CA=$(k3s kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
+    API_PORT=$(k3s kubectl config view --raw -o jsonpath='{.clusters[0].cluster.server}' | grep -oP ':\K[0-9]+$')
+
+    CERT_B64=$(base64 -w 0 < "${TEMP_DIR}/${CERT_NAME}.crt")
+    KEY_B64=$(base64 -w 0 < "${TEMP_DIR}/${CERT_NAME}.key")
+    HOSTNAME=$(hostname)
+
+    # Build kubeconfig
+    MINER_KUBECONFIG=$(cat <<KUBECFG
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: ${CLUSTER_CA}
+    server: https://${EXTERNAL_IP}:${API_PORT}
+  name: ${HOSTNAME}
+contexts:
+- context:
+    cluster: ${HOSTNAME}
+    user: ${HOSTNAME}
+    namespace: ${NAMESPACE}
+  name: ${HOSTNAME}
+current-context: ${CERT_NAME}
+users:
+- name: ${HOSTNAME}
+  user:
+    client-certificate-data: ${CERT_B64}
+    client-key-data: ${KEY_B64}
+KUBECFG
+)
+
+    KC_B64=$(echo "${MINER_KUBECONFIG}" | base64 -w 0)
+
+    # Store as secret
+    k3s kubectl apply -f - <<SECRETYAML
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${CERT_NAME}-kubeconfig
+  namespace: ${NAMESPACE}
+type: Opaque
+data:
+  kubeconfig: ${KC_B64}
+SECRETYAML
+
+    # Cleanup CSR from cluster
+    k3s kubectl delete csr "${CERT_NAME}-csr" 2>/dev/null || true
+
+    log "INFO" "Miner kubeconfig stored as secret '${CERT_NAME}-kubeconfig' in namespace '${NAMESPACE}'"
+fi
+
+# =============================================================================
+# STEP 11: SAVE STATE + SUCCESS
+# =============================================================================
+log "INFO" "Step 11: Saving state..."
+
+save_state "installed_stopped"
+
+GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -1 | tr -d '[:space:]' || echo "unknown")
+GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l | tr -d ' ')
+
+log "INFO" "Setup complete!"
+
+cat <<RESULT
+{
+  "ok": true,
+  "state": "installed_stopped",
+  "node_ip": "${NODE_IP}",
+  "external_ip": "${EXTERNAL_IP}",
+  "agent_port": ${AGENT_PORT},
+  "gpu": "${GPU_NAME}",
+  "gpu_count": ${GPU_COUNT},
+  "message": "K3s + Chutes stack installed. Run 'chutes-miner add-node' from control node while K3s is up."
+}
+RESULT

--- a/neurons/executor/lium-bridge/bin/setup-chutes
+++ b/neurons/executor/lium-bridge/bin/setup-chutes
@@ -79,15 +79,15 @@ HOTKEY_SEED="${HOTKEY_SEED#0x}"
 save_state "installing"
 
 # Detect GPU name early (before K3s takes over GPUs) and persist to state.json
-GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 | xargs || echo "")
+GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 | xargs) || GPU_NAME=""
 if [[ -n "${GPU_NAME}" ]]; then
     log "INFO" "Detected GPU: ${GPU_NAME}"
     python3 -c "
-import json
-s = json.load(open('${STATE_FILE}'))
-s['gpu_name'] = '${GPU_NAME}'
-json.dump(s, open('${STATE_FILE}', 'w'))
-"
+import json, sys
+s = json.load(open(sys.argv[1]))
+s['gpu_name'] = sys.argv[2]
+json.dump(s, open(sys.argv[1], 'w'))
+" "${STATE_FILE}" "${GPU_NAME}" 2>/dev/null || log "WARN" "Failed to save gpu_name to state"
 fi
 
 # =============================================================================

--- a/neurons/executor/lium-bridge/bin/setup-chutes
+++ b/neurons/executor/lium-bridge/bin/setup-chutes
@@ -44,10 +44,10 @@ save_state() {
     local state="$1"
     python3 -c "
 import json, sys
-s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None, 'gpu_name': None}
+s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None}
 try:
     old = json.load(open('${STATE_FILE}'))
-    for k in ('gpu_verified', 'node_name', 'gpu_name'):
+    for k in ('gpu_verified', 'node_name'):
         if k in old: s[k] = old[k]
 except: pass
 json.dump(s, open('${STATE_FILE}', 'w'))
@@ -77,18 +77,6 @@ done
 HOTKEY_SEED="${HOTKEY_SEED#0x}"
 
 save_state "installing"
-
-# Detect GPU name early (before K3s takes over GPUs) and persist to state.json
-GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 | xargs) || GPU_NAME=""
-if [[ -n "${GPU_NAME}" ]]; then
-    log "INFO" "Detected GPU: ${GPU_NAME}"
-    python3 -c "
-import json, sys
-s = json.load(open(sys.argv[1]))
-s['gpu_name'] = sys.argv[2]
-json.dump(s, open(sys.argv[1], 'w'))
-" "${STATE_FILE}" "${GPU_NAME}" 2>/dev/null || log "WARN" "Failed to save gpu_name to state"
-fi
 
 # =============================================================================
 # STEP 1: PREREQUISITES CHECK

--- a/neurons/executor/lium-bridge/bin/setup-chutes
+++ b/neurons/executor/lium-bridge/bin/setup-chutes
@@ -525,6 +525,24 @@ log "INFO" "Step 11: Saving state..."
 
 save_state "installed_stopped"
 
+# Stop K3s so GPU devices return to the host (executor container needs NVML access).
+# K3s will be started again by `bridgectl start`.
+log "INFO" "Stopping K3s to release GPU back to host..."
+systemctl stop k3s
+
+for i in $(seq 1 12); do
+    if ! systemctl is-active k3s >/dev/null 2>&1; then
+        break
+    fi
+    sleep 5
+done
+
+if systemctl is-active k3s >/dev/null 2>&1; then
+    log "WARN" "K3s did not stop within 1 min after setup, GPU may remain unavailable to host"
+else
+    log "INFO" "K3s stopped — GPU returned to host"
+fi
+
 GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -1 | tr -d '[:space:]' || echo "unknown")
 GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l | tr -d ' ')
 

--- a/neurons/executor/lium-bridge/bin/setup-chutes
+++ b/neurons/executor/lium-bridge/bin/setup-chutes
@@ -28,13 +28,11 @@ log() {
 fail() {
     local msg="$1"
     log "FATAL" "${msg}"
+    # Reset state to not_installed so retries are possible
+    save_state "not_installed"
     python3 -c "
 import json, sys
-state = 'error'
-try:
-    state = json.load(open('${STATE_FILE}'))['state']
-except: pass
-json.dump({'ok': False, 'state': state, 'error': sys.argv[1]}, sys.stdout)
+json.dump({'ok': False, 'state': 'not_installed', 'error': sys.argv[1]}, sys.stdout)
 " "${msg}"
     echo ""
     exit 1
@@ -106,9 +104,19 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update -qq
 apt-get install -y -qq jq curl socat conntrack openssl &>/dev/null
 
-# Install nvidia-container-toolkit if missing
+# Install or upgrade nvidia-container-toolkit (>=1.17 required for containerd config v3)
+_nctk_need_install=false
 if ! command -v nvidia-ctk &>/dev/null; then
-    log "INFO" "Installing nvidia-container-toolkit..."
+    _nctk_need_install=true
+else
+    _nctk_major=$(nvidia-ctk --version 2>/dev/null | grep -oP 'version \K[0-9]+' || echo "0")
+    _nctk_minor=$(nvidia-ctk --version 2>/dev/null | grep -oP 'version [0-9]+\.\K[0-9]+' || echo "0")
+    if [[ "${_nctk_major}" -lt 1 ]] || [[ "${_nctk_major}" -eq 1 && "${_nctk_minor}" -lt 17 ]]; then
+        _nctk_need_install=true
+    fi
+fi
+if [[ "${_nctk_need_install}" == "true" ]]; then
+    log "INFO" "Installing/upgrading nvidia-container-toolkit..."
     apt-get install -y -qq nvidia-container-toolkit &>/dev/null \
         || fail "Failed to install nvidia-container-toolkit"
 fi

--- a/neurons/executor/lium-bridge/bin/start-chutes
+++ b/neurons/executor/lium-bridge/bin/start-chutes
@@ -38,16 +38,22 @@ read_state() {
 
 save_state() {
     local state="$1"
+    local last_error="${2:-}"
     python3 -c "
 import json, sys
-s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None}
+s = {
+    'state': sys.argv[1],
+    'gpu_verified': False,
+    'node_name': None,
+    'last_error': sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] else None,
+}
 try:
     old = json.load(open('${STATE_FILE}'))
     for k in ('gpu_verified', 'node_name'):
         if k in old: s[k] = old[k]
 except: pass
 json.dump(s, open('${STATE_FILE}', 'w'))
-" "${state}"
+" "${state}" "${last_error}"
 }
 
 # =============================================================================
@@ -117,7 +123,18 @@ for i in $(seq 1 36); do
 done
 
 if [[ "${AGENT_HEALTHY}" == "false" ]]; then
-    log "WARN" "Agent pod not running after 3 min — continuing but flagging"
+    ERROR_MSG="Agent pod did not become healthy within 3 min"
+    log "FATAL" "${ERROR_MSG}"
+    save_state "error" "${ERROR_MSG}"
+    cat <<EOF
+{
+  "ok": false,
+  "state": "error",
+  "error": "${ERROR_MSG}",
+  "chutes": { "k3s_active": true, "agent_healthy": false }
+}
+EOF
+    exit 1
 fi
 
 log "INFO" "Pods status: agent=${AGENT_HEALTHY}"

--- a/neurons/executor/lium-bridge/bin/start-chutes
+++ b/neurons/executor/lium-bridge/bin/start-chutes
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# bridgectl start — start K3s + Chutes
+set -euo pipefail
+
+# --- Constants ---
+
+BRIDGE_DIR="/opt/lium-bridge"
+STATE_FILE="${BRIDGE_DIR}/state.json"
+LOG_FILE="/var/log/lium-bridge.log"
+
+# --- Logging ---
+
+log() {
+    local level="$1"; shift
+    local msg="[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${level}] $*"
+    echo "${msg}" >> "${LOG_FILE}" 2>/dev/null || true
+    echo "${msg}" >&2
+}
+
+fail() {
+    local msg="$1"
+    log "FATAL" "${msg}"
+    python3 -c "
+import json, sys
+state = 'error'
+try:
+    state = json.load(open('${STATE_FILE}'))['state']
+except: pass
+json.dump({'ok': False, 'state': state, 'error': sys.argv[1]}, sys.stdout)
+" "${msg}"
+    echo ""
+    exit 1
+}
+
+read_state() {
+    python3 -c "import json; print(json.load(open('${STATE_FILE}'))['state'])" 2>/dev/null || echo "unknown"
+}
+
+save_state() {
+    local state="$1"
+    python3 -c "
+import json, sys
+s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None}
+try:
+    old = json.load(open('${STATE_FILE}'))
+    for k in ('gpu_verified', 'node_name'):
+        if k in old: s[k] = old[k]
+except: pass
+json.dump(s, open('${STATE_FILE}', 'w'))
+" "${state}"
+}
+
+# =============================================================================
+# STEP 1: VALIDATE STATE
+# =============================================================================
+log "INFO" "Step 1: Validating state..."
+
+[[ -f "${STATE_FILE}" ]] || fail "State file not found — run setup-chutes first"
+
+CURRENT_STATE=$(read_state)
+
+# Idempotency: if already running, verify and return success
+if [[ "${CURRENT_STATE}" == "running" ]]; then
+    log "INFO" "Already in 'running' state, verifying..."
+    if systemctl is-active k3s >/dev/null 2>&1; then
+        AGENT_HEALTHY="false"
+        if k3s kubectl get pods -n chutes -l app.kubernetes.io/name=agent --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q "Running"; then
+            AGENT_HEALTHY="true"
+        fi
+        log "INFO" "Already running, K3s active"
+        cat <<EOF
+{
+  "ok": true,
+  "state": "running",
+  "chutes": { "k3s_active": true, "agent_healthy": ${AGENT_HEALTHY} }
+}
+EOF
+        exit 0
+    fi
+    log "WARN" "State says running but K3s not active, proceeding with start"
+fi
+
+if [[ "${CURRENT_STATE}" != "installed_stopped" && "${CURRENT_STATE}" != "stopped" ]]; then
+    fail "Cannot start: state is '${CURRENT_STATE}', expected 'installed_stopped' or 'stopped'"
+fi
+
+# =============================================================================
+# STEP 2: START K3S
+# =============================================================================
+log "INFO" "Step 2: Starting K3s..."
+
+systemctl start k3s
+
+log "INFO" "Waiting for node Ready..."
+for i in $(seq 1 24); do
+    if k3s kubectl get nodes 2>/dev/null | grep -q " Ready"; then
+        break
+    fi
+    sleep 5
+done
+k3s kubectl get nodes 2>/dev/null | grep -q " Ready" || fail "K3s node did not become Ready within 2 min"
+
+log "INFO" "K3s node is Ready"
+
+# =============================================================================
+# STEP 3: WAIT FOR PODS HEALTHY
+# =============================================================================
+log "INFO" "Step 3: Waiting for Chutes pods..."
+
+AGENT_HEALTHY="false"
+for i in $(seq 1 36); do
+    if k3s kubectl get pods -n chutes -l app.kubernetes.io/name=agent --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q "Running"; then
+        AGENT_HEALTHY="true"
+        break
+    fi
+    sleep 5
+done
+
+if [[ "${AGENT_HEALTHY}" == "false" ]]; then
+    log "WARN" "Agent pod not running after 3 min — continuing but flagging"
+fi
+
+log "INFO" "Pods status: agent=${AGENT_HEALTHY}"
+
+# =============================================================================
+# STEP 4: SAVE STATE + OUTPUT
+# =============================================================================
+log "INFO" "Step 4: Saving state..."
+
+save_state "running"
+
+log "INFO" "Start complete — Chutes active"
+
+cat <<EOF
+{
+  "ok": true,
+  "state": "running",
+  "chutes": { "k3s_active": true, "agent_healthy": ${AGENT_HEALTHY} }
+}
+EOF

--- a/neurons/executor/lium-bridge/bin/status
+++ b/neurons/executor/lium-bridge/bin/status
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# bridgectl status — read-only health check, returns JSON
+set -euo pipefail
+
+BRIDGE_DIR="/opt/lium-bridge"
+STATE_FILE="${BRIDGE_DIR}/state.json"
+
+# --- Read persisted state ---
+
+if [[ -f "${STATE_FILE}" ]]; then
+    PERSISTED_STATE=$(python3 -c "import json; print(json.load(open('${STATE_FILE}'))['state'])" 2>/dev/null || echo "unknown")
+    LAST_ERROR=$(python3 -c "import json; v=json.load(open('${STATE_FILE}')).get('last_error'); print(v if v else '')" 2>/dev/null || echo "")
+    NODE_NAME=$(python3 -c "import json; v=json.load(open('${STATE_FILE}')).get('node_name'); print(v if v else '')" 2>/dev/null || echo "")
+    GPU_VERIFIED=$(python3 -c "import json; print(str(json.load(open('${STATE_FILE}')).get('gpu_verified',False)).lower())" 2>/dev/null || echo "false")
+else
+    PERSISTED_STATE="not_installed"
+    LAST_ERROR=""
+    NODE_NAME=""
+    GPU_VERIFIED="false"
+fi
+
+# --- Check Lium executor ---
+
+RUNNER_CONTAINER="executor-runner"
+RUNNER_RUNNING="false"
+if docker inspect "${RUNNER_CONTAINER}" --format '{{.State.Running}}' 2>/dev/null | grep -q "true"; then
+    RUNNER_RUNNING="true"
+fi
+
+# --- Check K3s ---
+
+K3S_ACTIVE="false"
+if systemctl is-active k3s >/dev/null 2>&1; then
+    K3S_ACTIVE="true"
+fi
+
+# --- Check Chutes pods (only if K3s is active) ---
+
+AGENT_HEALTHY="false"
+PODS_RUNNING=0
+SERVER_LOCKED="false"
+
+if [[ "${K3S_ACTIVE}" == "true" ]]; then
+    # Count running pods
+    PODS_RUNNING=$(k3s kubectl get pods --all-namespaces --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l | tr -d ' ' || echo "0")
+
+    # Check chutes-agent health (chart uses app.kubernetes.io/name=agent)
+    if k3s kubectl get pods -n chutes -l app.kubernetes.io/name=agent --field-selector=status.phase=Running --no-headers 2>/dev/null | grep -q "Running"; then
+        AGENT_HEALTHY="true"
+    fi
+fi
+
+# --- Disk free ---
+
+DISK_FREE_GB=$(df -BG / | tail -1 | awk '{print $4}' | tr -d 'G')
+
+# --- Determine effective state ---
+# Cross-check persisted state with reality
+
+EFFECTIVE_STATE="${PERSISTED_STATE}"
+
+if [[ "${PERSISTED_STATE}" == "running" && "${K3S_ACTIVE}" == "false" ]]; then
+    EFFECTIVE_STATE="error"
+    LAST_ERROR="State says running but k3s is not active"
+fi
+
+if [[ "${PERSISTED_STATE}" == "stopped" && "${K3S_ACTIVE}" == "true" ]]; then
+    EFFECTIVE_STATE="error"
+    LAST_ERROR="State says stopped but k3s is still active"
+fi
+
+# --- Output JSON ---
+
+LAST_ERROR_JSON="null"
+if [[ -n "${LAST_ERROR}" ]]; then
+    LAST_ERROR_JSON="\"${LAST_ERROR}\""
+fi
+
+NODE_NAME_JSON="null"
+if [[ -n "${NODE_NAME}" ]]; then
+    NODE_NAME_JSON="\"${NODE_NAME}\""
+fi
+
+cat <<EOF
+{
+  "ok": true,
+  "state": "${EFFECTIVE_STATE}",
+  "lium": {
+    "runner_container": "${RUNNER_CONTAINER}",
+    "running": ${RUNNER_RUNNING}
+  },
+  "chutes": {
+    "k3s_active": ${K3S_ACTIVE},
+    "agent_healthy": ${AGENT_HEALTHY},
+    "server_locked": ${SERVER_LOCKED},
+    "gpu_verified": ${GPU_VERIFIED},
+    "pods_running": ${PODS_RUNNING},
+    "node_name": ${NODE_NAME_JSON}
+  },
+  "disk_free_gb": ${DISK_FREE_GB},
+  "last_error": ${LAST_ERROR_JSON}
+}
+EOF

--- a/neurons/executor/lium-bridge/bin/status
+++ b/neurons/executor/lium-bridge/bin/status
@@ -12,11 +12,13 @@ if [[ -f "${STATE_FILE}" ]]; then
     LAST_ERROR=$(python3 -c "import json; v=json.load(open('${STATE_FILE}')).get('last_error'); print(v if v else '')" 2>/dev/null || echo "")
     NODE_NAME=$(python3 -c "import json; v=json.load(open('${STATE_FILE}')).get('node_name'); print(v if v else '')" 2>/dev/null || echo "")
     GPU_VERIFIED=$(python3 -c "import json; print(str(json.load(open('${STATE_FILE}')).get('gpu_verified',False)).lower())" 2>/dev/null || echo "false")
+    GPU_NAME=$(python3 -c "import json; v=json.load(open('${STATE_FILE}')).get('gpu_name'); print(v if v else '')" 2>/dev/null || echo "")
 else
     PERSISTED_STATE="not_installed"
     LAST_ERROR=""
     NODE_NAME=""
     GPU_VERIFIED="false"
+    GPU_NAME=""
 fi
 
 # --- Check Lium executor ---
@@ -81,6 +83,11 @@ if [[ -n "${NODE_NAME}" ]]; then
     NODE_NAME_JSON="\"${NODE_NAME}\""
 fi
 
+GPU_NAME_JSON="null"
+if [[ -n "${GPU_NAME}" ]]; then
+    GPU_NAME_JSON="\"${GPU_NAME}\""
+fi
+
 cat <<EOF
 {
   "ok": true,
@@ -95,7 +102,8 @@ cat <<EOF
     "server_locked": ${SERVER_LOCKED},
     "gpu_verified": ${GPU_VERIFIED},
     "pods_running": ${PODS_RUNNING},
-    "node_name": ${NODE_NAME_JSON}
+    "node_name": ${NODE_NAME_JSON},
+    "gpu_name": ${GPU_NAME_JSON}
   },
   "disk_free_gb": ${DISK_FREE_GB},
   "last_error": ${LAST_ERROR_JSON}

--- a/neurons/executor/lium-bridge/bin/status
+++ b/neurons/executor/lium-bridge/bin/status
@@ -12,13 +12,11 @@ if [[ -f "${STATE_FILE}" ]]; then
     LAST_ERROR=$(python3 -c "import json; v=json.load(open('${STATE_FILE}')).get('last_error'); print(v if v else '')" 2>/dev/null || echo "")
     NODE_NAME=$(python3 -c "import json; v=json.load(open('${STATE_FILE}')).get('node_name'); print(v if v else '')" 2>/dev/null || echo "")
     GPU_VERIFIED=$(python3 -c "import json; print(str(json.load(open('${STATE_FILE}')).get('gpu_verified',False)).lower())" 2>/dev/null || echo "false")
-    GPU_NAME=$(python3 -c "import json; v=json.load(open('${STATE_FILE}')).get('gpu_name'); print(v if v else '')" 2>/dev/null || echo "")
 else
     PERSISTED_STATE="not_installed"
     LAST_ERROR=""
     NODE_NAME=""
     GPU_VERIFIED="false"
-    GPU_NAME=""
 fi
 
 # --- Check Lium executor ---
@@ -83,11 +81,6 @@ if [[ -n "${NODE_NAME}" ]]; then
     NODE_NAME_JSON="\"${NODE_NAME}\""
 fi
 
-GPU_NAME_JSON="null"
-if [[ -n "${GPU_NAME}" ]]; then
-    GPU_NAME_JSON="\"${GPU_NAME}\""
-fi
-
 cat <<EOF
 {
   "ok": true,
@@ -102,8 +95,7 @@ cat <<EOF
     "server_locked": ${SERVER_LOCKED},
     "gpu_verified": ${GPU_VERIFIED},
     "pods_running": ${PODS_RUNNING},
-    "node_name": ${NODE_NAME_JSON},
-    "gpu_name": ${GPU_NAME_JSON}
+    "node_name": ${NODE_NAME_JSON}
   },
   "disk_free_gb": ${DISK_FREE_GB},
   "last_error": ${LAST_ERROR_JSON}

--- a/neurons/executor/lium-bridge/bin/status
+++ b/neurons/executor/lium-bridge/bin/status
@@ -71,15 +71,12 @@ fi
 
 # --- Output JSON ---
 
-LAST_ERROR_JSON="null"
-if [[ -n "${LAST_ERROR}" ]]; then
-    LAST_ERROR_JSON="\"${LAST_ERROR}\""
-fi
+json_or_null() {
+    python3 -c "import json, sys; print(json.dumps(sys.argv[1] if sys.argv[1] else None))" "$1"
+}
 
-NODE_NAME_JSON="null"
-if [[ -n "${NODE_NAME}" ]]; then
-    NODE_NAME_JSON="\"${NODE_NAME}\""
-fi
+LAST_ERROR_JSON=$(json_or_null "${LAST_ERROR}")
+NODE_NAME_JSON=$(json_or_null "${NODE_NAME}")
 
 cat <<EOF
 {

--- a/neurons/executor/lium-bridge/bin/stop-chutes
+++ b/neurons/executor/lium-bridge/bin/stop-chutes
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# bridgectl stop — stop K3s + Chutes
+set -euo pipefail
+
+# --- Constants ---
+
+BRIDGE_DIR="/opt/lium-bridge"
+STATE_FILE="${BRIDGE_DIR}/state.json"
+LOG_FILE="/var/log/lium-bridge.log"
+
+# --- Logging ---
+
+log() {
+    local level="$1"; shift
+    local msg="[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${level}] $*"
+    echo "${msg}" >> "${LOG_FILE}" 2>/dev/null || true
+    echo "${msg}" >&2
+}
+
+fail() {
+    local msg="$1"
+    log "FATAL" "${msg}"
+    python3 -c "
+import json, sys
+state = 'error'
+try:
+    state = json.load(open('${STATE_FILE}'))['state']
+except: pass
+json.dump({'ok': False, 'state': state, 'error': sys.argv[1]}, sys.stdout)
+" "${msg}"
+    echo ""
+    exit 1
+}
+
+read_state() {
+    python3 -c "import json; print(json.load(open('${STATE_FILE}'))['state'])" 2>/dev/null || echo "unknown"
+}
+
+save_state() {
+    local state="$1"
+    python3 -c "
+import json, sys
+s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None}
+try:
+    old = json.load(open('${STATE_FILE}'))
+    for k in ('gpu_verified', 'node_name'):
+        if k in old: s[k] = old[k]
+except: pass
+json.dump(s, open('${STATE_FILE}', 'w'))
+" "${state}"
+}
+
+# =============================================================================
+# STEP 1: VALIDATE STATE
+# =============================================================================
+log "INFO" "Step 1: Validating state..."
+
+[[ -f "${STATE_FILE}" ]] || fail "State file not found — run setup-chutes first"
+
+CURRENT_STATE=$(read_state)
+
+# Idempotency: if already stopped, verify and return success
+if [[ "${CURRENT_STATE}" == "stopped" ]]; then
+    log "INFO" "Already in 'stopped' state, verifying..."
+    if ! systemctl is-active k3s >/dev/null 2>&1; then
+        log "INFO" "Already stopped, K3s inactive"
+        cat <<EOF
+{
+  "ok": true,
+  "state": "stopped",
+  "chutes": { "k3s_active": false, "agent_healthy": false }
+}
+EOF
+        exit 0
+    fi
+    log "WARN" "State says stopped but K3s still active, proceeding with stop"
+fi
+
+if [[ "${CURRENT_STATE}" != "running" && "${CURRENT_STATE}" != "stopped" && "${CURRENT_STATE}" != "installed_stopped" ]]; then
+    fail "Cannot stop: state is '${CURRENT_STATE}', expected 'running' or 'installed_stopped'"
+fi
+
+# =============================================================================
+# STEP 2: DELETE CHUTE DEPLOYMENTS
+# =============================================================================
+log "INFO" "Step 2: Deleting chute workload pods..."
+
+FORCED_PREEMPTION="false"
+
+if systemctl is-active k3s >/dev/null 2>&1; then
+    if k3s kubectl get pods -n chutes -l app.kubernetes.io/managed-by=gepetto --no-headers 2>/dev/null | grep -q .; then
+        log "INFO" "Terminating chute workload pods (60s grace period)..."
+        if ! k3s kubectl delete pods -n chutes -l app.kubernetes.io/managed-by=gepetto \
+            --grace-period=60 --timeout=90s >> "${LOG_FILE}" 2>&1; then
+            FORCED_PREEMPTION="true"
+            log "WARN" "Grace period exceeded, pods force-killed (forced_preemption=true)"
+        fi
+    else
+        log "INFO" "No chute workload pods found, skipping"
+    fi
+else
+    log "INFO" "K3s not active, skipping pod deletion"
+fi
+
+# =============================================================================
+# STEP 3: STOP K3S
+# =============================================================================
+log "INFO" "Step 3: Stopping K3s..."
+
+if systemctl is-active k3s >/dev/null 2>&1; then
+    systemctl stop k3s
+
+    for i in $(seq 1 12); do
+        if ! systemctl is-active k3s >/dev/null 2>&1; then
+            break
+        fi
+        sleep 5
+    done
+
+    if systemctl is-active k3s >/dev/null 2>&1; then
+        fail "K3s did not stop within 1 min"
+    fi
+
+    log "INFO" "K3s stopped"
+else
+    log "INFO" "K3s already stopped, skipping"
+fi
+
+# =============================================================================
+# STEP 4: SAVE STATE + OUTPUT
+# =============================================================================
+log "INFO" "Step 4: Saving state..."
+
+save_state "stopped"
+
+log "INFO" "Stop complete — Chutes stopped (forced_preemption=${FORCED_PREEMPTION})"
+
+cat <<EOF
+{
+  "ok": true,
+  "state": "stopped",
+  "chutes": { "k3s_active": false, "agent_healthy": false },
+  "forced_preemption": ${FORCED_PREEMPTION}
+}
+EOF

--- a/neurons/executor/lium-bridge/bin/stop-chutes
+++ b/neurons/executor/lium-bridge/bin/stop-chutes
@@ -133,6 +133,15 @@ log "INFO" "Step 4: Saving state..."
 
 save_state "stopped"
 
+# Collect GPU container IDs before output (so the list is ready for background restart)
+GPU_CONTAINER_IDS=""
+for cid in $(docker ps -q 2>/dev/null); do
+    devreq=$(docker inspect "${cid}" --format '{{.HostConfig.DeviceRequests}}' 2>/dev/null || true)
+    if [[ "${devreq}" == *"nvidia"* ]]; then
+        GPU_CONTAINER_IDS="${GPU_CONTAINER_IDS} ${cid}"
+    fi
+done
+
 log "INFO" "Stop complete — Chutes stopped (forced_preemption=${FORCED_PREEMPTION})"
 
 cat <<EOF
@@ -143,3 +152,21 @@ cat <<EOF
   "forced_preemption": ${FORCED_PREEMPTION}
 }
 EOF
+
+# =============================================================================
+# STEP 5: RESTART GPU CONTAINERS IN BACKGROUND
+# After K3s releases GPUs, Docker containers need restart to re-initialize NVML.
+# Run in background with delay so the SSH session and HTTP response complete first.
+# =============================================================================
+if [[ -n "${GPU_CONTAINER_IDS}" ]]; then
+    (
+        sleep 5
+        for cid in ${GPU_CONTAINER_IDS}; do
+            cname=$(docker inspect "${cid}" --format '{{.Name}}' 2>/dev/null | sed 's|^/||')
+            log "INFO" "Restarting GPU container: ${cname}"
+            docker restart "${cid}" >> "${LOG_FILE}" 2>&1 || log "WARN" "Failed to restart ${cname}"
+        done
+        log "INFO" "GPU container restart complete"
+    ) </dev/null >/dev/null 2>&1 &
+    disown
+fi

--- a/neurons/executor/lium-bridge/bin/uninstall-chutes
+++ b/neurons/executor/lium-bridge/bin/uninstall-chutes
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# bridgectl uninstall — remove K3s + Chutes stack, restore machine to pre-setup state
+# Preserves: /opt/lium-bridge/ (scripts, state, SSH config), lium-bridge user, log file
+set -euo pipefail
+
+# --- Constants ---
+
+BRIDGE_DIR="/opt/lium-bridge"
+STATE_FILE="${BRIDGE_DIR}/state.json"
+LOG_FILE="/var/log/lium-bridge.log"
+KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+
+# --- Logging ---
+
+log() {
+    local level="$1"; shift
+    local msg="[$(date -u +%Y-%m-%dT%H:%M:%SZ)] [${level}] $*"
+    echo "${msg}" >> "${LOG_FILE}" 2>/dev/null || true
+    echo "${msg}" >&2
+}
+
+fail() {
+    local msg="$1"
+    log "FATAL" "${msg}"
+    python3 -c "
+import json, sys
+state = 'error'
+try:
+    state = json.load(open('${STATE_FILE}'))['state']
+except: pass
+json.dump({'ok': False, 'state': state, 'error': sys.argv[1]}, sys.stdout)
+" "${msg}"
+    echo ""
+    exit 1
+}
+
+read_state() {
+    python3 -c "import json; print(json.load(open('${STATE_FILE}'))['state'])" 2>/dev/null || echo "unknown"
+}
+
+save_state() {
+    local state="$1"
+    python3 -c "
+import json, sys
+s = {'state': sys.argv[1], 'gpu_verified': False, 'node_name': None, 'last_error': None}
+json.dump(s, open('${STATE_FILE}', 'w'))
+" "${state}"
+}
+
+# =============================================================================
+# STEP 1: VALIDATE STATE
+# =============================================================================
+log "INFO" "Step 1: Validating state..."
+
+[[ -f "${STATE_FILE}" ]] || fail "State file not found — nothing to uninstall"
+
+CURRENT_STATE=$(read_state)
+
+# Idempotency: if already not_installed, return success
+if [[ "${CURRENT_STATE}" == "not_installed" ]]; then
+    log "INFO" "Already in 'not_installed' state, nothing to do"
+    cat <<EOF
+{
+  "ok": true,
+  "state": "not_installed",
+  "message": "Already uninstalled"
+}
+EOF
+    exit 0
+fi
+
+log "INFO" "Current state: ${CURRENT_STATE}"
+
+# =============================================================================
+# STEP 2: STOP K3S IF RUNNING
+# =============================================================================
+log "INFO" "Step 2: Stopping K3s if running..."
+
+if systemctl is-active k3s >/dev/null 2>&1; then
+    # Best-effort Helm cleanup while K3s is still up
+    if command -v helm &>/dev/null && [[ -f "${KUBECONFIG}" ]]; then
+        log "INFO" "Removing Helm releases before teardown..."
+        helm uninstall chutes -n chutes --kubeconfig "${KUBECONFIG}" --wait --timeout 2m >> "${LOG_FILE}" 2>&1 || true
+        helm uninstall gpu-operator -n gpu-operator --kubeconfig "${KUBECONFIG}" --wait --timeout 2m >> "${LOG_FILE}" 2>&1 || true
+    fi
+
+    systemctl stop k3s || true
+
+    for i in $(seq 1 12); do
+        if ! systemctl is-active k3s >/dev/null 2>&1; then
+            break
+        fi
+        sleep 5
+    done
+
+    if systemctl is-active k3s >/dev/null 2>&1; then
+        log "WARN" "K3s did not stop gracefully, continuing with uninstall anyway"
+    else
+        log "INFO" "K3s stopped"
+    fi
+else
+    log "INFO" "K3s not running, skipping"
+fi
+
+# =============================================================================
+# STEP 3: RUN K3S BUILT-IN UNINSTALL
+# =============================================================================
+log "INFO" "Step 3: Running K3s uninstall..."
+
+if [[ -x /usr/local/bin/k3s-uninstall.sh ]]; then
+    /usr/local/bin/k3s-uninstall.sh >> "${LOG_FILE}" 2>&1 || true
+    log "INFO" "K3s uninstall script completed"
+else
+    log "INFO" "k3s-uninstall.sh not found, skipping (may already be removed)"
+    # Manual fallback: stop and disable if systemd unit still exists
+    systemctl stop k3s >> "${LOG_FILE}" 2>&1 || true
+    systemctl disable k3s >> "${LOG_FILE}" 2>&1 || true
+fi
+
+# =============================================================================
+# STEP 4: CLEAN UP SYSTEM CONFIG
+# =============================================================================
+log "INFO" "Step 4: Cleaning up system config..."
+
+# Remove sysctl and kernel module configs created by setup-chutes
+rm -f /etc/sysctl.d/99-kubernetes.conf || true
+rm -f /etc/modules-load.d/kubernetes.conf || true
+
+# Remove helm binary
+rm -f /usr/local/bin/helm || true
+
+# Remove K3s registries config (k3s-uninstall may leave /etc/rancher)
+rm -rf /etc/rancher/k3s || true
+
+# Re-enable swap (setup-chutes commented it out in /etc/fstab)
+sed -i '/\sswap\s/s/^#//' /etc/fstab 2>/dev/null || true
+
+log "INFO" "System config cleaned"
+
+# =============================================================================
+# STEP 5: CLEAN HOST MOUNTS
+# =============================================================================
+log "INFO" "Step 5: Cleaning host mounts..."
+
+rm -rf /var/snap/cache || true
+rm -rf /var/lib/chutes || true
+
+log "INFO" "Host mounts cleaned"
+
+# =============================================================================
+# STEP 6: RESTART DOCKER
+# =============================================================================
+# k3s-uninstall.sh flushes ALL iptables rules, which breaks Docker networking
+log "INFO" "Step 6: Restarting Docker to restore iptables rules..."
+
+if systemctl is-active docker >/dev/null 2>&1 || systemctl is-enabled docker >/dev/null 2>&1; then
+    systemctl restart docker >> "${LOG_FILE}" 2>&1 || true
+
+    # Wait for Docker to become healthy
+    for i in $(seq 1 15); do
+        if docker info &>/dev/null; then
+            log "INFO" "Docker restarted and healthy"
+            break
+        fi
+        sleep 2
+    done
+else
+    log "INFO" "Docker not found, skipping"
+fi
+
+# =============================================================================
+# STEP 7: SAVE STATE + OUTPUT
+# =============================================================================
+log "INFO" "Step 7: Saving state..."
+
+save_state "not_installed"
+
+log "INFO" "Uninstall complete — machine restored to pre-setup state"
+
+cat <<EOF
+{
+  "ok": true,
+  "state": "not_installed",
+  "message": "K3s + Chutes stack removed. lium-bridge scripts preserved."
+}
+EOF

--- a/neurons/executor/lium-bridge/bridge
+++ b/neurons/executor/lium-bridge/bridge
@@ -135,7 +135,7 @@ cmd_enable() {
     # --- Step 6: Update .env ---
     step "6/6  Update .env"
 
-    bash "${EXECUTOR_DIR}/chutes-install.sh" \
+    bash "${SCRIPT_DIR}/chutes-install.sh" \
         --env-file "${ENV_FILE}" \
         --stage-secrets-dir "${STAGE_SECRETS}" \
         --bridge-host "host.docker.internal" \

--- a/neurons/executor/lium-bridge/bridge
+++ b/neurons/executor/lium-bridge/bridge
@@ -62,7 +62,7 @@ cmd_enable() {
         info "lium-bridge already installed, skipping"
     else
         local installer="${SCRIPT_DIR}/install_chutes_bridge.sh"
-        if [[ ! -x "${installer}" ]]; then
+        if [[ ! -f "${installer}" ]]; then
             err "Installer not found: ${installer}"
         fi
         info "Running install_chutes_bridge.sh ..."

--- a/neurons/executor/lium-bridge/bridge
+++ b/neurons/executor/lium-bridge/bridge
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# bridge — one-command setup for lium-bridge on the local GPU host.
+#
+# Usage:
+#   sudo ./lium-bridge/bridge enable    # full bridge infrastructure setup
+#   sudo ./lium-bridge/bridge disable   # flip CHUTES_BRIDGE_ENABLED=false
+#   ./lium-bridge/bridge status         # health check (no root needed)
+set -euo pipefail
+
+# --- Paths ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+EXECUTOR_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ENV_FILE="${EXECUTOR_DIR}/.env"
+ENV_TEMPLATE="${EXECUTOR_DIR}/.env.template"
+STAGE_SECRETS="${EXECUTOR_DIR}/stage-secrets"
+SSH_KEY="${STAGE_SECRETS}/chutes_bridge_key"
+SSH_PUBKEY="${SSH_KEY}.pub"
+KNOWN_HOSTS="${STAGE_SECRETS}/chutes_bridge_known_hosts"
+BRIDGE_USER="lium-bridge"
+BRIDGE_HOME="/var/lib/${BRIDGE_USER}"
+AUTHORIZED_KEYS="${BRIDGE_HOME}/.ssh/authorized_keys"
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+err()   { echo -e "${RED}[ERROR]${NC} $*" >&2; exit 1; }
+step()  { echo -e "\n${CYAN}==> $*${NC}"; }
+
+# ===================================================================
+#  enable
+# ===================================================================
+cmd_enable() {
+    # --- Step 1: Preflight ---
+    step "1/6  Preflight checks"
+
+    [[ $EUID -eq 0 ]] || err "enable requires root (use sudo)"
+
+    if ! command -v docker &>/dev/null; then
+        err "docker not found — install Docker first"
+    fi
+
+    if [[ ! -f "${ENV_FILE}" ]]; then
+        if [[ ! -f "${ENV_TEMPLATE}" ]]; then
+            err "Neither .env nor .env.template found in ${EXECUTOR_DIR}"
+        fi
+        cp "${ENV_TEMPLATE}" "${ENV_FILE}"
+        info "Created .env from .env.template — fill MINER_HOTKEY_SS58_ADDRESS before starting"
+    else
+        info ".env exists"
+    fi
+
+    # --- Step 2: Install lium-bridge (idempotent) ---
+    step "2/6  Install lium-bridge"
+
+    if id "${BRIDGE_USER}" &>/dev/null && [[ -d /opt/lium-bridge ]]; then
+        info "lium-bridge already installed, skipping"
+    else
+        local installer="${SCRIPT_DIR}/install_chutes_bridge.sh"
+        if [[ ! -x "${installer}" ]]; then
+            err "Installer not found: ${installer}"
+        fi
+        info "Running install_chutes_bridge.sh ..."
+        bash "${installer}"
+    fi
+
+    # --- Step 3: Generate SSH keypair (idempotent) ---
+    step "3/6  Generate SSH keypair"
+
+    mkdir -p "${STAGE_SECRETS}"
+    chmod 700 "${STAGE_SECRETS}"
+    # Give ownership to the calling user so docker compose can read secrets
+    if [[ -n "${SUDO_USER:-}" ]]; then
+        chown "${SUDO_USER}:${SUDO_USER}" "${STAGE_SECRETS}"
+    fi
+
+    if [[ -f "${SSH_KEY}" ]]; then
+        info "SSH key already exists at ${SSH_KEY}"
+    else
+        ssh-keygen -t ed25519 -f "${SSH_KEY}" -N "" -C "executor-bridge-key"
+        chmod 600 "${SSH_KEY}"
+        chmod 644 "${SSH_PUBKEY}"
+        if [[ -n "${SUDO_USER:-}" ]]; then
+            chown "${SUDO_USER}:${SUDO_USER}" "${SSH_KEY}" "${SSH_PUBKEY}"
+        fi
+        info "Generated ed25519 keypair"
+    fi
+
+    # --- Step 4: Install pubkey into authorized_keys (idempotent) ---
+    step "4/6  Install pubkey into authorized_keys"
+
+    if [[ ! -f "${SSH_PUBKEY}" ]]; then
+        err "Public key not found: ${SSH_PUBKEY}"
+    fi
+
+    local pubkey
+    pubkey="$(cat "${SSH_PUBKEY}")"
+
+    mkdir -p "$(dirname "${AUTHORIZED_KEYS}")"
+    touch "${AUTHORIZED_KEYS}"
+
+    if grep -qF "${pubkey}" "${AUTHORIZED_KEYS}" 2>/dev/null; then
+        info "Pubkey already in authorized_keys"
+    else
+        echo "${pubkey}" >> "${AUTHORIZED_KEYS}"
+        info "Appended pubkey to ${AUTHORIZED_KEYS}"
+    fi
+
+    chmod 700 "$(dirname "${AUTHORIZED_KEYS}")"
+    chmod 600 "${AUTHORIZED_KEYS}"
+    chown -R "${BRIDGE_USER}:${BRIDGE_USER}" "$(dirname "${AUTHORIZED_KEYS}")"
+
+    # --- Step 5: Generate known_hosts ---
+    step "5/6  Generate known_hosts"
+
+    info "Scanning host SSH fingerprint via ssh-keyscan ..."
+    docker run --rm --add-host=host.docker.internal:host-gateway \
+        alpine sh -c "apk add --no-cache -q openssh-client >/dev/null 2>&1 && ssh-keyscan -H host.docker.internal 2>/dev/null" \
+        > "${KNOWN_HOSTS}"
+
+    if [[ -s "${KNOWN_HOSTS}" ]]; then
+        if [[ -n "${SUDO_USER:-}" ]]; then
+            chown "${SUDO_USER}:${SUDO_USER}" "${KNOWN_HOSTS}"
+        fi
+        info "Wrote $(wc -l < "${KNOWN_HOSTS}") entries to ${KNOWN_HOSTS}"
+    else
+        warn "ssh-keyscan returned empty — the executor may fail StrictHostKeyChecking"
+    fi
+
+    # --- Step 6: Update .env ---
+    step "6/6  Update .env"
+
+    bash "${EXECUTOR_DIR}/chutes-install.sh" \
+        --env-file "${ENV_FILE}" \
+        --stage-secrets-dir "${STAGE_SECRETS}" \
+        --bridge-host "host.docker.internal" \
+        --auth-bypass "true"
+
+    # --- Done ---
+    echo ""
+    info "Bridge setup complete!"
+    echo ""
+    echo -e "Start the executor with:"
+    echo ""
+    echo -e "  ${CYAN}docker compose \\"
+    echo -e "    -f docker-compose.app.yml \\"
+    echo -e "    -f docker-compose.chutes-stage.override.yml \\"
+    echo -e "    -f docker-compose.local-image.override.yml \\"
+    echo -e "    up -d --force-recreate db executor monitor autoheal${NC}"
+    echo ""
+    echo -e "Then verify:  ${CYAN}curl http://127.0.0.1:8001/chutes/status${NC}"
+}
+
+# ===================================================================
+#  disable
+# ===================================================================
+cmd_disable() {
+    [[ $EUID -eq 0 ]] || err "disable requires root (use sudo)"
+
+    if [[ ! -f "${ENV_FILE}" ]]; then
+        err ".env not found at ${ENV_FILE}"
+    fi
+
+    if grep -q "^CHUTES_BRIDGE_ENABLED=" "${ENV_FILE}"; then
+        sed -i.bak "s|^CHUTES_BRIDGE_ENABLED=.*|CHUTES_BRIDGE_ENABLED=false|" "${ENV_FILE}"
+        rm -f "${ENV_FILE}.bak"
+    else
+        echo "CHUTES_BRIDGE_ENABLED=false" >> "${ENV_FILE}"
+    fi
+
+    info "Set CHUTES_BRIDGE_ENABLED=false in ${ENV_FILE}"
+    info "Restart executor for this to take effect."
+}
+
+# ===================================================================
+#  status
+# ===================================================================
+cmd_status() {
+    local ok=true
+
+    echo -e "${CYAN}Bridge Status${NC}"
+    echo "──────────────────────────────────"
+
+    # Bridge user
+    if id "${BRIDGE_USER}" &>/dev/null; then
+        echo -e "  Bridge user:       ${GREEN}installed${NC}"
+    else
+        echo -e "  Bridge user:       ${RED}missing${NC}"
+        ok=false
+    fi
+
+    # Bridge dir
+    if [[ -d /opt/lium-bridge ]]; then
+        echo -e "  Bridge dir:        ${GREEN}/opt/lium-bridge${NC}"
+    else
+        echo -e "  Bridge dir:        ${RED}missing${NC}"
+        ok=false
+    fi
+
+    # SSH key
+    if [[ -f "${SSH_KEY}" ]]; then
+        echo -e "  SSH key:           ${GREEN}present${NC}"
+    else
+        echo -e "  SSH key:           ${RED}missing${NC}"
+        ok=false
+    fi
+
+    # known_hosts
+    if [[ -s "${KNOWN_HOSTS}" ]]; then
+        echo -e "  known_hosts:       ${GREEN}present${NC}"
+    else
+        echo -e "  known_hosts:       ${YELLOW}missing or empty${NC}"
+        ok=false
+    fi
+
+    # .env
+    if [[ -f "${ENV_FILE}" ]]; then
+        local bridge_enabled
+        bridge_enabled=$(grep "^CHUTES_BRIDGE_ENABLED=" "${ENV_FILE}" 2>/dev/null | cut -d= -f2 || echo "unset")
+        if [[ "${bridge_enabled}" == "true" ]]; then
+            echo -e "  CHUTES_BRIDGE:     ${GREEN}enabled${NC}"
+        else
+            echo -e "  CHUTES_BRIDGE:     ${YELLOW}${bridge_enabled}${NC}"
+        fi
+    else
+        echo -e "  .env:              ${RED}missing${NC}"
+        ok=false
+    fi
+
+    # Executor health
+    if curl -sf http://127.0.0.1:8001/chutes/status &>/dev/null; then
+        echo -e "  Executor:          ${GREEN}responding${NC}"
+    else
+        echo -e "  Executor:          ${YELLOW}not responding${NC}"
+    fi
+
+    echo "──────────────────────────────────"
+    if $ok; then
+        echo -e "  Overall:           ${GREEN}ready${NC}"
+    else
+        echo -e "  Overall:           ${YELLOW}incomplete — run 'sudo ./lium-bridge/bridge enable'${NC}"
+    fi
+}
+
+# ===================================================================
+#  main
+# ===================================================================
+case "${1:-}" in
+    enable)  cmd_enable ;;
+    disable) cmd_disable ;;
+    status)  cmd_status ;;
+    *)
+        echo "Usage: $0 {enable|disable|status}"
+        echo ""
+        echo "  enable   — install bridge, generate keys, configure .env"
+        echo "  disable  — set CHUTES_BRIDGE_ENABLED=false in .env"
+        echo "  status   — check bridge health"
+        exit 1
+        ;;
+esac

--- a/neurons/executor/lium-bridge/bridge
+++ b/neurons/executor/lium-bridge/bridge
@@ -138,8 +138,7 @@ cmd_enable() {
     bash "${SCRIPT_DIR}/chutes-install.sh" \
         --env-file "${ENV_FILE}" \
         --stage-secrets-dir "${STAGE_SECRETS}" \
-        --bridge-host "host.docker.internal" \
-        --auth-bypass "true"
+        --bridge-host "host.docker.internal"
 
     # --- Done ---
     echo ""

--- a/neurons/executor/lium-bridge/chutes-install.sh
+++ b/neurons/executor/lium-bridge/chutes-install.sh
@@ -16,7 +16,6 @@ Options:
   --bridge-user USER           Bridge SSH user. Default: lium-bridge
   --connect-timeout SEC        SSH connect timeout. Default: 10
   --command-timeout SEC        Bridge command timeout. Default: 300
-  --auth-bypass true|false     Set CHUTES_STAGING_AUTH_BYPASS. Default: false
   --help, -h                   Show this help message
 
 This script does not:
@@ -38,7 +37,6 @@ BRIDGE_PORT="22"
 BRIDGE_USER="lium-bridge"
 CONNECT_TIMEOUT="10"
 COMMAND_TIMEOUT="300"
-AUTH_BYPASS="false"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -70,10 +68,6 @@ while [[ $# -gt 0 ]]; do
             COMMAND_TIMEOUT="$2"
             shift 2
             ;;
-        --auth-bypass)
-            AUTH_BYPASS="$2"
-            shift 2
-            ;;
         --help|-h)
             usage
             exit 0
@@ -85,11 +79,6 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-
-if [[ "${AUTH_BYPASS}" != "true" && "${AUTH_BYPASS}" != "false" ]]; then
-    echo "--auth-bypass must be true or false" >&2
-    exit 1
-fi
 
 if [[ -z "${BRIDGE_HOST}" ]]; then
     echo "--bridge-host must not be empty" >&2
@@ -128,7 +117,6 @@ upsert_env "CHUTES_BRIDGE_SSH_USER" "${BRIDGE_USER}"
 upsert_env "CHUTES_BRIDGE_SSH_KEY_PATH" "/run/secrets/chutes_bridge_key"
 upsert_env "CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC" "${CONNECT_TIMEOUT}"
 upsert_env "CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC" "${COMMAND_TIMEOUT}"
-upsert_env "CHUTES_STAGING_AUTH_BYPASS" "${AUTH_BYPASS}"
 upsert_env "CHUTES_BRIDGE_SSH_KEY_HOST_PATH" "${STAGE_SECRETS_DIR}/chutes_bridge_key"
 upsert_env "CHUTES_BRIDGE_SSH_KNOWN_HOSTS_HOST_PATH" "${STAGE_SECRETS_DIR}/chutes_bridge_known_hosts"
 
@@ -148,7 +136,6 @@ Configured values:
   CHUTES_BRIDGE_SSH_KEY_PATH=/run/secrets/chutes_bridge_key
   CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC=${CONNECT_TIMEOUT}
   CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC=${COMMAND_TIMEOUT}
-  CHUTES_STAGING_AUTH_BYPASS=${AUTH_BYPASS}
 
 Next steps:
   1. On the GPU host, run sudo ./install_chutes_bridge.sh if lium-bridge is not installed yet.
@@ -157,5 +144,5 @@ Next steps:
   4. Put the host fingerprint at ${STAGE_SECRETS_DIR}/chutes_bridge_known_hosts.
   5. Restart executor:
        docker compose -f docker-compose.app.yml -f docker-compose.chutes-stage.override.yml up -d --force-recreate executor
-  6. Smoke-test GET /chutes/status, then POST /chutes/install.
+  6. Smoke-test GET /chutes/status, then run a signed POST /chutes/install via the Phase 1 scripts.
 EOF

--- a/neurons/executor/lium-bridge/chutes-install.sh
+++ b/neurons/executor/lium-bridge/chutes-install.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Prepare this executor checkout for staging Chutes relay activation.
+
+Usage:
+  ./chutes-install.sh [options]
+
+Options:
+  --env-file PATH              Env file to update. Default: ./.env
+  --stage-secrets-dir PATH     Host directory for relay key and known_hosts. Default: ./stage-secrets
+  --bridge-host HOST           Host-reachable bridge address. Default: host.docker.internal
+  --bridge-port PORT           Bridge SSH port. Default: 22
+  --bridge-user USER           Bridge SSH user. Default: lium-bridge
+  --connect-timeout SEC        SSH connect timeout. Default: 10
+  --command-timeout SEC        Bridge command timeout. Default: 300
+  --auth-bypass true|false     Set CHUTES_STAGING_AUTH_BYPASS. Default: false
+  --help, -h                   Show this help message
+
+This script does not:
+  - install lium-bridge on the GPU host
+  - add the executor relay key to the host authorized_keys
+  - copy secret material into stage-secrets/
+  - restart docker compose automatically
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_ENV_FILE="${SCRIPT_DIR}/.env"
+DEFAULT_ENV_TEMPLATE="${SCRIPT_DIR}/.env.template"
+
+ENV_FILE="${DEFAULT_ENV_FILE}"
+STAGE_SECRETS_DIR="./stage-secrets"
+BRIDGE_HOST="host.docker.internal"
+BRIDGE_PORT="22"
+BRIDGE_USER="lium-bridge"
+CONNECT_TIMEOUT="10"
+COMMAND_TIMEOUT="300"
+AUTH_BYPASS="false"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env-file)
+            ENV_FILE="$2"
+            shift 2
+            ;;
+        --stage-secrets-dir)
+            STAGE_SECRETS_DIR="$2"
+            shift 2
+            ;;
+        --bridge-host)
+            BRIDGE_HOST="$2"
+            shift 2
+            ;;
+        --bridge-port)
+            BRIDGE_PORT="$2"
+            shift 2
+            ;;
+        --bridge-user)
+            BRIDGE_USER="$2"
+            shift 2
+            ;;
+        --connect-timeout)
+            CONNECT_TIMEOUT="$2"
+            shift 2
+            ;;
+        --command-timeout)
+            COMMAND_TIMEOUT="$2"
+            shift 2
+            ;;
+        --auth-bypass)
+            AUTH_BYPASS="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ "${AUTH_BYPASS}" != "true" && "${AUTH_BYPASS}" != "false" ]]; then
+    echo "--auth-bypass must be true or false" >&2
+    exit 1
+fi
+
+if [[ -z "${BRIDGE_HOST}" ]]; then
+    echo "--bridge-host must not be empty" >&2
+    exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+    if [[ ! -f "${DEFAULT_ENV_TEMPLATE}" ]]; then
+        echo "Missing env template: ${DEFAULT_ENV_TEMPLATE}" >&2
+        exit 1
+    fi
+    cp "${DEFAULT_ENV_TEMPLATE}" "${ENV_FILE}"
+    echo "Created ${ENV_FILE} from .env.template"
+fi
+
+mkdir -p "${STAGE_SECRETS_DIR}"
+chmod 700 "${STAGE_SECRETS_DIR}"
+
+upsert_env() {
+    local key="$1"
+    local value="$2"
+    local escaped
+
+    escaped="$(printf '%s' "${value}" | sed 's/[&|]/\\&/g')"
+    if grep -q "^${key}=" "${ENV_FILE}"; then
+        sed -i.bak "s|^${key}=.*|${key}=${escaped}|" "${ENV_FILE}"
+    else
+        printf '\n%s=%s\n' "${key}" "${value}" >> "${ENV_FILE}"
+    fi
+}
+
+upsert_env "CHUTES_BRIDGE_ENABLED" "true"
+upsert_env "CHUTES_BRIDGE_SSH_HOST" "${BRIDGE_HOST}"
+upsert_env "CHUTES_BRIDGE_SSH_PORT" "${BRIDGE_PORT}"
+upsert_env "CHUTES_BRIDGE_SSH_USER" "${BRIDGE_USER}"
+upsert_env "CHUTES_BRIDGE_SSH_KEY_PATH" "/run/secrets/chutes_bridge_key"
+upsert_env "CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC" "${CONNECT_TIMEOUT}"
+upsert_env "CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC" "${COMMAND_TIMEOUT}"
+upsert_env "CHUTES_STAGING_AUTH_BYPASS" "${AUTH_BYPASS}"
+upsert_env "CHUTES_BRIDGE_SSH_KEY_HOST_PATH" "${STAGE_SECRETS_DIR}/chutes_bridge_key"
+upsert_env "CHUTES_BRIDGE_SSH_KNOWN_HOSTS_HOST_PATH" "${STAGE_SECRETS_DIR}/chutes_bridge_known_hosts"
+
+rm -f "${ENV_FILE}.bak"
+
+cat <<EOF
+
+Prepared executor relay activation in:
+  Env file: ${ENV_FILE}
+  Stage secrets dir: ${STAGE_SECRETS_DIR}
+
+Configured values:
+  CHUTES_BRIDGE_ENABLED=true
+  CHUTES_BRIDGE_SSH_HOST=${BRIDGE_HOST}
+  CHUTES_BRIDGE_SSH_PORT=${BRIDGE_PORT}
+  CHUTES_BRIDGE_SSH_USER=${BRIDGE_USER}
+  CHUTES_BRIDGE_SSH_KEY_PATH=/run/secrets/chutes_bridge_key
+  CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC=${CONNECT_TIMEOUT}
+  CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC=${COMMAND_TIMEOUT}
+  CHUTES_STAGING_AUTH_BYPASS=${AUTH_BYPASS}
+
+Next steps:
+  1. On the GPU host, run sudo ./install_chutes_bridge.sh if lium-bridge is not installed yet.
+  2. Add the executor relay public key to /var/lib/lium-bridge/.ssh/authorized_keys on the GPU host.
+  3. Put the matching private key at ${STAGE_SECRETS_DIR}/chutes_bridge_key and chmod 600 it.
+  4. Put the host fingerprint at ${STAGE_SECRETS_DIR}/chutes_bridge_known_hosts.
+  5. Restart executor:
+       docker compose -f docker-compose.app.yml -f docker-compose.chutes-stage.override.yml up -d --force-recreate executor
+  6. Smoke-test GET /chutes/status, then POST /chutes/install.
+EOF

--- a/neurons/executor/lium-bridge/install_chutes_bridge.sh
+++ b/neurons/executor/lium-bridge/install_chutes_bridge.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# install_chutes_bridge.sh — one-liner installer for lium-bridge
+# Usage: curl -sfL https://install.lium.io/chutes-bridge | sh
+#
+# This installs the bridgectl command interface on the host.
+# It does NOT install K3s or Chutes — that's done by `bridgectl setup`.
+
+set -euo pipefail
+
+BRIDGE_DIR="/opt/lium-bridge"
+BRIDGE_USER="lium-bridge"
+LOG_FILE="/var/log/lium-bridge.log"
+
+# --- Colors ---
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*"; exit 1; }
+
+# --- Root check ---
+if [[ $EUID -ne 0 ]]; then
+    error "This script must be run as root (or with sudo)"
+fi
+
+info "Installing lium-bridge..."
+
+# --- Prerequisites ---
+
+info "Checking prerequisites..."
+
+if ! command -v nvidia-smi &>/dev/null; then
+    error "nvidia-smi not found. NVIDIA drivers must be installed."
+fi
+
+if ! command -v docker &>/dev/null; then
+    error "Docker not found. Docker must be installed."
+fi
+
+if ! command -v python3 &>/dev/null; then
+    error "python3 not found. Python 3 is required."
+fi
+
+GPU_NAME=$(nvidia-smi --query-gpu=name --format=csv,noheader | head -1)
+info "Detected GPU: ${GPU_NAME}"
+
+DISK_FREE=$(df -BG / | tail -1 | awk '{print $4}' | tr -d 'G')
+if [[ "${DISK_FREE}" -lt 100 ]]; then
+    warn "Only ${DISK_FREE}GB free disk space. Recommended: 200GB+"
+fi
+
+# --- Create system user ---
+
+if id "${BRIDGE_USER}" &>/dev/null; then
+    info "User ${BRIDGE_USER} already exists, skipping"
+else
+    info "Creating system user: ${BRIDGE_USER}"
+    useradd -r -s /bin/bash -d /var/lib/${BRIDGE_USER} -m ${BRIDGE_USER}
+    # Allow SSH key auth without password (password field must not be locked '!')
+    usermod -p '*' ${BRIDGE_USER}
+fi
+
+# --- Create directory structure ---
+
+info "Creating ${BRIDGE_DIR}..."
+mkdir -p "${BRIDGE_DIR}/bin"
+
+# --- Copy scripts ---
+# In production these would be downloaded from a URL.
+# For now, we expect them to be in the same directory as this script.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SCRIPTS=(bridgectl status setup-chutes start-chutes stop-chutes uninstall-chutes)
+
+for script in "${SCRIPTS[@]}"; do
+    src="${SCRIPT_DIR}/bin/${script}"
+    dst="${BRIDGE_DIR}/bin/${script}"
+    if [[ -f "${src}" ]]; then
+        cp "${src}" "${dst}"
+        chmod 755 "${dst}"
+        chown root:root "${dst}"
+        info "Installed: ${dst}"
+    else
+        warn "Script not found (skipping): ${src}"
+    fi
+done
+
+# --- Initial state ---
+
+STATE_FILE="${BRIDGE_DIR}/state.json"
+if [[ ! -f "${STATE_FILE}" ]]; then
+    cat > "${STATE_FILE}" <<'STATEJSON'
+{"state": "not_installed", "last_error": null, "node_name": null, "gpu_verified": false}
+STATEJSON
+    info "Created initial state: ${STATE_FILE}"
+else
+    info "State file already exists, preserving: ${STATE_FILE}"
+fi
+
+chmod 644 "${STATE_FILE}"
+
+# --- Log file ---
+
+touch "${LOG_FILE}"
+chown ${BRIDGE_USER}:${BRIDGE_USER} "${LOG_FILE}"
+chmod 644 "${LOG_FILE}"
+
+# --- SSH configuration ---
+
+SSH_CONF="/etc/ssh/sshd_config.d/lium-bridge.conf"
+info "Configuring restricted SSH access..."
+
+# Add our SSH public key to lium-bridge user
+BRIDGE_SSH_DIR="/var/lib/${BRIDGE_USER}/.ssh"
+mkdir -p "${BRIDGE_SSH_DIR}"
+chmod 700 "${BRIDGE_SSH_DIR}"
+
+# If authorized_keys doesn't exist, create an empty one (keys will be added by the platform)
+if [[ ! -f "${BRIDGE_SSH_DIR}/authorized_keys" ]]; then
+    touch "${BRIDGE_SSH_DIR}/authorized_keys"
+fi
+chmod 600 "${BRIDGE_SSH_DIR}/authorized_keys"
+chown -R "${BRIDGE_USER}:${BRIDGE_USER}" "${BRIDGE_SSH_DIR}"
+
+cat > "${SSH_CONF}" <<'SSHCONF'
+Match User lium-bridge
+    ForceCommand /opt/lium-bridge/bin/bridgectl
+    PermitTTY no
+    AllowTcpForwarding no
+    X11Forwarding no
+SSHCONF
+
+# Validate sshd config before reloading
+if sshd -t 2>/dev/null; then
+    systemctl reload sshd 2>/dev/null || systemctl reload ssh 2>/dev/null || true
+    info "SSH configured: ${SSH_CONF}"
+else
+    rm -f "${SSH_CONF}"
+    warn "SSH config validation failed, removed ${SSH_CONF}"
+fi
+
+# --- Sudoers ---
+
+SUDOERS_FILE="/etc/sudoers.d/lium-bridge"
+info "Configuring sudoers..."
+
+cat > "${SUDOERS_FILE}" <<SUDOERS
+# lium-bridge: restricted sudo for bridge scripts only
+${BRIDGE_USER} ALL=(root) NOPASSWD: ${BRIDGE_DIR}/bin/setup-chutes
+${BRIDGE_USER} ALL=(root) NOPASSWD: ${BRIDGE_DIR}/bin/start-chutes
+${BRIDGE_USER} ALL=(root) NOPASSWD: ${BRIDGE_DIR}/bin/stop-chutes
+${BRIDGE_USER} ALL=(root) NOPASSWD: ${BRIDGE_DIR}/bin/status
+${BRIDGE_USER} ALL=(root) NOPASSWD: ${BRIDGE_DIR}/bin/uninstall-chutes
+SUDOERS
+
+chmod 440 "${SUDOERS_FILE}"
+
+# Validate sudoers
+if visudo -c -f "${SUDOERS_FILE}" &>/dev/null; then
+    info "Sudoers configured: ${SUDOERS_FILE}"
+else
+    rm -f "${SUDOERS_FILE}"
+    error "Sudoers validation failed!"
+fi
+
+# --- Add shadeform/current user to docker group (for bridgectl) ---
+
+usermod -aG docker "${BRIDGE_USER}" 2>/dev/null || true
+
+# --- Done ---
+
+echo ""
+info "lium-bridge installed successfully!"
+info "  Bridge dir:  ${BRIDGE_DIR}"
+info "  Scripts:     ${BRIDGE_DIR}/bin/"
+info "  State:       ${STATE_FILE}"
+info "  Log:         ${LOG_FILE}"
+info "  SSH config:  ${SSH_CONF}"
+info ""
+info "Next step: bridgectl setup --validator-hotkey <ss58> --hotkey-ss58 <ss58> --hotkey-seed <hex>"
+echo ""
+
+# Quick status check
+"${BRIDGE_DIR}/bin/status"

--- a/neurons/executor/src/core/config.py
+++ b/neurons/executor/src/core/config.py
@@ -46,10 +46,6 @@ class Settings(BaseSettings):
         env="CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC",
         default=300,
     )
-    CHUTES_STAGING_AUTH_BYPASS: bool = Field(
-        env="CHUTES_STAGING_AUTH_BYPASS",
-        default=False,
-    )
 
     ENV: str = Field(env="ENV", default="dev")
 

--- a/neurons/executor/src/core/config.py
+++ b/neurons/executor/src/core/config.py
@@ -30,6 +30,27 @@ class Settings(BaseSettings):
     RENTING_PORT_RANGE: Optional[str] = Field(env="RENTING_PORT_RANGE", default=None)
     RENTING_PORT_MAPPINGS: Optional[str] = Field(env="RENTING_PORT_MAPPINGS", default=None)
 
+    CHUTES_BRIDGE_ENABLED: bool = Field(env="CHUTES_BRIDGE_ENABLED", default=False)
+    CHUTES_BRIDGE_SSH_HOST: Optional[str] = Field(env="CHUTES_BRIDGE_SSH_HOST", default=None)
+    CHUTES_BRIDGE_SSH_PORT: int = Field(env="CHUTES_BRIDGE_SSH_PORT", default=22)
+    CHUTES_BRIDGE_SSH_USER: str = Field(env="CHUTES_BRIDGE_SSH_USER", default="lium-bridge")
+    CHUTES_BRIDGE_SSH_KEY_PATH: str = Field(
+        env="CHUTES_BRIDGE_SSH_KEY_PATH",
+        default="/run/secrets/chutes_bridge_key",
+    )
+    CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC: int = Field(
+        env="CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC",
+        default=10,
+    )
+    CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC: int = Field(
+        env="CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC",
+        default=300,
+    )
+    CHUTES_STAGING_AUTH_BYPASS: bool = Field(
+        env="CHUTES_STAGING_AUTH_BYPASS",
+        default=False,
+    )
+
     ENV: str = Field(env="ENV", default="dev")
 
     DB_URI: str = Field(env="DB_URI")

--- a/neurons/executor/src/dependencies/auth.py
+++ b/neurons/executor/src/dependencies/auth.py
@@ -1,25 +1,11 @@
-from dataclasses import dataclass
-
-import time
-
-from fastapi import Header, HTTPException
+from fastapi import HTTPException
 import bittensor
 import json
 from core.config import settings
-from core.config import VALIDATOR_HOTKEY_SS58
 from core.logger import get_logger
-from datura.requests.validator_requests import AuthenticationPayload
 from payloads.backend import SignaturePayload, HardwareUtilizationPayload, PingPayload, ContainerUtilizationPayload
 
 logger = get_logger(__name__)
-AUTH_MESSAGE_MAX_AGE = 10
-
-
-@dataclass(frozen=True)
-class ChutesMutationAuth:
-    validator_hotkey: str
-    miner_hotkey: str
-    timestamp: int
 
 
 async def verify_signature(payload: SignaturePayload, message: str) -> None:
@@ -102,93 +88,3 @@ async def verify_container_logs_signature(container_name: str, timestamp: int, s
     await verify_signature(payload, message)
 
 
-async def verify_chutes_mutation_auth_from_headers(
-    x_validator_hotkey: str | None = Header(default=None, alias="X-Validator-Hotkey"),
-    x_miner_hotkey: str | None = Header(default=None, alias="X-Miner-Hotkey"),
-    x_timestamp: str | None = Header(default=None, alias="X-Timestamp"),
-    x_signature: str | None = Header(default=None, alias="X-Signature"),
-) -> ChutesMutationAuth:
-    missing_headers = []
-    if x_validator_hotkey is None:
-        missing_headers.append("X-Validator-Hotkey")
-    if x_miner_hotkey is None:
-        missing_headers.append("X-Miner-Hotkey")
-    if x_timestamp is None:
-        missing_headers.append("X-Timestamp")
-    if x_signature is None:
-        missing_headers.append("X-Signature")
-
-    if missing_headers:
-        raise HTTPException(
-            status_code=401,
-            detail=f"Missing auth headers: {', '.join(missing_headers)}",
-        )
-
-    if x_validator_hotkey != VALIDATOR_HOTKEY_SS58:
-        raise HTTPException(
-            status_code=403,
-            detail="Validator is not authorized for Chutes relay mutations",
-        )
-
-    expected_miner_hotkey = settings.MINER_HOTKEY_SS58_ADDRESS
-    if x_miner_hotkey != expected_miner_hotkey:
-        raise HTTPException(
-            status_code=403,
-            detail="Miner hotkey does not match this executor",
-        )
-
-    try:
-        timestamp_value = int(x_timestamp)
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=400,
-            detail=f"X-Timestamp must be a Unix timestamp. Received: {x_timestamp}",
-        ) from exc
-
-    timestamp_seconds = timestamp_value / 1000 if timestamp_value > 1e12 else timestamp_value
-    if timestamp_seconds < 946684800:
-        raise HTTPException(
-            status_code=400,
-            detail=f"X-Timestamp must be a Unix timestamp in seconds. Received invalid value: {x_timestamp}",
-        )
-
-    now = int(time.time())
-    time_diff = abs(now - timestamp_seconds)
-    if time_diff > AUTH_MESSAGE_MAX_AGE:
-        if timestamp_seconds < now - AUTH_MESSAGE_MAX_AGE:
-            raise HTTPException(
-                status_code=401,
-                detail=f"Authentication message too old. Timestamp is outside the allowed {AUTH_MESSAGE_MAX_AGE}-second window and must be regenerated.",
-            )
-        raise HTTPException(
-            status_code=401,
-            detail=f"Authentication message timestamp is too far in the future. Timestamp must be within {AUTH_MESSAGE_MAX_AGE} seconds of current time.",
-        )
-
-    payload = AuthenticationPayload(
-        validator_hotkey=x_validator_hotkey,
-        miner_hotkey=x_miner_hotkey,
-        timestamp=int(timestamp_seconds),
-    )
-    try:
-        normalized_signature = x_signature if x_signature.startswith('0x') else f'0x{x_signature}'
-        keypair = bittensor.Keypair(ss58_address=x_validator_hotkey)
-        if not keypair.verify(payload.blob_for_signing(), normalized_signature):
-            raise HTTPException(
-                status_code=401,
-                detail="Invalid signature",
-            )
-    except HTTPException:
-        raise
-    except Exception as exc:
-        logger.error("Error verifying Chutes mutation signature: %s", str(exc), exc_info=True)
-        raise HTTPException(
-            status_code=401,
-            detail=f"Signature verification error: {str(exc)}",
-        )
-
-    return ChutesMutationAuth(
-        validator_hotkey=x_validator_hotkey,
-        miner_hotkey=x_miner_hotkey,
-        timestamp=int(timestamp_seconds),
-    )

--- a/neurons/executor/src/dependencies/auth.py
+++ b/neurons/executor/src/dependencies/auth.py
@@ -1,11 +1,25 @@
-from fastapi import HTTPException
+from dataclasses import dataclass
+
+import time
+
+from fastapi import Header, HTTPException
 import bittensor
 import json
 from core.config import settings
+from core.config import VALIDATOR_HOTKEY_SS58
 from core.logger import get_logger
+from datura.requests.validator_requests import AuthenticationPayload
 from payloads.backend import SignaturePayload, HardwareUtilizationPayload, PingPayload, ContainerUtilizationPayload
 
 logger = get_logger(__name__)
+AUTH_MESSAGE_MAX_AGE = 10
+
+
+@dataclass(frozen=True)
+class ChutesMutationAuth:
+    validator_hotkey: str
+    miner_hotkey: str
+    timestamp: int
 
 
 async def verify_signature(payload: SignaturePayload, message: str) -> None:
@@ -86,3 +100,95 @@ async def verify_container_logs_signature(container_name: str, timestamp: int, s
 
     payload = SignaturePayload(signature=signature)
     await verify_signature(payload, message)
+
+
+async def verify_chutes_mutation_auth_from_headers(
+    x_validator_hotkey: str | None = Header(default=None, alias="X-Validator-Hotkey"),
+    x_miner_hotkey: str | None = Header(default=None, alias="X-Miner-Hotkey"),
+    x_timestamp: str | None = Header(default=None, alias="X-Timestamp"),
+    x_signature: str | None = Header(default=None, alias="X-Signature"),
+) -> ChutesMutationAuth:
+    missing_headers = []
+    if x_validator_hotkey is None:
+        missing_headers.append("X-Validator-Hotkey")
+    if x_miner_hotkey is None:
+        missing_headers.append("X-Miner-Hotkey")
+    if x_timestamp is None:
+        missing_headers.append("X-Timestamp")
+    if x_signature is None:
+        missing_headers.append("X-Signature")
+
+    if missing_headers:
+        raise HTTPException(
+            status_code=401,
+            detail=f"Missing auth headers: {', '.join(missing_headers)}",
+        )
+
+    if x_validator_hotkey != VALIDATOR_HOTKEY_SS58:
+        raise HTTPException(
+            status_code=403,
+            detail="Validator is not authorized for Chutes relay mutations",
+        )
+
+    expected_miner_hotkey = settings.MINER_HOTKEY_SS58_ADDRESS
+    if x_miner_hotkey != expected_miner_hotkey:
+        raise HTTPException(
+            status_code=403,
+            detail="Miner hotkey does not match this executor",
+        )
+
+    try:
+        timestamp_value = int(x_timestamp)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=f"X-Timestamp must be a Unix timestamp. Received: {x_timestamp}",
+        ) from exc
+
+    timestamp_seconds = timestamp_value / 1000 if timestamp_value > 1e12 else timestamp_value
+    if timestamp_seconds < 946684800:
+        raise HTTPException(
+            status_code=400,
+            detail=f"X-Timestamp must be a Unix timestamp in seconds. Received invalid value: {x_timestamp}",
+        )
+
+    now = int(time.time())
+    time_diff = abs(now - timestamp_seconds)
+    if time_diff > AUTH_MESSAGE_MAX_AGE:
+        if timestamp_seconds < now - AUTH_MESSAGE_MAX_AGE:
+            raise HTTPException(
+                status_code=401,
+                detail=f"Authentication message too old. Timestamp is outside the allowed {AUTH_MESSAGE_MAX_AGE}-second window and must be regenerated.",
+            )
+        raise HTTPException(
+            status_code=401,
+            detail=f"Authentication message timestamp is too far in the future. Timestamp must be within {AUTH_MESSAGE_MAX_AGE} seconds of current time.",
+        )
+
+    payload = AuthenticationPayload(
+        validator_hotkey=x_validator_hotkey,
+        miner_hotkey=x_miner_hotkey,
+        timestamp=int(timestamp_seconds),
+    )
+    try:
+        normalized_signature = x_signature if x_signature.startswith('0x') else f'0x{x_signature}'
+        keypair = bittensor.Keypair(ss58_address=x_validator_hotkey)
+        if not keypair.verify(payload.blob_for_signing(), normalized_signature):
+            raise HTTPException(
+                status_code=401,
+                detail="Invalid signature",
+            )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Error verifying Chutes mutation signature: %s", str(exc), exc_info=True)
+        raise HTTPException(
+            status_code=401,
+            detail=f"Signature verification error: {str(exc)}",
+        )
+
+    return ChutesMutationAuth(
+        validator_hotkey=x_validator_hotkey,
+        miner_hotkey=x_miner_hotkey,
+        timestamp=int(timestamp_seconds),
+    )

--- a/neurons/executor/src/executor.py
+++ b/neurons/executor/src/executor.py
@@ -1,6 +1,7 @@
 import logging
 
 from fastapi import FastAPI, Request
+from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 import uvicorn
@@ -26,7 +27,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
     )
     return JSONResponse(
         status_code=422,
-        content={"detail": exc.errors()},
+        content={"detail": jsonable_encoder(exc.errors())},
     )
 
 

--- a/neurons/executor/src/middlewares/miner.py
+++ b/neurons/executor/src/middlewares/miner.py
@@ -9,6 +9,11 @@ from core.config import settings
 from core.logger import _m, get_logger
 
 logger = get_logger(__name__)
+_ROUTE_LOCAL_AUTH_PATHS = {
+    "/chutes/install",
+    "/chutes/start",
+    "/chutes/stop",
+}
 
 
 class MinerMiddleware(BaseHTTPMiddleware):
@@ -25,19 +30,15 @@ class MinerMiddleware(BaseHTTPMiddleware):
         if request.url.path in ["/hardware_utilization", "/ping"]:
             return await call_next(request)
 
-        # Staging-only bypass for Chutes relay endpoints.
-        if settings.CHUTES_STAGING_AUTH_BYPASS and request.url.path in [
-            "/chutes/install",
-            "/chutes/start",
-            "/chutes/stop",
-        ]:
+        # Chutes relay mutation routes own their validator auth contract.
+        if request.url.path in _ROUTE_LOCAL_AUTH_PATHS:
             return await call_next(request)
-        
+
         # Skip for specific container hardware utilization endpoint
         # Pattern: /containers/{container_name}
         if re.match(r'^/containers(/[^/]+)?/?$', request.url.path):
             return await call_next(request)
-            
+
         default_extra = {
             'url': request.url.path,
             'client_host': request.client.host,

--- a/neurons/executor/src/middlewares/miner.py
+++ b/neurons/executor/src/middlewares/miner.py
@@ -24,6 +24,14 @@ class MinerMiddleware(BaseHTTPMiddleware):
         # Skip middleware for endpoints with their own signature verification
         if request.url.path in ["/hardware_utilization", "/ping"]:
             return await call_next(request)
+
+        # Staging-only bypass for Chutes relay endpoints.
+        if settings.CHUTES_STAGING_AUTH_BYPASS and request.url.path in [
+            "/chutes/install",
+            "/chutes/start",
+            "/chutes/stop",
+        ]:
+            return await call_next(request)
         
         # Skip for specific container hardware utilization endpoint
         # Pattern: /containers/{container_name}

--- a/neurons/executor/src/payloads/chutes.py
+++ b/neurons/executor/src/payloads/chutes.py
@@ -1,4 +1,11 @@
-from pydantic import BaseModel
+import re
+
+from pydantic import BaseModel, field_validator
+from substrateinterface.utils.ss58 import is_valid_ss58_address
+
+
+_SEED_PATTERN = re.compile(r"^(?:0x)?([0-9a-fA-F]{64})$")
+_NODE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$")
 
 
 class ChutesInstallPayload(BaseModel):
@@ -6,6 +13,33 @@ class ChutesInstallPayload(BaseModel):
     hotkey_ss58: str
     hotkey_seed: str
     node_name: str
+
+    @field_validator("validator_hotkey", "hotkey_ss58")
+    @classmethod
+    def validate_ss58(cls, value: str) -> str:
+        normalized = value.strip()
+        if not is_valid_ss58_address(normalized):
+            raise ValueError("must be a valid SS58 address")
+        return normalized
+
+    @field_validator("hotkey_seed")
+    @classmethod
+    def validate_hotkey_seed(cls, value: str) -> str:
+        normalized = value.strip()
+        match = _SEED_PATTERN.fullmatch(normalized)
+        if not match:
+            raise ValueError("must be 64 hex characters with optional 0x prefix")
+        return match.group(1).lower()
+
+    @field_validator("node_name")
+    @classmethod
+    def validate_node_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if not _NODE_NAME_PATTERN.fullmatch(normalized):
+            raise ValueError(
+                "must match hostname pattern ^[a-zA-Z0-9][a-zA-Z0-9._-]{0,62}$"
+            )
+        return normalized
 
 
 class ChutesCommandPayload(BaseModel):

--- a/neurons/executor/src/payloads/chutes.py
+++ b/neurons/executor/src/payloads/chutes.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class ChutesInstallPayload(BaseModel):
+    validator_hotkey: str
+    hotkey_ss58: str
+    hotkey_seed: str
+
+
+class ChutesCommandPayload(BaseModel):
+    pass

--- a/neurons/executor/src/payloads/chutes.py
+++ b/neurons/executor/src/payloads/chutes.py
@@ -1,7 +1,7 @@
 import re
 
+from bittensor.utils import is_valid_ss58_address
 from pydantic import BaseModel, field_validator
-from substrateinterface.utils.ss58 import is_valid_ss58_address
 
 
 _SEED_PATTERN = re.compile(r"^(?:0x)?([0-9a-fA-F]{64})$")

--- a/neurons/executor/src/payloads/chutes.py
+++ b/neurons/executor/src/payloads/chutes.py
@@ -1,7 +1,7 @@
 import re
 
 from pydantic import BaseModel, field_validator
-from substrateinterface.utils.ss58 import is_valid_ss58_address
+from bittensor.utils import is_valid_ss58_address
 
 
 _SEED_PATTERN = re.compile(r"^(?:0x)?([0-9a-fA-F]{64})$")

--- a/neurons/executor/src/payloads/chutes.py
+++ b/neurons/executor/src/payloads/chutes.py
@@ -13,6 +13,7 @@ class ChutesInstallPayload(BaseModel):
     hotkey_ss58: str
     hotkey_seed: str
     node_name: str
+    validator_signature: str
 
     @field_validator("validator_hotkey", "hotkey_ss58")
     @classmethod
@@ -43,4 +44,4 @@ class ChutesInstallPayload(BaseModel):
 
 
 class ChutesCommandPayload(BaseModel):
-    pass
+    validator_signature: str

--- a/neurons/executor/src/payloads/chutes.py
+++ b/neurons/executor/src/payloads/chutes.py
@@ -5,6 +5,7 @@ class ChutesInstallPayload(BaseModel):
     validator_hotkey: str
     hotkey_ss58: str
     hotkey_seed: str
+    node_name: str
 
 
 class ChutesCommandPayload(BaseModel):

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -169,6 +169,7 @@ def chutes_install(
             validator_hotkey=payload.validator_hotkey,
             hotkey_ss58=payload.hotkey_ss58,
             hotkey_seed=payload.hotkey_seed,
+            node_name=payload.node_name,
         )
     except Exception as exc:
         logger.error(_m("Chutes install failed", extra={"error": str(exc)}))

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -24,9 +24,23 @@ from core.config import VALIDATOR_HOTKEY_SS58
 from payloads.miner import UploadSShKeyPayload, GetPodLogsPaylod
 from payloads.backend import ContainerUtilizationPayload
 from payloads.chutes import ChutesCommandPayload, ChutesInstallPayload
-from dependencies.auth import verify_allowed_hotkey_signature, verify_ping_signature, verify_container_signature, verify_container_logs_signature
+from dependencies.auth import (
+    ChutesMutationAuth,
+    verify_allowed_hotkey_signature,
+    verify_chutes_mutation_auth_from_headers,
+    verify_ping_signature,
+    verify_container_signature,
+    verify_container_logs_signature,
+)
 
 logger = logging.getLogger(__name__)
+_KNOWN_CHUTES_ERRORS = (
+    ChutesRelayDisabledError,
+    ChutesBridgeConfigError,
+    ChutesTransportError,
+    ChutesMalformedResponseError,
+    ChutesExecutorError,
+)
 
 apis_router = APIRouter()
 
@@ -86,6 +100,34 @@ def _translate_chutes_error(exc: Exception) -> HTTPException:
     if isinstance(exc, (ChutesExecutorError, ChutesBridgeConfigError)):
         return HTTPException(status_code=500, detail=str(exc))
     return HTTPException(status_code=500, detail="Unexpected Chutes relay error")
+
+
+def _log_chutes_error(verb: str, exc: Exception) -> None:
+    logger.error(
+        _m(
+            "Chutes relay request failed",
+            extra={
+                "verb": verb,
+                "error_type": type(exc).__name__,
+                "error": str(exc),
+            },
+        ),
+    )
+
+
+def _validate_chutes_install_request(
+    payload: ChutesInstallPayload, auth: ChutesMutationAuth
+) -> None:
+    if payload.validator_hotkey != auth.validator_hotkey:
+        raise HTTPException(
+            status_code=400,
+            detail="validator_hotkey in request body must match X-Validator-Hotkey",
+        )
+    if payload.hotkey_ss58 != auth.miner_hotkey:
+        raise HTTPException(
+            status_code=400,
+            detail="hotkey_ss58 in request body must match X-Miner-Hotkey",
+        )
 
 
 @apis_router.post("/upload_ssh_key")
@@ -163,7 +205,9 @@ async def ping(_: None = Depends(verify_ping_signature)):
 def chutes_install(
     payload: ChutesInstallPayload,
     relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
+    auth: Annotated[ChutesMutationAuth, Depends(verify_chutes_mutation_auth_from_headers)],
 ):
+    _validate_chutes_install_request(payload, auth)
     try:
         return relay_service.install(
             validator_hotkey=payload.validator_hotkey,
@@ -171,8 +215,8 @@ def chutes_install(
             hotkey_seed=payload.hotkey_seed,
             node_name=payload.node_name,
         )
-    except Exception as exc:
-        logger.error(_m("Chutes install failed", extra={"error": str(exc)}))
+    except _KNOWN_CHUTES_ERRORS as exc:
+        _log_chutes_error("install", exc)
         raise _translate_chutes_error(exc)
 
 
@@ -180,11 +224,12 @@ def chutes_install(
 def chutes_start(
     _: ChutesCommandPayload,
     relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
+    __: Annotated[ChutesMutationAuth, Depends(verify_chutes_mutation_auth_from_headers)],
 ):
     try:
         return relay_service.start()
-    except Exception as exc:
-        logger.error(_m("Chutes start failed", extra={"error": str(exc)}))
+    except _KNOWN_CHUTES_ERRORS as exc:
+        _log_chutes_error("start", exc)
         raise _translate_chutes_error(exc)
 
 
@@ -192,11 +237,12 @@ def chutes_start(
 def chutes_stop(
     _: ChutesCommandPayload,
     relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
+    __: Annotated[ChutesMutationAuth, Depends(verify_chutes_mutation_auth_from_headers)],
 ):
     try:
         return relay_service.stop()
-    except Exception as exc:
-        logger.error(_m("Chutes stop failed", extra={"error": str(exc)}))
+    except _KNOWN_CHUTES_ERRORS as exc:
+        _log_chutes_error("stop", exc)
         raise _translate_chutes_error(exc)
 
 

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -116,7 +116,8 @@ def _log_chutes_error(verb: str, exc: Exception) -> None:
 def _validate_chutes_signature(message: str, signature: str) -> None:
     try:
         keypair = bittensor.Keypair(ss58_address=VALIDATOR_HOTKEY_SS58)
-        if not keypair.verify(message, signature):
+        normalized = signature if signature.startswith("0x") else f"0x{signature}"
+        if not keypair.verify(message, normalized):
             raise HTTPException(status_code=401, detail="Invalid validator signature")
     except HTTPException:
         raise

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -25,9 +25,7 @@ from payloads.miner import UploadSShKeyPayload, GetPodLogsPaylod
 from payloads.backend import ContainerUtilizationPayload
 from payloads.chutes import ChutesCommandPayload, ChutesInstallPayload
 from dependencies.auth import (
-    ChutesMutationAuth,
     verify_allowed_hotkey_signature,
-    verify_chutes_mutation_auth_from_headers,
     verify_ping_signature,
     verify_container_signature,
     verify_container_logs_signature,
@@ -115,19 +113,16 @@ def _log_chutes_error(verb: str, exc: Exception) -> None:
     )
 
 
-def _validate_chutes_install_request(
-    payload: ChutesInstallPayload, auth: ChutesMutationAuth
-) -> None:
-    if payload.validator_hotkey != auth.validator_hotkey:
-        raise HTTPException(
-            status_code=400,
-            detail="validator_hotkey in request body must match X-Validator-Hotkey",
-        )
-    if payload.hotkey_ss58 != auth.miner_hotkey:
-        raise HTTPException(
-            status_code=400,
-            detail="hotkey_ss58 in request body must match X-Miner-Hotkey",
-        )
+def _validate_chutes_signature(message: str, signature: str) -> None:
+    try:
+        keypair = bittensor.Keypair(ss58_address=VALIDATOR_HOTKEY_SS58)
+        if not keypair.verify(message, signature):
+            raise HTTPException(status_code=401, detail="Invalid validator signature")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning("Chutes signature verification failed: %s", exc)
+        raise HTTPException(status_code=401, detail="Invalid validator signature")
 
 
 @apis_router.post("/upload_ssh_key")
@@ -205,9 +200,8 @@ async def ping(_: None = Depends(verify_ping_signature)):
 def chutes_install(
     payload: ChutesInstallPayload,
     relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
-    auth: Annotated[ChutesMutationAuth, Depends(verify_chutes_mutation_auth_from_headers)],
 ):
-    _validate_chutes_install_request(payload, auth)
+    _validate_chutes_signature(payload.node_name, payload.validator_signature)
     try:
         return relay_service.install(
             validator_hotkey=payload.validator_hotkey,
@@ -222,10 +216,10 @@ def chutes_install(
 
 @apis_router.post("/chutes/start")
 def chutes_start(
-    _: ChutesCommandPayload,
+    payload: ChutesCommandPayload,
     relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
-    __: Annotated[ChutesMutationAuth, Depends(verify_chutes_mutation_auth_from_headers)],
 ):
+    _validate_chutes_signature("chutes_start", payload.validator_signature)
     try:
         return relay_service.start()
     except _KNOWN_CHUTES_ERRORS as exc:
@@ -235,10 +229,10 @@ def chutes_start(
 
 @apis_router.post("/chutes/stop")
 def chutes_stop(
-    _: ChutesCommandPayload,
+    payload: ChutesCommandPayload,
     relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
-    __: Annotated[ChutesMutationAuth, Depends(verify_chutes_mutation_auth_from_headers)],
 ):
+    _validate_chutes_signature("chutes_stop", payload.validator_signature)
     try:
         return relay_service.stop()
     except _KNOWN_CHUTES_ERRORS as exc:

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -7,13 +7,23 @@ import docker
 import bittensor
 from fastapi import APIRouter, Depends, Query, Header, HTTPException
 from fastapi.responses import StreamingResponse
+from core.logger import _m
 from services.miner_service import MinerService
 from services.pod_log_service import PodLogService
+from services.chutes_relay_service import (
+    ChutesBridgeConfigError,
+    ChutesExecutorError,
+    ChutesMalformedResponseError,
+    ChutesRelayDisabledError,
+    ChutesRelayService,
+    ChutesTransportError,
+)
 from services.hardware_service import get_system_metrics, get_container_metrics
 from core.config import VALIDATOR_HOTKEY_SS58
 
 from payloads.miner import UploadSShKeyPayload, GetPodLogsPaylod
 from payloads.backend import ContainerUtilizationPayload
+from payloads.chutes import ChutesCommandPayload, ChutesInstallPayload
 from dependencies.auth import verify_allowed_hotkey_signature, verify_ping_signature, verify_container_signature, verify_container_logs_signature
 
 logger = logging.getLogger(__name__)
@@ -66,6 +76,16 @@ def _validate_validator_signature(payload: UploadSShKeyPayload) -> None:
     except Exception as exc:
         logger.warning("Validator signature verification failed: %s", exc)
         raise HTTPException(status_code=401, detail="Invalid validator signature")
+
+
+def _translate_chutes_error(exc: Exception) -> HTTPException:
+    if isinstance(exc, (ChutesRelayDisabledError, ChutesTransportError)):
+        return HTTPException(status_code=409, detail=str(exc))
+    if isinstance(exc, ChutesMalformedResponseError):
+        return HTTPException(status_code=502, detail=str(exc))
+    if isinstance(exc, (ChutesExecutorError, ChutesBridgeConfigError)):
+        return HTTPException(status_code=500, detail=str(exc))
+    return HTTPException(status_code=500, detail="Unexpected Chutes relay error")
 
 
 @apis_router.post("/upload_ssh_key")
@@ -137,6 +157,53 @@ async def ping(_: None = Depends(verify_ping_signature)):
         dict: {"status": "pong"}
     """
     return {"status": "pong"}
+
+
+@apis_router.post("/chutes/install")
+def chutes_install(
+    payload: ChutesInstallPayload,
+    relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
+):
+    try:
+        return relay_service.install(
+            validator_hotkey=payload.validator_hotkey,
+            hotkey_ss58=payload.hotkey_ss58,
+            hotkey_seed=payload.hotkey_seed,
+        )
+    except Exception as exc:
+        logger.error(_m("Chutes install failed", extra={"error": str(exc)}))
+        raise _translate_chutes_error(exc)
+
+
+@apis_router.post("/chutes/start")
+def chutes_start(
+    _: ChutesCommandPayload,
+    relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
+):
+    try:
+        return relay_service.start()
+    except Exception as exc:
+        logger.error(_m("Chutes start failed", extra={"error": str(exc)}))
+        raise _translate_chutes_error(exc)
+
+
+@apis_router.post("/chutes/stop")
+def chutes_stop(
+    _: ChutesCommandPayload,
+    relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
+):
+    try:
+        return relay_service.stop()
+    except Exception as exc:
+        logger.error(_m("Chutes stop failed", extra={"error": str(exc)}))
+        raise _translate_chutes_error(exc)
+
+
+@apis_router.get("/chutes/status")
+def chutes_status(
+    relay_service: Annotated[ChutesRelayService, Depends(ChutesRelayService)],
+):
+    return relay_service.get_status_summary()
 
 
 @apis_router.get("/version")

--- a/neurons/executor/src/services/chutes_relay_service.py
+++ b/neurons/executor/src/services/chutes_relay_service.py
@@ -176,9 +176,9 @@ class ChutesRelayService:
         except subprocess.TimeoutExpired as exc:
             raise ChutesExecutorError(
                 f"Chutes bridge command '{verb}' timed out after {timeout}s"
-            ) from exc
+            ) from None
         except OSError as exc:
-            raise ChutesExecutorError(f"Failed to execute ssh for '{verb}': {exc}") from exc
+            raise ChutesExecutorError(f"Failed to execute ssh for '{verb}': {exc}") from None
 
         elapsed_ms = int((time.monotonic() - started_at) * 1000)
         stderr = (completed.stderr or "").strip()
@@ -217,6 +217,12 @@ class ChutesRelayService:
             raise ChutesMalformedResponseError(
                 f"Chutes bridge command '{verb}' returned non-object JSON"
             )
+
+        if payload.get("ok") is False:
+            raise ChutesExecutorError(
+                f"Chutes bridge command '{verb}' failed: {self._summarize_bridge_error(payload, stderr)}"
+            )
+
         return payload
 
     @staticmethod
@@ -244,3 +250,11 @@ class ChutesRelayService:
         if stderr:
             return stderr.splitlines()[-1]
         return "Unknown SSH transport error"
+
+    def _summarize_bridge_error(self, payload: dict[str, Any], stderr: str) -> str:
+        error = payload.get("error")
+        if isinstance(error, str) and error.strip():
+            return error.strip()
+        if stderr:
+            return self._summarize_stderr(stderr)
+        return "Bridge command returned ok=false"

--- a/neurons/executor/src/services/chutes_relay_service.py
+++ b/neurons/executor/src/services/chutes_relay_service.py
@@ -1,0 +1,223 @@
+import json
+import subprocess
+import time
+from typing import Any
+
+from core.config import settings
+from core.logger import _m, get_logger
+
+logger = get_logger(__name__)
+
+
+class ChutesRelayDisabledError(RuntimeError):
+    pass
+
+
+class ChutesBridgeConfigError(RuntimeError):
+    pass
+
+
+class ChutesTransportError(RuntimeError):
+    pass
+
+
+class ChutesMalformedResponseError(RuntimeError):
+    pass
+
+
+class ChutesExecutorError(RuntimeError):
+    pass
+
+
+class ChutesRelayService:
+    INSTALL_TIMEOUT_SEC = 3600
+    TRANSPORT_ERROR_MARKERS = (
+        "Permission denied",
+        "Connection refused",
+        "No route to host",
+        "Connection timed out",
+        "Host key verification failed",
+        "Could not resolve hostname",
+        "Operation timed out",
+        "Network is unreachable",
+    )
+
+    def build_bridge_command(self, verb: str, args: list[str] | None = None) -> list[str]:
+        if not settings.CHUTES_BRIDGE_ENABLED:
+            raise ChutesRelayDisabledError("Chutes bridge relay is disabled")
+        if not settings.CHUTES_BRIDGE_SSH_HOST:
+            raise ChutesBridgeConfigError(
+                "CHUTES_BRIDGE_SSH_HOST is required when bridge relay is enabled"
+            )
+
+        command = [
+            "ssh",
+            "-i",
+            settings.CHUTES_BRIDGE_SSH_KEY_PATH,
+            "-o",
+            "BatchMode=yes",
+            "-o",
+            "IdentitiesOnly=yes",
+            "-o",
+            "StrictHostKeyChecking=yes",
+            "-o",
+            f"ConnectTimeout={settings.CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC}",
+            "-p",
+            str(settings.CHUTES_BRIDGE_SSH_PORT),
+            f"{settings.CHUTES_BRIDGE_SSH_USER}@{settings.CHUTES_BRIDGE_SSH_HOST}",
+            "bridgectl",
+            verb,
+        ]
+        if args:
+            command.extend(args)
+        return command
+
+    def install(self, validator_hotkey: str, hotkey_ss58: str, hotkey_seed: str) -> dict[str, Any]:
+        return self._run_bridge_command(
+            "setup",
+            [
+                "--validator-hotkey",
+                validator_hotkey,
+                "--hotkey-ss58",
+                hotkey_ss58,
+                "--hotkey-seed",
+                hotkey_seed,
+            ],
+            timeout=self.INSTALL_TIMEOUT_SEC,
+        )
+
+    def start(self) -> dict[str, Any]:
+        return self._run_bridge_command(
+            "start",
+            timeout=settings.CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC,
+        )
+
+    def stop(self) -> dict[str, Any]:
+        return self._run_bridge_command(
+            "stop",
+            timeout=settings.CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC,
+        )
+
+    def status(self) -> dict[str, Any]:
+        return self._run_bridge_command(
+            "status",
+            timeout=settings.CHUTES_BRIDGE_COMMAND_TIMEOUT_SEC,
+        )
+
+    def get_status_summary(self) -> dict[str, Any]:
+        if not settings.CHUTES_BRIDGE_ENABLED:
+            return {
+                "ok": True,
+                "capability": {
+                    "bridge_enabled": False,
+                    "bridge_accessible": False,
+                    "can_install": False,
+                },
+                "bridge": None,
+                "error": "Chutes bridge relay is disabled",
+            }
+
+        try:
+            bridge = self.status()
+            return {
+                "ok": True,
+                "capability": {
+                    "bridge_enabled": True,
+                    "bridge_accessible": True,
+                    "can_install": True,
+                },
+                "bridge": bridge,
+                "error": None,
+            }
+        except (
+            ChutesTransportError,
+            ChutesRelayDisabledError,
+            ChutesBridgeConfigError,
+            ChutesMalformedResponseError,
+            ChutesExecutorError,
+        ) as exc:
+            return {
+                "ok": True,
+                "capability": {
+                    "bridge_enabled": True,
+                    "bridge_accessible": False,
+                    "can_install": False,
+                },
+                "bridge": None,
+                "error": str(exc),
+            }
+
+    def _run_bridge_command(
+        self,
+        verb: str,
+        args: list[str] | None = None,
+        timeout: int | None = None,
+    ) -> dict[str, Any]:
+        command = self.build_bridge_command(verb, args)
+        started_at = time.monotonic()
+        logger.info(_m("Running Chutes bridge command", extra={"verb": verb}))
+
+        try:
+            completed = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise ChutesExecutorError(
+                f"Chutes bridge command '{verb}' timed out after {timeout}s"
+            ) from exc
+        except OSError as exc:
+            raise ChutesExecutorError(f"Failed to execute ssh for '{verb}': {exc}") from exc
+
+        elapsed_ms = int((time.monotonic() - started_at) * 1000)
+        stderr = (completed.stderr or "").strip()
+        stdout = (completed.stdout or "").strip()
+
+        logger.info(
+            _m(
+                "Chutes bridge command finished",
+                extra={
+                    "verb": verb,
+                    "returncode": completed.returncode,
+                    "elapsed_ms": elapsed_ms,
+                },
+            )
+        )
+
+        if self._is_transport_error(completed.returncode, stderr):
+            raise ChutesTransportError(self._summarize_stderr(stderr))
+
+        if not stdout:
+            if completed.returncode == 0:
+                raise ChutesMalformedResponseError(
+                    f"Chutes bridge command '{verb}' returned empty output"
+                )
+            raise ChutesExecutorError(
+                f"Chutes bridge command '{verb}' failed: {self._summarize_stderr(stderr)}"
+            )
+
+        try:
+            payload = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            raise ChutesMalformedResponseError(
+                f"Chutes bridge command '{verb}' returned malformed JSON"
+            ) from exc
+
+        if not isinstance(payload, dict):
+            raise ChutesMalformedResponseError(
+                f"Chutes bridge command '{verb}' returned non-object JSON"
+            )
+        return payload
+
+    def _is_transport_error(self, returncode: int, stderr: str) -> bool:
+        if returncode == 255:
+            return True
+        return any(marker in stderr for marker in self.TRANSPORT_ERROR_MARKERS)
+
+    def _summarize_stderr(self, stderr: str) -> str:
+        if stderr:
+            return stderr.splitlines()[-1]
+        return "Unknown SSH transport error"

--- a/neurons/executor/src/services/chutes_relay_service.py
+++ b/neurons/executor/src/services/chutes_relay_service.py
@@ -207,18 +207,33 @@ class ChutesRelayService:
                 f"Chutes bridge command '{verb}' failed: {self._summarize_stderr(stderr)}"
             )
 
-        try:
-            payload = json.loads(stdout)
-        except json.JSONDecodeError as exc:
+        payload = self._extract_json(stdout)
+        if payload is None:
             raise ChutesMalformedResponseError(
                 f"Chutes bridge command '{verb}' returned malformed JSON"
-            ) from exc
+            )
 
         if not isinstance(payload, dict):
             raise ChutesMalformedResponseError(
                 f"Chutes bridge command '{verb}' returned non-object JSON"
             )
         return payload
+
+    @staticmethod
+    def _extract_json(stdout: str) -> dict[str, Any] | None:
+        """Extract JSON object from stdout that may contain non-JSON prefix (helm, k3s, etc.)."""
+        try:
+            return json.loads(stdout)
+        except json.JSONDecodeError:
+            pass
+        # Find the last '{' that starts a line — bridge scripts output JSON at the end
+        for i in range(len(stdout) - 1, -1, -1):
+            if stdout[i] == "{" and (i == 0 or stdout[i - 1] == "\n"):
+                try:
+                    return json.loads(stdout[i:])
+                except json.JSONDecodeError:
+                    continue
+        return None
 
     def _is_transport_error(self, returncode: int, stderr: str) -> bool:
         if returncode == 255:

--- a/neurons/executor/src/services/chutes_relay_service.py
+++ b/neurons/executor/src/services/chutes_relay_service.py
@@ -72,7 +72,13 @@ class ChutesRelayService:
             command.extend(args)
         return command
 
-    def install(self, validator_hotkey: str, hotkey_ss58: str, hotkey_seed: str) -> dict[str, Any]:
+    def install(
+        self,
+        validator_hotkey: str,
+        hotkey_ss58: str,
+        hotkey_seed: str,
+        node_name: str,
+    ) -> dict[str, Any]:
         return self._run_bridge_command(
             "setup",
             [
@@ -82,6 +88,8 @@ class ChutesRelayService:
                 hotkey_ss58,
                 "--hotkey-seed",
                 hotkey_seed,
+                "--node-name",
+                node_name,
             ],
             timeout=self.INSTALL_TIMEOUT_SEC,
         )

--- a/neurons/executor/tests/conftest.py
+++ b/neurons/executor/tests/conftest.py
@@ -8,11 +8,56 @@ heavy system dependencies (docker, etc.).
 
 import os
 import sys
+import types
 from unittest.mock import MagicMock
 
 # Mock docker before any src import so that routes/apis.py and related
 # services can be imported without a running Docker daemon.
 sys.modules["docker"] = MagicMock()
+sys.modules["pynvml"] = MagicMock()
+sys.modules["pkg_resources"] = MagicMock()
+sys.modules["dstack_sdk"] = MagicMock()
+
+
+class _FakeSession:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class _FakeSQLModel:
+    metadata = types.SimpleNamespace(create_all=lambda *_args, **_kwargs: None)
+
+    def __init_subclass__(cls, **_kwargs):
+        super().__init_subclass__()
+
+
+def _fake_field(*_args, **kwargs):
+    if "default_factory" in kwargs:
+        return kwargs["default_factory"]()
+    return kwargs.get("default")
+
+
+def _fake_create_engine(*_args, **_kwargs):
+    return object()
+
+
+def _fake_select(*_args, **_kwargs):
+    return object()
+
+
+sys.modules["sqlmodel"] = types.SimpleNamespace(
+    Field=_fake_field,
+    SQLModel=_FakeSQLModel,
+    Session=_FakeSession,
+    create_engine=_fake_create_engine,
+    select=_fake_select,
+)
 
 # Required env vars consumed by core.config.Settings at import time.
 os.environ.setdefault("MINER_HOTKEY_SS58_ADDRESS", "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY")
@@ -22,3 +67,12 @@ os.environ.setdefault("DB_URI", "sqlite:///tmp/test.db")
 _src = os.path.abspath(os.path.join(os.path.dirname(__file__), "../src"))
 if _src not in sys.path:
     sys.path.insert(0, _src)
+
+# Add repo root so local workspace dependencies like datura/ resolve in tests.
+_repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)
+
+_datura_root = os.path.join(_repo_root, "datura")
+if _datura_root not in sys.path:
+    sys.path.insert(0, _datura_root)

--- a/neurons/executor/tests/test_chutes_api.py
+++ b/neurons/executor/tests/test_chutes_api.py
@@ -1,7 +1,8 @@
 import os
+import subprocess
 import sys
-import types
 import unittest
+from contextlib import ExitStack, contextmanager
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
@@ -13,26 +14,77 @@ os.environ.setdefault(
 )
 os.environ.setdefault("DB_URI", "sqlite:///test.db")
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../datura")))
 
-class _DummyKeypair:
+from core.config import settings
+from datura.requests.validator_requests import AuthenticationPayload
+from executor import app
+from services.chutes_relay_service import ChutesExecutorError
+
+
+VALID_VALIDATOR_HOTKEY = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+VALID_HOTKEY_SS58 = "5D4jX4TqUkZwNwKAjjYrbk2FHFNN2U1TgFF6ZMuNPnjnKJVU"
+VALID_SEED = "0x" + ("ab" * 32)
+NORMALIZED_SEED = "ab" * 32
+VALID_NODE_NAME = "gpu-node-01"
+FIXED_NOW = 1_773_100_000
+
+
+def _signature_for(ss58_address: str, message: str) -> str:
+    return f"0xsig::{ss58_address}::{message}"
+
+
+class _SignedHeaderKeypair:
     def __init__(self, ss58_address=None):
         self.ss58_address = ss58_address
 
-    def verify(self, *_args, **_kwargs):
-        return False
-
-
-sys.modules.setdefault("bittensor", types.SimpleNamespace(Keypair=_DummyKeypair))
-
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
-
-from core.config import settings
-from executor import app
+    def verify(self, message, signature):
+        normalized = signature if signature.startswith("0x") else f"0x{signature}"
+        return normalized == _signature_for(self.ss58_address, message)
 
 
 class TestChutesApi(unittest.TestCase):
     def setUp(self):
         self.client = TestClient(app)
+
+    def _auth_headers(
+        self,
+        *,
+        validator_hotkey: str = VALID_VALIDATOR_HOTKEY,
+        miner_hotkey: str = VALID_HOTKEY_SS58,
+        timestamp: int = FIXED_NOW,
+        signature: str | None = None,
+    ) -> dict[str, str]:
+        blob = AuthenticationPayload(
+            validator_hotkey=validator_hotkey,
+            miner_hotkey=miner_hotkey,
+            timestamp=timestamp,
+        ).blob_for_signing()
+        return {
+            "X-Validator-Hotkey": validator_hotkey,
+            "X-Miner-Hotkey": miner_hotkey,
+            "X-Timestamp": str(timestamp),
+            "X-Signature": signature or _signature_for(validator_hotkey, blob),
+        }
+
+    @contextmanager
+    def _patched_auth(self):
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(settings, "MINER_HOTKEY_SS58_ADDRESS", VALID_HOTKEY_SS58)
+            )
+            stack.enter_context(
+                patch("dependencies.auth.VALIDATOR_HOTKEY_SS58", VALID_VALIDATOR_HOTKEY)
+            )
+            stack.enter_context(
+                patch("dependencies.auth.bittensor.Keypair", _SignedHeaderKeypair)
+            )
+            stack.enter_context(
+                patch("dependencies.auth.time.time", return_value=FIXED_NOW)
+            )
+            yield
 
     def test_status_when_bridge_disabled(self):
         with patch.object(settings, "CHUTES_BRIDGE_ENABLED", False):
@@ -60,51 +112,313 @@ class TestChutesApi(unittest.TestCase):
 
     def test_install_happy_path(self):
         with (
-            patch.object(settings, "CHUTES_STAGING_AUTH_BYPASS", True),
+            self._patched_auth(),
             patch(
                 "routes.apis.ChutesRelayService.install",
                 return_value={"ok": True, "state": "installed_stopped"},
-            ),
+            ) as install_mock,
         ):
             response = self.client.post(
                 "/chutes/install",
                 json={
-                    "validator_hotkey": "validator",
-                    "hotkey_ss58": "hotkey",
-                    "hotkey_seed": "seed",
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
                 },
+                headers=self._auth_headers(),
             )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["state"], "installed_stopped")
+        install_mock.assert_called_once_with(
+            validator_hotkey=VALID_VALIDATOR_HOTKEY,
+            hotkey_ss58=VALID_HOTKEY_SS58,
+            hotkey_seed=NORMALIZED_SEED,
+            node_name=VALID_NODE_NAME,
+        )
+
+    def test_install_requires_auth_headers(self):
+        response = self.client.post(
+            "/chutes/install",
+            json={
+                "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                "hotkey_ss58": VALID_HOTKEY_SS58,
+                "hotkey_seed": VALID_SEED,
+                "node_name": VALID_NODE_NAME,
+            },
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("Missing auth headers", response.json()["detail"])
+
+    def test_install_rejects_wrong_validator_header(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(
+                    validator_hotkey="5D4jX4TqUkZwNwKAjjYrbk2FHFNN2U1TgFF6ZMuNPnjnKJVV"
+                ),
+            )
+        self.assertEqual(response.status_code, 403)
+
+    def test_install_rejects_wrong_miner_header(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(
+                    miner_hotkey="5D4jX4TqUkZwNwKAjjYrbk2FHFNN2U1TgFF6ZMuNPnjnKJVV"
+                ),
+            )
+        self.assertEqual(response.status_code, 403)
+
+    def test_install_rejects_stale_timestamp(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(timestamp=FIXED_NOW - 60),
+            )
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("too old", response.json()["detail"])
+
+    def test_install_rejects_invalid_signature(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(signature="0xdeadbeef"),
+            )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["detail"], "Invalid signature")
+
+    def test_install_rejects_body_validator_mismatch(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_HOTKEY_SS58,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("validator_hotkey", response.json()["detail"])
+
+    def test_install_rejects_body_miner_mismatch(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("hotkey_ss58", response.json()["detail"])
+
+    def test_install_rejects_invalid_seed(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": "seed",
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 422)
+
+    def test_install_rejects_invalid_validator_hotkey(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": "invalid-ss58",
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 422)
+
+    def test_install_rejects_invalid_hotkey_ss58(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": "invalid-ss58",
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 422)
+
+    def test_install_rejects_invalid_node_name(self):
+        with self._patched_auth():
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": "-bad-node-name",
+                },
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 422)
 
     def test_start_happy_path(self):
         with (
-            patch.object(settings, "CHUTES_STAGING_AUTH_BYPASS", True),
+            self._patched_auth(),
             patch(
                 "routes.apis.ChutesRelayService.start",
                 return_value={"ok": True, "state": "running"},
             ),
         ):
-            response = self.client.post("/chutes/start", json={})
+            response = self.client.post(
+                "/chutes/start",
+                json={},
+                headers=self._auth_headers(),
+            )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["state"], "running")
 
+    def test_start_bridge_failure_returns_500(self):
+        with (
+            self._patched_auth(),
+            patch(
+                "routes.apis.ChutesRelayService.start",
+                side_effect=ChutesExecutorError("Agent pod did not become healthy within 3 min"),
+            ),
+        ):
+            response = self.client.post(
+                "/chutes/start",
+                json={},
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.json()["detail"],
+            "Agent pod did not become healthy within 3 min",
+        )
+
+    def test_install_known_error_logs_without_traceback_or_secret(self):
+        try:
+            try:
+                raise subprocess.TimeoutExpired(
+                    cmd=["ssh", "bridgectl", "setup", "--hotkey-seed", "super-secret-seed"],
+                    timeout=3600,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise ChutesExecutorError(
+                    "Chutes bridge command 'setup' timed out after 3600s"
+                ) from exc
+        except ChutesExecutorError as exc:
+            chained_error = exc
+
+        with (
+            self._patched_auth(),
+            patch(
+                "routes.apis.ChutesRelayService.install",
+                side_effect=chained_error,
+            ),
+            patch("routes.apis.logger.error") as logger_error,
+        ):
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": VALID_VALIDATOR_HOTKEY,
+                    "hotkey_ss58": VALID_HOTKEY_SS58,
+                    "hotkey_seed": VALID_SEED,
+                    "node_name": VALID_NODE_NAME,
+                },
+                headers=self._auth_headers(),
+            )
+
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(
+            response.json()["detail"],
+            "Chutes bridge command 'setup' timed out after 3600s",
+        )
+        self.assertNotIn("exc_info", logger_error.call_args.kwargs)
+        self.assertNotIn("super-secret-seed", str(logger_error.call_args))
+
+    def test_start_unexpected_error_bubbles_to_fastapi(self):
+        with (
+            self._patched_auth(),
+            patch(
+                "routes.apis.ChutesRelayService.start",
+                side_effect=TypeError("programming bug"),
+            ),
+        ):
+            with self.assertRaisesRegex(TypeError, "programming bug"):
+                self.client.post(
+                    "/chutes/start",
+                    json={},
+                    headers=self._auth_headers(),
+                )
+
     def test_stop_happy_path(self):
         with (
-            patch.object(settings, "CHUTES_STAGING_AUTH_BYPASS", True),
+            self._patched_auth(),
             patch(
                 "routes.apis.ChutesRelayService.stop",
                 return_value={"ok": True, "state": "stopped"},
             ),
         ):
-            response = self.client.post("/chutes/stop", json={})
+            response = self.client.post(
+                "/chutes/stop",
+                json={},
+                headers=self._auth_headers(),
+            )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["state"], "stopped")
 
-    def test_auth_bypass_flag_controls_post_routes(self):
-        with patch.object(settings, "CHUTES_STAGING_AUTH_BYPASS", False):
-            response = self.client.post("/chutes/start", json={})
-        self.assertEqual(response.status_code, 422)
+    def test_chutes_routes_bypass_global_miner_middleware(self):
+        with (
+            self._patched_auth(),
+            patch(
+                "routes.apis.ChutesRelayService.start",
+                return_value={"ok": True, "state": "running"},
+            ),
+        ):
+            response = self.client.post(
+                "/chutes/start",
+                json={},
+                headers=self._auth_headers(),
+            )
+        self.assertEqual(response.status_code, 200)
 
 
 if __name__ == "__main__":

--- a/neurons/executor/tests/test_chutes_api.py
+++ b/neurons/executor/tests/test_chutes_api.py
@@ -1,0 +1,111 @@
+import os
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+
+os.environ.setdefault(
+    "MINER_HOTKEY_SS58_ADDRESS",
+    "5D4jX4TqUkZwNwKAjjYrbk2FHFNN2U1TgFF6ZMuNPnjnKJVU",
+)
+os.environ.setdefault("DB_URI", "sqlite:///test.db")
+
+
+class _DummyKeypair:
+    def __init__(self, ss58_address=None):
+        self.ss58_address = ss58_address
+
+    def verify(self, *_args, **_kwargs):
+        return False
+
+
+sys.modules.setdefault("bittensor", types.SimpleNamespace(Keypair=_DummyKeypair))
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from core.config import settings
+from executor import app
+
+
+class TestChutesApi(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(app)
+
+    def test_status_when_bridge_disabled(self):
+        with patch.object(settings, "CHUTES_BRIDGE_ENABLED", False):
+            response = self.client.get("/chutes/status")
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["capability"]["bridge_enabled"])
+        self.assertFalse(payload["capability"]["bridge_accessible"])
+
+    def test_status_when_bridge_reachable(self):
+        status_payload = {
+            "ok": True,
+            "capability": {
+                "bridge_enabled": True,
+                "bridge_accessible": True,
+                "can_install": True,
+            },
+            "bridge": {"ok": True, "state": "not_installed"},
+            "error": None,
+        }
+        with patch("routes.apis.ChutesRelayService.get_status_summary", return_value=status_payload):
+            response = self.client.get("/chutes/status")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["bridge"]["state"], "not_installed")
+
+    def test_install_happy_path(self):
+        with (
+            patch.object(settings, "CHUTES_STAGING_AUTH_BYPASS", True),
+            patch(
+                "routes.apis.ChutesRelayService.install",
+                return_value={"ok": True, "state": "installed_stopped"},
+            ),
+        ):
+            response = self.client.post(
+                "/chutes/install",
+                json={
+                    "validator_hotkey": "validator",
+                    "hotkey_ss58": "hotkey",
+                    "hotkey_seed": "seed",
+                },
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["state"], "installed_stopped")
+
+    def test_start_happy_path(self):
+        with (
+            patch.object(settings, "CHUTES_STAGING_AUTH_BYPASS", True),
+            patch(
+                "routes.apis.ChutesRelayService.start",
+                return_value={"ok": True, "state": "running"},
+            ),
+        ):
+            response = self.client.post("/chutes/start", json={})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["state"], "running")
+
+    def test_stop_happy_path(self):
+        with (
+            patch.object(settings, "CHUTES_STAGING_AUTH_BYPASS", True),
+            patch(
+                "routes.apis.ChutesRelayService.stop",
+                return_value={"ok": True, "state": "stopped"},
+            ),
+        ):
+            response = self.client.post("/chutes/stop", json={})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["state"], "stopped")
+
+    def test_auth_bypass_flag_controls_post_routes(self):
+        with patch.object(settings, "CHUTES_STAGING_AUTH_BYPASS", False):
+            response = self.client.post("/chutes/start", json={})
+        self.assertEqual(response.status_code, 422)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/neurons/executor/tests/test_chutes_bridge_scripts.py
+++ b/neurons/executor/tests/test_chutes_bridge_scripts.py
@@ -1,0 +1,156 @@
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+BRIDGE_BIN_DIR = Path(__file__).resolve().parents[1] / "lium-bridge" / "bin"
+
+
+class TestChutesBridgeScripts(unittest.TestCase):
+    def _write_executable(self, path: Path, content: str) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(content), encoding="utf-8")
+        path.chmod(0o755)
+
+    def _render_script(self, workdir: Path, script_name: str) -> tuple[Path, Path, Path]:
+        bridge_dir = workdir / "opt" / "lium-bridge"
+        log_file = workdir / "var" / "log" / "lium-bridge.log"
+        log_file.parent.mkdir(parents=True, exist_ok=True)
+
+        script = (BRIDGE_BIN_DIR / script_name).read_text(encoding="utf-8")
+        script = script.replace('BRIDGE_DIR="/opt/lium-bridge"', f'BRIDGE_DIR="{bridge_dir}"')
+        script = script.replace(
+            'LOG_FILE="/var/log/lium-bridge.log"',
+            f'LOG_FILE="{log_file}"',
+        )
+
+        script_path = bridge_dir / "bin" / script_name
+        self._write_executable(script_path, script)
+        return script_path, bridge_dir, log_file
+
+    def test_bridgectl_does_not_log_hotkey_seed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workdir = Path(tmpdir)
+            bridgectl_path, bridge_dir, log_file = self._render_script(workdir, "bridgectl")
+
+            self._write_executable(
+                bridge_dir / "bin" / "setup-chutes",
+                """#!/usr/bin/env bash
+                echo '{"ok": true, "state": "installed_stopped"}'
+                """,
+            )
+
+            stub_dir = workdir / "stub-bin"
+            self._write_executable(
+                stub_dir / "sudo",
+                """#!/usr/bin/env bash
+                exec "$@"
+                """,
+            )
+
+            completed = subprocess.run(
+                [str(bridgectl_path), "setup", "--hotkey-seed", "super-secret-seed"],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "PATH": f"{stub_dir}:{os.environ['PATH']}",
+                },
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0)
+            self.assertIn('"ok": true', completed.stdout)
+
+            log_text = log_file.read_text(encoding="utf-8")
+            self.assertIn("Running verb=setup", log_text)
+            self.assertNotIn("super-secret-seed", log_text)
+
+    def test_start_chutes_unhealthy_agent_sets_error_state(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            workdir = Path(tmpdir)
+            start_path, bridge_dir, _ = self._render_script(workdir, "start-chutes")
+            state_file = bridge_dir / "state.json"
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(
+                json.dumps(
+                    {
+                        "state": "installed_stopped",
+                        "gpu_verified": False,
+                        "node_name": "gpu-node-01",
+                        "last_error": None,
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            stub_dir = workdir / "stub-bin"
+            active_flag = workdir / "k3s-active"
+            self._write_executable(
+                stub_dir / "systemctl",
+                f"""#!/usr/bin/env bash
+                if [[ "$1" == "start" && "$2" == "k3s" ]]; then
+                    touch "{active_flag}"
+                    exit 0
+                fi
+
+                if [[ "$1" == "is-active" && "$2" == "k3s" ]]; then
+                    [[ -f "{active_flag}" ]]
+                    exit $?
+                fi
+
+                exit 0
+                """,
+            )
+            self._write_executable(
+                stub_dir / "k3s",
+                """#!/usr/bin/env bash
+                if [[ "$1" == "kubectl" && "$2" == "get" && "$3" == "nodes" ]]; then
+                    echo "gpu-node-01 Ready"
+                    exit 0
+                fi
+
+                if [[ "$1" == "kubectl" && "$2" == "get" && "$3" == "pods" ]]; then
+                    exit 0
+                fi
+
+                exit 0
+                """,
+            )
+            self._write_executable(
+                stub_dir / "sleep",
+                """#!/usr/bin/env bash
+                exit 0
+                """,
+            )
+
+            completed = subprocess.run(
+                [str(start_path)],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "PATH": f"{stub_dir}:{os.environ['PATH']}",
+                },
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 1)
+
+            payload = json.loads(completed.stdout)
+            self.assertFalse(payload["ok"])
+            self.assertEqual(payload["state"], "error")
+            self.assertIn("did not become healthy", payload["error"])
+
+            persisted_state = json.loads(state_file.read_text(encoding="utf-8"))
+            self.assertEqual(persisted_state["state"], "error")
+            self.assertIn("did not become healthy", persisted_state["last_error"])
+            self.assertEqual(persisted_state["node_name"], "gpu-node-01")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/neurons/executor/tests/test_chutes_relay_service.py
+++ b/neurons/executor/tests/test_chutes_relay_service.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../s
 
 from core.config import settings
 from services.chutes_relay_service import (
+    ChutesExecutorError,
     ChutesMalformedResponseError,
     ChutesRelayService,
     ChutesTransportError,
@@ -73,6 +74,27 @@ class TestChutesRelayService(unittest.TestCase):
             payload = self.service.status()
         self.assertEqual(payload["state"], "not_installed")
 
+    def test_status_preserves_escaped_last_error(self):
+        completed = subprocess.CompletedProcess(
+            args=["ssh"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "ok": True,
+                    "state": "error",
+                    "last_error": 'bad "quote" and slash \\\\ content',
+                }
+            ),
+            stderr="",
+        )
+        with (
+            patch.object(settings, "CHUTES_BRIDGE_ENABLED", True),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_HOST", "127.0.0.1"),
+            patch("services.chutes_relay_service.subprocess.run", return_value=completed),
+        ):
+            payload = self.service.status()
+        self.assertEqual(payload["last_error"], 'bad "quote" and slash \\\\ content')
+
     def test_transport_failure_is_raised(self):
         completed = subprocess.CompletedProcess(
             args=["ssh"],
@@ -102,6 +124,46 @@ class TestChutesRelayService(unittest.TestCase):
         ):
             with self.assertRaises(ChutesMalformedResponseError):
                 self.service.status()
+
+    def test_ok_false_payload_is_raised_as_executor_error(self):
+        completed = subprocess.CompletedProcess(
+            args=["ssh"],
+            returncode=0,
+            stdout=json.dumps({"ok": False, "state": "error", "error": "agent unhealthy"}),
+            stderr="",
+        )
+        with (
+            patch.object(settings, "CHUTES_BRIDGE_ENABLED", True),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_HOST", "127.0.0.1"),
+            patch("services.chutes_relay_service.subprocess.run", return_value=completed),
+        ):
+            with self.assertRaisesRegex(ChutesExecutorError, "agent unhealthy"):
+                self.service.status()
+
+    def test_install_timeout_is_sanitized_and_has_no_cause(self):
+        timeout_error = subprocess.TimeoutExpired(
+            cmd=["ssh", "bridgectl", "setup", "--hotkey-seed", "super-secret-seed"],
+            timeout=self.service.INSTALL_TIMEOUT_SEC,
+        )
+        with (
+            patch.object(settings, "CHUTES_BRIDGE_ENABLED", True),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_HOST", "127.0.0.1"),
+            patch("services.chutes_relay_service.subprocess.run", side_effect=timeout_error),
+        ):
+            with self.assertRaises(ChutesExecutorError) as exc_info:
+                self.service.install(
+                    validator_hotkey="validator",
+                    hotkey_ss58="miner",
+                    hotkey_seed="super-secret-seed",
+                    node_name="gpu-node-01",
+                )
+
+        self.assertEqual(
+            str(exc_info.exception),
+            "Chutes bridge command 'setup' timed out after 3600s",
+        )
+        self.assertIsNone(exc_info.exception.__cause__)
+        self.assertNotIn("super-secret-seed", str(exc_info.exception))
 
 
 if __name__ == "__main__":

--- a/neurons/executor/tests/test_chutes_relay_service.py
+++ b/neurons/executor/tests/test_chutes_relay_service.py
@@ -1,0 +1,108 @@
+import json
+import os
+import subprocess
+import sys
+import unittest
+from unittest.mock import patch
+
+
+os.environ.setdefault(
+    "MINER_HOTKEY_SS58_ADDRESS",
+    "5D4jX4TqUkZwNwKAjjYrbk2FHFNN2U1TgFF6ZMuNPnjnKJVU",
+)
+os.environ.setdefault("DB_URI", "sqlite:///test.db")
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../src")))
+
+from core.config import settings
+from services.chutes_relay_service import (
+    ChutesMalformedResponseError,
+    ChutesRelayService,
+    ChutesTransportError,
+)
+
+
+class TestChutesRelayService(unittest.TestCase):
+    def setUp(self):
+        self.service = ChutesRelayService()
+
+    def test_build_bridge_command(self):
+        with (
+            patch.object(settings, "CHUTES_BRIDGE_ENABLED", True),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_HOST", "127.0.0.1"),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_PORT", 2222),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_USER", "lium-bridge"),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_KEY_PATH", "/tmp/key"),
+            patch.object(settings, "CHUTES_BRIDGE_CONNECT_TIMEOUT_SEC", 7),
+        ):
+            command = self.service.build_bridge_command("start")
+        self.assertEqual(
+            command,
+            [
+                "ssh",
+                "-i",
+                "/tmp/key",
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "IdentitiesOnly=yes",
+                "-o",
+                "StrictHostKeyChecking=yes",
+                "-o",
+                "ConnectTimeout=7",
+                "-p",
+                "2222",
+                "lium-bridge@127.0.0.1",
+                "bridgectl",
+                "start",
+            ],
+        )
+
+    def test_status_parses_valid_json(self):
+        completed = subprocess.CompletedProcess(
+            args=["ssh"],
+            returncode=0,
+            stdout=json.dumps({"ok": True, "state": "not_installed"}),
+            stderr="",
+        )
+        with (
+            patch.object(settings, "CHUTES_BRIDGE_ENABLED", True),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_HOST", "127.0.0.1"),
+            patch("services.chutes_relay_service.subprocess.run", return_value=completed),
+        ):
+            payload = self.service.status()
+        self.assertEqual(payload["state"], "not_installed")
+
+    def test_transport_failure_is_raised(self):
+        completed = subprocess.CompletedProcess(
+            args=["ssh"],
+            returncode=255,
+            stdout="",
+            stderr="ssh: connect to host 127.0.0.1 port 22: Connection refused",
+        )
+        with (
+            patch.object(settings, "CHUTES_BRIDGE_ENABLED", True),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_HOST", "127.0.0.1"),
+            patch("services.chutes_relay_service.subprocess.run", return_value=completed),
+        ):
+            with self.assertRaises(ChutesTransportError):
+                self.service.status()
+
+    def test_malformed_json_is_rejected(self):
+        completed = subprocess.CompletedProcess(
+            args=["ssh"],
+            returncode=0,
+            stdout="not-json",
+            stderr="",
+        )
+        with (
+            patch.object(settings, "CHUTES_BRIDGE_ENABLED", True),
+            patch.object(settings, "CHUTES_BRIDGE_SSH_HOST", "127.0.0.1"),
+            patch("services.chutes_relay_service.subprocess.run", return_value=completed),
+        ):
+            with self.assertRaises(ChutesMalformedResponseError):
+                self.service.status()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

### Task Link

[DAH-1866](https://www.notion.so/DAH-1866)

---

This PR adds **Phase 1 of the Lium ↔ Chutes Bridge**: a narrow relay that lets an operator switch a GPU machine between Lium executor mode and Chutes K3s mining mode — all without giving the executor daemon root access to the host.

**Core idea:** the Dockerized executor exposes four new HTTP endpoints (`/chutes/*`) that forward commands over a restricted SSH channel to a host-level control surface called `lium-bridge`. The bridge installs/starts/stops K3s + Chutes Helm charts and reports state as JSON. Node registration in Chutes (the `add-node` step) is handled separately by an external control-plane service (`chutes-host`) — the executor is never in the loop for that.

---

## Problem

Running Chutes GPU mining on a machine that is also registered as a Lium executor requires:

1. Installing K3s + Chutes Helm charts on the **bare host** (not inside the executor container).
2. Starting/stopping that stack on demand.
3. Keeping the executor container strictly unprivileged — it must not have arbitrary root access to the host.

There was no automated path to do this. Operators had to SSH manually and run host scripts by hand.

## Solution

### What gets installed on the GPU host — `lium-bridge`

A one-time installer (`install_chutes_bridge.sh`) bootstraps a restricted control surface under `/opt/lium-bridge/`:

- Creates a dedicated unprivileged OS user `lium-bridge`.
- Configures SSH `ForceCommand bridgectl` — the only thing this user can do over SSH is run `bridgectl`.
- Grants only the specific `sudo` rights bridgectl needs (install K3s, start/stop, status).

`bridgectl` is a dispatcher that routes to per-verb scripts:

| Script | What it does |
|---|---|
| `setup-chutes` | Installs K3s, Helm, NVIDIA GPU Operator, Chutes Helm charts; stores miner hotkey; saves `state=installed_stopped` |
| `start-chutes` | Starts K3s, waits for node Ready (2 min) + agent pod healthy (3 min); saves `state=running` |
| `stop-chutes` | Drains Chutes workload pods (60 s grace), stops K3s; saves `state=stopped` |
| `status` | Read-only health check: K3s active, agent pod, pod count, disk free |
| `uninstall-chutes` | Removes Helm releases, runs `k3s-uninstall.sh`, restores `state=not_installed` |

State is persisted in `/opt/lium-bridge/state.json`. All commands return JSON on stdout.

### How the executor connects to `lium-bridge`

The executor container reaches the bridge via SSH to `host.docker.internal` (mapped via `extra_hosts: host-gateway`), authenticating with a dedicated key mounted as a Docker secret. `StrictHostKeyChecking=yes` and `BatchMode=yes` are enforced.

```mermaid
flowchart TB
    subgraph gpu ["GPU Machine — 216.243.220.52"]
        direction TB
        subgraph docker ["Docker container"]
            exec["Executor API :8001"]
        end
        subgraph hostOS ["Host OS"]
            bridge["lium-bridge\n(SSH ForceCommand bridgectl)\n/opt/lium-bridge"]
            k3s["K3s standalone cluster\n+ Chutes Agent :32000"]
        end
        docker -->|"SSH host.docker.internal:22\n(dedicated key, ForceCommand only)"| hostOS
        bridge -->|"install / start / stop\nsystemd + helm\n(generates miner kubeconfig)"| k3s
    end

    subgraph cpu ["CPU Control Host — 100.52.69.174"]
        gepetto["Miner API + Gepetto scheduler\n:32000"]
    end

    chutes["Chutes validators\n(api.chutes.ai)"]
    chutes -->|"WebSocket\njob requests"| gepetto
    gepetto -->|"kubectl via miner kubeconfig\n(schedule + deploy workloads)"| k3s
```

### New executor API endpoints

| Method | Path | Delegates to |
|---|---|---|
| `GET` | `/chutes/status` | `bridgectl status` — always returns 200 with capability flags |
| `POST` | `/chutes/install` | `bridgectl setup --validator-hotkey … --hotkey-ss58 … --hotkey-seed … --node-name …` |
| `POST` | `/chutes/start` | `bridgectl start` |
| `POST` | `/chutes/stop` | `bridgectl stop` |

`GET /chutes/status` returns capability flags even when the bridge is disabled or unreachable, so callers can always probe without errors:

```json
{
  "ok": true,
  "capability": { "bridge_enabled": true, "bridge_accessible": true, "can_install": true },
  "bridge": { "state": "running", "k3s_active": true, "agent_healthy": true },
  "error": null
}
```

### End-to-end happy path (lium-backend → Chutes registered)

```mermaid
sequenceDiagram
    participant OPS as lium-backend<br/>(compute-app)
    participant EXEC as Executor :8001<br/>(GPU machine)
    participant BR as lium-bridge / bridgectl<br/>(GPU host OS)
    participant K3S as K3s + Chutes Agent<br/>(GPU host OS, :32000)
    participant NM as chutes-host + Miner API<br/>(CPU control host, out of scope)

    OPS->>EXEC: GET /chutes/status
    EXEC->>BR: ssh lium-bridge bridgectl status
    BR-->>EXEC: { state: "not_installed" }
    EXEC-->>OPS: capability + bridge state

    OPS->>EXEC: POST /chutes/install (hotkeys + node_name)
    EXEC->>BR: bridgectl setup --validator-hotkey … --node-name …
    BR->>K3S: install K3s + GPU Operator + Chutes charts
    BR-->>EXEC: { ok: true, state: "installed_stopped" }

    OPS->>EXEC: POST /chutes/start
    EXEC->>BR: bridgectl start
    BR->>K3S: start, wait for agent healthy
    BR-->>EXEC: { ok: true, state: "running" }

    Note over OPS,NM: Node registration is handled outside the executor (out of scope for this PR)
    OPS->>NM: PUT /nodes/ → POST /servers/ SSE
    NM-->>OPS: 202 + request_id, poll until completed
```

## Changes

- **`neurons/executor/lium-bridge/`** — new directory shipped alongside executor; contains `install_chutes_bridge.sh` + all `bridgectl` / `bin/` scripts
- **`src/services/chutes_relay_service.py`** — new `ChutesRelayService` class: builds SSH command, runs it via `subprocess`, parses JSON from stdout (handles helm/k3s noise before the JSON block), classifies errors into typed exceptions
- **`src/routes/apis.py`** — four new `/chutes/*` endpoints wired to `ChutesRelayService`; error translation maps typed exceptions to appropriate HTTP status codes (409 / 502 / 500)
- **`src/payloads/chutes.py`** — `ChutesInstallPayload` and `ChutesCommandPayload` Pydantic models
- **`src/core/config.py`** — `CHUTES_BRIDGE_*` settings + `CHUTES_STAGING_AUTH_BYPASS`
- **`src/middlewares/miner.py`** — staging auth bypass for `/chutes/install|start|stop` when `CHUTES_STAGING_AUTH_BYPASS=true`
- **`.env.template`** — documents all new env vars
- **`docker-compose.chutes-stage.override.yml`** — compose override for staging: mounts SSH key secret, known\_hosts, adds `host-gateway`
- **`tests/test_chutes_api.py`** + **`tests/test_chutes_relay_service.py`** — unit tests for API layer and relay service




## Risks

- **SSH key exposure** — the bridge SSH key is mounted as a Docker secret. If the executor container is compromised, the attacker can run `bridgectl` commands. Blast radius is limited to the allowlisted sudo scripts (no arbitrary root).
- **`CHUTES_STAGING_AUTH_BYPASS=true` must never reach production** — it bypasses miner signature verification for `/chutes/*`. The flag is `false` by default and guarded by a comment in `.env.template`.
- **Host-kernel dependency** — `setup-chutes` installs K3s and the NVIDIA GPU Operator. If the host has an unexpected kernel or NVIDIA driver version mismatch, setup can fail and leave the bridge in `state=error`. Manual recovery via `bridgectl uninstall` + re-run is required.
- **Executor container restart does not affect K3s** — K3s runs directly on the host. This is intentional but means K3s can be running even when the executor is down.

