### PR TITLE
chore: DAH-2442 — install sysbox 0.7.0 in dstacktee CVM pre-launch

### DIFF
--- a/neurons/executor/dstacktee/app/pre_launch_script.sh
+++ b/neurons/executor/dstacktee/app/pre_launch_script.sh
@@ -1,7 +1,7 @@
 chmod +x /usr/bin/containerd-shim-runc-v2
 # dstack-nvidia-0.5.11 bakes upstream sysbox CE 0.6.7, which rejects --gpus
 # (docker device requests) and so fails the SN51 sysbox/GPU compatibility
-# check. Stop the baked daemons and force-install the Datura sysbox build
+# check. Stop the baked daemons and force-install our own sysbox 0.7.0 build
 # (GPU-capable, same topology as prod 0.5.5 CVMs). The installer skips itself
 # whenever any sysbox-mgr.service unit-file exists -- on 0.5.11 the baked
 # /usr/lib unit always matches -- so stub out its check_existing gate; the
@@ -9,8 +9,7 @@ chmod +x /usr/bin/containerd-shim-runc-v2
 systemctl unmask sysbox-mgr sysbox-fs 2>/dev/null || true
 systemctl stop sysbox-mgr sysbox-fs 2>/dev/null || true
 systemctl disable sysbox-mgr sysbox-fs 2>/dev/null || true
-# TODO: pin digest
-docker run --rm --privileged --pid=host --net=host -v /:/host dstacktee/dstack-sysbox-installer:1.0.0@sha256:2f5dbea99176f3ea0362b85346b31b1160bfb70c1d98d1c8d375d57782127dd1 bash -c "sed -i '/^check_existing() {/,/^}/c\\check_existing() { return 0; }' /usr/local/bin/install-sysbox-complete.sh && /usr/local/bin/install-sysbox-complete.sh"
+docker run --rm --privileged --pid=host --net=host -v /:/host daturaai/dstack-sysbox-installer:0.7.0@sha256:6e7e8e643a8c70467de5232b74cc1f6263ccfcc99d628425de6f1d5d59e0f116 bash -c "sed -i '/^check_existing() {/,/^}/c\\check_existing() { return 0; }' /usr/local/bin/install-sysbox-complete.sh && /usr/local/bin/install-sysbox-complete.sh"
 systemctl restart docker
 # Warm the images the validator's sysbox/DinD probes run, so first-cycle
 # probes don't burn their timeout budget on multi-GB registry pulls.


### PR DESCRIPTION
## Describe your changes

Point the executor's dstacktee CVM pre-launch at our own **sysbox 0.7.0** installer image instead of the upstream `dstacktee/dstack-sysbox-installer:1.0.0` (sysbox 0.6.7) build.

- Image: `dstacktee/dstack-sysbox-installer:1.0.0@sha256:2f5dbea9…` → `daturaai/dstack-sysbox-installer:0.7.0@sha256:6e7e8e643a8c70467de5232b74cc1f6263ccfcc99d628425de6f1d5d59e0f116`
- Dropped the now-resolved `# TODO: pin digest` (the new image is Datura-owned and already digest-pinned).
- Comment now names the sysbox 0.7.0 build.

The installer image was built and published from [Datura-ai/dstack-sysbox-installer#1](https://github.com/Datura-ai/dstack-sysbox-installer/pull/1) (sysbox `v0.7.0`, commit `27cb713…`) via the repo's release workflow → `daturaai/dstack-sysbox-installer:0.7.0` (sigstore-attested). The digest above was verified identical across the GitHub release body and the DockerHub tag.

The `check_existing` stub-out workaround is unchanged and still matches the shipped `install-sysbox-complete.sh` (the `check_existing()` function is present), so the force-reinstall over 0.5.11's baked sysbox still applies.

## Issue ticket number and link

DAH-2442 — bump dstacktee CVM sysbox to 0.7.0

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests. — N/A: shell pre-launch script executed inside the CVM. Validated with `bash -n` + digest cross-check; runtime validation is a fresh CVM rental exercising the sysbox/GPU compatibility probe.
- [ ] Need to take care of performance? — No.
