### PR TITLE
DAH-2090, add forced executor validation endpoint

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -102,6 +102,9 @@ class Settings(BaseSettings):
     INTERNAL_PORT: int = Field(env="INTERNAL_PORT", default=8000)
     BLOCKS_FOR_JOB: int = 75  # 15 minutes
     JOB_TIME_OUT: int = 60 * 15  # 15 minutes
+    FORCED_VALIDATION_INTERNAL_TOKEN: str | None = Field(
+        env="FORCED_VALIDATION_INTERNAL_TOKEN", default=None
+    )
 
     REDIS_HOST: str = Field(env="REDIS_HOST", default="localhost")
     REDIS_PORT: int = Field(env="REDIS_PORT", default=6379)

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -23,6 +23,7 @@ from services.executor_connectivity.port_tester import PortTester
 from services.executor_connectivity.port_verifiers import BatchVerifier, FallbackVerifier
 from services.executor_connectivity_service import ExecutorConnectivityService
 from services.file_encrypt_service import FileEncryptService
+from services.forced_validation import ForceValidationRequestStore, ForceValidationService
 from services.matrix_validation_service import ValidationService
 from services.miner_service import MinerService
 from services.redis_service import GPU_ESTIMATES_CHANNEL, PENDING_PODS_PREFIX, RedisService
@@ -107,6 +108,13 @@ class Validator:
             task_service=task_service,
             redis_service=self.redis_service,
             attestation_service=self.attestation_service,
+        )
+        self.force_validation_service = ForceValidationService(
+            store=ForceValidationRequestStore(self.redis_service),
+            miner_service=self.miner_service,
+            subtensor_client=self.subtensor_client,
+            backend_client=self.backend_client,
+            file_encrypt_service=self.file_encrypt_service,
         )
 
         # init miner_scores: always load from Redis if present so accumulated

--- a/neurons/validators/src/payload_models/forced_validation.py
+++ b/neurons/validators/src/payload_models/forced_validation.py
@@ -1,0 +1,36 @@
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+ForceValidationStatus = Literal["queued", "running", "succeeded", "failed"]
+
+
+class ForceValidationCreateRequest(BaseModel):
+    executor_id: str
+    miner_hotkey: str
+
+
+class ForceValidationResult(BaseModel):
+    success: bool
+    message: str | None = None
+    score: float | None = None
+    job_score: float | None = None
+    gpu_model: str | None = None
+    gpu_count: int | None = None
+
+
+class ForceValidationError(BaseModel):
+    message: str
+
+
+class ForceValidationRequestRecord(BaseModel):
+    request_id: str
+    executor_id: str
+    miner_hotkey: str
+    status: ForceValidationStatus
+    stage: str
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    result: ForceValidationResult | None = None
+    error: ForceValidationError | None = None

--- a/neurons/validators/src/services/forced_validation.py
+++ b/neurons/validators/src/services/forced_validation.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 FORCED_VALIDATION_REQUEST_PREFIX = "forced_validation:request"
 FORCED_VALIDATION_ACTIVE_PREFIX = "forced_validation:active_executor"
+FORCED_VALIDATION_LATEST_PREFIX = "forced_validation:latest_executor"
 DEFAULT_REQUEST_TTL_SECONDS = 24 * 60 * 60
 
 
@@ -52,6 +53,9 @@ class ForceValidationRequestStore:
 
     def _active_key(self, executor_id: str) -> str:
         return f"{FORCED_VALIDATION_ACTIVE_PREFIX}:{executor_id}"
