### PR TITLE
DAH-2647: don't score an executor 0 on a port count that was never measured

### DIFF
--- a/neurons/validators/src/services/task/checks/port_connectivity.py
+++ b/neurons/validators/src/services/task/checks/port_connectivity.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+from services.port_utils import get_all_ports
+
 from ..messages import PortConnectivityMessages as Msg
 from ..messages import render_message
 from ..pipeline import CheckResult, Context
@@ -59,9 +61,17 @@ class PortConnectivityCheck:
             "sysbox_runtime": result.sysbox_runtime,
             "verified_port_count": verified_port_count,
         }
-        # DAH-2647: no_ports means the selector had nothing left to offer — a rental holds
-        # the whole declared range, and during teardown that snapshot is a moment stale.
-        ports_measured = result.status in ("ok", "no_working_ports")
+        # DAH-2647: no_ports carries two different facts. When the executor declares ports and
+        # a rental or filler holds all of them, the selector had nothing LEFT to offer — no
+        # verdict, and during a teardown that snapshot is a moment stale. When the executor
+        # declares none at all, that IS a verdict about the executor and must keep scoring 0.
+        # A malformed port_mappings makes the selector raise, which the service reports as
+        # "error" — so "no declared ports" is a verdict on either status, and only a probe
+        # that died on an executor with a readable declaration is genuinely unmeasured.
+        probe_reached_a_verdict = result.status in ("ok", "no_working_ports") or (
+            result.status in ("no_ports", "error") and self._declares_no_ports(ctx)
+        )
+        verified_port_count_or_none = verified_port_count if probe_reached_a_verdict else None
         updated_state = replace(
             ctx.state,
             specs={
@@ -70,7 +80,7 @@ class PortConnectivityCheck:
                 "verified_ports": [p.external for p in result.successful_ports],
             },
             sysbox_runtime=result.sysbox_runtime,
-            verified_port_count=verified_port_count if ports_measured else None,
+            verified_port_count=verified_port_count_or_none,
         )
 
         # DAH-2272 (tolerate): a customer rental force-removes port-check / DinD
@@ -184,3 +194,18 @@ class PortConnectivityCheck:
                 "state": updated_state,
             },
         )
+
+    @staticmethod
+    def _declares_no_ports(ctx: Context) -> bool:
+        """Whether the executor advertises no usable port at all, malformed declaration included.
+
+        get_all_ports parses miner-supplied JSON, so it raises on a malformed port_mappings.
+        Inside verification that raise is caught and surfaces as status="error"; here it would
+        escape the pipeline, so a declaration we cannot read counts as declaring nothing.
+        """
+        try:
+            return not get_all_ports(
+                ctx.executor.port_range, ctx.executor.port_mappings, ctx.executor.ssh_port
+            )
+        except Exception:
+            return True

--- a/neurons/validators/src/services/task/checks/port_connectivity.py
+++ b/neurons/validators/src/services/task/checks/port_connectivity.py
@@ -59,6 +59,11 @@ class PortConnectivityCheck:
             "sysbox_runtime": result.sysbox_runtime,
             "verified_port_count": verified_port_count,
         }
+        # DAH-2647: only ok/no_working_ports come from ports that were actually probed.
+        # no_ports means the selector had nothing left to offer (a rental holds the whole
+        # declared range, and during teardown that snapshot is a moment stale), and error
+        # means the check itself died — neither is evidence about the executor's ports.
+        ports_measured = result.status in ("ok", "no_working_ports")
         updated_state = replace(
             ctx.state,
             specs={
@@ -68,6 +73,7 @@ class PortConnectivityCheck:
             },
             sysbox_runtime=result.sysbox_runtime,
             verified_port_count=verified_port_count,
+            ports_measured=ports_measured,
         )
 
         # DAH-2272 (tolerate): a customer rental force-removes port-check / DinD

--- a/neurons/validators/src/services/task/checks/port_connectivity.py
+++ b/neurons/validators/src/services/task/checks/port_connectivity.py
@@ -59,10 +59,8 @@ class PortConnectivityCheck:
             "sysbox_runtime": result.sysbox_runtime,
             "verified_port_count": verified_port_count,
         }
