### PR TITLE
DAH-2386: Route TDX attestation to a QEMU 10.x verifier by vm_config qemu_version

### DIFF
--- a/neurons/validators/docker-compose.app.dstacktee.dev.yml
+++ b/neurons/validators/docker-compose.app.dstacktee.dev.yml
@@ -34,6 +34,18 @@ services:
       # {OS_IMAGE_HASH} is substituted by the verifier, not compose.
       - DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL=https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/mr_{OS_IMAGE_HASH}.tar.gz
 
+  # QEMU 10.2.1 (Canonical 1:10.2.1+ds-1ubuntu3.1) ACPI oracle + RTMR1 raw-kernel
+  # fix. A verifier image embeds exactly one QEMU version's ACPI oracle, so this
+  # second verifier receives only quotes whose vm_config qemu_version >= 10; the
+  # 9.2.1 prod fleet keeps routing to dstack-verifier above. Live but inert until a
+  # QEMU >= 10 host appears. Source: Datura-ai/dstack@spike/qemu10-oracle-rebuild
+  # (6124e6ea).
+  dstack-verifier-qemu10:
+    image: daturaai/dstack-verifier@sha256:3151aab51d618a0996cc353979c72b04f2137fd5be17be7487f1242faab3f83d
+    restart: unless-stopped
+    environment:
+      - DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL=https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/mr_{OS_IMAGE_HASH}.tar.gz
+
   validator:
     image: daturaai/compute-subnet-validator:dev
     env_file: ./.env
@@ -44,6 +56,7 @@ services:
       - REDIS_PORT=6379
       - ENABLE_TDX_ATTESTATION=true
       - TDX_VERIFIER_URL=http://dstack-verifier:8080/verify
+      - TDX_VERIFIER_QEMU10_URL=http://dstack-verifier-qemu10:8080/verify
       - ENABLE_ATTESTATION_WHITELIST=true
       - DEPLOY_ENV=LOCAL
     ports:
@@ -56,6 +69,7 @@ services:
       - db
       - redis
       - dstack-verifier
+      - dstack-verifier-qemu10
 
   connector:
     image: daturaai/compute-subnet-validator:dev

--- a/neurons/validators/docker-compose.app.dstacktee.yml
+++ b/neurons/validators/docker-compose.app.dstacktee.yml
@@ -34,6 +34,18 @@ services:
       # {OS_IMAGE_HASH} is substituted by the verifier, not compose.
       - DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL=https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/mr_{OS_IMAGE_HASH}.tar.gz
 
+  # QEMU 10.2.1 (Canonical 1:10.2.1+ds-1ubuntu3.1) ACPI oracle + RTMR1 raw-kernel
+  # fix. A verifier image embeds exactly one QEMU version's ACPI oracle, so this
+  # second verifier receives only quotes whose vm_config qemu_version >= 10; the
+  # 9.2.1 prod fleet keeps routing to dstack-verifier above. Live but inert until a
+  # QEMU >= 10 host appears. Source: Datura-ai/dstack@spike/qemu10-oracle-rebuild
+  # (6124e6ea).
+  dstack-verifier-qemu10:
+    image: daturaai/dstack-verifier@sha256:3151aab51d618a0996cc353979c72b04f2137fd5be17be7487f1242faab3f83d
+    restart: unless-stopped
+    environment:
+      - DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL=https://github.com/Datura-ai/private-ml-sdk/releases/download/v0.5.5/mr_{OS_IMAGE_HASH}.tar.gz
+
   validator:
     image: daturaai/compute-subnet-validator:latest
     env_file: ./.env
@@ -44,6 +56,7 @@ services:
       - REDIS_PORT=6379
       - ENABLE_TDX_ATTESTATION=true
       - TDX_VERIFIER_URL=http://dstack-verifier:8080/verify
+      - TDX_VERIFIER_QEMU10_URL=http://dstack-verifier-qemu10:8080/verify
       - ENABLE_ATTESTATION_WHITELIST=true
       - DEPLOY_ENV=PROD
     ports:
@@ -56,6 +69,7 @@ services:
       - db
       - redis
       - dstack-verifier
