### PR TITLE
Close stale subtensor websockets - DAH-1964

### DIFF
--- a/neurons/validators/src/clients/subtensor_client.py
+++ b/neurons/validators/src/clients/subtensor_client.py
@@ -26,6 +26,33 @@ SUBTENSOR_BACKOFF_INITIAL = 12
 SUBTENSOR_BACKOFF_MAX = 300
 
 
+def _close_subtensor_safely(subtensor) -> None:
+    """Close a bittensor.subtensor and its substrate/WS independently.
+
+    Why: the leaking-mid-rate-limit case can leave the WS in a half-broken
+    state where one close path raises while a sibling still works; we want
+    to drive the TCP FIN through whichever path still functions.
+    """
+    if subtensor is None:
+        return
+    try:
+        subtensor.close()
+    except Exception:
+        pass
+    substrate = getattr(subtensor, "substrate", None)
+    if substrate is not None:
+        try:
+            substrate.close()
+        except Exception:
+            pass
+        ws = getattr(substrate, "ws", None)
+        if ws is not None:
+            try:
+                ws.close()
+            except Exception:
+                pass
+
+
 @contextlib.contextmanager
 def _log_sync_block(name: str, *, extra: dict | None = None):
     """Time a synchronous call that runs inside the asyncio event loop. Emits a single
@@ -143,6 +170,7 @@ class SubtensorClient:
         return SubtensorClient._subtensor
 
     def initialize_subtensor(self):
+        new_subtensor = None
         try:
             logger.info(
                 _m(
@@ -150,12 +178,18 @@ class SubtensorClient:
                     extra=get_extra_info(self.default_extra),
                 ),
             )
-            subtensor = bittensor.subtensor(config=self.config)
+            new_subtensor = bittensor.subtensor(config=self.config)
 
             # check registered
-            self.check_registered(subtensor)
+            self.check_registered(new_subtensor)
 
-            SubtensorClient._subtensor = subtensor
+            old_subtensor = SubtensorClient._subtensor
+            SubtensorClient._subtensor = new_subtensor
+            # Hand-off complete; clear local ref so the finally block does not
+            # close the now-installed instance.
+            new_subtensor = None
+            if old_subtensor is not None:
+                _close_subtensor_safely(old_subtensor)
         except Exception as e:
             logger.error(
                 _m(
@@ -169,6 +203,11 @@ class SubtensorClient:
                 ),
                 exc_info=True,
             )
+        finally:
+            # If construction succeeded but install failed, close the orphan
+            # before its WS becomes a zombie counted against our source-IP cap.
+            if new_subtensor is not None:
+                _close_subtensor_safely(new_subtensor)
 
     def set_subtensor(self):
         if (

--- a/neurons/validators/tests/fixtures/incentive_fixtures.py
+++ b/neurons/validators/tests/fixtures/incentive_fixtures.py
@@ -41,6 +41,7 @@ def mock_settings(monkeypatch):
     monkeypatch.setattr(settings, "NEW_BURNERS", [100, 101])
     monkeypatch.setattr(settings, "ENABLE_NEW_BURN_LOGIC", True)
     monkeypatch.setattr(settings, "DRY_RUN", False)
+    monkeypatch.setattr(settings, "SKIP_COLLATERAL_PENALTY", False)
     monkeypatch.setattr(settings, "incentive", IncentiveConfig(
         algorithm="default",
     ))

--- a/neurons/validators/tests/prod_snapshot/test_prod_snapshot_incentive.py
+++ b/neurons/validators/tests/prod_snapshot/test_prod_snapshot_incentive.py
@@ -131,6 +131,11 @@ def prod_settings(monkeypatch, prod_snapshot: dict) -> None:
     monkeypatch.setattr(settings, "BURNERS", s["BURNERS"])
     monkeypatch.setattr(settings, "NEW_BURNERS", s["NEW_BURNERS"])
     monkeypatch.setattr(settings, "ENABLE_NEW_BURN_LOGIC", s["ENABLE_NEW_BURN_LOGIC"])
+    monkeypatch.setattr(
+        settings,
+        "SKIP_COLLATERAL_PENALTY",
+        s.get("SKIP_COLLATERAL_PENALTY", False),
+    )
     monkeypatch.setattr(settings, "incentive", IncentiveConfig(algorithm="default"))
 
 


### PR DESCRIPTION
## Describe your changes

- Add safe subtensor cleanup that attempts to close the subtensor, substrate, and underlying websocket independently.
- Close the previous validator subtensor instance after a successful replacement.
- Close a newly constructed subtensor if initialization fails before it is installed.

Related DAH-1964 PRs:
- Datura-ai/lium-io-backend#592
- Datura-ai/lium-miner-portal#119

## Issue ticket number and link

[DAH-1964](https://www.notion.so/DAH-1964)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests.
- [ ] Need to take care of performance?