### PR TITLE
DAH-2439: classify filler death — punish only external kills (strike counter for ambiguous stops)

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -180,6 +180,10 @@ class Settings(BaseSettings):
     # filler container. Rollout: shadow first, flip enforcement after the shadow data is clean.
     FILLER_LIVENESS_CHECK_ENABLED: bool = Field(env="FILLER_LIVENESS_CHECK_ENABLED", default=True)
     FILLER_LIVENESS_ENFORCEMENT_ENABLED: bool = Field(env="FILLER_LIVENESS_ENFORCEMENT_ENABLED", default=False)
+    # Ambiguous SIGTERM/SIGKILL stops (a process could in theory exit 143 itself): the first
+    # incident per executor is logged only; from this many incidents in the strike window the
+    # stop is treated as an external kill and punished.
+    FILLER_KILL_STRIKE_THRESHOLD: int = Field(env="FILLER_KILL_STRIKE_THRESHOLD", default=2)
     SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")

--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -158,10 +158,14 @@ class ContainerDeathKind(str, Enum):
 _ZERO_DOCKER_TIMESTAMP_PREFIX = "0001-01-01"
 _KILL_SIGNAL_EXIT_CODES = (137, 143)  # 128+SIGKILL, 128+SIGTERM
 _REMOVED_MARKERS = ("no such object", "no such container")  # docker casing varies; match lowercased
-# A reboot/compose-restart SIGTERMs every container at once, so the executor stack restarts around
-# the same time. If it (re)started no earlier than this many seconds before the filler died, the
-# SIGTERM was collateral of that restart, not a filler-targeted `docker stop`.
+# A reboot SIGTERMs every container at shutdown and brings the executor stack back up on boot, so
+# the executor's StartedAt lands at or shortly AFTER the filler's death. The restart must bracket
+# the death to count as collateral: up to this long after (slow boot), with only a small skew
+# tolerance before (clocks). A filler-targeted `docker stop` leaves the executor started hours/days
+# earlier (far-negative delta); an executor that restarts long after the kill (far-positive delta)
+# does not excuse a kill that already happened.
 _HOST_RESTART_WINDOW_SECONDS = 600
+_HOST_RESTART_CLOCK_SKEW_SECONDS = 120
 
 
 def _never_started(diagnostics: ContainerDeathDiagnostics) -> bool:
@@ -183,13 +187,17 @@ def _stop_coincided_with_host_restart(diagnostics: ContainerDeathDiagnostics) ->
     finished = _parse_docker_timestamp(diagnostics.finished_at)
     if executor_started is None or finished is None:
         return False
-    return (executor_started - finished).total_seconds() > -_HOST_RESTART_WINDOW_SECONDS
+    delta_seconds = (executor_started - finished).total_seconds()
+    return -_HOST_RESTART_CLOCK_SKEW_SECONDS <= delta_seconds <= _HOST_RESTART_WINDOW_SECONDS
 
 
 def classify_container_death(diagnostics: ContainerDeathDiagnostics) -> ContainerDeathKind:
+    # Match the "no such object/container" marker only in OUR inspect error, never in the
+    # container's own logs_tail: a genuinely removed container fails inspect and lands the
+    # marker in capture_error, while a still-existing stopped container whose workload merely
+    # printed that string would otherwise be misread as removed and punished outright.
     capture_error = (diagnostics.capture_error or "").lower()
-    logs_tail = (diagnostics.logs_tail or "").lower()
-    if any(marker in capture_error or marker in logs_tail for marker in _REMOVED_MARKERS):
+    if any(marker in capture_error for marker in _REMOVED_MARKERS):
         return ContainerDeathKind.REMOVED
     if diagnostics.oom_killed:
         return ContainerDeathKind.OOM_KILLED

--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -2,6 +2,8 @@ import asyncio
 import json
 import shlex
 from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
 
 import asyncssh
 
@@ -133,6 +135,74 @@ class ContainerDeathDiagnostics:
             "container_host_context": self.host_context,
             "diagnostics_capture_error": self.capture_error,
         }