+      - dstack-verifier-qemu10
 
   connector:
     image: daturaai/compute-subnet-validator:latest

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -214,6 +214,12 @@ class Settings(BaseSettings):
     # TDX Attestation settings
     ENABLE_TDX_ATTESTATION: bool = Field(env="ENABLE_TDX_ATTESTATION", default=False)
     TDX_VERIFIER_URL: str | None = Field(env="TDX_VERIFIER_URL", default=None)
+    # A verifier image embeds exactly one QEMU version's ACPI oracle, so it can
+    # verify exactly one host-QEMU version. TDX_VERIFIER_URL pins the default
+    # (QEMU 9.2.1) oracle; this optional second verifier carries the QEMU 10.x
+    # oracle. Quotes whose vm_config qemu_version major >= 10 route here when it is
+    # configured; unset (default) keeps the single-verifier behavior unchanged.
+    TDX_VERIFIER_QEMU10_URL: str | None = Field(env="TDX_VERIFIER_QEMU10_URL", default=None)
     ENABLE_ATTESTATION_WHITELIST: bool = Field(env="ENABLE_ATTESTATION_WHITELIST", default=False)
 
     # G4 — TCB/advisory enforcement (CVM attestation gap remediation).

--- a/neurons/validators/src/services/attestation_service.py
+++ b/neurons/validators/src/services/attestation_service.py
@@ -100,6 +100,11 @@ class AttestationService:
         self.enabled: bool = bool(
             settings.ENABLE_TDX_ATTESTATION and settings.TDX_VERIFIER_URL)
         self.verifier_url: str | None = settings.TDX_VERIFIER_URL
+        # A verifier image embeds exactly one QEMU version's ACPI oracle; this
+        # optional second verifier carries the QEMU 10.x oracle. When configured,
+        # quotes from QEMU >= 10 hosts route here (see _select_verifier_url). It
+        # never widens `enabled`, which stays keyed on the primary verifier only.
+        self.verifier_qemu10_url: str | None = settings.TDX_VERIFIER_QEMU10_URL
         self.quote_timeout: int = 60
         # Injected by FastAPI DI or passed explicitly (ioc / validator core).
         # Used for the minimal-G5 CVM ratchet and the re-attest cadence; both
@@ -152,15 +157,71 @@ class AttestationService:
                                 host_key.encode("utf-8")).hexdigest()
         return f"0x{digest}"
 
+    @staticmethod
+    def _parse_qemu_version(quote_json: str) -> str | None:
+        """Best-effort extraction of vm_config.qemu_version from a verifier quote.
+
+        vm_config rides in the quote either as a JSON string (the verifier's wire
+        format) or as an already-decoded object; both are handled. Returns None on
+        any parse failure so callers can fall back to the default verifier — this
+        must never raise (it runs on every prod attestation).
+        """
+        try:
+            payload = json.loads(quote_json) if isinstance(quote_json, str) else quote_json
+            if not isinstance(payload, dict):
+                return None
+            vm_config = payload.get("vm_config")
+            if isinstance(vm_config, str):
+                vm_config = json.loads(vm_config)
+            if not isinstance(vm_config, dict):
+                return None
+            version = vm_config.get("qemu_version")
+            return version if isinstance(version, str) and version.strip() else None
+        except Exception:
+            return None
+
+    def _select_verifier_url(self, quote_json: str) -> str:
+        """Pick the verifier whose embedded QEMU ACPI oracle matches the quote.
+
+        One verifier image embeds exactly one QEMU version's ACPI oracle, so a
+        quote produced on a QEMU >= 10 host must be routed to the qemu10 verifier
+        when one is configured. Everything else — no qemu10 verifier configured, a
+        QEMU 9.x host (the entire prod fleet stamps 9.2.1), or an absent/unparseable
+        version — routes to the default verifier.
+
+        Runs on every attestation, so it is ultra-defensive: any exception, missing
+        field, or unparseable version falls back to the default verifier and can
+        never break the existing 9.x path.
+        """
+        try:
+            if not self.verifier_qemu10_url:
+                return self.verifier_url
+            version = self._parse_qemu_version(quote_json)
+            if version is None:
+                return self.verifier_url
+            major = int(version.strip().split(".")[0])
+            if major >= 10:
+                return self.verifier_qemu10_url
+        except Exception:
+            return self.verifier_url
+        return self.verifier_url
+
     async def _call_verifier(self, quote_json: str, executor: ExecutorSSHInfo) -> dict:
         if not self.verifier_url:
             raise AttestationError("TDX verifier URL is not configured")
 