+
+    def _latest_key(self, executor_id: str) -> str:
+        return f"{FORCED_VALIDATION_LATEST_PREFIX}:{executor_id}"
 
     async def create_request(
         self, *, executor_id: str, miner_hotkey: str
@@ -83,6 +87,14 @@ class ForceValidationRequestStore:
         if isinstance(raw, bytes):
             raw = raw.decode("utf-8")
         return ForceValidationRequestRecord.model_validate_json(raw)
+
+    async def get_latest_request(self, executor_id: str) -> ForceValidationRequestRecord:
+        request_id = await self.redis_service.redis.get(self._latest_key(executor_id))
+        if request_id is None:
+            raise ForceValidationNotFound()
+        if isinstance(request_id, bytes):
+            request_id = request_id.decode("utf-8")
+        return await self.get_request(request_id)
 
     async def update(
         self,
@@ -125,6 +137,11 @@ class ForceValidationRequestStore:
             record.model_dump_json(),
             ex=self.request_ttl_seconds,
         )
+        await self.redis_service.redis.set(
+            self._latest_key(record.executor_id),
+            record.request_id,
+            ex=self.request_ttl_seconds,
+        )
 
 
 class ForceValidationService:
@@ -157,6 +174,9 @@ class ForceValidationService:
 
     async def get_request(self, request_id: str) -> ForceValidationRequestRecord:
         return await self.store.get_request(request_id)
+
+    async def get_latest_request(self, executor_id: str) -> ForceValidationRequestRecord:
+        return await self.store.get_latest_request(executor_id)
 
     async def validate(self, request_id: str) -> ForceValidationRequestRecord:
         record = await self.store.get_request(request_id)

--- a/neurons/validators/src/services/forced_validation.py
+++ b/neurons/validators/src/services/forced_validation.py
@@ -91,12 +91,17 @@ class ForceValidationRequestStore:
         return ForceValidationRequestRecord.model_validate_json(raw)
 
     async def get_latest_request(self, executor_id: str) -> ForceValidationRequestRecord:
-        request_id = await self.redis_service.redis.get(self._latest_key(executor_id))
+        latest_key = self._latest_key(executor_id)
+        request_id = await self.redis_service.redis.get(latest_key)
         if request_id is None:
             raise ForceValidationNotFound()
         if isinstance(request_id, bytes):
             request_id = request_id.decode("utf-8")
-        return await self.get_request(request_id)
+        record = await self.get_request(request_id)
+        if record.status in TERMINAL_STATUSES:
+            await self._delete_latest_pointer(latest_key, record.request_id)
+            raise ForceValidationNotFound()
+        return record
 
     async def update(
         self,
@@ -141,11 +146,7 @@ class ForceValidationRequestStore:
             ex=self.request_ttl_seconds,
         )
         if record.status in TERMINAL_STATUSES:
-            latest_request_id = await self.redis_service.redis.get(latest_key)
-            if isinstance(latest_request_id, bytes):
-                latest_request_id = latest_request_id.decode("utf-8")
-            if latest_request_id == record.request_id:
-                await self.redis_service.redis.delete(latest_key)
+            await self._delete_latest_pointer(latest_key, record.request_id)
             return
 
         await self.redis_service.redis.set(
@@ -153,6 +154,13 @@ class ForceValidationRequestStore:
             record.request_id,
             ex=self.request_ttl_seconds,
         )
+
+    async def _delete_latest_pointer(self, latest_key: str, request_id: str) -> None:
+        latest_request_id = await self.redis_service.redis.get(latest_key)
+        if isinstance(latest_request_id, bytes):
+            latest_request_id = latest_request_id.decode("utf-8")
+        if latest_request_id == request_id:
+            await self.redis_service.redis.delete(latest_key)
 
 
 class ForceValidationService:

--- a/neurons/validators/src/services/forced_validation.py
+++ b/neurons/validators/src/services/forced_validation.py
@@ -1,0 +1,242 @@
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from datetime import UTC, datetime
+from uuid import uuid4
+
+from payload_models.forced_validation import (
+    ForceValidationError,
+    ForceValidationRequestRecord,
+    ForceValidationResult,
+)
+from payload_models.payloads import MinerJobRequestPayload
+
+from clients.backend_client import BackendClient
+from clients.subtensor_client import SubtensorClient
+from core.config import settings
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.file_encrypt_service import FileEncryptService
+from services.miner_service import MinerService
+from services.redis_service import RedisService
+from services.task_service import JobResult
+
+logger = logging.getLogger(__name__)
+
+FORCED_VALIDATION_REQUEST_PREFIX = "forced_validation:request"
+FORCED_VALIDATION_ACTIVE_PREFIX = "forced_validation:active_executor"
+DEFAULT_REQUEST_TTL_SECONDS = 24 * 60 * 60
+
+
+class ForceValidationConflict(Exception):
+    pass
+
+
+class ForceValidationNotFound(Exception):
+    pass
+
+
+class ForceValidationRequestStore:
+    def __init__(
+        self,
+        redis_service: RedisService,
+        *,
+        request_ttl_seconds: int = DEFAULT_REQUEST_TTL_SECONDS,
+        active_ttl_seconds: int | None = None,
+    ):
+        self.redis_service = redis_service
+        self.request_ttl_seconds = request_ttl_seconds
+        self.active_ttl_seconds = active_ttl_seconds or settings.JOB_TIME_OUT + 600
+
+    def _request_key(self, request_id: str) -> str:
+        return f"{FORCED_VALIDATION_REQUEST_PREFIX}:{request_id}"
+
+    def _active_key(self, executor_id: str) -> str:
+        return f"{FORCED_VALIDATION_ACTIVE_PREFIX}:{executor_id}"
+
+    async def create_request(
+        self, *, executor_id: str, miner_hotkey: str
+    ) -> ForceValidationRequestRecord:
+        request_id = str(uuid4())
+        active_created = await self.redis_service.redis.set(
+            self._active_key(executor_id),
+            request_id,
+            nx=True,
+            ex=self.active_ttl_seconds,
+        )
+        if not active_created:
+            raise ForceValidationConflict()
+
+        record = ForceValidationRequestRecord(
+            request_id=request_id,
+            executor_id=executor_id,
+            miner_hotkey=miner_hotkey,
+            status="queued",
+            stage="queued",
+        )
+        await self._save(record)
+        return record
+
+    async def get_request(self, request_id: str) -> ForceValidationRequestRecord:
+        raw = await self.redis_service.redis.get(self._request_key(request_id))
+        if raw is None:
+            raise ForceValidationNotFound()
+        if isinstance(raw, bytes):
+            raw = raw.decode("utf-8")
+        return ForceValidationRequestRecord.model_validate_json(raw)
+
+    async def update(
+        self,
+        request_id: str,
+        *,
+        status: str | None = None,
+        stage: str | None = None,
+        result: ForceValidationResult | None = None,
+        error: ForceValidationError | None = None,
+    ) -> ForceValidationRequestRecord:
+        record = await self.get_request(request_id)
+        update_data = {}
+        if status is not None:
+            update_data["status"] = status
+        if stage is not None:
+            update_data["stage"] = stage
+        if result is not None:
+            update_data["result"] = result
+            update_data["error"] = None
+        if error is not None:
+            update_data["error"] = error
+            update_data["result"] = None
+        updated = record.model_copy(
+            update={**update_data, "updated_at": datetime.now(UTC)}
+        )
+        await self._save(updated)
+        return updated
+
+    async def release_active_executor(self, executor_id: str, request_id: str) -> None:
+        active_key = self._active_key(executor_id)
+        active_request_id = await self.redis_service.redis.get(active_key)
+        if isinstance(active_request_id, bytes):
+            active_request_id = active_request_id.decode("utf-8")
+        if active_request_id == request_id:
+            await self.redis_service.redis.delete(active_key)
+
+    async def _save(self, record: ForceValidationRequestRecord) -> None:
+        await self.redis_service.redis.set(
+            self._request_key(record.request_id),
+            record.model_dump_json(),
+            ex=self.request_ttl_seconds,
+        )
+
+
+class ForceValidationService:
+    def __init__(
+        self,
+        *,
+        store: ForceValidationRequestStore,
+        miner_service: MinerService,
+        subtensor_client: SubtensorClient,
+        backend_client: BackendClient,
+        file_encrypt_service: FileEncryptService,
+        task_factory: Callable[[Coroutine], asyncio.Task] = asyncio.create_task,
+    ):
+        self.store = store
+        self.miner_service = miner_service
+        self.subtensor_client = subtensor_client
+        self.backend_client = backend_client
+        self.file_encrypt_service = file_encrypt_service
+        self.task_factory = task_factory
+
+    async def create_request(
+        self, executor_id: str, miner_hotkey: str
+    ) -> ForceValidationRequestRecord:
+        record = await self.store.create_request(
+            executor_id=executor_id,
+            miner_hotkey=miner_hotkey,
+        )
+        self.task_factory(self.validate(record.request_id))
+        return record
+
+    async def get_request(self, request_id: str) -> ForceValidationRequestRecord:
+        return await self.store.get_request(request_id)
+
+    async def validate(self, request_id: str) -> ForceValidationRequestRecord:
+        record = await self.store.get_request(request_id)
+        try:
+            await self.store.update(
+                request_id,
+                status="running",
+                stage="resolving_miner",
+            )
+            miner = await self._resolve_miner(record.miner_hotkey)
+
+            await self.store.update(request_id, stage="preparing_validation")
+            rented_data = await self.backend_client.get_all_rented_executors()
+            if rented_data is None:
+                rented_data = RentedExecutorsResponse(executors={})
+            encrypted_files = self.file_encrypt_service.ecrypt_miner_job_files()
+
+            payload = MinerJobRequestPayload(
+                job_batch_id=f"forced-{request_id}",
+                miner_hotkey=miner.hotkey,
+                miner_coldkey=miner.coldkey,
+                miner_address=miner.axon_info.ip,
+                miner_port=miner.axon_info.port,
+            )
+
+            await self.store.update(request_id, stage="running_validation")
+            result = await self.miner_service.request_single_executor_validation(
+                payload=payload,
+                encrypted_files=encrypted_files,
+                rented_data=rented_data,
+                executor_id=record.executor_id,
+            )
+
+            await self.store.update(request_id, stage="finalizing")
+            await self.miner_service.publish_machine_specs(
+                [result],
+                record.miner_hotkey,
+                miner.coldkey,
+            )
+
+            terminal_result = self._build_terminal_result(result)
+            return await self.store.update(
+                request_id,
+                status="succeeded" if terminal_result.success else "failed",
+                stage="completed",
+                result=terminal_result,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Forced validation failed",
+                extra={
+                    "request_id": request_id,
+                    "executor_id": record.executor_id,
+                    "miner_hotkey": record.miner_hotkey,
+                },
+            )
+            return await self.store.update(
+                request_id,
+                status="failed",
+                stage="completed",
+                error=ForceValidationError(message=str(exc)),
+            )
+        finally:
+            await self.store.release_active_executor(record.executor_id, request_id)
+
+    async def _resolve_miner(self, miner_hotkey: str):
+        miners = await self.subtensor_client.get_miners()
+        matches = [miner for miner in miners if miner.hotkey == miner_hotkey]
+        if not matches:
+            raise ValueError(f"Miner {miner_hotkey} was not found in subtensor")
+        return matches[0]
+
+    @staticmethod
+    def _build_terminal_result(result: JobResult) -> ForceValidationResult:
+        success = result.log_status == "info"
+        return ForceValidationResult(
+            success=success,
+            message=result.log_text,
+            score=result.score,
+            job_score=result.job_score,
+            gpu_model=result.gpu_model,
+            gpu_count=result.gpu_count,
+        )

--- a/neurons/validators/src/services/forced_validation.py
+++ b/neurons/validators/src/services/forced_validation.py
@@ -14,6 +14,7 @@ from payload_models.payloads import MinerJobRequestPayload
 from clients.backend_client import BackendClient
 from clients.subtensor_client import SubtensorClient
 from core.config import settings
+from core.utils import _m, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.file_encrypt_service import FileEncryptService
 from services.miner_service import MinerService
@@ -169,6 +170,12 @@ class ForceValidationService:
             executor_id=executor_id,
             miner_hotkey=miner_hotkey,
         )