-        # DAH-2647: only ok/no_working_ports come from ports that were actually probed.
-        # no_ports means the selector had nothing left to offer (a rental holds the whole
-        # declared range, and during teardown that snapshot is a moment stale), and error
-        # means the check itself died — neither is evidence about the executor's ports.
+        # DAH-2647: no_ports means the selector had nothing left to offer — a rental holds
+        # the whole declared range, and during teardown that snapshot is a moment stale.
         ports_measured = result.status in ("ok", "no_working_ports")
         updated_state = replace(
             ctx.state,
@@ -72,8 +70,7 @@ class PortConnectivityCheck:
                 "verified_ports": [p.external for p in result.successful_ports],
             },
             sysbox_runtime=result.sysbox_runtime,
-            verified_port_count=verified_port_count,
-            ports_measured=ports_measured,
+            verified_port_count=verified_port_count if ports_measured else None,
         )
 
         # DAH-2272 (tolerate): a customer rental force-removes port-check / DinD

--- a/neurons/validators/src/services/task/checks/port_count.py
+++ b/neurons/validators/src/services/task/checks/port_count.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from services.const import MIN_PORT_COUNT
 
 from ..messages import PortCountMessages as Msg, render_message
-from ..pipeline import CheckResult, Context
+from ..pipeline import CheckResult, Context, ContextState
 
 
 class PortCountCheck:
@@ -19,13 +19,10 @@ class PortCountCheck:
     fatal = True
 
     async def run(self, ctx: Context) -> CheckResult:
-        port_count: int = ctx.state.verified_port_count
+        port_count: int | None = ctx.state.verified_port_count
 