-        url = self.verifier_url.rstrip("/")
+        base_url = self._select_verifier_url(quote_json)
+        url = base_url.rstrip("/")
         if not url.endswith("/verify"):
             url = f"{url}/verify"
 
-        logger.info(f"[VERIFIER REQUEST] Posting to {url} for {executor.address}:{executor.port}")
+        selected_qemu10 = bool(self.verifier_qemu10_url and base_url == self.verifier_qemu10_url)
+        verifier = "qemu10" if selected_qemu10 else "default"
+        qemu_version = self._parse_qemu_version(quote_json)
+        logger.info(
+            f"[VERIFIER REQUEST] Posting to {url} (verifier={verifier}, qemu_version={qemu_version}) "
+            f"for {executor.address}:{executor.port}"
+        )
 
         timeout = aiohttp.ClientTimeout(total=self.quote_timeout)
         async with aiohttp.ClientSession(timeout=timeout) as session:

--- a/neurons/validators/tests/test_attestation_verifier_routing.py
+++ b/neurons/validators/tests/test_attestation_verifier_routing.py
@@ -1,0 +1,160 @@
+import json
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+from neurons.validators.src.services.attestation_service import AttestationService  # noqa: E402
+
+from core.config import settings  # noqa: E402
+
+THIS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = THIS_DIR / ".." / ".." / ".."
+VALIDATOR_SRC = REPO_ROOT / "neurons" / "validators" / "src"
+if str(VALIDATOR_SRC) not in sys.path:
+    sys.path.insert(0, str(VALIDATOR_SRC))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
+
+if "celium_collateral_contracts" not in sys.modules:
+    module = types.ModuleType("celium_collateral_contracts")
+
+    class CollateralContract:  # type: ignore
+        ...
+
+    module.CollateralContract = CollateralContract
+    sys.modules["celium_collateral_contracts"] = module
+
+
+DEFAULT_URL = "https://verifier.default/verify"
+QEMU10_URL = "https://verifier.qemu10/verify"
+
+FIXTURE_PATH = THIS_DIR / "fixtures" / "tdx_quote.json"
+
+
+def _make_service(monkeypatch, *, qemu10_url: str | None) -> AttestationService:
+    """Construct the service with settings patched BEFORE __init__ reads them.
+
+    __init__ snapshots TDX_VERIFIER_URL / TDX_VERIFIER_QEMU10_URL, so the patch
+    has to be in place at construction time.
+    """
+    monkeypatch.setattr(settings, "ENABLE_TDX_ATTESTATION", True)
+    monkeypatch.setattr(settings, "TDX_VERIFIER_URL", DEFAULT_URL)
+    monkeypatch.setattr(settings, "TDX_VERIFIER_QEMU10_URL", qemu10_url)
+    return AttestationService()
+
+
+def _quote(qemu_version: Any, *, vm_config_as_string: bool = True) -> str:
+    """Build a verifier-style quote JSON string carrying a qemu_version."""
+    vm_config: dict[str, Any] = {"spec_version": 1, "image": "dstack-x"}
+    if qemu_version is not _OMIT:
+        vm_config["qemu_version"] = qemu_version
+    payload = {
+        "quote": "deadbeef",
+        "vm_config": json.dumps(vm_config) if vm_config_as_string else vm_config,
+    }
+    return json.dumps(payload)
+
+
+_OMIT = object()  # sentinel: leave qemu_version out of vm_config entirely
+
+
+# ---------------------------------------------------------------------------
+# _select_verifier_url — routing decisions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", ["10.2.1", "10", "11.0.0", "12.1"])
+def test_qemu10_or_newer_routes_to_qemu10_verifier(monkeypatch, version):
+    service = _make_service(monkeypatch, qemu10_url=QEMU10_URL)
+    assert service._select_verifier_url(_quote(version)) == QEMU10_URL
+
+
+@pytest.mark.parametrize("version", ["9.2.1", "8.2.2", "9", "2.0"])
+def test_qemu9_or_older_routes_to_default_verifier(monkeypatch, version):
+    service = _make_service(monkeypatch, qemu10_url=QEMU10_URL)
+    assert service._select_verifier_url(_quote(version)) == DEFAULT_URL
+
+
+def test_qemu10_unset_always_routes_to_default(monkeypatch):
+    service = _make_service(monkeypatch, qemu10_url=None)
+    # Even a QEMU 10 quote must fall back to the default when no qemu10 URL exists.
+    assert service._select_verifier_url(_quote("10.2.1")) == DEFAULT_URL
+    assert service._select_verifier_url(_quote("9.2.1")) == DEFAULT_URL
+
+
+def test_vm_config_as_dict_and_as_string_both_route(monkeypatch):
+    service = _make_service(monkeypatch, qemu10_url=QEMU10_URL)
+    assert service._select_verifier_url(_quote("10.2.1", vm_config_as_string=True)) == QEMU10_URL
+    assert service._select_verifier_url(_quote("10.2.1", vm_config_as_string=False)) == QEMU10_URL
+    assert service._select_verifier_url(_quote("9.2.1", vm_config_as_string=True)) == DEFAULT_URL
+    assert service._select_verifier_url(_quote("9.2.1", vm_config_as_string=False)) == DEFAULT_URL
+
+
+# ---------------------------------------------------------------------------
+# _select_verifier_url — defensive fallbacks (must never raise)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "quote_json",
+    [
+        "{ this is not json",              # malformed JSON
+        "",                                # empty string
+        "null",                            # decodes to None, not a dict
+        "[]",                              # decodes to a list, not a dict
+        "\"just-a-string\"",               # decodes to a str, not a dict
+        json.dumps({"quote": "x"}),        # vm_config missing entirely
+        json.dumps({"vm_config": "{ not json"}),      # vm_config is unparseable JSON
+        json.dumps({"vm_config": "[]"}),              # vm_config decodes to non-dict
+        json.dumps({"vm_config": {}}),                # vm_config present, no qemu_version
+    ],
+)
+def test_malformed_or_missing_falls_back_to_default(monkeypatch, quote_json):
+    service = _make_service(monkeypatch, qemu10_url=QEMU10_URL)
+    assert service._select_verifier_url(quote_json) == DEFAULT_URL
+
+
+@pytest.mark.parametrize("version", ["q35", "", "  ", "abc", "x.y.z", "v10", "10a"])
+def test_weird_version_strings_fall_back_to_default(monkeypatch, version):
+    service = _make_service(monkeypatch, qemu10_url=QEMU10_URL)
+    assert service._select_verifier_url(_quote(version)) == DEFAULT_URL
+
+
+@pytest.mark.parametrize("version", [None, 10, 10.2, True, ["10"], _OMIT])
+def test_non_string_or_absent_version_falls_back_to_default(monkeypatch, version):
+    service = _make_service(monkeypatch, qemu10_url=QEMU10_URL)
+    # None / non-string / omitted qemu_version must never raise and must default.
+    assert service._select_verifier_url(_quote(version)) == DEFAULT_URL
+
+
+def test_select_never_raises_on_arbitrary_garbage(monkeypatch):
+    service = _make_service(monkeypatch, qemu10_url=QEMU10_URL)
+    for garbage in ["{}", "0", "true", "{\"vm_config\": 123}", "{\"vm_config\": null}"]:
+        assert service._select_verifier_url(garbage) == DEFAULT_URL
+
+
+def test_real_fixture_quote_routes_to_default(monkeypatch):
+    # The committed fixture stamps qemu_version 8.2.2 → default verifier.
+    service = _make_service(monkeypatch, qemu10_url=QEMU10_URL)
+    quote_response = json.loads(FIXTURE_PATH.read_text())["quote_response"]
+    assert service._select_verifier_url(json.dumps(quote_response)) == DEFAULT_URL
+
+
+# ---------------------------------------------------------------------------
+# _parse_qemu_version — best-effort extraction
+# ---------------------------------------------------------------------------
+
+
+def test_parse_qemu_version_string_and_dict_forms():
+    assert AttestationService._parse_qemu_version(_quote("10.2.1")) == "10.2.1"
+    assert AttestationService._parse_qemu_version(_quote("8.2.2", vm_config_as_string=False)) == "8.2.2"
+
+
+@pytest.mark.parametrize(
+    "quote_json",
+    ["{ bad json", "", "null", json.dumps({"quote": "x"}), json.dumps({"vm_config": {}})],
+)
+def test_parse_qemu_version_returns_none_on_failure(quote_json):
+    assert AttestationService._parse_qemu_version(quote_json) is None