+        logger.info(
+            _m(
+                "Force validation queued",
+                extra=get_extra_info(self._get_log_extra(record)),
+            )
+        )
         self.task_factory(self.validate(record.request_id))
         return record
 
@@ -180,15 +187,21 @@ class ForceValidationService:
 
     async def validate(self, request_id: str) -> ForceValidationRequestRecord:
         record = await self.store.get_request(request_id)
+        logger.info(
+            _m(
+                "Force validation started",
+                extra=get_extra_info(self._get_log_extra(record)),
+            )
+        )
         try:
-            await self.store.update(
-                request_id,
+            record = await self._update_request(
+                record,
                 status="running",
                 stage="resolving_miner",
             )
             miner = await self._resolve_miner(record.miner_hotkey)
 
-            await self.store.update(request_id, stage="preparing_validation")
+            record = await self._update_request(record, stage="preparing_validation")
             rented_data = await self.backend_client.get_all_rented_executors()
             if rented_data is None:
                 rented_data = RentedExecutorsResponse(executors={})
@@ -202,7 +215,7 @@ class ForceValidationService:
                 miner_port=miner.axon_info.port,
             )
 
-            await self.store.update(request_id, stage="running_validation")
+            record = await self._update_request(record, stage="running_validation")
             result = await self.miner_service.request_single_executor_validation(
                 payload=payload,
                 encrypted_files=encrypted_files,
@@ -210,7 +223,7 @@ class ForceValidationService:
                 executor_id=record.executor_id,
             )
 
-            await self.store.update(request_id, stage="finalizing")
+            record = await self._update_request(record, stage="finalizing")
             await self.miner_service.publish_machine_specs(
                 [result],
                 record.miner_hotkey,
@@ -218,27 +231,50 @@ class ForceValidationService:
             )
 
             terminal_result = self._build_terminal_result(result)