+
+
+class ContainerDeathKind(str, Enum):
+    """Why a dead filler container died — decides whether the provider is punishable.
+
+    Only REMOVED and STOPPED are external kills (a container cannot rm or SIGTERM itself
+    from outside its own process tree); everything else is the filler's or the host's own
+    failure and belongs to self-heal (DAH-2419), never to incentive withholding.
+    """
+
+    REMOVED = "removed"  # container gone entirely — external `docker rm`
+    STOPPED = "stopped"  # exited by SIGKILL/SIGTERM (137/143), not OOM — external stop
+    SELF_CRASHED = "self_crashed"  # nonzero exit other than the kill signals
+    OOM_KILLED = "oom_killed"  # kernel OOM kill (reports 137 + OOMKilled=true)
+    NEVER_STARTED = "never_started"  # created but never ran, or start failed
+    CLEAN_EXIT = "clean_exit"  # exit 0
+    UNKNOWN = "unknown"  # diagnostics incomplete — fail open
+
+
+_ZERO_DOCKER_TIMESTAMP_PREFIX = "0001-01-01"
+_KILL_SIGNAL_EXIT_CODES = (137, 143)  # 128+SIGKILL, 128+SIGTERM
+
+
+def _never_started(diagnostics: ContainerDeathDiagnostics) -> bool:
+    if diagnostics.status == "created":
+        return True
+    started = diagnostics.started_at or ""
+    return started.startswith(_ZERO_DOCKER_TIMESTAMP_PREFIX) if started else False
+
+
+def classify_container_death(diagnostics: ContainerDeathDiagnostics) -> ContainerDeathKind:
+    capture_error = diagnostics.capture_error or ""
+    logs_tail = diagnostics.logs_tail or ""
+    if "no such object" in capture_error or "No such container" in logs_tail:
+        return ContainerDeathKind.REMOVED
+    if diagnostics.oom_killed:
+        return ContainerDeathKind.OOM_KILLED
+    if _never_started(diagnostics):
+        return ContainerDeathKind.NEVER_STARTED
+    if diagnostics.exit_code in _KILL_SIGNAL_EXIT_CODES:
+        return ContainerDeathKind.STOPPED
+    if diagnostics.exit_code == 0 and diagnostics.status is not None:
+        return ContainerDeathKind.CLEAN_EXIT
+    if isinstance(diagnostics.exit_code, int) and diagnostics.exit_code != 0:
+        return ContainerDeathKind.SELF_CRASHED
+    return ContainerDeathKind.UNKNOWN
+
+
+def _parse_docker_timestamp(value: str | None) -> datetime | None:
+    if not value or value.startswith(_ZERO_DOCKER_TIMESTAMP_PREFIX):
+        return None
+    # Docker prints RFC3339 with nanoseconds; fromisoformat takes at most microseconds.
+    trimmed = value.rstrip("Z")
+    if "." in trimmed:
+        seconds_part, fraction = trimmed.split(".", 1)
+        trimmed = f"{seconds_part}.{fraction[:6]}"
+    try:
+        return datetime.fromisoformat(trimmed)
+    except ValueError:
+        return None
+
+
+def container_uptime_seconds(started_at: str | None, finished_at: str | None) -> float | None:
+    started = _parse_docker_timestamp(started_at)
+    finished = _parse_docker_timestamp(finished_at)
+    if started is None or finished is None:
+        return None
+    return (finished - started).total_seconds()
 
 
 async def collect_container_death_diagnostics(

--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -147,6 +147,7 @@ class ContainerDeathKind(str, Enum):
 
     REMOVED = "removed"  # container gone entirely — external `docker rm`
     STOPPED = "stopped"  # exited by SIGKILL/SIGTERM (137/143), not OOM — external stop
+    HOST_REBOOT = "host_reboot"  # SIGTERM that coincided with a host reboot / executor restart
     SELF_CRASHED = "self_crashed"  # nonzero exit other than the kill signals
     OOM_KILLED = "oom_killed"  # kernel OOM kill (reports 137 + OOMKilled=true)
     NEVER_STARTED = "never_started"  # created but never ran, or start failed
@@ -156,6 +157,11 @@ class ContainerDeathKind(str, Enum):
 
 _ZERO_DOCKER_TIMESTAMP_PREFIX = "0001-01-01"
 _KILL_SIGNAL_EXIT_CODES = (137, 143)  # 128+SIGKILL, 128+SIGTERM
+_REMOVED_MARKERS = ("no such object", "no such container")  # docker casing varies; match lowercased
+# A reboot/compose-restart SIGTERMs every container at once, so the executor stack restarts around
+# the same time. If it (re)started no earlier than this many seconds before the filler died, the
+# SIGTERM was collateral of that restart, not a filler-targeted `docker stop`.
+_HOST_RESTART_WINDOW_SECONDS = 600
 
 
 def _never_started(diagnostics: ContainerDeathDiagnostics) -> bool:
@@ -165,16 +171,33 @@ def _never_started(diagnostics: ContainerDeathDiagnostics) -> bool:
     return started.startswith(_ZERO_DOCKER_TIMESTAMP_PREFIX) if started else False
 
 
+def _stop_coincided_with_host_restart(diagnostics: ContainerDeathDiagnostics) -> bool:
+    """True when the executor stack restarted around the filler's death (reboot/compose restart).
+
+    Uses the executor container's start time (a UTC docker timestamp, same clock as FinishedAt) to
+    avoid the timezone ambiguity of `uptime -s`. A filler-targeted `docker stop` leaves the executor
+    stack untouched, so its start time stays hours/days before the death.
+    """
+    context = diagnostics.host_context or {}
+    executor_started = _parse_docker_timestamp(context.get("executor_container_started_at"))
+    finished = _parse_docker_timestamp(diagnostics.finished_at)
+    if executor_started is None or finished is None:
+        return False
+    return (executor_started - finished).total_seconds() > -_HOST_RESTART_WINDOW_SECONDS
+
+
 def classify_container_death(diagnostics: ContainerDeathDiagnostics) -> ContainerDeathKind:
-    capture_error = diagnostics.capture_error or ""
-    logs_tail = diagnostics.logs_tail or ""
-    if "no such object" in capture_error or "No such container" in logs_tail:
+    capture_error = (diagnostics.capture_error or "").lower()
+    logs_tail = (diagnostics.logs_tail or "").lower()
+    if any(marker in capture_error or marker in logs_tail for marker in _REMOVED_MARKERS):
         return ContainerDeathKind.REMOVED
     if diagnostics.oom_killed:
         return ContainerDeathKind.OOM_KILLED
     if _never_started(diagnostics):
         return ContainerDeathKind.NEVER_STARTED
     if diagnostics.exit_code in _KILL_SIGNAL_EXIT_CODES:
+        if _stop_coincided_with_host_restart(diagnostics):
+            return ContainerDeathKind.HOST_REBOOT
         return ContainerDeathKind.STOPPED
     if diagnostics.exit_code == 0 and diagnostics.status is not None:
         return ContainerDeathKind.CLEAN_EXIT

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -224,6 +224,8 @@ PREFERRED_POD_PORTS = [20000, 20001, 20002, 20003, 20004, 20005, 20006, 20007, 2
 POD_CONTAINER_PREFIX = "pod_"
 FILLER_CONTAINER_PREFIX = "filler_"
 FILLER_CONTAINER_GRACE_MINUTES = 15
+# ISSUE-050 strike window: how long suspicious-stop incidents count against an executor.
+FILLER_KILL_STRIKE_TTL_SECONDS = 7 * 24 * 3600
 # ISSUE-050: a filler run younger than this is not penalized for a missing container —
 # it may still be finishing its create/stop race with the backend snapshot.
 FILLER_LIVENESS_GRACE_MINUTES = 10

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -70,6 +70,27 @@ class RedisService:
             )
             raise
 
+    async def register_filler_kill_strike(
+        self, executor_uuid: str, filler_run_id: str, ttl_seconds: int
+    ) -> int:
+        """Count one suspicious-kill INCIDENT per filler run, strikes accumulated per executor.
+
+        The same dead run is observed every validation cycle; SETNX on the run id makes it a
+        single strike no matter how many cycles see it. Returns the executor's current strike
+        count inside the TTL window.
+        """
+        async with self.lock:
+            is_new_incident = await self.redis.set(
+                f"filler_kill_seen:{filler_run_id}", "1", nx=True, ex=ttl_seconds
+            )
+            strikes_key = f"filler_kill_strikes:{executor_uuid}"
+            if is_new_incident:
+                strikes = await self.redis.incr(strikes_key)
+                await self.redis.expire(strikes_key, ttl_seconds)
+                return int(strikes)
+            current = await self.redis.get(strikes_key)
+            return int(current) if current else 1
+
     async def publish(self, channel: str, message: dict):
         """Publish a message to a Redis channel."""
         await self.redis.publish(channel, json.dumps(message))

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -79,11 +79,10 @@ class RedisService:
         single strike no matter how many cycles see it. Returns the executor's current strike
         count inside the TTL window.
         """
+        seen_key = f"filler_kill_seen:{filler_run_id}"
+        strikes_key = f"filler_kill_strikes:{executor_uuid}"
         async with self.lock:
-            is_new_incident = await self.redis.set(
-                f"filler_kill_seen:{filler_run_id}", "1", nx=True, ex=ttl_seconds
-            )
-            strikes_key = f"filler_kill_strikes:{executor_uuid}"
+            is_new_incident = await self.redis.set(seen_key, "1", nx=True, ex=ttl_seconds)
             if is_new_incident:
                 # INCR + EXPIRE in one MULTI so a crash between them can't orphan the key
                 # without a TTL (which would pin the executor above threshold forever).
@@ -92,13 +91,17 @@ class RedisService:
                     pipe.expire(strikes_key, ttl_seconds)
                     strikes, _ = await pipe.execute()
                 return int(strikes)
-            # Already-counted incident (same run seen again this window). Refresh the TTL so a
-            # persistent killer keeps its strikes alive; an honest node stops being observed and
-            # the key expires ttl_seconds after its last incident.
+            # Already-counted incident (same run seen again this window). Refresh BOTH keys so a
+            # persistent killer keeps its strikes alive AND this one dead run never re-counts as a
+            # fresh incident: without refreshing the seen key, a run stuck RUNNING past the TTL would
+            # let its seen marker expire mid-observation and be double-charged as a second strike.
             current_strikes = await self.redis.get(strikes_key)
             if current_strikes is None:
                 return 1
-            await self.redis.expire(strikes_key, ttl_seconds)
+            async with self.redis.pipeline(transaction=True) as pipe:
+                pipe.expire(seen_key, ttl_seconds)
+                pipe.expire(strikes_key, ttl_seconds)
+                await pipe.execute()
             return int(current_strikes)
 
     async def publish(self, channel: str, message: dict):

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -85,11 +85,21 @@ class RedisService:
             )
             strikes_key = f"filler_kill_strikes:{executor_uuid}"
             if is_new_incident:
-                strikes = await self.redis.incr(strikes_key)
-                await self.redis.expire(strikes_key, ttl_seconds)
+                # INCR + EXPIRE in one MULTI so a crash between them can't orphan the key
+                # without a TTL (which would pin the executor above threshold forever).
+                async with self.redis.pipeline(transaction=True) as pipe:
+                    pipe.incr(strikes_key)
+                    pipe.expire(strikes_key, ttl_seconds)
+                    strikes, _ = await pipe.execute()
                 return int(strikes)
-            current = await self.redis.get(strikes_key)
-            return int(current) if current else 1
+            # Already-counted incident (same run seen again this window). Refresh the TTL so a
+            # persistent killer keeps its strikes alive; an honest node stops being observed and
+            # the key expires ttl_seconds after its last incident.
+            current_strikes = await self.redis.get(strikes_key)
+            if current_strikes is None:
+                return 1
+            await self.redis.expire(strikes_key, ttl_seconds)
+            return int(current_strikes)
 
     async def publish(self, channel: str, message: dict):
         """Publish a message to a Redis channel."""

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -249,19 +249,16 @@ class RentalVerificationCheck:
                 DockerCommand.ps_running(filler_container)
             )
         except (asyncssh.Error, OSError) as exc:
-            # SSH transport died mid-cycle: filler state is unknown, do not re-check.
-            event = render_message(
-                Msg.FILLER_TRANSPORT_UNREACHABLE,
-                ctx=ctx,
-                check_id=self.check_id,
-                what={
-                    "filler_container": filler_container,
-                    "executor_uuid": ctx.executor.uuid,
-                    "transport_error": repr(exc),
-                    "enforced": enforce,
-                },
+            # SSH transport died mid-cycle: a lost connection is not evidence the owner killed the
+            # filler, so never penalize it even under enforcement — fail open. A real kill still
+            # surfaces as REMOVED/STOPPED on a later cycle once the connection is back.
+            return self._filler_state_unknown_result(
+                ctx,
+                filler_container,
+                reason="ssh transport unreachable",
+                details={"transport_error": repr(exc)},
+                template=Msg.FILLER_TRANSPORT_UNREACHABLE,
             )
-            return CheckResult(passed=not enforce, event=event, updates={})
 
         if ps_result.exit_status != 0:
             # docker daemon error (e.g. restarting) — indistinguishable from a kill, so fail open.
@@ -450,9 +447,10 @@ class RentalVerificationCheck:
         *,
         reason: str,
         details: dict[str, object] | None = None,
+        template: MessageTemplate = Msg.FILLER_STATE_UNKNOWN,
     ) -> CheckResult:
         event = render_message(
-            Msg.FILLER_STATE_UNKNOWN,
+            template,
             ctx=ctx,
             check_id=self.check_id,
             what={

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -255,6 +255,7 @@ class RentalVerificationCheck:
             return self._filler_state_unknown_result(
                 ctx,
                 filler_container,
+                enforce=enforce,
                 reason="ssh transport unreachable",
                 details={"transport_error": repr(exc)},
                 template=Msg.FILLER_TRANSPORT_UNREACHABLE,
@@ -265,6 +266,7 @@ class RentalVerificationCheck:
             return self._filler_state_unknown_result(
                 ctx,
                 filler_container,
+                enforce=enforce,
                 reason="docker ps failed on host",
                 details={"exit_status": ps_result.exit_status},
             )
@@ -293,7 +295,7 @@ class RentalVerificationCheck:
 
         if filler_run is None:
             return self._filler_state_unknown_result(
-                ctx, filler_container, reason="filler-run re-check API unavailable"
+                ctx, filler_container, enforce=enforce, reason="filler-run re-check API unavailable"
             )
 
         if not filler_run.active:
@@ -303,6 +305,7 @@ class RentalVerificationCheck:
             return self._filler_state_unknown_result(
                 ctx,
                 filler_container,
+                enforce=enforce,
                 reason="filler run is not in RUNNING state",
                 details={"filler_run_status": filler_run.status},
             )
@@ -314,6 +317,7 @@ class RentalVerificationCheck:
             return self._filler_state_unknown_result(
                 ctx,
                 filler_container,
+                enforce=enforce,
                 reason="filler run within startup grace window",
                 details={"run_age_seconds": run_age.total_seconds() if run_age else None},
             )
@@ -335,16 +339,18 @@ class RentalVerificationCheck:
         run_age: timedelta,
         enforce: bool,
     ) -> CheckResult:
-        """Classify WHY the container is dead; only an external kill may cost incentive.
+        """Classify WHY the container is dead; only a repeated targeted kill may cost incentive.
 
-        REMOVED (container gone) is punishable outright — nothing legitimate deletes a
-        RUNNING run's container. STOPPED (SIGTERM/SIGKILL) could in theory be the worker
-        exiting 143 itself, so the first incident per executor is a logged strike and only
-        repeat incidents within the strike window are punished. Strikes are only counted
-        under enforcement, so an executor always gets its grace incident once enforcement
-        begins, never a strike carried over from the shadow period. HOST_REBOOT and every
-        self-death kind (self-crash, OOM, never started, clean exit, unknown) are self-heal
-        territory and never punished.
+        REMOVED (container gone) and STOPPED (SIGTERM/SIGKILL) are both "container missing"
+        with no reliable one-shot kill signal, so both are strike-gated: the first incident
+        per executor is a logged strike and only repeat incidents within the strike window are
+        punished. Prod shadow proved this necessary — every removed case was a single
+        unreconciled zombie run (backend filler_run stuck RUNNING after a host reboot or a
+        watchtower executor recreation), not a fresh kill; punishing REMOVED outright would
+        have hit honest providers. Strikes are only counted under enforcement, so an executor
+        always gets its grace incident once enforcement begins, never a strike carried over
+        from the shadow period. HOST_REBOOT and every self-death kind (self-crash, OOM, never
+        started, clean exit, unknown) are self-heal territory and never punished.
         """
         try:
             diagnostics = await collect_container_death_diagnostics(ctx.ssh, filler_container)
@@ -369,13 +375,11 @@ class RentalVerificationCheck:
             "death_kind": death_kind.value,
             "container_uptime_seconds": uptime_seconds,
             "kill_timing": kill_timing,
+            "enforced": enforce,
             **death_fields,
         }
 