-        # DAH-2647: nothing was probed this cycle, so port_count is an absent measurement
-        # rather than a verdict. Scoring the executor 0 on it zeroes healthy nodes over an
-        # SSH drop or a teardown-stale rental snapshot. Leave the last published count
-        # standing and let the next cycle measure.
-        if not ctx.state.ports_measured:
+        # DAH-2647: failing on an absent measurement zeroes healthy nodes.
+        if port_count is None:
             event = render_message(
                 Msg.PORT_COUNT_NOT_MEASURED,
                 ctx=ctx,
@@ -38,15 +35,7 @@ class PortCountCheck:
         rented_executor = rented_data.executors.get(ctx.executor.uuid) if rented_data else None
         is_rented = rented_executor is not None and len(rented_executor.pods) > 0
 
-        updated_state = replace(
-            ctx.state,
-            specs={
-                **ctx.state.specs,
-                "available_port_count": port_count,
-                "port_range": ctx.executor.port_range,
-                "port_mappings": ctx.executor.port_mappings,
-            },
-        )
+        updated_state = self._state_with_published_port_count(ctx, port_count)
 
         if not is_rented and port_count < MIN_PORT_COUNT:
             event = render_message(
@@ -74,4 +63,17 @@ class PortCountCheck:
             passed=True,
             event=event,
             updates={"port_count": port_count, "state": updated_state},
+        )
+
+    @staticmethod
+    def _state_with_published_port_count(ctx: Context, port_count: int) -> ContextState:
+        """The state carrying this cycle's port availability into the specs the backend stores."""
+        return replace(
+            ctx.state,
+            specs={
+                **ctx.state.specs,
+                "available_port_count": port_count,
+                "port_range": ctx.executor.port_range,
+                "port_mappings": ctx.executor.port_mappings,
+            },
         )

--- a/neurons/validators/src/services/task/checks/port_count.py
+++ b/neurons/validators/src/services/task/checks/port_count.py
@@ -19,7 +19,19 @@ class PortCountCheck:
     fatal = True
 
     async def run(self, ctx: Context) -> CheckResult:
-        port_count = ctx.state.verified_port_count
+        port_count: int = ctx.state.verified_port_count
+
+        # DAH-2647: nothing was probed this cycle, so port_count is an absent measurement
+        # rather than a verdict. Scoring the executor 0 on it zeroes healthy nodes over an
+        # SSH drop or a teardown-stale rental snapshot. Leave the last published count
+        # standing and let the next cycle measure.
+        if not ctx.state.ports_measured:
+            event = render_message(
+                Msg.PORT_COUNT_NOT_MEASURED,
+                ctx=ctx,
+                check_id=self.check_id,
+            )
+            return CheckResult(passed=True, event=event)
 
         # Check if executor is rented (same pattern as rented_machine.py)
         rented_data = ctx.state.rented_data

--- a/neurons/validators/src/services/task/checks/rental_verification.py
+++ b/neurons/validators/src/services/task/checks/rental_verification.py
@@ -123,6 +123,17 @@ class RentalVerificationCheck:
         # Get verified ports from PortConnectivityCheck
         verified_ports = ctx.state.specs.get("verified_ports", []) if ctx.state.specs else []
 
+        # DAH-2647: PortCountCheck no longer halts a cycle whose port probe reached no verdict,
+        # so the empty list below is now reachable without meaning "this executor has no ports".
+        if ctx.state.verified_port_count is None:
+            event = render_message(
+                Msg.SKIPPED_PORTS_NOT_MEASURED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={"executor_uuid": executor.uuid},
+            )
+            return CheckResult(passed=True, event=event, updates={})
+
         # Fail if no verified ports are available (safety check - should be caught by PortConnectivityCheck)
         if not verified_ports:
             event = render_message(

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -984,6 +984,13 @@ class RentalVerificationMessages:
         category="policy",
         impact="Proceed without backend rental verification",
     )
+    SKIPPED_PORTS_NOT_MEASURED = MessageTemplate(
+        event="Rental verification skipped, ports not measured",
+        reason="RENTAL_CHECK_SKIPPED_PORTS_NOT_MEASURED",
+        severity="info",
+        category="runtime",
+        impact="Proceed without backend rental verification",
+    )
     VERIFIED = MessageTemplate(
         event="Rental verification successful",
         reason="RENTAL_VERIFIED",

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -793,6 +793,13 @@ class PortCountMessages:
         impact="Score set to 0",
         remediation="Increase port range or check port mappings configuration.",
     )
+    PORT_COUNT_NOT_MEASURED = MessageTemplate(
+        event="Port availability not measured",
+        reason="PORT_COUNT_NOT_MEASURED",
+        severity="info",
+        category="runtime",
+        impact="Proceed",
+    )
 
 
 VERIFYX_DEBUG_DOC_URL = (

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -101,11 +101,10 @@ class ContextState:
     gpu_splitting_min_count: int | None = None
     gpu_model_count: Optional[str] = None
     gpu_uuids: Optional[str] = None
-    verified_port_count: int = 0
-    # DAH-2647: False when the port probe never reached a verdict this cycle — no port
-    # could be selected, or the SSH session died mid-check. verified_port_count is then
-    # zero for lack of a measurement, not because the executor has no working ports.
-    ports_measured: bool = True
+    # DAH-2647: None = PortConnectivityCheck reached no verdict this cycle — no port could
+    # be selected, or the SSH session died mid-check. Only that check sets None; a zero
+    # would read as "this executor has no working ports" and PortCountCheck scores it 0.
+    verified_port_count: int | None = 0
     rented_data: RentedExecutorsResponse | None = None
     gpu_metrics: dict | None = None
     inspector_event: dict | None = None

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -102,6 +102,10 @@ class ContextState:
     gpu_model_count: Optional[str] = None
     gpu_uuids: Optional[str] = None
     verified_port_count: int = 0
+    # DAH-2647: False when the port probe never reached a verdict this cycle — no port
+    # could be selected, or the SSH session died mid-check. verified_port_count is then
+    # zero for lack of a measurement, not because the executor has no working ports.
+    ports_measured: bool = True
     rented_data: RentedExecutorsResponse | None = None
     gpu_metrics: dict | None = None
     inspector_event: dict | None = None

--- a/neurons/validators/tests/test_port_connectivity_check.py
+++ b/neurons/validators/tests/test_port_connectivity_check.py
@@ -6,7 +6,7 @@ from neurons.validators.src.services.executor_connectivity.models import PortPai
 from neurons.validators.src.services.task.checks.port_connectivity import PortConnectivityCheck
 from neurons.validators.src.services.task.messages import PortConnectivityMessages as Msg
 
-from tests.helpers import build_context_config, build_services, build_state
+from tests.helpers import build_context_config, build_services, build_state, default_executor
 
 
 # Mock result class matching DockerConnectionCheckResult
@@ -195,21 +195,32 @@ async def test_port_connectivity_check(
 
 
 @pytest.mark.parametrize(
-    "status,probed_port_count,expected_count",
+    "status,probed_port_count,port_range,expected_count",
     [
-        ("ok", 3, 3),
-        ("no_working_ports", 0, 0),
-        ("no_ports", 0, None),
-        ("error", 0, None),
+        ("ok", 3, "8000-8010", 3),
+        ("no_working_ports", 0, "8000-8010", 0),
+        # the executor declares ports and something holds them all: no verdict
+        ("no_ports", 0, "8000-8010", None),
+        # the executor declares none at all: that IS a verdict about the executor
+        ("no_ports", 0, "", 0),
+        # a declaration we cannot even parse counts as declaring nothing, and must not raise
+        ("no_ports", 0, "not-json", 0),
+        # the selector raises on that same malformed value, so it also arrives as "error"
+        ("error", 0, "not-json", 0),
+        ("error", 0, "8000-8010", None),
     ],
 )
 @pytest.mark.asyncio
 async def test_port_connectivity_reports_no_count_when_it_never_probed(
-    status, probed_port_count, expected_count, context_factory
+    status, probed_port_count, port_range, expected_count, context_factory
 ):
-    """DAH-2647: no_ports and error carry no evidence about the executor's ports, so they must
-    reach PortCountCheck as an absent count rather than as a measured zero."""
+    """DAH-2647: a probe that reached no verdict must reach PortCountCheck as an absent count
+    rather than as a measured zero — but an executor that declares no ports is a verdict."""
+    executor = default_executor()
+    executor.port_range = "" if port_range == "not-json" else port_range
+    executor.port_mappings = {"": "[]", "not-json": "not-json"}.get(port_range)
     ctx = context_factory(
+        executor=executor,
         services=build_services(
             redis=DummyRedis(),
             backend=DummyBackendService(),

--- a/neurons/validators/tests/test_port_connectivity_check.py
+++ b/neurons/validators/tests/test_port_connectivity_check.py
@@ -191,6 +191,40 @@ async def test_port_connectivity_check(
                 assert result.updates["state"].verified_port_count == 0
 
 
+@pytest.mark.parametrize(
+    "status,verified_port_count,expected_measured",
+    [
+        ("ok", 3, True),
+        ("no_working_ports", 0, True),
+        ("no_ports", 0, False),
+        ("error", 0, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_port_connectivity_flags_a_cycle_that_never_probed(
+    status, verified_port_count, expected_measured, context_factory
+):
+    """DAH-2647: no_ports and error carry no evidence about the executor's ports."""
+    connectivity_service = DummyConnectivityService(
+        success=status == "ok",
+        verified_port_count=verified_port_count,
+        status=status,
+    )
+    ctx = context_factory(
+        services=build_services(
+            redis=DummyRedis(),
+            backend=DummyBackendService(),
+            connectivity=connectivity_service,
+        ),
+        config=build_context_config(job_batch_id="batch-123"),
+        state=build_state(),
+    )
+
+    result = await PortConnectivityCheck().run(ctx)
+
+    assert result.updates["state"].ports_measured is expected_measured
+
+
 @pytest.mark.asyncio
 async def test_port_connectivity_passes_filler_ports_as_exclusions(context_factory):
     """DAH-2527: an idle filler holds ports without creating a pod, so this executor has no entry

--- a/neurons/validators/tests/test_port_connectivity_check.py
+++ b/neurons/validators/tests/test_port_connectivity_check.py
@@ -187,34 +187,35 @@ async def test_port_connectivity_check(
             assert result.updates["state"].sysbox_runtime == sysbox_runtime
             if verify_success:
                 assert result.updates["state"].verified_port_count == 100
+            elif status_override == "skipped_rental_active":
+                # DAH-2647: the check was skipped, so it reports no count rather than zero.
+                assert result.updates["state"].verified_port_count is None
             else:
                 assert result.updates["state"].verified_port_count == 0
 
 
 @pytest.mark.parametrize(
-    "status,verified_port_count,expected_measured",
+    "status,probed_port_count,expected_count",
     [
-        ("ok", 3, True),
-        ("no_working_ports", 0, True),
-        ("no_ports", 0, False),
-        ("error", 0, False),
+        ("ok", 3, 3),
+        ("no_working_ports", 0, 0),
+        ("no_ports", 0, None),
+        ("error", 0, None),
     ],
 )
 @pytest.mark.asyncio
-async def test_port_connectivity_flags_a_cycle_that_never_probed(
-    status, verified_port_count, expected_measured, context_factory
+async def test_port_connectivity_reports_no_count_when_it_never_probed(
+    status, probed_port_count, expected_count, context_factory
 ):
-    """DAH-2647: no_ports and error carry no evidence about the executor's ports."""
-    connectivity_service = DummyConnectivityService(
-        success=status == "ok",
-        verified_port_count=verified_port_count,
-        status=status,
-    )
+    """DAH-2647: no_ports and error carry no evidence about the executor's ports, so they must
+    reach PortCountCheck as an absent count rather than as a measured zero."""
     ctx = context_factory(
         services=build_services(
             redis=DummyRedis(),
             backend=DummyBackendService(),
-            connectivity=connectivity_service,
+            connectivity=DummyConnectivityService(
+                success=status == "ok", verified_port_count=probed_port_count, status=status
+            ),
         ),
         config=build_context_config(job_batch_id="batch-123"),
         state=build_state(),
@@ -222,7 +223,7 @@ async def test_port_connectivity_flags_a_cycle_that_never_probed(
 
     result = await PortConnectivityCheck().run(ctx)
 
-    assert result.updates["state"].ports_measured is expected_measured
+    assert result.updates["state"].verified_port_count == expected_count
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_port_count_check.py
+++ b/neurons/validators/tests/test_port_count_check.py
@@ -46,6 +46,28 @@ async def test_port_count_insufficient_fails_when_not_rented(context_factory, po
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("port_count", [0, MIN_PORT_COUNT - 1])
+async def test_port_count_unmeasured_passes_when_not_rented(context_factory, port_count):
+    """DAH-2647: a cycle that never probed must not read as 'this executor has no ports'."""
+    ctx = context_factory(state=build_state(verified_port_count=port_count, ports_measured=False))
+
+    result = await PortCountCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.PORT_COUNT_NOT_MEASURED.reason
+
+
+@pytest.mark.asyncio
+async def test_port_count_unmeasured_keeps_the_published_count(context_factory):
+    """DAH-2647: an absent measurement must not overwrite the count the listing reads."""
+    ctx = context_factory(state=build_state(verified_port_count=0, ports_measured=False))
+
+    result = await PortCountCheck().run(ctx)
+
+    assert "state" not in result.updates
+
+
+@pytest.mark.asyncio
 async def test_port_count_insufficient_passes_when_rented(context_factory):
     """Check passes when port count < MIN_PORT_COUNT but executor is rented."""
     rented_data = RentedExecutorsResponse(

--- a/neurons/validators/tests/test_port_count_check.py
+++ b/neurons/validators/tests/test_port_count_check.py
@@ -46,24 +46,14 @@ async def test_port_count_insufficient_fails_when_not_rented(context_factory, po
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("port_count", [0, MIN_PORT_COUNT - 1])
-async def test_port_count_unmeasured_passes_when_not_rented(context_factory, port_count):
+async def test_port_count_unmeasured_passes_when_not_rented(context_factory):
     """DAH-2647: a cycle that never probed must not read as 'this executor has no ports'."""
-    ctx = context_factory(state=build_state(verified_port_count=port_count, ports_measured=False))
+    ctx = context_factory(state=build_state(verified_port_count=None))
 
     result = await PortCountCheck().run(ctx)
 
     assert result.passed is True
     assert result.event.reason_code == Msg.PORT_COUNT_NOT_MEASURED.reason
-
-
-@pytest.mark.asyncio
-async def test_port_count_unmeasured_keeps_the_published_count(context_factory):
-    """DAH-2647: an absent measurement must not overwrite the count the listing reads."""
-    ctx = context_factory(state=build_state(verified_port_count=0, ports_measured=False))
-
-    result = await PortCountCheck().run(ctx)
-
     assert "state" not in result.updates
 
 

--- a/neurons/validators/tests/test_rental_verification_check.py
+++ b/neurons/validators/tests/test_rental_verification_check.py
@@ -122,6 +122,28 @@ async def test_rental_verification_no_ports():
 
 
 @pytest.mark.asyncio
+async def test_rental_verification_skipped_when_ports_were_never_measured():
+    """DAH-2647: PortCountCheck no longer halts an unmeasured cycle, so the empty port list is
+    reachable without meaning the executor has none — skip instead of zeroing it here."""
+    backend_client = DummyBackendClient(
+        response=ExecutorHealthCheckResponse(success=True, error=None, details={})
+    )
+    services = build_services(backend=backend_client, container_cleanup=ContainerCleanup())
+    state = build_state(specs={}, verified_port_count=None)
+
+    from tests.helpers import make_context
+    ctx = make_context(services=services, state=state)
+
+    with patch("neurons.validators.src.services.task.checks.rental_verification.settings") as mock_settings:
+        mock_settings.SKIP_RENTAL_VERIFICATION = False
+        result = await RentalVerificationCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SKIPPED_PORTS_NOT_MEASURED.reason
+    assert backend_client.called_with is None
+
+
+@pytest.mark.asyncio
 async def test_rental_verification_success():
     """Test successful rental verification."""
     backend_client = DummyBackendClient(


### PR DESCRIPTION
## The bug

`PortCountCheck` is `fatal = True` and reads `verified_port_count` from the port
connectivity check. That count is zero in two cases that are not a verdict about the
executor:

- `status = "error"` — the check itself died, usually `Port verification error: SSH
  connection closed`;
- `status = "no_ports"` — the port selector had nothing to offer because a rental holds
  the whole declared range. During teardown that snapshot is a moment stale: the port
  check selects ports from `ctx.state.rented_data` (pod still listed), then re-fetches
  fresh rental data on failure, and `PortCountCheck` reads the fresh one — so its
  `is_rented` guard no longer applies and the zero count goes through.

Either way a healthy node is scored 0 for the cycle and drops out of the listing until
the next one, ~15 minutes.

## Prod, 7 days

168 `INSUFFICIENT_PORTS` events with `available_port_count = 0`, all on unrented
executors. Joined by `pipeline_id` to the port check in the same cycle:

| port check status | events |
|---|---|
| `no_working_ports` — really unreachable, correctly zeroed | 131 |
| `error` — SSH dropped mid-check | 36 |
| `no_ports` — teardown-stale rental | 1 |

So 37 of 168 zeroed a node the validator never actually measured. Reproduced on staging
on 2026-08-11 at 08:52:15 UTC, 11 seconds after the final billing of a deleted cluster
pod: `available_port_count: 0, required: 3`, cycle terminated, node out of the listing.

25 of the 28 affected executors run a filler, so `RentalVerificationCheck` takes its
filler branch downstream and the cycle completes normally.

## The change

`ContextState.verified_port_count` becomes `int | None`, following the `None = not
measured this cycle` convention its neighbours already use. `PortConnectivityCheck` sets
`None` on `no_ports` / `error`, and `PortCountCheck` passes the cycle through instead of
failing on it. `no_working_ports` still fails exactly as before — that one is a real
measurement.

The executor still leaves the listing for that cycle: the published specs carry no
`available_port_count`, same as today. Only the score is fixed.

## Not in scope

A fully rented node ends every cycle with zero free ports, because `prepare_ports_data`
hands the renter every free verified port and only holds ports back for sibling GPUs.
That produces 1573 `no_ports` events a week in prod. They are noise — those executors are
rented, so the pipeline ends at `RENTED` and the score is untouched. Reserving
`MIN_PORT_COUNT` for the validator would silence it, but it changes what a renter gets
and belongs in its own ticket.