-            return await self.store.update(
+            record = await self.store.update(
                 request_id,
                 status="succeeded" if terminal_result.success else "failed",
                 stage="completed",
                 result=terminal_result,
             )
+            logger.info(
+                _m(
+                    "Force validation finished",
+                    extra=get_extra_info(
+                        self._get_log_extra(
+                            record,
+                            success=terminal_result.success,
+                            score=terminal_result.score,
+                            job_score=terminal_result.job_score,
+                        )
+                    ),
+                )
+            )
+            return record
         except Exception as exc:
             logger.exception(
-                "Forced validation failed",
-                extra={
-                    "request_id": request_id,
-                    "executor_id": record.executor_id,
-                    "miner_hotkey": record.miner_hotkey,
-                },
+                _m(
+                    "Force validation failed",
+                    extra=get_extra_info(
+                        self._get_log_extra(record, error=str(exc))
+                    ),
+                )
             )
-            return await self.store.update(
+            record = await self.store.update(
                 request_id,
                 status="failed",
                 stage="completed",
                 error=ForceValidationError(message=str(exc)),
             )
+            logger.info(
+                _m(
+                    "Force validation finished",
+                    extra=get_extra_info(
+                        self._get_log_extra(record, success=False, error=str(exc))
+                    ),
+                )
+            )
+            return record
         finally:
             await self.store.release_active_executor(record.executor_id, request_id)
 
@@ -260,3 +296,49 @@ class ForceValidationService:
             gpu_model=result.gpu_model,
             gpu_count=result.gpu_count,
         )
+
+    async def _update_request(
+        self,
+        record: ForceValidationRequestRecord,
+        *,
+        status: str | None = None,
+        stage: str | None = None,
+    ) -> ForceValidationRequestRecord:
+        updated = await self.store.update(
+            record.request_id,
+            status=status,
+            stage=stage,
+        )
+        logger.info(
+            _m(
+                "Force validation stage changed",
+                extra=get_extra_info(self._get_log_extra(updated)),
+            )
+        )
+        return updated
+
+    @staticmethod
+    def _get_log_extra(
+        record: ForceValidationRequestRecord,
+        *,
+        success: bool | None = None,
+        score: float | None = None,
+        job_score: float | None = None,
+        error: str | None = None,
+    ) -> dict:
+        extra = {
+            "request_id": record.request_id,
+            "executor_id": record.executor_id,
+            "miner_hotkey": record.miner_hotkey,
+            "status": record.status,
+            "stage": record.stage,
+        }
+        if success is not None:
+            extra["success"] = success
+        if score is not None:
+            extra["score"] = score
+        if job_score is not None:
+            extra["job_score"] = job_score
+        if error is not None:
+            extra["error"] = error
+        return extra

--- a/neurons/validators/src/services/forced_validation.py
+++ b/neurons/validators/src/services/forced_validation.py
@@ -27,6 +27,7 @@ FORCED_VALIDATION_REQUEST_PREFIX = "forced_validation:request"
 FORCED_VALIDATION_ACTIVE_PREFIX = "forced_validation:active_executor"
 FORCED_VALIDATION_LATEST_PREFIX = "forced_validation:latest_executor"
 DEFAULT_REQUEST_TTL_SECONDS = 24 * 60 * 60
+TERMINAL_STATUSES = {"succeeded", "failed"}
 
 
 class ForceValidationConflict(Exception):
@@ -133,13 +134,22 @@ class ForceValidationRequestStore:
             await self.redis_service.redis.delete(active_key)
 
     async def _save(self, record: ForceValidationRequestRecord) -> None:
+        latest_key = self._latest_key(record.executor_id)
         await self.redis_service.redis.set(
             self._request_key(record.request_id),
             record.model_dump_json(),
             ex=self.request_ttl_seconds,
         )
+        if record.status in TERMINAL_STATUSES:
+            latest_request_id = await self.redis_service.redis.get(latest_key)
+            if isinstance(latest_request_id, bytes):
+                latest_request_id = latest_request_id.decode("utf-8")
+            if latest_request_id == record.request_id:
+                await self.redis_service.redis.delete(latest_key)
+            return
+
         await self.redis_service.redis.set(
-            self._latest_key(record.executor_id),
+            latest_key,
             record.request_id,
             ex=self.request_ttl_seconds,
         )

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -6,10 +6,9 @@ import time
 from typing import Annotated
 
 import aiohttp
-from asyncssh import SSHKey
 import asyncssh
 import bittensor
-from clients.miner_client import MinerClient
+from asyncssh import SSHKey
 from datura.requests.miner_requests import (
     AcceptJobRequest,
     AcceptSSHKeyRequest,
@@ -28,7 +27,6 @@ from datura.requests.validator_requests import (
     ssh_pubkey_signing_blob,
 )
 from fastapi import Depends
-from clients.validator_portal_api import ValidatorPortalAPI
 from payload_models.payloads import (
     BackupContainerRequest,
     RestoreContainerRequest,
@@ -55,6 +53,8 @@ from payload_models.payloads import (
 )
 from tenacity import RetryError
 
+from clients.miner_client import MinerClient
+from clients.validator_portal_api import ValidatorPortalAPI
 from core.config import settings
 from core.utils import _m, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
@@ -687,6 +687,129 @@ class MinerService:
             "miner_coldkey": payload.miner_coldkey,
             "results": [job_result],
         }
+
+    async def request_single_executor_validation(
+        self,
+        payload: MinerJobRequestPayload,
+        encrypted_files: MinerJobEnryptedFiles,
+        rented_data: RentedExecutorsResponse,
+        executor_id: str,
+    ) -> JobResult:
+        if settings.USE_REST_API:
+            return await self._request_single_executor_validation_via_rest(
+                payload,
+                encrypted_files,
+                rented_data,
+                executor_id,
+            )
+        return await self._request_single_executor_validation_via_websocket(
+            payload,
+            encrypted_files,
+            rented_data,
+            executor_id,
+        )
+
+    @staticmethod
+    def _get_single_matching_executor(
+        executors: list[ExecutorSSHInfo],
+        executor_id: str,
+    ) -> ExecutorSSHInfo:
+        matches = [executor for executor in executors if executor.uuid == executor_id]
+        if len(matches) != 1:
+            raise ValueError(
+                f"Miner returned {len(matches)} executors matching {executor_id}"
+            )
+        return matches[0]
+
+    async def _request_single_executor_validation_via_websocket(
+        self,
+        payload: MinerJobRequestPayload,
+        encrypted_files: MinerJobEnryptedFiles,
+        rented_data: RentedExecutorsResponse,
+        executor_id: str,
+    ) -> JobResult:
+        loop = asyncio.get_event_loop()
+        my_key: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
+        default_extra = {
+            "job_batch_id": payload.job_batch_id,
+            "miner_hotkey": payload.miner_hotkey,
+            "miner_address": payload.miner_address,
+            "miner_port": payload.miner_port,
+            "executor_id": executor_id,
+        }
+
+        miner_client = MinerClient(
+            loop=loop,
+            miner_address=payload.miner_address,
+            miner_port=payload.miner_port,
+            miner_hotkey=payload.miner_hotkey,
+            my_hotkey=my_key.ss58_address,
+            keypair=my_key,
+            miner_url=f"ws://{payload.miner_address}:{payload.miner_port}/websocket/{my_key.ss58_address}",
+        )
+
+        private_key = None
+        public_key = None
+        async with miner_client:
+            try:
+                private_key, public_key = self.ssh_service.generate_ssh_key(my_key.ss58_address)
+                await miner_client.send_model(
+                    SSHPubKeySubmitRequest(
+                        public_key=public_key,
+                        validator_signature=self._sign_validator_pubkey(my_key, public_key),
+                        executor_id=executor_id,
+                        miner_hotkey=payload.miner_hotkey,
+                    )
+                )
+
+                msg = await asyncio.wait_for(
+                    miner_client.job_state.miner_accepted_ssh_key_or_failed_future,
+                    timeout=JOB_LENGTH,
+                )
+                if isinstance(msg, FailedRequest):
+                    raise RuntimeError(
+                        f"Miner returned FailedRequest: {msg.details or 'unknown reason'}"
+                    )
+                if not isinstance(msg, AcceptSSHKeyRequest):
+                    raise RuntimeError(f"Unexpected response from miner: {msg}")
+
+                executor = self._get_single_matching_executor(msg.executors, executor_id)
+                return await asyncio.wait_for(
+                    self.task_service.create_task(
+                        miner_info=payload,
+                        executor_info=executor,
+                        keypair=my_key,
+                        private_key=private_key.decode("utf-8"),
+                        public_key=public_key.decode("utf-8"),
+                        encrypted_files=encrypted_files,
+                        rented_data=rented_data,
+                        # forced validation has no per-cycle digest snapshot; empty is the
+                        # fail-open value that skips the digest check (never penalizes).
+                        default_docker_image_digests={},
+                    ),
+                    timeout=settings.JOB_TIME_OUT - 120,
+                )
+            finally:
+                if public_key is not None:
+                    try:
+                        await miner_client.send_model(
+                            SSHPubKeyRemoveRequest(
+                                public_key=public_key,
+                                validator_signature=self._sign_validator_pubkey(my_key, public_key),
+                                executor_id=executor_id,
+                                miner_hotkey=payload.miner_hotkey,
+                            )
+                        )
+                    except Exception as e:
+                        logger.warning(
+                            _m(
+                                "Failed to remove SSH key after forced validation",
+                                extra=get_extra_info({
+                                    **default_extra,
+                                    "error": _get_error_details(e),
+                                }),
+                            ),
+                        )
 
     async def publish_machine_specs(
         self, results: list[JobResult], miner_hotkey: str, miner_coldkey: str
@@ -1682,6 +1805,83 @@ class MinerService:
         # Use model_dump_json and parse back to ensure proper serialization
         # This handles bytes fields correctly (base64 encoding)
         return json.loads(request.model_dump_json())
+
+    async def _request_single_executor_validation_via_rest(
+        self,
+        payload: MinerJobRequestPayload,
+        encrypted_files: MinerJobEnryptedFiles,
+        rented_data: RentedExecutorsResponse,
+        executor_id: str,
+    ) -> JobResult:
+        my_key: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
+        default_extra = {
+            "job_batch_id": payload.job_batch_id,
+            "miner_hotkey": payload.miner_hotkey,
+            "miner_address": payload.miner_address,
+            "miner_port": payload.miner_port,
+            "executor_id": executor_id,
+        }
+        base_url = f"http://{payload.miner_address}:{payload.miner_port}"
+        private_key = None
+        public_key = None
+
+        try:
+            private_key, public_key = self.ssh_service.generate_ssh_key(my_key.ss58_address)
+            ssh_request = SSHPubKeySubmitRequest(
+                public_key=public_key,
+                validator_signature=self._sign_validator_pubkey(my_key, public_key),
+                executor_id=executor_id,
+                miner_hotkey=payload.miner_hotkey,
+            )
+            headers = self._generate_auth_headers(my_key, payload.miner_hotkey)
+            headers["Content-Type"] = "application/json"
+
+            status, response_data = await self._make_rest_request(
+                method="POST",
+                url=f"{base_url}/api/validator/ssh-pubkey-submit",
+                json_data=self._serialize_request(ssh_request),
+                headers=headers,
+                timeout=REST_SSH_SUBMIT_TIMEOUT,
+                log_extra=default_extra,
+                operation_name="Forced validation SSH key submit",
+            )
+            if status != 200 or response_data is None:
+                raise RuntimeError("Failed to submit SSH key to miner via REST API")
+
+            msg = _parse_miner_response(response_data)
+            if isinstance(msg, FailedRequest):
+                raise RuntimeError(
+                    f"Miner returned FailedRequest: {msg.details or 'unknown reason'}"
+                )
+            if not isinstance(msg, AcceptSSHKeyRequest):
+                raise RuntimeError(f"Unexpected response from miner: {msg}")
+
+            executor = self._get_single_matching_executor(msg.executors, executor_id)
+            return await asyncio.wait_for(
+                self.task_service.create_task(
+                    miner_info=payload,
+                    executor_info=executor,
+                    keypair=my_key,
+                    private_key=private_key.decode("utf-8"),
+                    public_key=public_key.decode("utf-8"),
+                    encrypted_files=encrypted_files,
+                    rented_data=rented_data,
+                    # forced validation has no per-cycle digest snapshot; empty is the
+                    # fail-open value that skips the digest check (never penalizes).
+                    default_docker_image_digests={},
+                ),
+                timeout=settings.JOB_TIME_OUT - 120,
+            )
+        finally:
+            if public_key is not None:
+                await self._remove_ssh_key_via_rest(
+                    base_url=base_url,
+                    my_key=my_key,
+                    public_key=public_key,
+                    miner_hotkey=payload.miner_hotkey,
+                    executor_id=executor_id,
+                    log_extra=default_extra,
+                )
 
     async def _request_job_to_miner(
         self,

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Annotated
 
@@ -41,6 +42,8 @@ class TaskService:
         self.redis_service = redis_service
         self.attestation_service = attestation_service
         self.wallet = settings.get_bittensor_wallet()
+        self._active_validation_tasks_lock = asyncio.Lock()
+        self._active_validation_tasks: dict[str, asyncio.Task[JobResult]] = {}
 
         # Initialize pipeline factory with all required services
         self.pipeline_factory = PipelineFactory(
@@ -54,6 +57,63 @@ class TaskService:
         )
 
     async def create_task(
+        self,
+        miner_info: MinerJobRequestPayload,
+        executor_info: ExecutorSSHInfo,
+        keypair: bittensor.Keypair,
+        private_key: str,
+        public_key: str,
+        encrypted_files: MinerJobEnryptedFiles,
+        rented_data: RentedExecutorsResponse,
+        default_docker_image_digests: dict[str, str],
+        attestation_nonce: AttestationNonce | None = None,
+    ):
+        executor_id = executor_info.uuid
+
+        async with self._active_validation_tasks_lock:
+            task = self._active_validation_tasks.get(executor_id)
+            if task is None or task.done():
+                task = asyncio.create_task(
+                    self._create_task_impl(
+                        miner_info=miner_info,
+                        executor_info=executor_info,
+                        keypair=keypair,
+                        private_key=private_key,
+                        public_key=public_key,
+                        encrypted_files=encrypted_files,
+                        rented_data=rented_data,
+                        default_docker_image_digests=default_docker_image_digests,
+                        attestation_nonce=attestation_nonce,
+                    )
+                )
+                self._active_validation_tasks[executor_id] = task
+            else:
+                # If a validation task was already started for this executor, join it
+                # instead of starting a competing pipeline.
+                logger.info(
+                    _m(
+                        "Joining active validation task",
+                        extra=get_extra_info({
+                            "job_batch_id": miner_info.job_batch_id,
+                            "miner_hotkey": miner_info.miner_hotkey,
+                            "executor_uuid": executor_id,
+                        }),
+                    ),
+                )
+
+        try:
+            return await task
+        except asyncio.CancelledError as exc:
+            if task.cancelled():
+                raise RuntimeError("Validation task was cancelled") from exc
+            raise
+        finally:
+            if task.done():
+                async with self._active_validation_tasks_lock:
+                    if self._active_validation_tasks.get(executor_id) is task:
+                        self._active_validation_tasks.pop(executor_id, None)
+
+    async def _create_task_impl(
         self,
         miner_info: MinerJobRequestPayload,
         executor_info: ExecutorSSHInfo,

--- a/neurons/validators/src/validator.py
+++ b/neurons/validators/src/validator.py
@@ -1,12 +1,18 @@
 import asyncio
 import logging
+from typing import Annotated
 
 import uvicorn
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Header, HTTPException, Request
+from payload_models.forced_validation import (
+    ForceValidationCreateRequest,
+    ForceValidationRequestRecord,
+)
 
 from core.config import settings
 from core.utils import configure_logs_of_other_modules, wait_for_services_sync
 from core.validator import Validator
+from services.forced_validation import ForceValidationConflict, ForceValidationNotFound
 
 configure_logs_of_other_modules()
 wait_for_services_sync()
@@ -14,6 +20,7 @@ wait_for_services_sync()
 
 async def app_lifespan(app: FastAPI):
     validator = Validator()
+    app.state.validator = validator
     # Run the miner in the background
     task = asyncio.create_task(validator.start())
 
@@ -36,6 +43,65 @@ app = FastAPI(
     title=settings.PROJECT_NAME,
     lifespan=app_lifespan,
 )
+
+
+def validate_internal_token(
+    x_internal_token: Annotated[str | None, Header(alias="X-Internal-Token")] = None,
+) -> None:
+    expected_token = settings.FORCED_VALIDATION_INTERNAL_TOKEN
+    if expected_token:
+        if x_internal_token != expected_token:
+            raise HTTPException(status_code=401, detail="Invalid internal token")
+        return
+    if settings.ENV != "dev" and settings.DEPLOY_ENV in {"PROD", "STAGE"}:
+        raise HTTPException(
+            status_code=503,
+            detail="Forced validation internal token is not configured",
+        )
+
+
+def get_force_validation_service(request: Request):
+    validator = getattr(request.app.state, "validator", None)
+    if validator is None or not hasattr(validator, "force_validation_service"):
+        raise HTTPException(status_code=503, detail="Validator services are not ready")
+    return validator.force_validation_service
+
+
+@app.post(
+    "/internal/forced-validations",
+    response_model=ForceValidationRequestRecord,
+    dependencies=[Depends(validate_internal_token)],
+)
+async def create_forced_validation(
+    payload: ForceValidationCreateRequest,
+    service=Depends(get_force_validation_service),
+):
+    try:
+        return await service.create_request(
+            executor_id=payload.executor_id,
+            miner_hotkey=payload.miner_hotkey,
+        )
+    except ForceValidationConflict:
+        raise HTTPException(
+            status_code=409,
+            detail="Forced validation is already running for this executor",
+        )
+
+
+@app.get(
+    "/internal/forced-validations/{request_id}",
+    response_model=ForceValidationRequestRecord,
+    dependencies=[Depends(validate_internal_token)],
+)
+async def get_forced_validation(
+    request_id: str,
+    service=Depends(get_force_validation_service),
+):
+    try:
+        return await service.get_request(request_id)
+    except ForceValidationNotFound:
+        raise HTTPException(status_code=404, detail="Forced validation request not found")
+
 
 reload = True if settings.ENV == "dev" else False
 

--- a/neurons/validators/src/validator.py
+++ b/neurons/validators/src/validator.py
@@ -89,6 +89,21 @@ async def create_forced_validation(
 
 
 @app.get(
+    "/internal/forced-validations/executors/{executor_id}/latest",
+    response_model=ForceValidationRequestRecord,
+    dependencies=[Depends(validate_internal_token)],
+)
+async def get_latest_forced_validation(
+    executor_id: str,
+    service=Depends(get_force_validation_service),
+):
+    try:
+        return await service.get_latest_request(executor_id)
+    except ForceValidationNotFound:
+        raise HTTPException(status_code=404, detail="Forced validation request not found")
+
+
+@app.get(
     "/internal/forced-validations/{request_id}",
     response_model=ForceValidationRequestRecord,
     dependencies=[Depends(validate_internal_token)],

--- a/neurons/validators/tests/test_forced_validation.py
+++ b/neurons/validators/tests/test_forced_validation.py
@@ -190,6 +190,23 @@ async def test_store_keeps_newer_latest_pointer_when_old_request_finishes_late()
 
 
 @pytest.mark.asyncio
+async def test_store_hides_existing_terminal_latest_request():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+    record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    await store.update(record.request_id, status="failed", stage="completed")
+    await store.redis_service.redis.set(store._latest_key("exec-1"), record.request_id)
+
+    with pytest.raises(ForceValidationNotFound):
+        await store.get_latest_request("exec-1")
+    assert await store.redis_service.redis.get(store._latest_key("exec-1")) is None
+
+
+@pytest.mark.asyncio
 async def test_single_executor_validation_runs_matching_executor_and_cleans_up(monkeypatch):
     executor = _executor("exec-1")
     service = MinerService.__new__(MinerService)

--- a/neurons/validators/tests/test_forced_validation.py
+++ b/neurons/validators/tests/test_forced_validation.py
@@ -8,6 +8,7 @@ import services.miner_service as miner_service_module
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.forced_validation import (
     ForceValidationConflict,
+    ForceValidationNotFound,
     ForceValidationRequestStore,
 )
 from services.miner_service import MinerService
@@ -147,6 +148,45 @@ async def test_store_releases_active_marker_after_terminal_state():
         miner_hotkey="miner-hotkey",
     )
     assert next_record.request_id != record.request_id
+
+
+@pytest.mark.asyncio
+async def test_store_removes_latest_pointer_after_terminal_state():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+    record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+
+    await store.update(record.request_id, status="failed", stage="completed")
+
+    loaded = await store.get_request(record.request_id)
+    assert loaded.status == "failed"
+    with pytest.raises(ForceValidationNotFound):
+        await store.get_latest_request("exec-1")
+
+
+@pytest.mark.asyncio
+async def test_store_keeps_newer_latest_pointer_when_old_request_finishes_late():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+    old_record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    await store.release_active_executor("exec-1", old_record.request_id)
+    new_record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+
+    await store.update(old_record.request_id, status="failed", stage="completed")
+
+    loaded = await store.get_latest_request("exec-1")
+    assert loaded.request_id == new_record.request_id
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_forced_validation.py
+++ b/neurons/validators/tests/test_forced_validation.py
@@ -1,0 +1,199 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from datura.requests.miner_requests import AcceptSSHKeyRequest, ExecutorSSHInfo
+from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+
+import services.miner_service as miner_service_module
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.forced_validation import (
+    ForceValidationConflict,
+    ForceValidationRequestStore,
+)
+from services.miner_service import MinerService
+from services.task_service import JobResult
+
+
+class FakeRedis:
+    def __init__(self):
+        self.data = {}
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self.data:
+            return None
+        self.data[key] = value
+        return True
+
+    async def get(self, key):
+        return self.data.get(key)
+
+    async def delete(self, key):
+        self.data.pop(key, None)
+
+
+class FakeRedisService:
+    def __init__(self):
+        self.redis = FakeRedis()
+
+
+def _executor(executor_id: str = "exec-1") -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=executor_id,
+        address="10.0.0.1",
+        port=8000,
+        ssh_username="root",
+        ssh_port=22,
+        python_path="/usr/bin/python3",
+        root_dir="/root",
+    )
+
+
+def _payload() -> MinerJobRequestPayload:
+    return MinerJobRequestPayload(
+        job_batch_id="forced-req",
+        miner_hotkey="miner-hotkey",
+        miner_coldkey="miner-coldkey",
+        miner_address="127.0.0.1",
+        miner_port=8000,
+    )
+
+
+def _encrypted_files() -> MinerJobEnryptedFiles:
+    return MinerJobEnryptedFiles(
+        encrypt_key="key",
+        all_keys={},
+        tmp_directory="/tmp",
+        machine_scrape_file_name="machine.py",
+    )
+
+
+def _job_result(executor: ExecutorSSHInfo) -> JobResult:
+    return JobResult(
+        spec={},
+        executor_info=executor,
+        score=1,
+        job_score=1,
+        job_batch_id="forced-req",
+        log_status="info",
+        log_text="ok",
+        gpu_model="H100",
+        gpu_count=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_accepts_request_and_returns_status():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+
+    record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    loaded = await store.get_request(record.request_id)
+
+    assert loaded.request_id == record.request_id
+    assert loaded.executor_id == "exec-1"
+    assert loaded.status == "queued"
+
+
+@pytest.mark.asyncio
+async def test_store_rejects_duplicate_active_executor():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+    await store.create_request(executor_id="exec-1", miner_hotkey="miner-hotkey")
+
+    with pytest.raises(ForceValidationConflict):
+        await store.create_request(executor_id="exec-1", miner_hotkey="miner-hotkey")
+
+
+@pytest.mark.asyncio
+async def test_store_releases_active_marker_after_terminal_state():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+    record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    await store.update(record.request_id, status="failed", stage="completed")
+    await store.release_active_executor("exec-1", record.request_id)
+
+    next_record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    assert next_record.request_id != record.request_id
+
+
+@pytest.mark.asyncio
+async def test_single_executor_validation_runs_matching_executor_and_cleans_up(monkeypatch):
+    executor = _executor("exec-1")
+    service = MinerService.__new__(MinerService)
+    service.ssh_service = MagicMock()
+    service.ssh_service.generate_ssh_key.return_value = (b"private", b"public")
+    service.task_service = MagicMock()
+    service.task_service.create_task = AsyncMock(return_value=_job_result(executor))
+    service._make_rest_request = AsyncMock(
+        return_value=(200, AcceptSSHKeyRequest(executors=[executor]).model_dump(mode="json"))
+    )
+    service._remove_ssh_key_via_rest = AsyncMock(return_value=True)
+
+    keypair = MagicMock(ss58_address="validator-hotkey")
+    keypair.sign.return_value = b"sig"
+    wallet = MagicMock()
+    wallet.get_hotkey.return_value = keypair
+    monkeypatch.setattr("services.miner_service.settings.USE_REST_API", True)
+    monkeypatch.setattr(
+        type(miner_service_module.settings),
+        "get_bittensor_wallet",
+        lambda self: wallet,
+    )
+
+    result = await service.request_single_executor_validation(
+        payload=_payload(),
+        encrypted_files=_encrypted_files(),
+        rented_data=RentedExecutorsResponse(executors={}),
+        executor_id="exec-1",
+    )
+
+    assert result.executor_info.uuid == "exec-1"
+    service.task_service.create_task.assert_awaited_once()
+    service._remove_ssh_key_via_rest.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_single_executor_validation_rejects_missing_executor_and_cleans_up(monkeypatch):
+    service = MinerService.__new__(MinerService)
+    service.ssh_service = MagicMock()
+    service.ssh_service.generate_ssh_key.return_value = (b"private", b"public")
+    service.task_service = MagicMock()
+    service.task_service.create_task = AsyncMock()
+    service._make_rest_request = AsyncMock(
+        return_value=(200, AcceptSSHKeyRequest(executors=[_executor("other")]).model_dump(mode="json"))
+    )
+    service._remove_ssh_key_via_rest = AsyncMock(return_value=True)
+
+    keypair = MagicMock(ss58_address="validator-hotkey")
+    keypair.sign.return_value = b"sig"
+    wallet = MagicMock()
+    wallet.get_hotkey.return_value = keypair
+    monkeypatch.setattr("services.miner_service.settings.USE_REST_API", True)
+    monkeypatch.setattr(
+        type(miner_service_module.settings),
+        "get_bittensor_wallet",
+        lambda self: wallet,
+    )
+
+    with pytest.raises(ValueError):
+        await service.request_single_executor_validation(
+            payload=_payload(),
+            encrypted_files=_encrypted_files(),
+            rented_data=RentedExecutorsResponse(executors={}),
+            executor_id="exec-1",
+        )
+
+    service.task_service.create_task.assert_not_called()
+    service._remove_ssh_key_via_rest.assert_awaited_once()

--- a/neurons/validators/tests/test_forced_validation.py
+++ b/neurons/validators/tests/test_forced_validation.py
@@ -99,6 +99,27 @@ async def test_store_accepts_request_and_returns_status():
 
 
 @pytest.mark.asyncio
+async def test_store_returns_latest_request_for_executor():
+    store = ForceValidationRequestStore(
+        FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60
+    )
+    first_record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+    await store.update(first_record.request_id, status="failed", stage="completed")
+    await store.release_active_executor("exec-1", first_record.request_id)
+    second_record = await store.create_request(
+        executor_id="exec-1",
+        miner_hotkey="miner-hotkey",
+    )
+
+    loaded = await store.get_latest_request("exec-1")
+
+    assert loaded.request_id == second_record.request_id
+
+
+@pytest.mark.asyncio
 async def test_store_rejects_duplicate_active_executor():
     store = ForceValidationRequestStore(
         FakeRedisService(), request_ttl_seconds=60, active_ttl_seconds=60

--- a/neurons/validators/tests/test_task_service.py
+++ b/neurons/validators/tests/test_task_service.py
@@ -1,0 +1,115 @@
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.task.models import JobResult
+from services.task.service import TaskService
+
+
+def _executor(executor_id: str = "exec-1") -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=executor_id,
+        address="10.0.0.1",
+        port=8000,
+        ssh_username="root",
+        ssh_port=22,
+        python_path="/usr/bin/python3",
+        root_dir="/root",
+    )
+
+
+def _payload(job_batch_id: str) -> MinerJobRequestPayload:
+    return MinerJobRequestPayload(
+        job_batch_id=job_batch_id,
+        miner_hotkey="miner-hotkey",
+        miner_coldkey="miner-coldkey",
+        miner_address="127.0.0.1",
+        miner_port=8000,
+    )
+
+
+def _encrypted_files() -> MinerJobEnryptedFiles:
+    return MinerJobEnryptedFiles(
+        encrypt_key="key",
+        all_keys={},
+        tmp_directory="/tmp",
+        machine_scrape_file_name="machine.py",
+    )
+
+
+def _job_result(executor: ExecutorSSHInfo) -> JobResult:
+    return JobResult(
+        spec={},
+        executor_info=executor,
+        score=1,
+        job_score=1,
+        job_batch_id="cycle-job",
+        log_status="info",
+        log_text="ok",
+        gpu_model="H100",
+        gpu_count=1,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_task_joins_active_validation_for_same_executor():
+    service = TaskService.__new__(TaskService)
+    service._active_validation_tasks_lock = asyncio.Lock()
+    service._active_validation_tasks = {}
+
+    executor = _executor()
+    expected_result = _job_result(executor)
+    started = asyncio.Event()
+    release = asyncio.Event()
+    calls = 0
+
+    async def create_task_impl(**_kwargs):
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return expected_result
+
+    service._create_task_impl = create_task_impl
+    keypair = MagicMock()
+    encrypted_files = _encrypted_files()
+    rented_data = RentedExecutorsResponse(executors={})
+
+    first = asyncio.create_task(
+        service.create_task(
+            miner_info=_payload("cycle-job"),
+            executor_info=executor,
+            keypair=keypair,
+            private_key="private",
+            public_key="public",
+            encrypted_files=encrypted_files,
+            rented_data=rented_data,
+            default_docker_image_digests={},
+        )
+    )
+    await started.wait()
+
+    second = asyncio.create_task(
+        service.create_task(
+            miner_info=_payload("forced-job"),
+            executor_info=executor,
+            keypair=keypair,
+            private_key="private",
+            public_key="public",
+            encrypted_files=encrypted_files,
+            rented_data=rented_data,
+            default_docker_image_digests={},
+        )
+    )
+
+    release.set()
+    first_result, second_result = await asyncio.gather(first, second)
+
+    assert first_result is expected_result
+    assert second_result is expected_result
+    assert calls == 1
+    assert service._active_validation_tasks == {}


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2090](https://www.notion.so/Add-forced-executor-validation-endpoint-35fb8bfdbde9814ebaf3c2f6a4b094dd)

---

## Problem

New executors can take too long to appear in compute-app because validation only happens when the regular validator cycle reaches the target executor. Operators need an internal path that can request validation for one known `executor_id` + `miner_hotkey`, poll the request status, and recover an active in-progress request after a portal refresh.

## Solution

Add a validator-side forced validation workflow backed by Redis. The validator now exposes internal create/read/latest endpoints, rejects duplicate active requests for the same executor, runs the existing validation pipeline against exactly one executor, publishes machine specs through the existing ingestion path, stores terminal status/result for polling by `request_id`, and keeps the latest lookup active-only.

`GET /internal/forced-validations/executors/{executor_id}/latest` is intentionally active-only: it returns a non-terminal request for refresh recovery while validation is still running, and it may return 404 after the request reaches `succeeded` or `failed`. Terminal results remain available through `GET /internal/forced-validations/{request_id}` for the request TTL and are rendered by the current polling session; they are not restored as a sticky latest result after page reload.

## Changes

- Added forced validation request/result payload models.
- Added `ForceValidationRequestStore` with request TTL and active-executor locking via Redis `SET NX EX`.
- Added latest-request storage per executor for active page-refresh recovery.
- Added `ForceValidationService` for request creation, status updates, background validation, terminal result storage, and active marker cleanup.
- Added single-executor validation helpers to `MinerService` for both REST and websocket miner paths.
- Added internal validator endpoints:
  - `POST /internal/forced-validations`
  - `GET /internal/forced-validations/{request_id}`
  - `GET /internal/forced-validations/executors/{executor_id}/latest`
- Added optional `FORCED_VALIDATION_INTERNAL_TOKEN` guard for non-dev deployments.
- Added focused tests for request store behavior, duplicate rejection, active latest lookup, latest cleanup after terminal status, active marker cleanup, and single-executor validation cleanup.

## Deployment Steps

Use GitHub Action.

Deployment config must provide `FORCED_VALIDATION_INTERNAL_TOKEN` and a stable internal validator service URL. Staging is already wired in `lium-io-deployment`; production wiring is covered by the companion deployment PR.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

- Miner Portal backend: https://github.com/Datura-ai/lium-miner-portal/pull/128
- Miner Portal frontend: https://github.com/Datura-ai/lium-miner-portal-frontend/pull/123
- Deployment prod token: https://github.com/Datura-ai/lium-io-deployment/pull/22

## Risks

- The internal endpoint must stay behind trusted networking and the internal token outside dev.
- Forced validation reuses SSH key submission/removal and task execution paths, so regressions would affect targeted validation cleanup or single-executor job execution.
- Portal calls will fail auth if the portal-side token and validator-side token drift.
- Live staging verification with a real executor is still required before enabling broadly.

## Test Cases

### Test Case 1

**Actions**

Run from `neurons/validators`:

```bash
pdm run pytest tests/test_forced_validation.py
```

**Expected Output**

All forced validation validator tests pass.

### Test Case 2

**Actions**

Run from repo root:

```bash
git diff --check
```

**Expected Output**

No whitespace or conflict-marker issues are reported.

## Checklist

- [ ] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described