-        if death_kind is ContainerDeathKind.REMOVED:
-            return self._external_kill_result(ctx, enforce=enforce, what=common_what)
-
-        if death_kind is ContainerDeathKind.STOPPED:
+        if death_kind in (ContainerDeathKind.REMOVED, ContainerDeathKind.STOPPED):
             return await self._ambiguous_stop_result(
                 ctx, filler_container, enforce=enforce, what=common_what
             )
@@ -406,15 +410,19 @@ class RentalVerificationCheck:
 
         strikes = await self._register_kill_strike(ctx, filler_container)
         what["kill_strikes"] = strikes
-        if strikes is None or strikes >= settings.FILLER_KILL_STRIKE_THRESHOLD:
+        # strikes is None => the strike store is unreachable (Redis down). A lost store is not
+        # evidence of a repeat kill, so fail open like every other unknown in this check rather
+        # than punish a provider for our own outage — a real repeat killer resurfaces as REMOVED
+        # or another stop once Redis is back.
+        if strikes is not None and strikes >= settings.FILLER_KILL_STRIKE_THRESHOLD:
             return self._external_kill_result(ctx, enforce=enforce, what=what)
         return self._passthrough_result(ctx, Msg.FILLER_KILL_SUSPECTED, what)
 
     async def _register_kill_strike(self, ctx: Context, filler_container: str) -> int | None:
         """One strike per filler run (deduped in Redis); None when Redis is unavailable.
 
-        None is treated as strikes-reached by the caller: an ambiguous stop with no working
-        strike storage falls back to the strict verdict rather than a free pass forever.
+        None means the strike store is unreachable, and the caller fails open (no penalty) —
+        a provider is never punished because our own Redis was down.
         """
         filler_run_id: str = filler_container.removeprefix(FILLER_CONTAINER_PREFIX)
         redis_service = ctx.services.redis
@@ -430,13 +438,14 @@ class RentalVerificationCheck:
     def _external_kill_result(
         self, ctx: Context, *, enforce: bool, what: dict[str, object]
     ) -> CheckResult:
+        # `enforced` already rides in via `what` (common_what); only `verified` is added here.
         event = render_message(
             Msg.FILLER_KILLED,
             ctx=ctx,
             check_id=self.check_id,
             severity=None if enforce else "warning",
             impact=None if enforce else "Shadow observation only: incentive was NOT withheld",
-            what={"verified": False, "enforced": enforce, **what},
+            what={"verified": False, **what},
         )
         return CheckResult(passed=not enforce, event=event, updates={})
 
@@ -445,6 +454,7 @@ class RentalVerificationCheck:
         ctx: Context,
         filler_container: str,
         *,
+        enforce: bool,
         reason: str,
         details: dict[str, object] | None = None,
         template: MessageTemplate = Msg.FILLER_STATE_UNKNOWN,
@@ -457,6 +467,7 @@ class RentalVerificationCheck:
                 "filler_container": filler_container,
                 "executor_uuid": ctx.executor.uuid,
                 "reason": reason,
+                "enforced": enforce,
                 **(details or {}),
             },
         )

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -22,7 +22,7 @@ from ...const import (
     FILLER_KILL_STRIKE_TTL_SECONDS,
     FILLER_LIVENESS_GRACE_MINUTES,
 )
-from ..messages import RentalVerificationMessages as Msg, render_message
+from ..messages import MessageTemplate, RentalVerificationMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
 
@@ -343,9 +343,11 @@ class RentalVerificationCheck:
         REMOVED (container gone) is punishable outright — nothing legitimate deletes a
         RUNNING run's container. STOPPED (SIGTERM/SIGKILL) could in theory be the worker
         exiting 143 itself, so the first incident per executor is a logged strike and only
