### PR TITLE
DAH-1645: show executor tier in miner CLI

### DIFF
--- a/datura/datura/requests/miner_requests.py
+++ b/datura/datura/requests/miner_requests.py
@@ -52,6 +52,7 @@ class ExecutorSSHInfo(pydantic.BaseModel):
     price_per_gpu: float | None = None
     ssh_host_key: str | None = None
     tdx_quote: str | None = None
+    tier: str | None = None
 
 
 class AcceptSSHKeyRequest(BaseMinerRequest):

--- a/neurons/miners/migrations/versions/a7c3d1f80e21_executor_tier.py
+++ b/neurons/miners/migrations/versions/a7c3d1f80e21_executor_tier.py
@@ -1,0 +1,38 @@
+"""Executor tier column
+
+Adds a ``tier`` column to the executor table so the miner CLI can surface
+whether each executor is ``secure`` or ``spot`` (DAH-1645). Defaults to
+``"secure"`` to keep legacy rows valid.
+
+Revision ID: a7c3d1f80e21
+Revises: 33be5b1944a8
+Create Date: 2026-05-14 08:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = "a7c3d1f80e21"
+down_revision: Union[str, None] = "33be5b1944a8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "executor",
+        sa.Column(
+            "tier",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'secure'"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("executor", "tier")

--- a/neurons/miners/src/daos/executor.py
+++ b/neurons/miners/src/daos/executor.py
@@ -69,6 +69,8 @@ class ExecutorDao(BaseDao):
         existing_executor.address = executor.address
         existing_executor.port = executor.port
         existing_executor.price_per_gpu = executor.price_per_gpu
+        if executor.tier:
+            existing_executor.tier = executor.tier
         self.session.commit()
         self.session.refresh(existing_executor)
         return existing_executor

--- a/neurons/miners/src/models/executor.py
+++ b/neurons/miners/src/models/executor.py
@@ -15,6 +15,9 @@ class Executor(SQLModel, table=True):
     validator: str
     price_per_hour: float | None = None
     price_per_gpu: float | None = None
+    # Mirrors the tier the provider chose in the Portal; "secure" is the
+    # marketplace default so legacy rows that never received a sync stay valid.
+    tier: str = Field(default="secure", nullable=False, max_length=16)
 
     def __str__(self):
         return f"{self.address}:{self.port}"

--- a/neurons/miners/src/protocol/miner_portal_request.py
+++ b/neurons/miners/src/protocol/miner_portal_request.py
@@ -56,6 +56,7 @@ class SyncExecutorPayload(BaseModel):
     address: str
     port: int
     price_per_gpu: float | None = None
+    tier: str | None = None
 
 
 class AddExecutorRequest(BaseMinerPortalRequest):

--- a/neurons/miners/src/services/cli_service.py
+++ b/neurons/miners/src/services/cli_service.py
@@ -536,12 +536,18 @@ class CliService:
                     "address": executor.address,
                     "port": executor.port,
                     "validator": executor.validator,
-                    "price_per_gpu": executor.price_per_gpu
+                    "price_per_gpu": executor.price_per_gpu,
+                    "tier": (executor.tier or "secure"),
                 }
                 for executor in executors
             ]
             for ex in result:
-                self.logger.info(f"{ex['uuid']} {ex['address']}:{ex['port']} -> validator: {ex['validator']}, price_per_gpu (USD/gpu/h): {ex['price_per_gpu']}")
+                self.logger.info(
+                    f"{ex['uuid']} {ex['address']}:{ex['port']} -> "
+                    f"validator: {ex['validator']}, "
+                    f"price_per_gpu (USD/gpu/h): {ex['price_per_gpu']}, "
+                    f"tier: {ex['tier']}"
+                )
             return True
         except Exception as e:
             self.logger.error("Failed in showing an executor: %s", str(e))

--- a/neurons/miners/src/services/executor_service.py
+++ b/neurons/miners/src/services/executor_service.py
@@ -118,6 +118,7 @@ class ExecutorService:
                 address=payload.executor.address,
                 port=payload.executor.port,
                 price_per_gpu=payload.executor.price_per_gpu,
+                tier=payload.executor.tier or "secure",
             )
             self.executor_dao.update_by_uuid(executor.uuid, executor)
 


### PR DESCRIPTION
## Describe your changes

- Adds a `tier` column to the miner `Executor` model with an alembic migration (default `'secure'` so legacy rows stay valid).
- Threads `tier` through `SyncExecutorPayload` in both protocol copies (datura `miner_requests.py` + miners `miner_portal_request.py`).
- Miner `executor_service.update` and `ExecutorDao.update_by_uuid` apply tier from `UpdateExecutorRequest`.
- `lium provider show-executors` now prints `tier: secure|spot` per executor, so providers can audit tier assignments without bouncing through the Portal UI.

Paired backend change: Datura-ai/lium-miner-portal `feat/DAH-1645-immediate-price-updates` populates the new field in all three `SyncExecutorPayload` construction sites in `miner_consumer.py`.

## Issue ticket number and link

[DAH-1645 — BE/FE Pending price flow for Pod price update](https://www.notion.so/BE-FE-Pending-price-flow-for-Pod-price-update-2bcb8bfdbde98060bb49f256bb39ef64)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests. (miner pytest suite 14/14 pass; validator suite 9/9 pass)
- [ ] Need to take care of performance? No — single string column read on CLI list path; no extra queries.