### PR TITLE
DAH-2329, read soft_limit_price_rate from shared config

### DIFF
--- a/neurons/validators/pdm.lock
+++ b/neurons/validators/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "dev"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:d24a3d057bc9c825d6ab5680ea10aa99d0c5f1c996ac2154060c0ad1bbf4f506"
+content_hash = "sha256:ff6cbbf6ebdde7685ac77880b448c3dea112370c47d69cf26597dad37c257760"
 
 [[metadata.targets]]
 requires_python = ">=3.11,<3.13"
@@ -1245,7 +1245,7 @@ files = [
 
 [[package]]
 name = "lium-core"
-version = "0.1.4"
+version = "0.1.5"
 requires_python = ">=3.11"
 summary = "Shared core library for Lium platform"
 groups = ["default"]
@@ -1254,8 +1254,8 @@ dependencies = [
     "requests>=2.31.0",
 ]
 files = [
-    {file = "lium_core-0.1.4-py3-none-any.whl", hash = "sha256:9a982cbf8f6bb71fd1528e97b97e52083ce37e78b870c530d9d74fe5823c35e0"},
-    {file = "lium_core-0.1.4.tar.gz", hash = "sha256:d96692168011cb278478a5d044e4d62ac8994309551da9097d1d095e64b9fb7e"},
+    {file = "lium_core-0.1.5-py3-none-any.whl", hash = "sha256:62b718d9dfb029c897330765d769a0af1a69fc54cc43fe2cd11df96a55fa5b87"},
+    {file = "lium_core-0.1.5.tar.gz", hash = "sha256:0fda76ca77cee5a5376efef3bb0fda5efc63d54a57725086bf635210a61e8b7e"},
 ]
 
 [[package]]

--- a/neurons/validators/pyproject.toml
+++ b/neurons/validators/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "celium-collateral==1.1.6",
     "databases>=0.9.0",
     "datura @ file:///${PROJECT_ROOT}/../../datura",
-    "lium-core>=0.1.4",
+    "lium-core>=0.1.5",
     "fastapi>=0.110.3",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.10.1",

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -176,7 +176,7 @@ class Settings(BaseSettings):
     SSH_DEBUG_LOGGING: bool = Field(env="SSH_DEBUG_LOGGING", default=True, description="Enable verbose asyncssh SSH handshake debug logging")
 
     # DAH-2250 — unrented incentive soft price limit. When True, an unrented executor
-    # whose price_per_gpu exceeds market p90 * SOFT_LIMIT_PRICE_RATE loses the unrented
+    # whose price_per_gpu exceeds market p90 * soft_limit_price_rate loses the unrented
     # rental incentive while staying active. When False, the breach is only logged
     # (shadow mode) so prod impact can be observed before enforcing.
     ENABLE_UNRENTED_SOFT_PRICE_LIMIT: bool = Field(env="ENABLE_UNRENTED_SOFT_PRICE_LIMIT", default=False)

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -32,11 +32,6 @@ from services.task_service import JobResult
 
 logger = get_logger(__name__)
 
-# DAH-2250 — unrented incentive soft price limit (section 3 of the market-pricing
-# proposal). An unrented executor whose price_per_gpu exceeds the market p90 times
-# this multiplier forfeits the unrented rental incentive but stays active.
-SOFT_LIMIT_PRICE_RATE = 1.1
-
 
 # ── Snapshot models ──────────────────────────────────────────────────────────
 
@@ -176,7 +171,7 @@ class RentalPriceIncentive(DefaultIncentive):
         return base_model
 
     def _is_over_soft_price_limit(self, result: JobResult) -> bool:
-        # miner price_per_gpu above the market p90 ceiling (p90 * SOFT_LIMIT_PRICE_RATE)
+        # miner price_per_gpu above the market p90 ceiling (p90 * soft_limit_price_rate)
         price_per_gpu = result.executor_info.price_per_gpu
         if not price_per_gpu:
             return False
@@ -184,12 +179,13 @@ class RentalPriceIncentive(DefaultIncentive):
         p90 = shared_client.config.machine_prices_p90.get(result.gpu_model)
         if not p90:
             return False
-        return price_per_gpu > p90 * SOFT_LIMIT_PRICE_RATE
+        return price_per_gpu > p90 * shared_client.config.soft_limit_price_rate
 
     def _log_soft_price_limit(self, result: JobResult) -> None:
         # structured log for every unrented executor over the p90 soft ceiling
         enforced = settings.ENABLE_UNRENTED_SOFT_PRICE_LIMIT
         p90 = shared_client.config.machine_prices_p90.get(result.gpu_model)
+        rate = shared_client.config.soft_limit_price_rate
         logger.info(
             _m(
                 "Unrented executor over market p90 soft price limit"
@@ -200,8 +196,8 @@ class RentalPriceIncentive(DefaultIncentive):
                     "gpu_count": result.gpu_count,
                     "price_per_gpu": result.executor_info.price_per_gpu,
                     "machine_price_p90": p90,
-                    "soft_limit_rate": SOFT_LIMIT_PRICE_RATE,
-                    "soft_limit_threshold": p90 * SOFT_LIMIT_PRICE_RATE if p90 else None,
+                    "soft_limit_rate": rate,
+                    "soft_limit_threshold": p90 * rate if p90 else None,
                     "enforced": enforced,
                     "reason": "price_above_market_p90_soft_limit",
                     "pool": "rental_excluded" if enforced else "rental_kept_shadow",


### PR DESCRIPTION
## What

The validator's unrented soft price limit multiplier was a local constant
`SOFT_LIMIT_PRICE_RATE = 1.1` in `incentive/rental_price.py`, duplicating the
same value published by compute-app in `core/constants.py`. This makes the
validator consume it from shared config instead, so there is a single source of
truth (compute-app publishes it via `/v1/shared-config`).

## Changes

- `incentive/rental_price.py`: drop the local `SOFT_LIMIT_PRICE_RATE` constant;
  read `shared_client.config.soft_limit_price_rate` at each use site (mirrors how
  `machine_prices_p90` is already consumed).
- `core/config.py`: update the comment referencing the old constant.
- `pyproject.toml` + `pdm.lock`: bump `lium-core` to `>=0.1.5` (the release that
  adds the `soft_limit_price_rate` field, backward-compatible default 1.1).

No behavior change: the published value is 1.1, identical to the dropped constant.

## Testing

`pdm run pytest` — 850 passed, 8 skipped locally (incl. rental price incentive
flow + prod snapshot; the value 1.1 is unchanged so snapshots are identical).

## Related

- lium-core 0.1.5 (adds `soft_limit_price_rate`) — released to PyPI.
- compute-app DAH-2329 (#729) publishes the field and reads it via a single
  in-process SharedConfig surface.