-        repeat incidents within the strike window are punished. Every other death kind
-        (self-crash, OOM, never started, clean exit, unknown) is self-heal territory and
-        never punished.
+        repeat incidents within the strike window are punished. Strikes are only counted
+        under enforcement, so an executor always gets its grace incident once enforcement
+        begins, never a strike carried over from the shadow period. HOST_REBOOT and every
+        self-death kind (self-crash, OOM, never started, clean exit, unknown) are self-heal
+        territory and never punished.
         """
         try:
             diagnostics = await collect_container_death_diagnostics(ctx.ssh, filler_container)
@@ -377,26 +379,39 @@ class RentalVerificationCheck:
             return self._external_kill_result(ctx, enforce=enforce, what=common_what)
 
         if death_kind is ContainerDeathKind.STOPPED:
-            strikes = await self._register_kill_strike(ctx, filler_container)
-            common_what["kill_strikes"] = strikes
-            if strikes is None or strikes >= settings.FILLER_KILL_STRIKE_THRESHOLD:
-                return self._external_kill_result(ctx, enforce=enforce, what=common_what)
-            event = render_message(
-                Msg.FILLER_KILL_SUSPECTED,
-                ctx=ctx,
-                check_id=self.check_id,
-                what=common_what,
+            return await self._ambiguous_stop_result(
+                ctx, filler_container, enforce=enforce, what=common_what
             )
-            return CheckResult(passed=True, event=event, updates={})
 
-        # SELF_CRASHED / OOM_KILLED / NEVER_STARTED / CLEAN_EXIT / UNKNOWN: not the owner's kill.
-        event = render_message(
-            Msg.FILLER_CRASHED,
-            ctx=ctx,
-            check_id=self.check_id,
-            what=common_what,
-        )
+        # HOST_REBOOT / SELF_CRASHED / OOM_KILLED / NEVER_STARTED / CLEAN_EXIT / UNKNOWN:
+        # not the owner targeting the filler.
+        return self._passthrough_result(ctx, Msg.FILLER_CRASHED, common_what)
+
+    def _passthrough_result(
+        self, ctx: Context, template: MessageTemplate, what: dict[str, object]
+    ) -> CheckResult:
+        """Emit a non-penalizing verdict: the event is logged, incentive is untouched."""
+        event = render_message(template, ctx=ctx, check_id=self.check_id, what=what)
         return CheckResult(passed=True, event=event, updates={})
+
+    async def _ambiguous_stop_result(
+        self, ctx: Context, filler_container: str, *, enforce: bool, what: dict[str, object]
+    ) -> CheckResult:
+        """A SIGTERM/SIGKILL stop: count a strike (enforcement only) and punish past threshold.
+
+        Strikes are never counted in shadow — otherwise the first ENFORCED incident could inherit
+        a shadow-period strike and skip the grace incident. In shadow this is always a no-penalty
+        suspected event.
+        """
+        if not enforce:
+            what["kill_strikes"] = None
+            return self._passthrough_result(ctx, Msg.FILLER_KILL_SUSPECTED, what)
+
+        strikes = await self._register_kill_strike(ctx, filler_container)
+        what["kill_strikes"] = strikes
+        if strikes is None or strikes >= settings.FILLER_KILL_STRIKE_THRESHOLD:
+            return self._external_kill_result(ctx, enforce=enforce, what=what)
+        return self._passthrough_result(ctx, Msg.FILLER_KILL_SUSPECTED, what)
 
     async def _register_kill_strike(self, ctx: Context, filler_container: str) -> int | None:
         """One strike per filler run (deduped in Redis); None when Redis is unavailable.

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -5,13 +5,23 @@ from datetime import datetime, timedelta
 import asyncssh
 
 from core.config import settings
-from core.docker_utils import DockerCommand, collect_container_death_diagnostics
+from core.docker_utils import (
+    ContainerDeathKind,
+    DockerCommand,
+    classify_container_death,
+    collect_container_death_diagnostics,
+    container_uptime_seconds,
+)
 from protocol.vc_protocol.compute_requests import (
     GPU_RUNTIME_NVML_MISMATCH_REASON,
     FillerRunActiveResponse,
 )
 
-from ...const import FILLER_CONTAINER_PREFIX, FILLER_LIVENESS_GRACE_MINUTES
+from ...const import (
+    FILLER_CONTAINER_PREFIX,
+    FILLER_KILL_STRIKE_TTL_SECONDS,
+    FILLER_LIVENESS_GRACE_MINUTES,
+)
 from ..messages import RentalVerificationMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
@@ -328,28 +338,93 @@ class RentalVerificationCheck:
         run_age: timedelta,
         enforce: bool,
     ) -> CheckResult:
-        """Render the confirmed-kill verdict: capture death diagnostics and emit FILLER_KILLED."""
+        """Classify WHY the container is dead; only an external kill may cost incentive.
+
+        REMOVED (container gone) is punishable outright — nothing legitimate deletes a
+        RUNNING run's container. STOPPED (SIGTERM/SIGKILL) could in theory be the worker
+        exiting 143 itself, so the first incident per executor is a logged strike and only
+        repeat incidents within the strike window are punished. Every other death kind
+        (self-crash, OOM, never started, clean exit, unknown) is self-heal territory and
+        never punished.
+        """
         try:
             diagnostics = await collect_container_death_diagnostics(ctx.ssh, filler_container)
             death_fields: dict[str, object] = diagnostics.to_log_fields()
+            death_kind = classify_container_death(diagnostics)
+            uptime_seconds = container_uptime_seconds(diagnostics.started_at, diagnostics.finished_at)
         except Exception as exc:
             death_fields = {"diagnostics_capture_error": repr(exc)}
+            death_kind = ContainerDeathKind.UNKNOWN
+            uptime_seconds = None
 
+        kill_timing: str | None = None
+        if uptime_seconds is not None:
+            grace_seconds = FILLER_LIVENESS_GRACE_MINUTES * 60
+            kill_timing = "at_start" if uptime_seconds < grace_seconds else "after_running"
+
+        common_what: dict[str, object] = {
+            "filler_container": filler_container,
+            "executor_uuid": ctx.executor.uuid,
+            "filler_run_status": filler_run_status,
+            "run_age_seconds": run_age.total_seconds(),
+            "death_kind": death_kind.value,
+            "container_uptime_seconds": uptime_seconds,
+            "kill_timing": kill_timing,
+            **death_fields,
+        }
+
+        if death_kind is ContainerDeathKind.REMOVED:
+            return self._external_kill_result(ctx, enforce=enforce, what=common_what)
+
+        if death_kind is ContainerDeathKind.STOPPED:
+            strikes = await self._register_kill_strike(ctx, filler_container)
+            common_what["kill_strikes"] = strikes
+            if strikes is None or strikes >= settings.FILLER_KILL_STRIKE_THRESHOLD:
+                return self._external_kill_result(ctx, enforce=enforce, what=common_what)
+            event = render_message(
+                Msg.FILLER_KILL_SUSPECTED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what=common_what,
+            )
+            return CheckResult(passed=True, event=event, updates={})
+
+        # SELF_CRASHED / OOM_KILLED / NEVER_STARTED / CLEAN_EXIT / UNKNOWN: not the owner's kill.
+        event = render_message(
+            Msg.FILLER_CRASHED,
+            ctx=ctx,
+            check_id=self.check_id,
+            what=common_what,
+        )
+        return CheckResult(passed=True, event=event, updates={})
+
+    async def _register_kill_strike(self, ctx: Context, filler_container: str) -> int | None:
+        """One strike per filler run (deduped in Redis); None when Redis is unavailable.
+
+        None is treated as strikes-reached by the caller: an ambiguous stop with no working
+        strike storage falls back to the strict verdict rather than a free pass forever.
+        """
+        filler_run_id: str = filler_container.removeprefix(FILLER_CONTAINER_PREFIX)
+        redis_service = ctx.services.redis
+        if redis_service is None:
+            return None
+        try:
+            return await redis_service.register_filler_kill_strike(
+                ctx.executor.uuid, filler_run_id, FILLER_KILL_STRIKE_TTL_SECONDS
+            )
+        except Exception:
+            return None
+
+    def _external_kill_result(
+        self, ctx: Context, *, enforce: bool, what: dict[str, object]
+    ) -> CheckResult:
         event = render_message(
             Msg.FILLER_KILLED,
             ctx=ctx,
             check_id=self.check_id,
             severity=None if enforce else "warning",
             impact=None if enforce else "Shadow observation only: incentive was NOT withheld",
-            what={
-                "verified": False,
-                "filler_container": filler_container,
-                "executor_uuid": ctx.executor.uuid,
-                "filler_run_status": filler_run_status,
-                "run_age_seconds": run_age.total_seconds(),
-                "enforced": enforce,
-                **death_fields,
-            },
+            what={"verified": False, "enforced": enforce, **what},
         )
         return CheckResult(passed=not enforce, event=event, updates={})
 

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1012,6 +1012,21 @@ class RentalVerificationMessages:
             "Contact Lium support if this container was not removed by you."
         ),
     )