### PR DESCRIPTION
## Describe your changes

**Context.** A `dstack-verifier` image embeds exactly **one** QEMU version's ACPI oracle, so one verifier can attest exactly one host-QEMU version. RTMR0 is a byte-exact SHA-384 of the QEMU-emitted ACPI tables, so a quote from a different QEMU version simply does not verify against the wrong oracle. The prod fleet runs **QEMU 9.2.1** (default verifier, digest-pinned, unchanged). This PR adds an optional **second** verifier plus version-based routing so a future mixed 9.x/10.x fleet stays verifiable, with today's behavior byte-for-byte unchanged.

**What changed**

- **Config** (`neurons/validators/src/core/config.py`): new optional `TDX_VERIFIER_QEMU10_URL` (default `None`).
- **Routing** (`neurons/validators/src/services/attestation_service.py`):
  - `_parse_qemu_version` reads `vm_config.qemu_version` from a quote, handling both wire forms — `vm_config` as a JSON string and as an already-decoded object.
  - `_select_verifier_url` routes a quote to the qemu10 verifier **only** when that URL is configured **and** the parsed major version is `>= 10`; everything else (no qemu10 URL, a 9.x host, or an absent/unparseable version) routes to the default verifier.
  - Ultra-defensive: the whole body is wrapped in `try/except` and any failure falls back to the default verifier. This runs on every attestation (the entire 9.2.1 fleet), so it can never break the existing path.
  - `_call_verifier` now selects the URL via the helper and logs which verifier was chosen (`verifier=qemu10|default`, plus the parsed `qemu_version`). The not-configured guard and `/verify` suffix logic are unchanged.
