### PR TITLE
DAH-2251 - Pay 1% of cycle emission to referrers by default

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -174,10 +174,13 @@ class Settings(BaseSettings):
     # miner's score is left exactly as it was, so referral emission moves value from
     # burn to referrers and never dilutes mining. See `_apply_referral_pool`.
     #
-    # REFERRAL_EMISSION_SHARE is env-tunable and defaults to INERT (0.0): nothing is
-    # redirected until ops sets a non-zero share at launch (coordinated with the backend
-    # referral rail).
-    REFERRAL_EMISSION_SHARE: float = Field(env="REFERRAL_EMISSION_SHARE", default=0.0)
+    # DAH-2251 launch: the share is 1% of the cycle total, shipped as the DEFAULT rather
+    # than left inert for ops to set per host. Every validator has to apply the same pool
+    # or Yuma consensus reads the difference as deviation, so a per-operator env cannot
+    # launch this — the same reason NEW_BURNERS and the burn share ship with the code
+    # rather than as host config. Still env-tunable: an operator can override, and setting
+    # it back to 0.0 disables the pool without a release.
+    REFERRAL_EMISSION_SHARE: float = Field(env="REFERRAL_EMISSION_SHARE", default=0.01)
 
     # DAH-2251 — fail-closed feed of epoch-stable referral EMA weights, served by the
     # backend at `<COMPUTE_REST_API_URL>/v1/referral-weights`. Left unset it is DERIVED


### PR DESCRIPTION
## Describe your changes

Launches the referral pool merged in #1162. It has been inert since it landed: `REFERRAL_EMISSION_SHARE` defaults to `0.0`, and `_apply_referral_pool` returns before it even reads the feed when the share is not positive. This sets the default to `0.01`.

**Why the default and not an env var.** The comment #1162 shipped assumed ops would set the env at launch. That cannot work here: every validator has to apply the same pool, or Yuma consensus reads the difference as deviation, and a share set on one validator gets averaged away by the ones still running `0.0`. This is the same reason `NEW_BURNERS` and the burn share ship with the code rather than as host config. The field stays env-tunable — an operator can override, and setting it back to `0.0` disables the pool without a release.

**What 1% means.** It is 1% of the **cycle total**, not of the 9% rented pool. The pool is `min(share * total_score, burn_total)`, where `total_score` sums every score in the cycle. It is funded entirely out of residual burn, so no miner is diluted: every non-burn score is left untouched, the cycle total is conserved, and the cap means a thin burn epoch shrinks referral rather than touching the rented or unrented pools.

**Safe to merge ahead of the rest of the rollout — every path fails closed.** The backend flag is still off in prod, so no user is attributed, so the feed publishes no weights, so the pool finds no eligible referrer and returns without moving anything. The one real behaviour change on merge is that the validator now calls the feed once per cycle where it previously short-circuited. That call is aiohttp on the async path with the staleness guard from #1162, and an unreachable, stale or empty feed is treated as no referral emission.

**Merge order.** Land [lium-io-backend "enable the miner referral incentive in prod"](https://github.com/Datura-ai/lium-io-backend/pull/843) first. The validator rejects a feed more than `REFERRAL_FEED_MAX_STALENESS_EPOCHS` (3) behind its current epoch, so the backend should already be accruing before the share goes non-zero. Both directions fail closed, so this is about avoiding log noise, not risk.

## Issue ticket number and link

DAH-2251 — provider referral emission.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [ ] Need to take care of performance?

`tests/test_referral_emission_pool.py` + `tests/test_referral_feed_client.py` pass (23), and the wider incentive/burn/weight selection passes (180 passed, 4 skipped). No test needed changing — nothing asserted the inert default, which is worth knowing: the launch value is not currently pinned by a test. The one ruff error in this file (`StrEnum`) is pre-existing on `main` and reproduces with this change stashed.

Performance: one extra HTTP GET per weight-setting cycle, already async and already timeout-guarded by #1162.