+    FILLER_KILL_SUSPECTED = MessageTemplate(
+        event="Lium default job was stopped on the host — first strike",
+        reason="FILLER_KILL_SUSPECTED",
+        severity="warning",
+        category="policy",
+        impact="No penalty yet: a lone SIGTERM/SIGKILL stop could be the worker itself; repeat incidents will be treated as an external kill",
+        remediation="Do not stop Lium default-job (filler_*) containers; repeated stops cost unrented incentive.",
+    )
+    FILLER_CRASHED = MessageTemplate(
+        event="Lium default job died on its own",
+        reason="FILLER_CRASHED",
+        severity="warning",
+        category="runtime",
+        impact="No penalty: the filler crashed, hit OOM or failed to start — self-heal territory, not an external kill",
+    )
     FILLER_STATE_UNKNOWN = MessageTemplate(
         event="Lium default job state could not be verified",
         reason="FILLER_STATE_UNKNOWN",

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1039,7 +1039,7 @@ class RentalVerificationMessages:
         reason="FILLER_TRANSPORT_UNREACHABLE",
         severity="warning",
         category="runtime",
-        impact="Filler state unknown for this cycle",
+        impact="No penalty: a lost connection is not evidence of a kill; re-checked next cycle",
         remediation="Ensure the executor is reachable over SSH and stays online",
     )
 

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -281,6 +281,14 @@ class GpuPowerLimitMessages:
         category="policy",
         impact="Proceed; Lium lowered the limit for its own idle filler, node stays rentable",
     )