- **Compose** (`docker-compose.app.dstacktee.yml` + `.dev.yml`): new `dstack-verifier-qemu10` service pinned by digest `daturaai/dstack-verifier@sha256:3151aab51d618a0996cc353979c72b04f2137fd5be17be7487f1242faab3f83d` (tag `0.5.11-qemu10.2.1`), same restart policy and `DSTACK_VERIFIER_IMAGE_DOWNLOAD_URL` as the default verifier; validator gains `TDX_VERIFIER_QEMU10_URL` env and a `depends_on` entry. `docker-compose.local.yml` is intentionally untouched.
- **Tests** (`tests/test_attestation_verifier_routing.py`): 40 unit cases over the routing/parse helpers — 10.x → qemu10 URL, 9.x → default, qemu10 unset → default, malformed/missing/absent/weird versions never raise and default, and both `vm_config` wire forms.

**Why this is prod-inert.** Routing defaults to the primary verifier; the 9.2.1 fleet stamps `qemu_version` 9.2.1 and continues to the default verifier; the qemu10 path is live but only reachable from a QEMU `>= 10` host. `self.enabled` still keys on the primary URL only, so the new setting never changes whether attestation is on.

**Evidence.** The qemu10 verifier was proven end-to-end against a real TDX domain: MRTD stable, RTMR0 delta equal to exactly the three expected ACPI events, the RTMR1 raw-bzImage measurement fix applied for QEMU >= 10, and `is_valid=true`. The oracle is a reproducible Canonical build (`qemu` `1:10.2.1+ds-1ubuntu3.1`). Source: [Datura-ai/dstack@spike/qemu10-oracle-rebuild](https://github.com/Datura-ai/dstack/tree/spike/qemu10-oracle-rebuild) (commits `94dc90c1` Canonical-10.2.1 oracle + `6124e6ea` RTMR1 raw-kernel fix).

**Deploy note.** No action required at deploy — the routing helper falls back to the default verifier for every 9.x quote. Setting `TDX_VERIFIER_QEMU10_URL` (as the dstacktee compose files now do) enables the qemu10 path; leaving it unset disables it entirely, restoring exact single-verifier behavior.

_Tested locally: `pytest test_attestation_verifier_routing.py` → 40 passed; the existing `test_attestation_service.py` + `test_attestation_gaps_g1_g4.py` → 34 passed (after syncing the local `.venv` datura copy, which was stale). `ruff@0.5.1 check` clean on all touched files._

## Issue ticket number and link

No ticket provided.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance? No — the helper does one bounded JSON parse per attestation on an already-in-memory quote string; negligible relative to the network round-trip to the verifier.