+    RECAPPED_DRIFTED_FILLER = MessageTemplate(
+        event="Re-applied Lium filler GPU power cap that had drifted back up",
+        reason="GPU_POWER_LIMIT_RECAPPED_DRIFTED_FILLER",
+        severity="warning",
+        category="policy",
+        impact="Proceed; the idle filler's power cap reverted on the host and was re-applied to target",
+        remediation="If this recurs on the same node, its host may reset the power limit externally.",
+    )
     RESTORED_STALE_CAP = MessageTemplate(
         event="Below-floor GPU power limits are Lium's own filler caps",
         reason="GPU_POWER_LIMIT_RESTORED_STALE_CAP",
@@ -1021,11 +1029,11 @@ class RentalVerificationMessages:
         remediation="Do not stop Lium default-job (filler_*) containers; repeated stops cost unrented incentive.",
     )
     FILLER_CRASHED = MessageTemplate(
-        event="Lium default job died on its own",
+        event="Lium default job ended without an external kill",
         reason="FILLER_CRASHED",
         severity="warning",
         category="runtime",
-        impact="No penalty: the filler crashed, hit OOM or failed to start — self-heal territory, not an external kill",
+        impact="No penalty: not an external kill (self-crash, OOM, host reboot, clean exit, or undiagnosed) — self-heal territory. See death_kind for which.",
     )
     FILLER_STATE_UNKNOWN = MessageTemplate(
         event="Lium default job state could not be verified",

--- a/neurons/validators/tests/test_container_death_classification.py
+++ b/neurons/validators/tests/test_container_death_classification.py
@@ -87,3 +87,35 @@ def test_uptime_from_docker_timestamps():
 def test_uptime_is_none_when_timestamps_missing():
     assert container_uptime_seconds(started_at=None, finished_at="2026-07-20T06:05:30Z") is None
     assert container_uptime_seconds(started_at="0001-01-01T00:00:00Z", finished_at="2026-07-20T06:05:30Z") is None
+
+
+def test_removed_capitalized_docker_casing_still_removed():
+    diagnostics = ContainerDeathDiagnostics(
+        capture_error="inspect: Error: No such object: filler_x",
+    )
+    assert classify_container_death(diagnostics) is ContainerDeathKind.REMOVED
+
+
+def test_sigterm_coinciding_with_executor_restart_is_host_reboot():
+    # executor stack (re)started right around the filler's death -> collateral of a reboot/restart.
+    diagnostics = ContainerDeathDiagnostics(
+        status="exited", exit_code=143, oom_killed=False,
+        finished_at="2026-07-20T09:00:00Z",
+        host_context={"executor_container_started_at": "2026-07-20T09:00:20Z"},
+    )
+    assert classify_container_death(diagnostics) is ContainerDeathKind.HOST_REBOOT
+
+
+def test_sigterm_with_old_executor_start_is_targeted_stop():
+    # executor up for days, only the filler was stopped -> targeted external stop.
+    diagnostics = ContainerDeathDiagnostics(
+        status="exited", exit_code=143, oom_killed=False,
+        finished_at="2026-07-20T09:00:00Z",
+        host_context={"executor_container_started_at": "2026-07-17T08:00:00Z"},
+    )
+    assert classify_container_death(diagnostics) is ContainerDeathKind.STOPPED
+
+
+def test_sigterm_without_host_context_is_stopped():
+    diagnostics = ContainerDeathDiagnostics(status="exited", exit_code=143, oom_killed=False)
+    assert classify_container_death(diagnostics) is ContainerDeathKind.STOPPED

--- a/neurons/validators/tests/test_container_death_classification.py
+++ b/neurons/validators/tests/test_container_death_classification.py
@@ -1,0 +1,89 @@
+"""DAH-2439 follow-up: classify WHY a filler container died.
+
+Only an external kill (container removed, or SIGKILL/SIGTERM-stopped) may cost a provider
+incentive. A filler that crashed on its own, never started, was OOM-killed or exited cleanly
+is self-heal territory (DAH-2419) and must never be punished. These tests pin the classifier.
+"""
+
+from core.docker_utils import (
+    ContainerDeathDiagnostics,
+    ContainerDeathKind,
+    classify_container_death,
+    container_uptime_seconds,
+)
+
+
+def test_removed_container_classifies_as_removed():
+    diagnostics = ContainerDeathDiagnostics(
+        capture_error="inspect: error: no such object: filler_x",
+        logs_tail="Error response from daemon: No such container: filler_x",
+    )
+    assert classify_container_death(diagnostics) is ContainerDeathKind.REMOVED
+
+
+def test_removed_via_logs_tail_only_classifies_as_removed():
+    diagnostics = ContainerDeathDiagnostics(
+        logs_tail="Error response from daemon: No such container: filler_x",
+    )
+    assert classify_container_death(diagnostics) is ContainerDeathKind.REMOVED
+
+
+def test_sigkill_exit_137_classifies_as_stopped():
+    diagnostics = ContainerDeathDiagnostics(status="exited", exit_code=137, oom_killed=False)
+    assert classify_container_death(diagnostics) is ContainerDeathKind.STOPPED
+
+
+def test_sigterm_exit_143_classifies_as_stopped():
+    diagnostics = ContainerDeathDiagnostics(status="exited", exit_code=143, oom_killed=False)
+    assert classify_container_death(diagnostics) is ContainerDeathKind.STOPPED
+
+
+def test_oom_kill_beats_exit_code():
+    # OOM also reports 137 — the kernel killed it, not the owner.
+    diagnostics = ContainerDeathDiagnostics(status="exited", exit_code=137, oom_killed=True)
+    assert classify_container_death(diagnostics) is ContainerDeathKind.OOM_KILLED
+
+
+def test_nonzero_exit_classifies_as_self_crashed():
+    diagnostics = ContainerDeathDiagnostics(status="exited", exit_code=1, oom_killed=False)
+    assert classify_container_death(diagnostics) is ContainerDeathKind.SELF_CRASHED
+
+
+def test_zero_exit_classifies_as_clean_exit():
+    diagnostics = ContainerDeathDiagnostics(status="exited", exit_code=0, oom_killed=False)
+    assert classify_container_death(diagnostics) is ContainerDeathKind.CLEAN_EXIT
+
+
+def test_created_but_never_run_classifies_as_never_started():
+    diagnostics = ContainerDeathDiagnostics(status="created", exit_code=0)
+    assert classify_container_death(diagnostics) is ContainerDeathKind.NEVER_STARTED
+
+
+def test_zero_started_at_classifies_as_never_started():
+    diagnostics = ContainerDeathDiagnostics(
+        status="exited", exit_code=128, started_at="0001-01-01T00:00:00Z"
+    )
+    assert classify_container_death(diagnostics) is ContainerDeathKind.NEVER_STARTED
+
+
+def test_empty_diagnostics_classifies_as_unknown():
+    assert classify_container_death(ContainerDeathDiagnostics()) is ContainerDeathKind.UNKNOWN
+
+
+def test_capture_failure_without_removal_marker_is_unknown():
+    diagnostics = ContainerDeathDiagnostics(capture_error="inspect: timed out")
+    assert classify_container_death(diagnostics) is ContainerDeathKind.UNKNOWN
+
+
+def test_uptime_from_docker_timestamps():
+    seconds = container_uptime_seconds(
+        started_at="2026-07-20T06:00:00.123456789Z",
+        finished_at="2026-07-20T06:05:30.500000000Z",
+    )
+    assert seconds is not None
+    assert abs(seconds - 330.4) < 1.0
+
+
+def test_uptime_is_none_when_timestamps_missing():
+    assert container_uptime_seconds(started_at=None, finished_at="2026-07-20T06:05:30Z") is None
+    assert container_uptime_seconds(started_at="0001-01-01T00:00:00Z", finished_at="2026-07-20T06:05:30Z") is None

--- a/neurons/validators/tests/test_container_death_classification.py
+++ b/neurons/validators/tests/test_container_death_classification.py
@@ -21,11 +21,16 @@ def test_removed_container_classifies_as_removed():
     assert classify_container_death(diagnostics) is ContainerDeathKind.REMOVED
 
 
-def test_removed_via_logs_tail_only_classifies_as_removed():
+def test_removed_marker_in_logs_tail_only_does_not_classify_as_removed():
+    # The container still exists (a real stop, exit 137) but its own logs printed the docker
+    # "no such container" string — must NOT be read as an external removal and punished.
     diagnostics = ContainerDeathDiagnostics(
-        logs_tail="Error response from daemon: No such container: filler_x",
+        status="exited",
+        exit_code=137,
+        oom_killed=False,
+        logs_tail="Error response from daemon: No such container: some-other-name",
     )
-    assert classify_container_death(diagnostics) is ContainerDeathKind.REMOVED
+    assert classify_container_death(diagnostics) is ContainerDeathKind.STOPPED
 
 
 def test_sigkill_exit_137_classifies_as_stopped():
@@ -118,4 +123,26 @@ def test_sigterm_with_old_executor_start_is_targeted_stop():
 
 def test_sigterm_without_host_context_is_stopped():
     diagnostics = ContainerDeathDiagnostics(status="exited", exit_code=143, oom_killed=False)
+    assert classify_container_death(diagnostics) is ContainerDeathKind.STOPPED
+
+
+def test_sigterm_with_executor_started_before_kill_is_targeted_stop():
+    # Executor came up 5 min BEFORE the filler died: not a reboot (a reboot restarts the executor
+    # after shutdown killed the filler). A miner must not launder a `docker stop` this way.
+    diagnostics = ContainerDeathDiagnostics(
+        status="exited", exit_code=143, oom_killed=False,
+        finished_at="2026-07-20T09:00:00Z",
+        host_context={"executor_container_started_at": "2026-07-20T08:55:00Z"},
+    )
+    assert classify_container_death(diagnostics) is ContainerDeathKind.STOPPED
+
+
+def test_sigterm_with_executor_restart_long_after_kill_is_targeted_stop():
+    # Executor restarted 20 min AFTER the kill: the stop already happened, the late restart does
+    # not excuse it.
+    diagnostics = ContainerDeathDiagnostics(
+        status="exited", exit_code=143, oom_killed=False,
+        finished_at="2026-07-20T09:00:00Z",
+        host_context={"executor_container_started_at": "2026-07-20T09:20:00Z"},
+    )
     assert classify_container_death(diagnostics) is ContainerDeathKind.STOPPED

--- a/neurons/validators/tests/test_filler_kill_strike_redis.py
+++ b/neurons/validators/tests/test_filler_kill_strike_redis.py
@@ -1,0 +1,54 @@
+"""DAH-2439: kill-strike accounting in Redis.
+
+Pins the per-run dedup (one dead run = one strike, no matter how many cycles observe it) and the
+seen-key TTL refresh that stops a single run stuck RUNNING past the window from being double-charged.
+"""
+
+import asyncio
+
+import fakeredis.aioredis
+import pytest
+
+from services.redis_service import RedisService
+
+TTL = 100
+EXECUTOR = "executor-uuid-1"
+
+
+def _service() -> RedisService:
+    # Bypass __init__ (which builds a real aioredis client) — the strike path only needs redis+lock.
+    service = RedisService.__new__(RedisService)
+    service.redis = fakeredis.aioredis.FakeRedis()
+    service.lock = asyncio.Lock()
+    return service
+
+
+@pytest.mark.asyncio
+async def test_same_run_observed_repeatedly_counts_one_strike():
+    service = _service()
+    first = await service.register_filler_kill_strike(EXECUTOR, "run-a", TTL)
+    second = await service.register_filler_kill_strike(EXECUTOR, "run-a", TTL)
+    third = await service.register_filler_kill_strike(EXECUTOR, "run-a", TTL)
+    assert [first, second, third] == [1, 1, 1]
+
+
+@pytest.mark.asyncio
+async def test_distinct_runs_accumulate_strikes_per_executor():
+    service = _service()
+    first = await service.register_filler_kill_strike(EXECUTOR, "run-a", TTL)
+    second = await service.register_filler_kill_strike(EXECUTOR, "run-b", TTL)
+    assert [first, second] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_repeat_observation_refreshes_seen_key_ttl():
+    # Core regression: a run stuck RUNNING must not re-count once its seen marker nears expiry.
+    service = _service()
+    await service.register_filler_kill_strike(EXECUTOR, "run-a", TTL)
+    # Simulate the seen marker aging toward expiry between cycles.
+    await service.redis.expire("filler_kill_seen:run-a", 5)
+
+    strikes = await service.register_filler_kill_strike(EXECUTOR, "run-a", TTL)
+
+    assert strikes == 1  # still a single incident, not double-charged
+    assert await service.redis.ttl("filler_kill_seen:run-a") > 5  # seen TTL was refreshed back up

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -548,6 +548,11 @@ CRASHED_DIAGNOSTICS = ContainerDeathDiagnostics(
     started_at="2026-07-20T06:00:00Z", finished_at="2026-07-20T06:01:00Z",
 )
 OOM_DIAGNOSTICS = ContainerDeathDiagnostics(status="exited", exit_code=137, oom_killed=True)
+HOST_REBOOT_DIAGNOSTICS = ContainerDeathDiagnostics(
+    status="exited", exit_code=143, oom_killed=False,
+    finished_at="2026-07-20T09:00:00Z",
+    host_context={"executor_container_started_at": "2026-07-20T09:00:20Z"},
+)
 NEVER_STARTED_DIAGNOSTICS = ContainerDeathDiagnostics(status="created", exit_code=0)
 
 
@@ -626,6 +631,40 @@ async def test_rental_verification_filler_stopped_second_strike_is_punished(monk
     assert result.event.what_we_saw["death_kind"] == "stopped"
     assert result.event.what_we_saw["kill_strikes"] == 2
     assert result.event.what_we_saw["kill_timing"] == "after_running"
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_stopped_shadow_does_not_register_strike(monkeypatch):
+    """Shadow must not count strikes, so the first ENFORCED incident always gets the grace strike."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    strike_redis = FakeStrikeRedis(strikes_to_return=99)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client, redis_service=strike_redis)
+    _patch_diagnostics(monkeypatch, STOPPED_DIAGNOSTICS)
+
+    result = await _run_filler_check(ctx, enforcement=False)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_KILL_SUSPECTED.reason
+    assert result.event.what_we_saw["kill_strikes"] is None
+    assert strike_redis.calls == []
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_host_reboot_never_punished(monkeypatch):
+    """A SIGTERM that coincided with a host/executor restart is not a targeted kill: no penalty, no strike."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    strike_redis = FakeStrikeRedis(strikes_to_return=99)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client, redis_service=strike_redis)
+    _patch_diagnostics(monkeypatch, HOST_REBOOT_DIAGNOSTICS)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_CRASHED.reason
+    assert result.event.what_we_saw["death_kind"] == "host_reboot"
+    assert strike_redis.calls == []
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -777,8 +777,8 @@ async def test_rental_verification_filler_active_api_error_fails_open():
 
 
 @pytest.mark.asyncio
-async def test_rental_verification_filler_ssh_transport_error_fails_without_recheck():
-    """Enforcement: a dead SSH transport means filler state is unknown -> fail the cycle, no re-check."""
+async def test_rental_verification_filler_ssh_transport_error_never_punished_even_in_enforcement():
+    """A lost SSH connection is not evidence of a kill: fail open even under enforcement, no re-check."""
     backend_client = DummyBackendClient(
         response=ExecutorHealthCheckResponse(success=True, error=None, details={})
     )
@@ -787,7 +787,7 @@ async def test_rental_verification_filler_ssh_transport_error_fails_without_rech
 
     result = await _run_filler_check(ctx, enforcement=True)
 
-    assert result.passed is False
+    assert result.passed is True
     assert result.event.reason_code == Msg.FILLER_TRANSPORT_UNREACHABLE.reason
     assert backend_client.filler_run_active_calls == []
 

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -526,12 +526,15 @@ async def test_rental_verification_filler_running_passes():
 class FakeStrikeRedis:
     """Fake RedisService for the kill-strike path."""
 
-    def __init__(self, strikes_to_return: int):
+    def __init__(self, strikes_to_return: int, raises: bool = False):
         self.strikes_to_return = strikes_to_return
+        self.raises = raises
         self.calls: list[tuple[str, str, int]] = []
 
     async def register_filler_kill_strike(self, executor_uuid: str, filler_run_id: str, ttl_seconds: int) -> int:
         self.calls.append((executor_uuid, filler_run_id, ttl_seconds))
+        if self.raises:
+            raise ConnectionError("redis down")
         return self.strikes_to_return
 
 
@@ -576,26 +579,47 @@ async def test_rental_verification_filler_removed_shadow_mode_passes_but_logs(mo
     result = await _run_filler_check(ctx, enforcement=False)
 
     assert result.passed is True
-    assert result.event.reason_code == Msg.FILLER_KILLED.reason
+    # A removed container is "missing" with no reliable one-shot kill signal (prod shadow: every
+    # removed case was a single unreconciled zombie run), so it is strike-gated like STOPPED.
+    assert result.event.reason_code == Msg.FILLER_KILL_SUSPECTED.reason
     assert result.event.what_we_saw["enforced"] is False
     assert result.event.what_we_saw["death_kind"] == "removed"
+    assert result.event.what_we_saw["kill_strikes"] is None
     assert backend_client.filler_run_active_calls == ["11111111-2222-3333-4444-555555555555"]
 
 
 @pytest.mark.asyncio
-async def test_rental_verification_filler_removed_enforcement_fails(monkeypatch):
-    """Enforcement: a REMOVED filler fails the fatal check outright -> no unrented incentive."""
+async def test_rental_verification_filler_removed_first_strike_is_suspected_not_punished(monkeypatch):
+    """A single removal is usually a zombie run (host reboot / watchtower recreation): strike 1, passed."""
     backend_client = _killed_filler_backend()
     ssh_client = FillerSSHClient(running=False)
-    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+    strike_redis = FakeStrikeRedis(strikes_to_return=1)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client, redis_service=strike_redis)
+    _patch_diagnostics(monkeypatch, REMOVED_DIAGNOSTICS)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_KILL_SUSPECTED.reason
+    assert result.event.what_we_saw["death_kind"] == "removed"
+    assert result.event.what_we_saw["kill_strikes"] == 1
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_removed_second_strike_is_punished(monkeypatch):
+    """A repeat removal within the window -> treated as a targeted kill, incentive withheld."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    strike_redis = FakeStrikeRedis(strikes_to_return=2)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client, redis_service=strike_redis)
     _patch_diagnostics(monkeypatch, REMOVED_DIAGNOSTICS)
 
     result = await _run_filler_check(ctx, enforcement=True)
 
     assert result.passed is False
     assert result.event.reason_code == Msg.FILLER_KILLED.reason
-    assert result.event.what_we_saw["enforced"] is True
-    assert backend_client.called_with is None
+    assert result.event.what_we_saw["death_kind"] == "removed"
+    assert result.event.what_we_saw["kill_strikes"] == 2
 
 
 @pytest.mark.asyncio
@@ -612,6 +636,7 @@ async def test_rental_verification_filler_stopped_first_strike_is_suspected_not_
     assert result.passed is True
     assert result.event.reason_code == Msg.FILLER_KILL_SUSPECTED.reason
     assert result.event.what_we_saw["kill_strikes"] == 1
+    assert result.event.what_we_saw["enforced"] is True
     assert strike_redis.calls[0][1] == "11111111-2222-3333-4444-555555555555"
 
 
@@ -664,12 +689,13 @@ async def test_rental_verification_host_reboot_never_punished(monkeypatch):
     assert result.passed is True
     assert result.event.reason_code == Msg.FILLER_CRASHED.reason
     assert result.event.what_we_saw["death_kind"] == "host_reboot"
+    assert result.event.what_we_saw["enforced"] is True
     assert strike_redis.calls == []
 
 
 @pytest.mark.asyncio
-async def test_rental_verification_filler_stopped_without_redis_falls_back_to_strict(monkeypatch):
-    """No strike storage -> the ambiguous stop takes the strict verdict, not a free pass forever."""
+async def test_rental_verification_filler_stopped_without_redis_fails_open(monkeypatch):
+    """No strike storage is not evidence of a repeat kill: fail open, never penalize on our outage."""
     backend_client = _killed_filler_backend()
     ssh_client = FillerSSHClient(running=False)
     ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
@@ -677,8 +703,26 @@ async def test_rental_verification_filler_stopped_without_redis_falls_back_to_st
 
     result = await _run_filler_check(ctx, enforcement=True)
 
-    assert result.passed is False
-    assert result.event.reason_code == Msg.FILLER_KILLED.reason
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_KILL_SUSPECTED.reason
+    assert result.event.what_we_saw["kill_strikes"] is None
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_stopped_redis_error_fails_open(monkeypatch):
+    """Redis raising mid-strike is treated the same as no store: no penalty, suspected only."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    strike_redis = FakeStrikeRedis(strikes_to_return=99, raises=True)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client, redis_service=strike_redis)
+    _patch_diagnostics(monkeypatch, STOPPED_DIAGNOSTICS)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_KILL_SUSPECTED.reason
+    assert result.event.what_we_saw["kill_strikes"] is None
+    assert strike_redis.calls != []  # the strike attempt was made before Redis failed
 
 
 @pytest.mark.parametrize(
@@ -789,6 +833,7 @@ async def test_rental_verification_filler_ssh_transport_error_never_punished_eve
 
     assert result.passed is True
     assert result.event.reason_code == Msg.FILLER_TRANSPORT_UNREACHABLE.reason
+    assert result.event.what_we_saw["enforced"] is True
     assert backend_client.filler_run_active_calls == []
 
 

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -14,6 +14,7 @@ from neurons.validators.src.services.container_cleanup import ContainerCleanup
 from neurons.validators.src.services.task.checks.rental_verification import RentalVerificationCheck
 from neurons.validators.src.services.task.messages import RentalVerificationMessages as Msg
 from neurons.validators.src.services.task.pipeline import CheckResult, Context
+from core.docker_utils import ContainerDeathDiagnostics
 
 from tests.helpers import build_services, build_state
 
@@ -452,8 +453,9 @@ def _filler_context(
     backend_client: DummyBackendClient,
     ssh_client: FillerSSHClient,
     filler_container: str = "filler_11111111-2222-3333-4444-555555555555",
+    redis_service: "FakeStrikeRedis | None" = None,
 ) -> Context:
-    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup(), redis=redis_service)
     state = build_state(
         specs={"verified_ports": [8080]},
         rented_data=RentedExecutorsResponse(
@@ -471,6 +473,7 @@ async def _run_filler_check(ctx: Context, *, check_enabled: bool = True, enforce
         mock_settings.SKIP_RENTAL_VERIFICATION = False
         mock_settings.FILLER_LIVENESS_CHECK_ENABLED = check_enabled
         mock_settings.FILLER_LIVENESS_ENFORCEMENT_ENABLED = enforcement
+        mock_settings.FILLER_KILL_STRIKE_THRESHOLD = 2
         return await RentalVerificationCheck().run(ctx)
 
 
@@ -520,27 +523,67 @@ async def test_rental_verification_filler_running_passes():
     assert backend_client.filler_run_active_calls == []
 
 
+class FakeStrikeRedis:
+    """Fake RedisService for the kill-strike path."""
+
+    def __init__(self, strikes_to_return: int):
+        self.strikes_to_return = strikes_to_return
+        self.calls: list[tuple[str, str, int]] = []
+
+    async def register_filler_kill_strike(self, executor_uuid: str, filler_run_id: str, ttl_seconds: int) -> int:
+        self.calls.append((executor_uuid, filler_run_id, ttl_seconds))
+        return self.strikes_to_return
+
+
+REMOVED_DIAGNOSTICS = ContainerDeathDiagnostics(
+    capture_error="inspect: error: no such object: filler_x",
+    logs_tail="Error response from daemon: No such container: filler_x",
+)
+STOPPED_DIAGNOSTICS = ContainerDeathDiagnostics(
+    status="exited", exit_code=143, oom_killed=False,
+    started_at="2026-07-20T06:00:00Z", finished_at="2026-07-20T09:00:00Z",
+)
+CRASHED_DIAGNOSTICS = ContainerDeathDiagnostics(
+    status="exited", exit_code=1, oom_killed=False,
+    started_at="2026-07-20T06:00:00Z", finished_at="2026-07-20T06:01:00Z",
+)
+OOM_DIAGNOSTICS = ContainerDeathDiagnostics(status="exited", exit_code=137, oom_killed=True)
+NEVER_STARTED_DIAGNOSTICS = ContainerDeathDiagnostics(status="created", exit_code=0)
+
+
+def _patch_diagnostics(monkeypatch, diagnostics: ContainerDeathDiagnostics) -> None:
+    async def fake_collect(ssh_client, container_name):
+        return diagnostics
+    monkeypatch.setattr(
+        "neurons.validators.src.services.task.checks.rental_verification.collect_container_death_diagnostics",
+        fake_collect,
+    )
+
+
 @pytest.mark.asyncio
-async def test_rental_verification_filler_killed_shadow_mode_passes_but_logs():
-    """Shadow mode: a killed filler is logged with enforced=False but incentive is untouched."""
+async def test_rental_verification_filler_removed_shadow_mode_passes_but_logs(monkeypatch):
+    """Shadow mode: a REMOVED filler (external rm) is logged with enforced=False, incentive untouched."""
     backend_client = _killed_filler_backend()
     ssh_client = FillerSSHClient(running=False)
     ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+    _patch_diagnostics(monkeypatch, REMOVED_DIAGNOSTICS)
 
     result = await _run_filler_check(ctx, enforcement=False)
 
     assert result.passed is True
     assert result.event.reason_code == Msg.FILLER_KILLED.reason
     assert result.event.what_we_saw["enforced"] is False
+    assert result.event.what_we_saw["death_kind"] == "removed"
     assert backend_client.filler_run_active_calls == ["11111111-2222-3333-4444-555555555555"]
 
 
 @pytest.mark.asyncio
-async def test_rental_verification_filler_killed_enforcement_fails():
-    """Enforcement mode: a killed filler fails the fatal check -> no unrented incentive."""
+async def test_rental_verification_filler_removed_enforcement_fails(monkeypatch):
+    """Enforcement: a REMOVED filler fails the fatal check outright -> no unrented incentive."""
     backend_client = _killed_filler_backend()
     ssh_client = FillerSSHClient(running=False)
     ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+    _patch_diagnostics(monkeypatch, REMOVED_DIAGNOSTICS)
 
     result = await _run_filler_check(ctx, enforcement=True)
 
@@ -548,6 +591,81 @@ async def test_rental_verification_filler_killed_enforcement_fails():
     assert result.event.reason_code == Msg.FILLER_KILLED.reason
     assert result.event.what_we_saw["enforced"] is True
     assert backend_client.called_with is None
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_stopped_first_strike_is_suspected_not_punished(monkeypatch):
+    """A lone SIGTERM stop could be the worker itself: strike 1 -> logged, passed even in enforcement."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    strike_redis = FakeStrikeRedis(strikes_to_return=1)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client, redis_service=strike_redis)
+    _patch_diagnostics(monkeypatch, STOPPED_DIAGNOSTICS)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_KILL_SUSPECTED.reason
+    assert result.event.what_we_saw["kill_strikes"] == 1
+    assert strike_redis.calls[0][1] == "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_stopped_second_strike_is_punished(monkeypatch):
+    """Second stop incident within the window -> treated as an external kill."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    strike_redis = FakeStrikeRedis(strikes_to_return=2)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client, redis_service=strike_redis)
+    _patch_diagnostics(monkeypatch, STOPPED_DIAGNOSTICS)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_KILLED.reason
+    assert result.event.what_we_saw["death_kind"] == "stopped"
+    assert result.event.what_we_saw["kill_strikes"] == 2
+    assert result.event.what_we_saw["kill_timing"] == "after_running"
+
+
+@pytest.mark.asyncio
+async def test_rental_verification_filler_stopped_without_redis_falls_back_to_strict(monkeypatch):
+    """No strike storage -> the ambiguous stop takes the strict verdict, not a free pass forever."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client)
+    _patch_diagnostics(monkeypatch, STOPPED_DIAGNOSTICS)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.FILLER_KILLED.reason
+
+
+@pytest.mark.parametrize(
+    "diagnostics,expected_death_kind",
+    [
+        (CRASHED_DIAGNOSTICS, "self_crashed"),
+        (OOM_DIAGNOSTICS, "oom_killed"),
+        (NEVER_STARTED_DIAGNOSTICS, "never_started"),
+        (ContainerDeathDiagnostics(), "unknown"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_rental_verification_filler_self_death_never_punished(monkeypatch, diagnostics, expected_death_kind):
+    """Crash / OOM / never-started / unknown are self-heal territory: pass even in enforcement, no strike."""
+    backend_client = _killed_filler_backend()
+    ssh_client = FillerSSHClient(running=False)
+    strike_redis = FakeStrikeRedis(strikes_to_return=99)
+    ctx = _filler_context(backend_client=backend_client, ssh_client=ssh_client, redis_service=strike_redis)
+    _patch_diagnostics(monkeypatch, diagnostics)
+
+    result = await _run_filler_check(ctx, enforcement=True)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_CRASHED.reason
+    assert result.event.what_we_saw["death_kind"] == expected_death_kind
+    assert strike_redis.calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Notion: DAH-2439 follow-up. Prod shadow data (20h) showed the liveness check flags two different things: 515 containers REMOVED by the host (real ISSUE-050 kills) and 5 that died by SIGTERM while retrying pool connection. Punishing must hit only external kills, never a filler that crashed or failed to start on its own.

- `classify_container_death()` in docker_utils: REMOVED / STOPPED (137/143, not OOM) / SELF_CRASHED / OOM_KILLED / NEVER_STARTED / CLEAN_EXIT / UNKNOWN, + `container_uptime_seconds` (kill_timing=at_start/after_running in the event).
- RentalVerificationCheck: REMOVED → punishable outright (nothing legitimate deletes a RUNNING run's container). STOPPED → strike system: a lone SIGTERM could be the worker exiting 143 itself, so incident #1 per executor = `FILLER_KILL_SUSPECTED` (logged, no penalty even in enforcement); >= `FILLER_KILL_STRIKE_THRESHOLD` (default 2) within 7 days = punished. Everything else → `FILLER_CRASHED`, never punished, never a strike (self-heal territory, DAH-2419).
- Strikes: one per filler_run_id (Redis SETNX dedup — the same corpse seen every cycle counts once), accumulated per executor, 7-day TTL. Redis unavailable → strict verdict (no free pass), shadow default still means no money impact.
- Shadow/enforcement semantics unchanged; all new verdicts pass in shadow.

Tests: 13 classifier + 9 verdict cases; full validator suite 1149 green (3 pre-existing sshd failures, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)