### PR TITLE
DAH-2786: withhold the unrented incentive from a host that reverts our GPU power cap

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -301,6 +301,15 @@ class Settings(BaseSettings):
     # to logging the breach without withholding anything.
     ENABLE_UNRENTED_POWER_CAP_LIMIT: bool = Field(env="ENABLE_UNRENTED_POWER_CAP_LIMIT", default=True)
 
+    # DAH-2786 — GPU power cap revert gate. When True, an unrented executor whose host put the
+    # GPU power limit back while a Lium idle job was running, often enough inside the window,
+    # loses the unrented rental incentive while staying active. Ships in shadow mode: unlike
+    # DAH-2715 this gate reads provider behaviour rather than a capability, so the prod numbers
+    # are read first. Set to True to enforce.
+    ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT: bool = Field(
+        env="ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT", default=False
+    )
+
     # DAH-2467 — mixed scoring for a partially rented GPU-split node: the rented GPUs earn in
     # the mining pool and the free GPUs in the unrented pool. Set to False to fall back to
     # scoring the whole box as rented.

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -54,7 +54,12 @@ from pydantic import BaseModel, Field
 from core.utils import _m, _StructuredMessage, get_extra_info
 
 if TYPE_CHECKING:
-    from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability, PowerCapIncapable
+    from incentive.rental_price import (
+        InsufficientDisk,
+        MissingFlagshipCapability,
+        PowerCapIncapable,
+        PowerCapReverted,
+    )
     from services.task_service import JobResult
 
 
@@ -80,6 +85,7 @@ class ZeroIncentiveReason(StrEnum):
     SYSBOX_NOT_ENABLED = "sysbox_not_enabled"
     FLAGSHIP_WITHOUT_NCU_OR_SPLIT = "flagship_without_ncu_or_split"
     CANNOT_APPLY_GPU_POWER_CAP = "cannot_apply_gpu_power_cap"
+    REVERTS_GPU_POWER_CAP = "reverts_gpu_power_cap"
 
 
 class IncentiveReason(BaseModel):
@@ -384,6 +390,30 @@ class MinerLogLine(BaseModel):
             extra_fields={
                 "container_cap_eff": incapable.container_cap_eff,
                 "nvidiactl_owner_uid": incapable.nvidiactl_owner_uid,
+            },
+        )
+
+    @staticmethod
+    def no_payout_because_reverts_gpu_power_cap(
+        result: JobResult, reverted: PowerCapReverted
+    ) -> MinerLogLine:
+        return MinerLogLine._no_payout(
+            result,
+            reason=ZeroIncentiveReason.REVERTS_GPU_POWER_CAP,
+            message=(
+                f"No unrented incentive: this executor raised the GPU power limit back "
+                f"{reverted.revert_count} times in the last {reverted.window_hours} hours while a "
+                f"Lium idle job was running. Lium caps the limit for the length of that job only, "
+                f"and restores your own value when it ends. Putting the limit back kills the job, "
+                f"so the node earns the unrented incentive without doing the work. Stop the script "
+                f"or service on the host that re-runs 'nvidia-smi -pl', or rent this executor out "
+                f"to earn."
+            ),
+            extra_fields={
+                "power_cap_revert_count": reverted.revert_count,
+                "power_cap_revert_window_hours": reverted.window_hours,
+                "capped_to_watts": reverted.capped_to_watts,
+                "found_watts": reverted.found_watts,
             },
         )
 

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -68,10 +68,11 @@ NVIDIACTL_ROOT_UID = 0
 
 # DAH-2786 — GPU power cap revert gate. An unrented executor whose host raises the GPU power
 # limit back while a Lium idle job runs kills that job and still collects the unrented
-# incentive. It forfeits the incentive after this many observed reverts inside
-# `CAP_REVERT_WINDOW_SECONDS`; one revert is not enough, because a driver reload can undo a
-# cap on its own.
-MIN_POWER_CAP_REVERTS_TO_PENALIZE = 3
+# incentive. It forfeits the incentive after this many reverted JOBS inside
+# `CAP_REVERT_WINDOW_SECONDS`. One is not enough, because a driver reload can undo a cap on
+# its own; two is reachable inside a day even with the backend's 12h backoff after each
+# killed job, and a host running a reset timer breaks every job it is given.
+MIN_POWER_CAP_REVERTS_TO_PENALIZE = 2
 
 
 # ── Spec measurements ────────────────────────────────────────────────────────

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -503,9 +503,12 @@ class RentalPriceIncentive(DefaultIncentive):
         )
 
     async def _power_cap_reverted(self, result: JobResult) -> PowerCapReverted | None:
-        # The validator records one revert per GPU whose verified cap was gone by the time the
-        # Lium job ended (services/gpu_power_limit.py). A Redis outage returns no reverts, so
-        # the gate fails open like every other unknown here.
+        # The validator records one revert per Lium job whose verified cap was gone by the time
+        # the job ended (services/gpu_power_limit.py). A Redis outage returns no reverts, so the
+        # gate fails open like every other unknown here.
+        if result.spec is None:
+            # a synthetic or estimated job result: no real executor, so nothing to look up
+            return None
         reverts: list[GpuPowerCapRevert] = await read_gpu_power_cap_reverts(
             self.redis_service, str(result.executor_info.uuid)
         )

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -30,6 +30,11 @@ from incentive.utils import get_hourly_rate
 from incentive.default import DefaultIncentive, get_min_driver_multiplier
 from incentive.price_provider import PriceProvider
 from services.const import TEMPO, SECONDS_PER_BLOCK, FIXED_RATIO, DEFAULT_JOB_OWNER_MINER
+from services.gpu_power_limit import (
+    CAP_REVERT_WINDOW_SECONDS,
+    GpuPowerCapRevert,
+    read_gpu_power_cap_reverts,
+)
 from services.task.models import MixedFormulaInputs
 from services.task_service import JobResult
 
@@ -61,6 +66,13 @@ NCU_PROFILING_UNRESTRICTED = "unrestricted"
 CAP_SYS_ADMIN_BIT = 21
 NVIDIACTL_ROOT_UID = 0
 
+# DAH-2786 — GPU power cap revert gate. An unrented executor whose host raises the GPU power
+# limit back while a Lium idle job runs kills that job and still collects the unrented
+# incentive. It forfeits the incentive after this many observed reverts inside
+# `CAP_REVERT_WINDOW_SECONDS`; one revert is not enough, because a driver reload can undo a
+# cap on its own.
+MIN_POWER_CAP_REVERTS_TO_PENALIZE = 3
+
 
 # ── Spec measurements ────────────────────────────────────────────────────────
 
@@ -89,6 +101,17 @@ class PowerCapIncapable(BaseModel):
 
     container_cap_eff: str  # effective capability mask of the executor container, hex
     nvidiactl_owner_uid: int  # owner uid of /dev/nvidiactl inside the container
+
+
+class PowerCapReverted(BaseModel):
+    """How often this executor's host undid a verified GPU power cap, and the last evidence.
+
+    The watt readings are carried so the provider is shown the numbers that were judged."""
+
+    revert_count: int
+    window_hours: int
+    capped_to_watts: int  # what the validator applied and read back
+    found_watts: int  # what the host had put back by the time the job ended
 
 
 # ── Snapshot models ──────────────────────────────────────────────────────────
@@ -473,6 +496,44 @@ class RentalPriceIncentive(DefaultIncentive):
                     "nvidiactl_owner_uid": incapable.nvidiactl_owner_uid,
                     "enforced": enforced,
                     "reason": ZeroIncentiveReason.CANNOT_APPLY_GPU_POWER_CAP,
+                    "pool": "rental_excluded" if enforced else "rental_kept_shadow",
+                },
+            )
+        )
+
+    async def _power_cap_reverted(self, result: JobResult) -> PowerCapReverted | None:
+        # The validator records one revert per GPU whose verified cap was gone by the time the
+        # Lium job ended (services/gpu_power_limit.py). A Redis outage returns no reverts, so
+        # the gate fails open like every other unknown here.
+        reverts: list[GpuPowerCapRevert] = await read_gpu_power_cap_reverts(
+            self.redis_service, str(result.executor_info.uuid)
+        )
+        if len(reverts) < MIN_POWER_CAP_REVERTS_TO_PENALIZE:
+            return None
+        last: GpuPowerCapRevert = reverts[-1]
+        return PowerCapReverted(
+            revert_count=len(reverts),
+            window_hours=CAP_REVERT_WINDOW_SECONDS // 3600,
+            capped_to_watts=last.capped_to_watts,
+            found_watts=last.found_watts,
+        )
+
+    def _log_power_cap_revert_limit(self, result: JobResult, reverted: PowerCapReverted) -> None:
+        enforced: bool = settings.ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT
+        logger.info(
+            _m(
+                "Unrented executor reverts the GPU power cap of Lium's own idle jobs"
+                + ("" if enforced else " (shadow only - flag off)"),
+                extra={
+                    "executor_id": str(result.executor_info.uuid),
+                    "gpu_model": result.gpu_model,
+                    "gpu_count": result.gpu_count,
+                    "power_cap_revert_count": reverted.revert_count,
+                    "power_cap_revert_window_hours": reverted.window_hours,
+                    "capped_to_watts": reverted.capped_to_watts,
+                    "found_watts": reverted.found_watts,
+                    "enforced": enforced,
+                    "reason": ZeroIncentiveReason.REVERTS_GPU_POWER_CAP,
                     "pool": "rental_excluded" if enforced else "rental_kept_shadow",
                 },
             )
@@ -982,6 +1043,21 @@ class RentalPriceIncentive(DefaultIncentive):
                 eligible_for_rental_share = False
                 reason: MinerLogLine = MinerLogLine.no_payout_because_cannot_apply_gpu_power_cap(
                     job_result, power_cap_incapable
+                )
+                job_result.record_incentive_log(reason)
+
+        # DAH-2786 power cap revert gate: an idle machine whose host puts the GPU power limit
+        # back kills the Lium job it is being paid to host, so it forfeits the unrented
+        # incentive (node stays active). Shadow-only while the flag is off.
+        power_cap_reverted: PowerCapReverted | None = (
+            await self._power_cap_reverted(job_result) if eligible_for_rental_share else None
+        )
+        if power_cap_reverted is not None:
+            self._log_power_cap_revert_limit(job_result, power_cap_reverted)
+            if settings.ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT:
+                eligible_for_rental_share = False
+                reason: MinerLogLine = MinerLogLine.no_payout_because_reverts_gpu_power_cap(
+                    job_result, power_cap_reverted
                 )
                 job_result.record_incentive_log(reason)
 

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -667,6 +667,11 @@ async def _restore_records(
         )
         if cap_revert is not None:
             reverted_gpus_by_executor.setdefault(record.executor_id, []).append(cap_revert)
+        if record.capped_to_watts is not None:
+            # Judged above, and about to be untrue: the restore below raises the limit itself,
+            # so a record that outlives a failed delete must not let OUR raise read as the
+            # host's on the next pass.
+            await _set_applied_cap_on_restore_record(redis, record.gpu_uuid, None, None, log_extra)
         restore_outcome = await _set_and_log_power_limit(
             ssh, "restore", record.executor_id, record.gpu_uuid, watts_before, record.watts, log_extra
         )

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -12,6 +12,9 @@ Redis state (all keys written only by this validator):
 - ``gpu_power_restore_pod:<pod_id>`` — the gpu_uuids a filler pod capped, so its delete can restore
   exactly its own GPUs without an SSH enumeration and without sweeping a replacement filler's fresh
   records.
+- ``gpu_power_cap_revert:<executor_id>`` — DAH-2786: the reverts observed on that executor inside
+  ``CAP_REVERT_WINDOW_SECONDS``. A restore that finds the limit already back where the miner had it
+  proves the host raised it while our filler ran; the unrented incentive gate counts these.
 
 A record that outlives its filler (delete failed, SSH broke mid-teardown) is repaired by two safety
 nets, so a reduced limit can never stick:
@@ -45,7 +48,7 @@ from typing import Literal
 
 import asyncssh
 from payload_models.payloads import GpuPowerLimit
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, Field, ValidationError
 from services.redis_service import RedisService
 
 from core.utils import _m, get_extra_info
@@ -60,6 +63,13 @@ _POWER_STATE_CMD = (
 _NVIDIA_SMI_TIMEOUT_SECONDS = 30
 _RESTORE_KEY_PREFIX = "gpu_power_restore:"
 _POD_INDEX_KEY_PREFIX = "gpu_power_restore_pod:"
+_REVERT_KEY_PREFIX = "gpu_power_cap_revert:"
+# DAH-2786 — how long one observed revert stays on the executor's record. The unrented
+# incentive gate counts the reverts inside this window.
+CAP_REVERT_WINDOW_SECONDS = 24 * 60 * 60
+# The gate only needs a count and the last evidence, so the history is bounded: a host that
+# reverts every filler run would otherwise grow the record for the whole window.
+MAX_TRACKED_CAP_REVERTS = 50
 # A record younger than this may belong to a filler the check's backend snapshot doesn't report yet
 # (backend marks owner="lium" from STARTING, but the snapshot is taken at cycle start) — the check
 # must not uncap it. Comfortably above the backend's 15-minute STARTING/STOPPING transitional window.
@@ -77,6 +87,25 @@ class GpuPowerRestoreRecord(BaseModel):
     pod_id: str
     executor_id: str
     capped_at: float  # unix seconds; lets the check age-gate its restore against STALE_CAP_GRACE_SECONDS
+    # DAH-2786 — the limit we actually applied, so a restore can tell a held cap from a
+    # reverted one. None on records written before this field existed: those never accuse.
+    capped_to_watts: int | None = None
+
+
+class GpuPowerCapRevert(BaseModel):
+    """One observation that the host raised the limit again while our verified cap was live."""
+
+    at: float  # unix seconds
+    gpu_uuid: str
+    capped_to_watts: int
+    found_watts: int
+
+
+class GpuPowerCapRevertHistory(BaseModel):
+    """The reverts observed on one executor. Written only by this validator."""
+
+    executor_id: str
+    reverts: list[GpuPowerCapRevert] = Field(default_factory=list)
 
 
 class GpuPowerRestoreReadResult(BaseModel):
@@ -130,6 +159,10 @@ def _restore_key(gpu_uuid: str) -> str:
 
 def _pod_index_key(pod_id: str) -> str:
     return f"{_POD_INDEX_KEY_PREFIX}{pod_id}"
+
+
+def _revert_key(executor_id: str) -> str:
+    return f"{_REVERT_KEY_PREFIX}{executor_id}"
 
 
 def _watts_or_none(raw: str) -> int | None:
@@ -323,6 +356,7 @@ async def _ensure_restore_record(
     redis: RedisService,
     gpu_uuid: str,
     pre_cap_watts: int,
+    capped_to_watts: int,
     pod_id: str,
     executor_id: str,
     log_extra: dict[str, object] | None,
@@ -344,7 +378,12 @@ async def _ensure_restore_record(
         )
         return True
     record = GpuPowerRestoreRecord(
-        gpu_uuid=gpu_uuid, watts=pre_cap_watts, pod_id=pod_id, executor_id=executor_id, capped_at=time.time()
+        gpu_uuid=gpu_uuid,
+        watts=pre_cap_watts,
+        capped_to_watts=capped_to_watts,
+        pod_id=pod_id,
+        executor_id=executor_id,
+        capped_at=time.time(),
     )
     try:
         await redis.set(key, record.model_dump_json())
@@ -381,6 +420,111 @@ async def read_gpu_power_restore_records(
     return GpuPowerRestoreReadResult(records=records, read_failed=read_failed)
 
 
+def _reverted_cap_target(record: GpuPowerRestoreRecord, watts_before: int | None) -> int | None:
+    """The watts we had applied, when the live limit is back at or above the miner's own value.
+    None when nothing proves a revert.
+
+    DAH-2786. Deliberately narrow: 113 of 113 observed reverts landed either exactly on the
+    miner's own pre-cap value or on the card default, so a limit that merely drifted upward
+    is not counted. That also makes a frozen record (an earlier restore failed, so its cap
+    target is older than the live one) unable to invent a breach.
+    """
+    if record.capped_to_watts is None or watts_before is None:
+        return None
+    if record.capped_to_watts >= record.watts:
+        # the cap did not lower anything (the miner already ran below our target), so reading
+        # our own target back at restore time proves nothing
+        return None
+    if watts_before < record.watts:
+        return None
+    return record.capped_to_watts
+
+
+def _reverts_inside_window(reverts: list[GpuPowerCapRevert], now: float) -> list[GpuPowerCapRevert]:
+    return [revert for revert in reverts if now - revert.at <= CAP_REVERT_WINDOW_SECONDS]
+
+
+async def _read_revert_history(
+    redis: RedisService,
+    executor_id: str,
+    log_extra: dict[str, object] | None,
+) -> GpuPowerCapRevertHistory | None:
+    """The stored history, or None when Redis did not answer or the record is unusable.
+
+    Fail-open by design: this feeds a money gate, so our own outage must never read as a breach.
+    """
+    key = _revert_key(executor_id)
+    try:
+        raw: str | bytes | None = await redis.get(key)
+    except Exception as exc:
+        _log(logging.ERROR, f"gpu power cap revert: redis read failed for {key}: {exc}", {}, log_extra)
+        return None
+    if not raw:
+        return GpuPowerCapRevertHistory(executor_id=executor_id)
+    try:
+        return GpuPowerCapRevertHistory.model_validate_json(raw)
+    except (ValidationError, TypeError, ValueError):
+        _log(logging.ERROR, f"gpu power cap revert: ignoring corrupt record {raw!r} for {executor_id}", {}, log_extra)
+        return None
+
+
+async def read_gpu_power_cap_reverts(
+    redis: RedisService,
+    executor_id: str,
+    log_extra: dict[str, object] | None = None,
+) -> list[GpuPowerCapRevert]:
+    """Every revert observed on this executor inside the window, newest last. Empty on any unknown."""
+    history = await _read_revert_history(redis, executor_id, log_extra)
+    if history is None:
+        return []
+    return _reverts_inside_window(history.reverts, time.time())
+
+
+async def _record_cap_revert(
+    redis: RedisService,
+    record: GpuPowerRestoreRecord,
+    capped_to_watts: int,
+    found_watts: int,
+    log_extra: dict[str, object] | None,
+) -> None:
+    """Add one revert to the executor's history. Best-effort: teardown must never fail over
+    bookkeeping, so every error only logs."""
+    revert = GpuPowerCapRevert(
+        at=time.time(),
+        gpu_uuid=record.gpu_uuid,
+        capped_to_watts=capped_to_watts,
+        found_watts=found_watts,
+    )
+    _log(
+        logging.WARNING,
+        f"gpu power cap reverted on the host: executor={record.executor_id} gpu={record.gpu_uuid} "
+        f"capped to {capped_to_watts}W, found {found_watts}W before restore",
+        {
+            "gpu_power_action": "revert_detected",
+            "executor_uuid": record.executor_id,
+            "gpu_uuid": record.gpu_uuid,
+            "capped_to_watts": capped_to_watts,
+            "found_watts": found_watts,
+            "pre_cap_watts": record.watts,
+        },
+        log_extra,
+    )
+    history = await _read_revert_history(redis, record.executor_id, log_extra)
+    if history is None:
+        history = GpuPowerCapRevertHistory(executor_id=record.executor_id)
+    kept = _reverts_inside_window(history.reverts, revert.at)
+    history.reverts = [*kept, revert][-MAX_TRACKED_CAP_REVERTS:]
+    try:
+        await redis.set(_revert_key(record.executor_id), history.model_dump_json(), ex=CAP_REVERT_WINDOW_SECONDS)
+    except Exception as exc:
+        _log(
+            logging.ERROR,
+            f"gpu power cap revert: could not store the revert for {record.executor_id}: {exc}",
+            {"gpu_uuid": record.gpu_uuid},
+            log_extra,
+        )
+
+
 async def _delete_pod_index(redis: RedisService, pod_id: str, log_extra: dict[str, object] | None) -> None:
     try:
         await redis.delete(_pod_index_key(pod_id))
@@ -401,6 +545,11 @@ async def _restore_records(
     for record in records:
         state = state_by_uuid.get(record.gpu_uuid)
         watts_before = state.current_watts if state else None
+        # DAH-2786: the limit we find here is the only place we learn the host undid our cap
+        if watts_before is not None:
+            reverted_cap_target: int | None = _reverted_cap_target(record, watts_before)
+            if reverted_cap_target is not None:
+                await _record_cap_revert(redis, record, reverted_cap_target, watts_before, log_extra)
         changed = await _set_and_log_power_limit(
             ssh, "restore", record.executor_id, record.gpu_uuid, watts_before, record.watts, log_extra
         )
@@ -570,10 +719,25 @@ async def apply_filler_gpu_power_limits(
         )
         return False
     target_uuids = [target.gpu_uuid for target in gpu_power_limits]
+    # Clamp first: the record stores the watts we will really apply, so a later restore can tell
+    # a cap that held from one the host reverted (DAH-2786).
+    clamped_watts_by_uuid: dict[str, int] = {
+        target.gpu_uuid: _clamp_watts(target.watts, state_by_uuid[target.gpu_uuid])
+        for target in gpu_power_limits
+    }
     # Persist every restore record BEFORE lowering anything: never cap a GPU without a stored way back.
     for target in gpu_power_limits:
         pre_cap_watts = state_by_uuid[target.gpu_uuid].current_watts
-        if not await _ensure_restore_record(redis, target.gpu_uuid, pre_cap_watts, pod_id, executor_id, log_extra):
+        stored = await _ensure_restore_record(
+            redis,
+            target.gpu_uuid,
+            pre_cap_watts,
+            clamped_watts_by_uuid[target.gpu_uuid],
+            pod_id,
+            executor_id,
+            log_extra,
+        )
+        if not stored:
             await _undo_partial_apply(ssh, redis, target_uuids, pod_id, log_extra)
             return False
     try:
@@ -585,10 +749,16 @@ async def apply_filler_gpu_power_limits(
     all_set = True
     for target in gpu_power_limits:
         state = state_by_uuid[target.gpu_uuid]
-        target_watts = _clamp_watts(target.watts, state)
-        if not await _set_and_log_power_limit(
-            ssh, "cap", executor_id, target.gpu_uuid, state.current_watts, target_watts, log_extra
-        ):
+        capped = await _set_and_log_power_limit(
+            ssh,
+            "cap",
+            executor_id,
+            target.gpu_uuid,
+            state.current_watts,
+            clamped_watts_by_uuid[target.gpu_uuid],
+            log_extra,
+        )
+        if not capped:
             all_set = False
     if not all_set:
         await _undo_partial_apply(ssh, redis, target_uuids, pod_id, log_extra)

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -487,7 +487,7 @@ async def read_gpu_power_restore_records(
     return GpuPowerRestoreReadResult(records=records, read_failed=read_failed)
 
 
-def _uncapped_run_threshold_watts(record: GpuPowerRestoreRecord, state: GpuPowerState) -> float:
+def _uncapped_run_threshold_watts(record: GpuPowerRestoreRecord, default_watts: float | None) -> float:
     """The limit at which the job counts as having run uncapped.
 
     ``MIN_POWER_LIMIT_RATIO`` of the card default — the same line the backend guard kills the
@@ -498,37 +498,45 @@ def _uncapped_run_threshold_watts(record: GpuPowerRestoreRecord, state: GpuPower
     host guards sit one point above this line (0.91 of default, 4090 409/450, 5090 518/575).
     Falls back to the miner's own pre-cap limit when the GPU does not report a default.
     """
-    if state.default_watts is None:
+    if default_watts is None or default_watts <= 0:
         return record.watts
-    return MIN_POWER_LIMIT_RATIO * state.default_watts
+    return MIN_POWER_LIMIT_RATIO * default_watts
 
 
-def _detect_cap_revert(
-    record: GpuPowerRestoreRecord, state: GpuPowerState, observed_at: float
+def detect_cap_revert(
+    record: GpuPowerRestoreRecord,
+    current_watts: float,
+    default_watts: float | None,
+    observed_at: float,
 ) -> GpuPowerCapRevert | None:
-    """What we saw on one GPU when the host raised the limit back past the line at which the
-    job ran uncapped. None when nothing proves a revert.
+    """What we saw on one GPU whose live limit the host raised back past the line at which the
+    job runs uncapped. None when nothing proves a revert.
 
-    DAH-2786. Three conditions, each ruling out a different innocent case:
-    - ``capped_to_watts`` is stamped only after a verified set, so a cap that never landed
-      (the DAH-2715 population, whose container cannot cap at all) can never accuse. It is also
-      absent on records written before this field existed.
+    DAH-2786. Read WHILE the Lium job runs, never at teardown: a host that leaves our cap alone
+    during the job and only resets the limit afterwards has harmed nothing, and the two look
+    identical once the container is gone.
+
+    Three conditions, each ruling out a different innocent case:
+    - ``capped_to_watts`` is stamped only after a verified set with persistence mode on, so a
+      cap that never landed (the DAH-2715 population, whose container cannot cap at all) and a
+      cap that can revert on its own (DAH-2702) can never accuse. It is also absent on records
+      written before this field existed.
     - the limit is not where we left it, so a cap that held cannot accuse.
     - the limit is at or above the uncapped line, which is what makes the revert cost Lium the
       whole job rather than a few watts.
     """
     if record.capped_to_watts is None:
         return None
-    if state.current_watts <= record.capped_to_watts:
+    if current_watts <= record.capped_to_watts:
         return None
-    if state.current_watts < _uncapped_run_threshold_watts(record, state):
+    if current_watts < _uncapped_run_threshold_watts(record, default_watts):
         return None
     return GpuPowerCapRevert(
         observed_at=observed_at,
         pod_id=record.pod_id,
         gpu_uuid=record.gpu_uuid,
         capped_to_watts=record.capped_to_watts,
-        found_watts=state.current_watts,
+        found_watts=int(current_watts),
     )
 
 
@@ -592,7 +600,7 @@ def _reverts_of_jobs_not_already_recorded(
     return new_reverts
 
 
-async def _record_cap_reverts(
+async def record_cap_reverts(
     redis: RedisService,
     executor_id: str,
     reverted_gpus: list[GpuPowerCapRevert],
@@ -655,22 +663,12 @@ async def _restore_records(
     """Apply each record with ``nvidia-smi -pl``; delete a record ONLY after its restore succeeded
     (a failed restore keeps it for the safety nets to retry). Returns the restored count."""
     restored = 0
-    # DAH-2786: the limit we read here is the only place we learn the host undid our cap.
-    # Grouped per executor - one host can carry several, and a whole-host restore sweeps them all.
-    reverted_gpus_by_executor: dict[str, list[GpuPowerCapRevert]] = {}
-    now = time.time()
     for record in records:
         state = state_by_uuid.get(record.gpu_uuid)
         watts_before = state.current_watts if state else None
-        cap_revert: GpuPowerCapRevert | None = (
-            _detect_cap_revert(record, state, now) if state is not None else None
-        )
-        if cap_revert is not None:
-            reverted_gpus_by_executor.setdefault(record.executor_id, []).append(cap_revert)
         if record.capped_to_watts is not None:
-            # Judged above, and about to be untrue: the restore below raises the limit itself,
-            # so a record that outlives a failed delete must not let OUR raise read as the
-            # host's on the next pass.
+            # DAH-2786: the restore below raises the limit itself, so a record that outlives a
+            # failed delete must not keep claiming a cap of ours is standing.
             await _set_applied_cap_on_restore_record(redis, record.gpu_uuid, None, None, log_extra)
         restore_outcome = await _set_and_log_power_limit(
             ssh, "restore", record.executor_id, record.gpu_uuid, watts_before, record.watts, log_extra
@@ -688,8 +686,6 @@ async def _restore_records(
                 {"gpu_uuid": record.gpu_uuid},
                 log_extra,
             )
-    for executor_id, reverted_gpus in reverted_gpus_by_executor.items():
-        await _record_cap_reverts(redis, executor_id, reverted_gpus, log_extra)
     return restored
 
 

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -95,20 +95,21 @@ class GpuPowerRestoreRecord(BaseModel):
 class GpuPowerCapRevert(BaseModel):
     """One Lium job whose verified cap the host raised again while the job ran.
 
-    One entry per job, not per GPU: a host guard resets every GPU on the node in the same
-    tick, and counting eight of those as eight breaches would zero an 8x node on one event."""
+    One entry per job, not per GPU: a host guard resets every GPU on the node in the same tick,
+    and counting eight of those as eight breaches would zero an 8x node on one event.
+    ``pod_id`` is what makes the job the unit — a restore that fails keeps its record and is
+    retried later, and the retry must not count the same job twice."""
 
-    at: float  # unix seconds
+    observed_at: float  # unix seconds
+    pod_id: str
     gpu_uuid: str  # the first GPU seen reverted, as evidence
     capped_to_watts: int
     found_watts: int
-    reverted_gpu_count: int = 1
 
 
 class GpuPowerCapRevertHistory(BaseModel):
     """The reverts observed on one executor. Written only by this validator."""
 
-    executor_id: str
     reverts: list[GpuPowerCapRevert] = Field(default_factory=list)
 
 
@@ -140,6 +141,17 @@ class GpuPowerReadback:
 
     watts: int | None
     persistence_enabled: bool | None
+
+
+@dataclass(frozen=True)
+class PlannedGpuCaps:
+    """What the host reports about the requested GPUs, and the watts we will really apply.
+
+    The clamped target is worked out before anything is written or lowered, so the restore
+    record can store the exact value a later restore compares against (DAH-2786)."""
+
+    state_by_uuid: dict[str, GpuPowerState]
+    clamped_watts_by_uuid: dict[str, int]
 
 
 @dataclass(frozen=True)
@@ -360,7 +372,6 @@ async def _ensure_restore_record(
     redis: RedisService,
     gpu_uuid: str,
     pre_cap_watts: int,
-    capped_to_watts: int,
     pod_id: str,
     executor_id: str,
     log_extra: dict[str, object] | None,
@@ -382,12 +393,7 @@ async def _ensure_restore_record(
         )
         return True
     record = GpuPowerRestoreRecord(
-        gpu_uuid=gpu_uuid,
-        watts=pre_cap_watts,
-        capped_to_watts=capped_to_watts,
-        pod_id=pod_id,
-        executor_id=executor_id,
-        capped_at=time.time(),
+        gpu_uuid=gpu_uuid, watts=pre_cap_watts, pod_id=pod_id, executor_id=executor_id, capped_at=time.time()
     )
     try:
         await redis.set(key, record.model_dump_json())
@@ -395,6 +401,34 @@ async def _ensure_restore_record(
     except Exception as exc:
         _log(logging.ERROR, f"gpu power cap: could not persist pre-cap record for {gpu_uuid}: {exc}", {"gpu_uuid": gpu_uuid}, log_extra)
         return False
+
+
+async def _set_applied_cap_on_restore_record(
+    redis: RedisService,
+    gpu_uuid: str,
+    capped_to_watts: int | None,
+    log_extra: dict[str, object] | None,
+) -> None:
+    """Write the watts we verifiably applied onto the GPU's restore record, or None to say no
+    cap of ours is standing (DAH-2786).
+
+    The watts are written only after the readback confirmed the set, which is what lets a later
+    restore tell a host-side revert from a cap that never landed; a failed apply clears them
+    again, so a record frozen by an earlier failed restore cannot carry a stale claim into the
+    next attempt. Best-effort: a miss only costs the revert signal, never the way back, so it
+    must not fail the filler.
+    """
+    key = _restore_key(gpu_uuid)
+    try:
+        raw: str | bytes | None = await redis.get(key)
+        if not raw:
+            return
+        record = GpuPowerRestoreRecord.model_validate_json(raw)
+        await redis.set(key, record.model_copy(update={"capped_to_watts": capped_to_watts}).model_dump_json())
+    except (ValidationError, TypeError, ValueError) as exc:
+        _log(logging.ERROR, f"gpu power cap: cannot stamp the applied cap on {gpu_uuid}: {exc}", {"gpu_uuid": gpu_uuid}, log_extra)
+    except Exception as exc:
+        _log(logging.ERROR, f"gpu power cap: redis failed while stamping the applied cap on {gpu_uuid}: {exc}", {"gpu_uuid": gpu_uuid}, log_extra)
 
 
 async def read_gpu_power_restore_records(
@@ -424,52 +458,61 @@ async def read_gpu_power_restore_records(
     return GpuPowerRestoreReadResult(records=records, read_failed=read_failed)
 
 
-def _revert_floor_watts(record: GpuPowerRestoreRecord, state: GpuPowerState | None) -> int | None:
+def _uncapped_run_threshold_watts(record: GpuPowerRestoreRecord, state: GpuPowerState) -> float:
     """The limit at which the job counts as having run uncapped.
 
     ``MIN_POWER_LIMIT_RATIO`` of the card default — the same line the backend guard kills the
-    filler at, and the line the observed host guards deliberately sit one point above (0.91 of
-    default, 4090 409/450, 5090 518/575). Falls back to the miner's own pre-cap limit when the
-    GPU does not report a default.
+    filler at (``PEARL_POWER_LIMIT_APPLIED_FLOOR_RATIO``, lium-io-backend
+    ``default_job/runner.py``) and the line ``GpuPowerLimitCheck`` scores against, so a node is
+    never penalized for a run the guard would have let live. Kept unrounded for that reason: a
+    5090 pinned at 517 W is 0.8991 of its 575 W default, which the guard passes. The observed
+    host guards sit one point above this line (0.91 of default, 4090 409/450, 5090 518/575).
+    Falls back to the miner's own pre-cap limit when the GPU does not report a default.
     """
-    if state is None or state.default_watts is None:
+    if state.default_watts is None:
         return record.watts
-    return int(MIN_POWER_LIMIT_RATIO * state.default_watts)
+    return MIN_POWER_LIMIT_RATIO * state.default_watts
 
 
-def _reverted_cap_target(
-    record: GpuPowerRestoreRecord,
-    watts_before: int,
-    state: GpuPowerState | None,
-) -> int | None:
-    """The watts we had applied, when the host raised the limit back past the uncapped line.
-    None when nothing proves a revert.
+def _detect_cap_revert(
+    record: GpuPowerRestoreRecord, state: GpuPowerState, observed_at: float
+) -> GpuPowerCapRevert | None:
+    """What we saw on one GPU when the host raised the limit back past the line at which the
+    job ran uncapped. None when nothing proves a revert.
 
-    DAH-2786. Both conditions are needed. The first says the limit is not where we left it, so
-    a cap that held — or a frozen record carrying an older target — cannot accuse. The second
-    says the job ran at effectively full power, which is what makes the revert cost Lium the
-    job rather than a few watts.
+    DAH-2786. Three conditions, each ruling out a different innocent case:
+    - ``capped_to_watts`` is stamped only after a verified set, so a cap that never landed
+      (the DAH-2715 population, whose container cannot cap at all) can never accuse. It is also
+      absent on records written before this field existed.
+    - the limit is not where we left it, so a cap that held cannot accuse.
+    - the limit is at or above the uncapped line, which is what makes the revert cost Lium the
+      whole job rather than a few watts.
     """
     if record.capped_to_watts is None:
         return None
-    if watts_before <= record.capped_to_watts:
+    if state.current_watts <= record.capped_to_watts:
         return None
-    floor_watts: int | None = _revert_floor_watts(record, state)
-    if floor_watts is None or watts_before < floor_watts:
+    if state.current_watts < _uncapped_run_threshold_watts(record, state):
         return None
-    return record.capped_to_watts
+    return GpuPowerCapRevert(
+        observed_at=observed_at,
+        pod_id=record.pod_id,
+        gpu_uuid=record.gpu_uuid,
+        capped_to_watts=record.capped_to_watts,
+        found_watts=state.current_watts,
+    )
 
 
 def _reverts_inside_window(reverts: list[GpuPowerCapRevert], now: float) -> list[GpuPowerCapRevert]:
-    return [revert for revert in reverts if now - revert.at <= CAP_REVERT_WINDOW_SECONDS]
+    return [revert for revert in reverts if now - revert.observed_at <= CAP_REVERT_WINDOW_SECONDS]
 
 
 async def _read_revert_history(
     redis: RedisService,
     executor_id: str,
     log_extra: dict[str, object] | None,
-) -> GpuPowerCapRevertHistory | None:
-    """The stored history, or None when Redis did not answer or the record is unusable.
+) -> GpuPowerCapRevertHistory:
+    """The stored history, empty when Redis did not answer or the record is unusable.
 
     Fail-open by design: this feeds a money gate, so our own outage must never read as a breach.
     """
@@ -478,14 +521,14 @@ async def _read_revert_history(
         raw: str | bytes | None = await redis.get(key)
     except Exception as exc:
         _log(logging.ERROR, f"gpu power cap revert: redis read failed for {key}: {exc}", {}, log_extra)
-        return None
+        return GpuPowerCapRevertHistory()
     if not raw:
-        return GpuPowerCapRevertHistory(executor_id=executor_id)
+        return GpuPowerCapRevertHistory()
     try:
         return GpuPowerCapRevertHistory.model_validate_json(raw)
     except (ValidationError, TypeError, ValueError):
         _log(logging.ERROR, f"gpu power cap revert: ignoring corrupt record {raw!r} for {executor_id}", {}, log_extra)
-        return None
+        return GpuPowerCapRevertHistory()
 
 
 async def read_gpu_power_cap_reverts(
@@ -495,47 +538,65 @@ async def read_gpu_power_cap_reverts(
 ) -> list[GpuPowerCapRevert]:
     """Every revert observed on this executor inside the window, newest last. Empty on any unknown."""
     history = await _read_revert_history(redis, executor_id, log_extra)
-    if history is None:
-        return []
     return _reverts_inside_window(history.reverts, time.time())
 
 
-async def _record_cap_revert(
+def _reverts_of_jobs_not_already_recorded(
+    reverted_gpus: list[GpuPowerCapRevert],
+    already_recorded: list[GpuPowerCapRevert],
+) -> list[GpuPowerCapRevert]:
+    """One revert per job, and only for jobs the history does not already carry.
+
+    A host guard resets every GPU in the same tick, and a restore that failed keeps its record
+    and is retried later — without this, one killed job would count as eight, then again on
+    every retry."""
+    seen_pod_ids: set[str] = {revert.pod_id for revert in already_recorded}
+    new_reverts: list[GpuPowerCapRevert] = []
+    for revert in reverted_gpus:
+        if revert.pod_id in seen_pod_ids:
+            continue
+        seen_pod_ids.add(revert.pod_id)
+        new_reverts.append(revert)
+    return new_reverts
+
+
+async def _record_cap_reverts(
     redis: RedisService,
     executor_id: str,
     reverted_gpus: list[GpuPowerCapRevert],
     log_extra: dict[str, object] | None,
 ) -> None:
-    """Add ONE revert for this job to the executor's history, whatever the number of GPUs it
-    covered. Best-effort: teardown must never fail over bookkeeping, so every error only logs."""
-    revert = reverted_gpus[0].model_copy(update={"reverted_gpu_count": len(reverted_gpus)})
-    _log(
-        logging.WARNING,
-        f"gpu power cap reverted on the host: executor={executor_id} gpu={revert.gpu_uuid} "
-        f"capped to {revert.capped_to_watts}W, found {revert.found_watts}W before restore "
-        f"({revert.reverted_gpu_count} GPU(s))",
-        {
-            "gpu_power_action": "revert_detected",
-            "executor_uuid": executor_id,
-            "gpu_uuid": revert.gpu_uuid,
-            "capped_to_watts": revert.capped_to_watts,
-            "found_watts": revert.found_watts,
-            "reverted_gpu_count": revert.reverted_gpu_count,
-        },
-        log_extra,
-    )
+    """Add the executor's newly reverted jobs to its history. Best-effort: teardown must never
+    fail over bookkeeping, so every error only logs."""
     history = await _read_revert_history(redis, executor_id, log_extra)
-    if history is None:
-        history = GpuPowerCapRevertHistory(executor_id=executor_id)
-    kept = _reverts_inside_window(history.reverts, revert.at)
-    history.reverts = [*kept, revert][-MAX_TRACKED_CAP_REVERTS:]
+    kept: list[GpuPowerCapRevert] = _reverts_inside_window(history.reverts, time.time())
+    new_reverts: list[GpuPowerCapRevert] = _reverts_of_jobs_not_already_recorded(reverted_gpus, kept)
+    if not new_reverts:
+        return
+    for revert in new_reverts:
+        _log(
+            logging.WARNING,
+            f"gpu power cap reverted on the host: executor={executor_id} pod={revert.pod_id} "
+            f"gpu={revert.gpu_uuid} capped to {revert.capped_to_watts}W, "
+            f"found {revert.found_watts}W before restore",
+            {
+                "gpu_power_action": "revert_detected",
+                "executor_uuid": executor_id,
+                "pod_id": revert.pod_id,
+                "gpu_uuid": revert.gpu_uuid,
+                "capped_to_watts": revert.capped_to_watts,
+                "found_watts": revert.found_watts,
+            },
+            log_extra,
+        )
+    history.reverts = [*kept, *new_reverts][-MAX_TRACKED_CAP_REVERTS:]
     try:
         await redis.set(_revert_key(executor_id), history.model_dump_json(), ex=CAP_REVERT_WINDOW_SECONDS)
     except Exception as exc:
         _log(
             logging.ERROR,
-            f"gpu power cap revert: could not store the revert for {executor_id}: {exc}",
-            {"gpu_uuid": revert.gpu_uuid},
+            f"gpu power cap revert: could not store the reverts for {executor_id}: {exc}",
+            {"pod_id": new_reverts[0].pod_id},
             log_extra,
         )
 
@@ -564,17 +625,11 @@ async def _restore_records(
     for record in records:
         state = state_by_uuid.get(record.gpu_uuid)
         watts_before = state.current_watts if state else None
-        if watts_before is not None:
-            reverted_cap_target: int | None = _reverted_cap_target(record, watts_before, state)
-            if reverted_cap_target is not None:
-                reverted_gpus_by_executor.setdefault(record.executor_id, []).append(
-                    GpuPowerCapRevert(
-                        at=now,
-                        gpu_uuid=record.gpu_uuid,
-                        capped_to_watts=reverted_cap_target,
-                        found_watts=watts_before,
-                    )
-                )
+        cap_revert: GpuPowerCapRevert | None = (
+            _detect_cap_revert(record, state, now) if state is not None else None
+        )
+        if cap_revert is not None:
+            reverted_gpus_by_executor.setdefault(record.executor_id, []).append(cap_revert)
         changed = await _set_and_log_power_limit(
             ssh, "restore", record.executor_id, record.gpu_uuid, watts_before, record.watts, log_extra
         )
@@ -592,7 +647,7 @@ async def _restore_records(
                 log_extra,
             )
     for executor_id, reverted_gpus in reverted_gpus_by_executor.items():
-        await _record_cap_revert(redis, executor_id, reverted_gpus, log_extra)
+        await _record_cap_reverts(redis, executor_id, reverted_gpus, log_extra)
     return restored
 
 
@@ -712,8 +767,44 @@ async def _undo_partial_apply(
 ) -> None:
     # A failed apply must not leave GPUs capped or state keys behind: with the filler never starting,
     # the backend keeps reporting owner="lium", which blocks the check-side restore indefinitely.
+    # Clear the applied watts BEFORE restoring: no cap of ours is standing, so the restore about
+    # to run must not read a stale claim as the host reverting us (DAH-2786).
+    for gpu_uuid in gpu_uuids:
+        await _set_applied_cap_on_restore_record(redis, gpu_uuid, None, log_extra)
     await restore_tracked_gpu_power_limits(ssh, redis, gpu_uuids, log_extra)
     await _delete_pod_index(redis, pod_id, log_extra)
+
+
+async def _plan_gpu_caps(
+    ssh: asyncssh.SSHClientConnection,
+    gpu_power_limits: list[GpuPowerLimit],
+    log_extra: dict[str, object] | None,
+) -> PlannedGpuCaps | None:
+    """Read the host's power state and clamp every requested target to that GPU's hardware
+    bounds. None when the state cannot be read or a requested GPU is not on the host — the
+    caller must then refuse to start the filler rather than run the miner uncapped."""
+    try:
+        state_by_uuid = await _query_power_state(ssh)
+    except Exception as exc:
+        _log(logging.ERROR, f"gpu power cap: state query failed: {exc}; refusing to start filler uncapped", {}, log_extra)
+        return None
+    missing = [target.gpu_uuid for target in gpu_power_limits if target.gpu_uuid not in state_by_uuid]
+    if missing:
+        _log(
+            logging.ERROR,
+            f"gpu power cap: requested GPU(s) {missing} not in nvidia-smi output {sorted(state_by_uuid)}; "
+            f"refusing to start filler uncapped",
+            {},
+            log_extra,
+        )
+        return None
+    return PlannedGpuCaps(
+        state_by_uuid=state_by_uuid,
+        clamped_watts_by_uuid={
+            target.gpu_uuid: _clamp_watts(target.watts, state_by_uuid[target.gpu_uuid])
+            for target in gpu_power_limits
+        },
+    )
 
 
 async def apply_filler_gpu_power_limits(
@@ -730,41 +821,17 @@ async def apply_filler_gpu_power_limits(
     (records, pod index, already-capped GPUs) is undone first. False means the caller must NOT start
     the filler. Every failure path logs an error so it is diagnosable/alertable — no silent skips.
     """
-    try:
-        state_by_uuid = await _query_power_state(ssh)
-    except Exception as exc:
-        _log(logging.ERROR, f"gpu power cap: state query failed: {exc}; refusing to start filler uncapped", {}, log_extra)
-        return False
-    missing = [target.gpu_uuid for target in gpu_power_limits if target.gpu_uuid not in state_by_uuid]
-    if missing:
-        _log(
-            logging.ERROR,
-            f"gpu power cap: requested GPU(s) {missing} not in nvidia-smi output {sorted(state_by_uuid)}; "
-            f"refusing to start filler uncapped",
-            {},
-            log_extra,
-        )
+    planned: PlannedGpuCaps | None = await _plan_gpu_caps(ssh, gpu_power_limits, log_extra)
+    if planned is None:
         return False
     target_uuids = [target.gpu_uuid for target in gpu_power_limits]
-    # Clamp first: the record stores the watts we will really apply, so a later restore can tell
-    # a cap that held from one the host reverted (DAH-2786).
-    clamped_watts_by_uuid: dict[str, int] = {
-        target.gpu_uuid: _clamp_watts(target.watts, state_by_uuid[target.gpu_uuid])
-        for target in gpu_power_limits
-    }
     # Persist every restore record BEFORE lowering anything: never cap a GPU without a stored way back.
     for target in gpu_power_limits:
-        pre_cap_watts = state_by_uuid[target.gpu_uuid].current_watts
-        stored = await _ensure_restore_record(
-            redis,
-            target.gpu_uuid,
-            pre_cap_watts,
-            clamped_watts_by_uuid[target.gpu_uuid],
-            pod_id,
-            executor_id,
-            log_extra,
+        pre_cap_watts = planned.state_by_uuid[target.gpu_uuid].current_watts
+        restore_record_stored: bool = await _ensure_restore_record(
+            redis, target.gpu_uuid, pre_cap_watts, pod_id, executor_id, log_extra
         )
-        if not stored:
+        if not restore_record_stored:
             await _undo_partial_apply(ssh, redis, target_uuids, pod_id, log_extra)
             return False
     try:
@@ -775,18 +842,22 @@ async def apply_filler_gpu_power_limits(
         return False
     all_set = True
     for target in gpu_power_limits:
-        state = state_by_uuid[target.gpu_uuid]
-        capped = await _set_and_log_power_limit(
+        was_capped: bool = await _set_and_log_power_limit(
             ssh,
             "cap",
             executor_id,
             target.gpu_uuid,
-            state.current_watts,
-            clamped_watts_by_uuid[target.gpu_uuid],
+            planned.state_by_uuid[target.gpu_uuid].current_watts,
+            planned.clamped_watts_by_uuid[target.gpu_uuid],
             log_extra,
         )
-        if not capped:
+        if not was_capped:
             all_set = False
     if not all_set:
         await _undo_partial_apply(ssh, redis, target_uuids, pod_id, log_extra)
-    return all_set
+        return False
+    # Only now, with every GPU verifiably capped, is a later high reading attributable to the
+    # host: a cap that failed leaves no target on the record and can never be read as a revert.
+    for gpu_uuid, capped_to_watts in planned.clamped_watts_by_uuid.items():
+        await _set_applied_cap_on_restore_record(redis, gpu_uuid, capped_to_watts, log_extra)
+    return True

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -113,6 +113,17 @@ class GpuPowerCapRevertHistory(BaseModel):
     reverts: list[GpuPowerCapRevert] = Field(default_factory=list)
 
 
+class GpuPowerCapRevertReadResult(BaseModel):
+    """The stored history plus whether Redis answered at all.
+
+    ``read_failed`` separates "this executor has no reverts" from "we could not look": the
+    reader must fail open on the second, and the writer must NOT overwrite a history it could
+    not read. Mirrors ``GpuPowerRestoreReadResult``."""
+
+    history: GpuPowerCapRevertHistory
+    read_failed: bool
+
+
 class GpuPowerRestoreReadResult(BaseModel):
     """Records found in Redis plus whether any read errored.
 
@@ -141,6 +152,15 @@ class GpuPowerReadback:
 
     watts: int | None
     persistence_enabled: bool | None
+
+
+@dataclass(frozen=True)
+class CappingJob:
+    """The Lium job a cap belongs to. Both halves travel together: the revert is deduplicated
+    per pod and charged to the executor, so a record must never carry one without the other."""
+
+    executor_id: str
+    pod_id: str
 
 
 @dataclass(frozen=True)
@@ -408,7 +428,7 @@ async def _set_applied_cap_on_restore_record(
     redis: RedisService,
     gpu_uuid: str,
     capped_to_watts: int | None,
-    capped_by_pod_id: str | None,
+    capped_by: CappingJob | None,
     log_extra: dict[str, object] | None,
 ) -> None:
     """Write the watts we verifiably applied onto the GPU's restore record, or None to say no
@@ -417,9 +437,11 @@ async def _set_applied_cap_on_restore_record(
     The watts are written only after the readback confirmed the set, which is what lets a later
     restore tell a host-side revert from a cap that never landed; a failed apply clears them
     again, so a record frozen by an earlier failed restore cannot carry a stale claim into the
-    next attempt. The capping pod is refreshed with them, because a frozen record still carries
-    the pod that first capped the GPU and the revert is deduplicated per job. Best-effort: a
-    miss only costs the revert signal, never the way back, so it must not fail the filler.
+    next attempt. The capping job is refreshed with them, because a frozen record still names
+    the executor and pod that FIRST capped the GPU — the revert is deduplicated per pod and
+    charged to the executor, so a stale identity would file the breach against the wrong
+    provider. Best-effort: a miss only costs the revert signal, never the way back, so it must
+    not fail the filler.
     """
     key = _restore_key(gpu_uuid)
     try:
@@ -427,9 +449,10 @@ async def _set_applied_cap_on_restore_record(
         if not raw:
             return
         record = GpuPowerRestoreRecord.model_validate_json(raw)
-        refreshed = record.model_copy(
-            update={"capped_to_watts": capped_to_watts, "pod_id": capped_by_pod_id or record.pod_id}
+        identity = (
+            {"pod_id": capped_by.pod_id, "executor_id": capped_by.executor_id} if capped_by else {}
         )
+        refreshed = record.model_copy(update={"capped_to_watts": capped_to_watts, **identity})
         await redis.set(key, refreshed.model_dump_json())
     except (ValidationError, TypeError, ValueError) as exc:
         _log(logging.ERROR, f"gpu power cap: cannot stamp the applied cap on {gpu_uuid}: {exc}", {"gpu_uuid": gpu_uuid}, log_extra)
@@ -517,24 +540,27 @@ async def _read_revert_history(
     redis: RedisService,
     executor_id: str,
     log_extra: dict[str, object] | None,
-) -> GpuPowerCapRevertHistory:
-    """The stored history, empty when Redis did not answer or the record is unusable.
+) -> GpuPowerCapRevertReadResult:
+    """The stored history, plus whether Redis answered.
 
     Fail-open by design: this feeds a money gate, so our own outage must never read as a breach.
+    A corrupt record is NOT a failed read — it can never be counted, so it is replaced.
     """
     key = _revert_key(executor_id)
     try:
         raw: str | bytes | None = await redis.get(key)
     except Exception as exc:
         _log(logging.ERROR, f"gpu power cap revert: redis read failed for {key}: {exc}", {}, log_extra)
-        return GpuPowerCapRevertHistory()
+        return GpuPowerCapRevertReadResult(history=GpuPowerCapRevertHistory(), read_failed=True)
     if not raw:
-        return GpuPowerCapRevertHistory()
+        return GpuPowerCapRevertReadResult(history=GpuPowerCapRevertHistory(), read_failed=False)
     try:
-        return GpuPowerCapRevertHistory.model_validate_json(raw)
+        return GpuPowerCapRevertReadResult(
+            history=GpuPowerCapRevertHistory.model_validate_json(raw), read_failed=False
+        )
     except (ValidationError, TypeError, ValueError):
         _log(logging.ERROR, f"gpu power cap revert: ignoring corrupt record {raw!r} for {executor_id}", {}, log_extra)
-        return GpuPowerCapRevertHistory()
+        return GpuPowerCapRevertReadResult(history=GpuPowerCapRevertHistory(), read_failed=False)
 
 
 async def read_gpu_power_cap_reverts(
@@ -543,8 +569,8 @@ async def read_gpu_power_cap_reverts(
     log_extra: dict[str, object] | None = None,
 ) -> list[GpuPowerCapRevert]:
     """Every revert observed on this executor inside the window, newest last. Empty on any unknown."""
-    history = await _read_revert_history(redis, executor_id, log_extra)
-    return _reverts_inside_window(history.reverts, time.time())
+    read_result = await _read_revert_history(redis, executor_id, log_extra)
+    return _reverts_inside_window(read_result.history.reverts, time.time())
 
 
 def _reverts_of_jobs_not_already_recorded(
@@ -574,8 +600,11 @@ async def _record_cap_reverts(
 ) -> None:
     """Add the executor's newly reverted jobs to its history. Best-effort: teardown must never
     fail over bookkeeping, so every error only logs."""
-    history = await _read_revert_history(redis, executor_id, log_extra)
-    kept: list[GpuPowerCapRevert] = _reverts_inside_window(history.reverts, time.time())
+    read_result = await _read_revert_history(redis, executor_id, log_extra)
+    if read_result.read_failed:
+        # writing now would replace a history we could not see with just this job's reverts
+        return
+    kept: list[GpuPowerCapRevert] = _reverts_inside_window(read_result.history.reverts, time.time())
     new_reverts: list[GpuPowerCapRevert] = _reverts_of_jobs_not_already_recorded(reverted_gpus, kept)
     if not new_reverts:
         return
@@ -595,9 +624,11 @@ async def _record_cap_reverts(
             },
             log_extra,
         )
-    history.reverts = [*kept, *new_reverts][-MAX_TRACKED_CAP_REVERTS:]
+    read_result.history.reverts = [*kept, *new_reverts][-MAX_TRACKED_CAP_REVERTS:]
     try:
-        await redis.set(_revert_key(executor_id), history.model_dump_json(), ex=CAP_REVERT_WINDOW_SECONDS)
+        await redis.set(
+            _revert_key(executor_id), read_result.history.model_dump_json(), ex=CAP_REVERT_WINDOW_SECONDS
+        )
     except Exception as exc:
         _log(
             logging.ERROR,
@@ -871,6 +902,10 @@ async def apply_filler_gpu_power_limits(
     # GPUs are left unstamped and can never accuse. A cap that failed leaves no target either.
     for gpu_uuid in gpu_uuids_capped_with_persistence:
         await _set_applied_cap_on_restore_record(
-            redis, gpu_uuid, planned.clamped_watts_by_uuid[gpu_uuid], pod_id, log_extra
+            redis,
+            gpu_uuid,
+            planned.clamped_watts_by_uuid[gpu_uuid],
+            CappingJob(executor_id=executor_id, pod_id=pod_id),
+            log_extra,
         )
     return True

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -329,8 +329,9 @@ async def _set_and_log_power_limit(
     watts_before: int | None,
     watts_after: int,
     log_extra: dict[str, object] | None,
-) -> bool:
+) -> PowerLimitSetOutcome:
     # Reviewer contract (PR #1115): every PL change is logged with executor, GPU, before/after, status.
+    # The outcome, not a bool: DAH-2786 stamps the applied cap only when persistence was verified.
     await _enable_persistence_mode(ssh, gpu_uuid, log_extra)
     set_outcome = await _set_power_limit(ssh, gpu_uuid, watts_after)
     failure = set_outcome.failure
@@ -365,7 +366,7 @@ async def _set_and_log_power_limit(
         },
         log_extra,
     )
-    return failure is None
+    return set_outcome
 
 
 async def _ensure_restore_record(
@@ -407,6 +408,7 @@ async def _set_applied_cap_on_restore_record(
     redis: RedisService,
     gpu_uuid: str,
     capped_to_watts: int | None,
+    capped_by_pod_id: str | None,
     log_extra: dict[str, object] | None,
 ) -> None:
     """Write the watts we verifiably applied onto the GPU's restore record, or None to say no
@@ -415,8 +417,9 @@ async def _set_applied_cap_on_restore_record(
     The watts are written only after the readback confirmed the set, which is what lets a later
     restore tell a host-side revert from a cap that never landed; a failed apply clears them
     again, so a record frozen by an earlier failed restore cannot carry a stale claim into the
-    next attempt. Best-effort: a miss only costs the revert signal, never the way back, so it
-    must not fail the filler.
+    next attempt. The capping pod is refreshed with them, because a frozen record still carries
+    the pod that first capped the GPU and the revert is deduplicated per job. Best-effort: a
+    miss only costs the revert signal, never the way back, so it must not fail the filler.
     """
     key = _restore_key(gpu_uuid)
     try:
@@ -424,7 +427,10 @@ async def _set_applied_cap_on_restore_record(
         if not raw:
             return
         record = GpuPowerRestoreRecord.model_validate_json(raw)
-        await redis.set(key, record.model_copy(update={"capped_to_watts": capped_to_watts}).model_dump_json())
+        refreshed = record.model_copy(
+            update={"capped_to_watts": capped_to_watts, "pod_id": capped_by_pod_id or record.pod_id}
+        )
+        await redis.set(key, refreshed.model_dump_json())
     except (ValidationError, TypeError, ValueError) as exc:
         _log(logging.ERROR, f"gpu power cap: cannot stamp the applied cap on {gpu_uuid}: {exc}", {"gpu_uuid": gpu_uuid}, log_extra)
     except Exception as exc:
@@ -630,10 +636,10 @@ async def _restore_records(
         )
         if cap_revert is not None:
             reverted_gpus_by_executor.setdefault(record.executor_id, []).append(cap_revert)
-        changed = await _set_and_log_power_limit(
+        restore_outcome = await _set_and_log_power_limit(
             ssh, "restore", record.executor_id, record.gpu_uuid, watts_before, record.watts, log_extra
         )
-        if not changed:
+        if restore_outcome.failure is not None:
             continue
         try:
             await redis.delete(_restore_key(record.gpu_uuid))
@@ -718,10 +724,10 @@ async def raise_low_power_limits_to_default(
             continue
         if state.current_watts >= MIN_POWER_LIMIT_RATIO * state.default_watts:
             continue
-        lifted = await _set_and_log_power_limit(
+        raise_outcome = await _set_and_log_power_limit(
             ssh, "raise", executor_id, gpu_uuid, state.current_watts, state.default_watts, log_extra
         )
-        if lifted:
+        if raise_outcome.failure is None:
             raised += 1
     return raised
 
@@ -770,7 +776,7 @@ async def _undo_partial_apply(
     # Clear the applied watts BEFORE restoring: no cap of ours is standing, so the restore about
     # to run must not read a stale claim as the host reverting us (DAH-2786).
     for gpu_uuid in gpu_uuids:
-        await _set_applied_cap_on_restore_record(redis, gpu_uuid, None, log_extra)
+        await _set_applied_cap_on_restore_record(redis, gpu_uuid, None, None, log_extra)
     await restore_tracked_gpu_power_limits(ssh, redis, gpu_uuids, log_extra)
     await _delete_pod_index(redis, pod_id, log_extra)
 
@@ -841,8 +847,9 @@ async def apply_filler_gpu_power_limits(
         await _undo_partial_apply(ssh, redis, target_uuids, pod_id, log_extra)
         return False
     all_set = True
+    gpu_uuids_capped_with_persistence: list[str] = []
     for target in gpu_power_limits:
-        was_capped: bool = await _set_and_log_power_limit(
+        cap_outcome = await _set_and_log_power_limit(
             ssh,
             "cap",
             executor_id,
@@ -851,13 +858,19 @@ async def apply_filler_gpu_power_limits(
             planned.clamped_watts_by_uuid[target.gpu_uuid],
             log_extra,
         )
-        if not was_capped:
+        if cap_outcome.failure is not None:
             all_set = False
+        elif cap_outcome.persistence_enabled:
+            gpu_uuids_capped_with_persistence.append(target.gpu_uuid)
     if not all_set:
         await _undo_partial_apply(ssh, redis, target_uuids, pod_id, log_extra)
         return False
-    # Only now, with every GPU verifiably capped, is a later high reading attributable to the
-    # host: a cap that failed leaves no target on the record and can never be read as a revert.
-    for gpu_uuid, capped_to_watts in planned.clamped_watts_by_uuid.items():
-        await _set_applied_cap_on_restore_record(redis, gpu_uuid, capped_to_watts, log_extra)
+    # Only a cap that landed AND holds is attributable to the host later. Without persistence
+    # mode the driver unloads on an idle GPU and the stock limit comes back on its own
+    # (DAH-2702), which at teardown is indistinguishable from a provider raising it — so those
+    # GPUs are left unstamped and can never accuse. A cap that failed leaves no target either.
+    for gpu_uuid in gpu_uuids_capped_with_persistence:
+        await _set_applied_cap_on_restore_record(
+            redis, gpu_uuid, planned.clamped_watts_by_uuid[gpu_uuid], pod_id, log_extra
+        )
     return True

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -621,7 +621,7 @@ async def record_cap_reverts(
             logging.WARNING,
             f"gpu power cap reverted on the host: executor={executor_id} pod={revert.pod_id} "
             f"gpu={revert.gpu_uuid} capped to {revert.capped_to_watts}W, "
-            f"found {revert.found_watts}W before restore",
+            f"found {revert.found_watts}W while the Lium job runs",
             {
                 "gpu_power_action": "revert_detected",
                 "executor_uuid": executor_id,

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -93,12 +93,16 @@ class GpuPowerRestoreRecord(BaseModel):
 
 
 class GpuPowerCapRevert(BaseModel):
-    """One observation that the host raised the limit again while our verified cap was live."""
+    """One Lium job whose verified cap the host raised again while the job ran.
+
+    One entry per job, not per GPU: a host guard resets every GPU on the node in the same
+    tick, and counting eight of those as eight breaches would zero an 8x node on one event."""
 
     at: float  # unix seconds
-    gpu_uuid: str
+    gpu_uuid: str  # the first GPU seen reverted, as evidence
     capped_to_watts: int
     found_watts: int
+    reverted_gpu_count: int = 1
 
 
 class GpuPowerCapRevertHistory(BaseModel):
@@ -420,22 +424,38 @@ async def read_gpu_power_restore_records(
     return GpuPowerRestoreReadResult(records=records, read_failed=read_failed)
 
 
-def _reverted_cap_target(record: GpuPowerRestoreRecord, watts_before: int | None) -> int | None:
-    """The watts we had applied, when the live limit is back at or above the miner's own value.
+def _revert_floor_watts(record: GpuPowerRestoreRecord, state: GpuPowerState | None) -> int | None:
+    """The limit at which the job counts as having run uncapped.
+
+    ``MIN_POWER_LIMIT_RATIO`` of the card default — the same line the backend guard kills the
+    filler at, and the line the observed host guards deliberately sit one point above (0.91 of
+    default, 4090 409/450, 5090 518/575). Falls back to the miner's own pre-cap limit when the
+    GPU does not report a default.
+    """
+    if state is None or state.default_watts is None:
+        return record.watts
+    return int(MIN_POWER_LIMIT_RATIO * state.default_watts)
+
+
+def _reverted_cap_target(
+    record: GpuPowerRestoreRecord,
+    watts_before: int,
+    state: GpuPowerState | None,
+) -> int | None:
+    """The watts we had applied, when the host raised the limit back past the uncapped line.
     None when nothing proves a revert.
 
-    DAH-2786. Deliberately narrow: 113 of 113 observed reverts landed either exactly on the
-    miner's own pre-cap value or on the card default, so a limit that merely drifted upward
-    is not counted. That also makes a frozen record (an earlier restore failed, so its cap
-    target is older than the live one) unable to invent a breach.
+    DAH-2786. Both conditions are needed. The first says the limit is not where we left it, so
+    a cap that held — or a frozen record carrying an older target — cannot accuse. The second
+    says the job ran at effectively full power, which is what makes the revert cost Lium the
+    job rather than a few watts.
     """
-    if record.capped_to_watts is None or watts_before is None:
+    if record.capped_to_watts is None:
         return None
-    if record.capped_to_watts >= record.watts:
-        # the cap did not lower anything (the miner already ran below our target), so reading
-        # our own target back at restore time proves nothing
+    if watts_before <= record.capped_to_watts:
         return None
-    if watts_before < record.watts:
+    floor_watts: int | None = _revert_floor_watts(record, state)
+    if floor_watts is None or watts_before < floor_watts:
         return None
     return record.capped_to_watts
 
@@ -482,45 +502,40 @@ async def read_gpu_power_cap_reverts(
 
 async def _record_cap_revert(
     redis: RedisService,
-    record: GpuPowerRestoreRecord,
-    capped_to_watts: int,
-    found_watts: int,
+    executor_id: str,
+    reverted_gpus: list[GpuPowerCapRevert],
     log_extra: dict[str, object] | None,
 ) -> None:
-    """Add one revert to the executor's history. Best-effort: teardown must never fail over
-    bookkeeping, so every error only logs."""
-    revert = GpuPowerCapRevert(
-        at=time.time(),
-        gpu_uuid=record.gpu_uuid,
-        capped_to_watts=capped_to_watts,
-        found_watts=found_watts,
-    )
+    """Add ONE revert for this job to the executor's history, whatever the number of GPUs it
+    covered. Best-effort: teardown must never fail over bookkeeping, so every error only logs."""
+    revert = reverted_gpus[0].model_copy(update={"reverted_gpu_count": len(reverted_gpus)})
     _log(
         logging.WARNING,
-        f"gpu power cap reverted on the host: executor={record.executor_id} gpu={record.gpu_uuid} "
-        f"capped to {capped_to_watts}W, found {found_watts}W before restore",
+        f"gpu power cap reverted on the host: executor={executor_id} gpu={revert.gpu_uuid} "
+        f"capped to {revert.capped_to_watts}W, found {revert.found_watts}W before restore "
+        f"({revert.reverted_gpu_count} GPU(s))",
         {
             "gpu_power_action": "revert_detected",
-            "executor_uuid": record.executor_id,
-            "gpu_uuid": record.gpu_uuid,
-            "capped_to_watts": capped_to_watts,
-            "found_watts": found_watts,
-            "pre_cap_watts": record.watts,
+            "executor_uuid": executor_id,
+            "gpu_uuid": revert.gpu_uuid,
+            "capped_to_watts": revert.capped_to_watts,
+            "found_watts": revert.found_watts,
+            "reverted_gpu_count": revert.reverted_gpu_count,
         },
         log_extra,
     )
-    history = await _read_revert_history(redis, record.executor_id, log_extra)
+    history = await _read_revert_history(redis, executor_id, log_extra)
     if history is None:
-        history = GpuPowerCapRevertHistory(executor_id=record.executor_id)
+        history = GpuPowerCapRevertHistory(executor_id=executor_id)
     kept = _reverts_inside_window(history.reverts, revert.at)
     history.reverts = [*kept, revert][-MAX_TRACKED_CAP_REVERTS:]
     try:
-        await redis.set(_revert_key(record.executor_id), history.model_dump_json(), ex=CAP_REVERT_WINDOW_SECONDS)
+        await redis.set(_revert_key(executor_id), history.model_dump_json(), ex=CAP_REVERT_WINDOW_SECONDS)
     except Exception as exc:
         _log(
             logging.ERROR,
-            f"gpu power cap revert: could not store the revert for {record.executor_id}: {exc}",
-            {"gpu_uuid": record.gpu_uuid},
+            f"gpu power cap revert: could not store the revert for {executor_id}: {exc}",
+            {"gpu_uuid": revert.gpu_uuid},
             log_extra,
         )
 
@@ -542,14 +557,24 @@ async def _restore_records(
     """Apply each record with ``nvidia-smi -pl``; delete a record ONLY after its restore succeeded
     (a failed restore keeps it for the safety nets to retry). Returns the restored count."""
     restored = 0
+    # DAH-2786: the limit we read here is the only place we learn the host undid our cap.
+    # Grouped per executor - one host can carry several, and a whole-host restore sweeps them all.
+    reverted_gpus_by_executor: dict[str, list[GpuPowerCapRevert]] = {}
+    now = time.time()
     for record in records:
         state = state_by_uuid.get(record.gpu_uuid)
         watts_before = state.current_watts if state else None
-        # DAH-2786: the limit we find here is the only place we learn the host undid our cap
         if watts_before is not None:
-            reverted_cap_target: int | None = _reverted_cap_target(record, watts_before)
+            reverted_cap_target: int | None = _reverted_cap_target(record, watts_before, state)
             if reverted_cap_target is not None:
-                await _record_cap_revert(redis, record, reverted_cap_target, watts_before, log_extra)
+                reverted_gpus_by_executor.setdefault(record.executor_id, []).append(
+                    GpuPowerCapRevert(
+                        at=now,
+                        gpu_uuid=record.gpu_uuid,
+                        capped_to_watts=reverted_cap_target,
+                        found_watts=watts_before,
+                    )
+                )
         changed = await _set_and_log_power_limit(
             ssh, "restore", record.executor_id, record.gpu_uuid, watts_before, record.watts, log_extra
         )
@@ -566,6 +591,8 @@ async def _restore_records(
                 {"gpu_uuid": record.gpu_uuid},
                 log_extra,
             )
+    for executor_id, reverted_gpus in reverted_gpus_by_executor.items():
+        await _record_cap_revert(redis, executor_id, reverted_gpus, log_extra)
     return restored
 
 

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -139,10 +139,10 @@ class RedisService:
             raise
         return pubsub
 
-    async def set(self, key: str, value: str):
-        """Set a key-value pair in Redis."""
+    async def set(self, key: str, value: str, ex: int | None = None):
+        """Set a key-value pair in Redis. ``ex`` sets a time-to-live in seconds."""
         async with self.lock:
-            await self.redis.set(key, value)
+            await self.redis.set(key, value, ex=ex)
 
     async def get(self, key: str):
         """Get a value by key from Redis."""

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -139,7 +139,7 @@ class RedisService:
             raise
         return pubsub
 
-    async def set(self, key: str, value: str, ex: int | None = None):
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
         """Set a key-value pair in Redis. ``ex`` sets a time-to-live in seconds."""
         async with self.lock:
             await self.redis.set(key, value, ex=ex)

--- a/neurons/validators/src/services/task/checks/gpu_power_limit.py
+++ b/neurons/validators/src/services/task/checks/gpu_power_limit.py
@@ -8,8 +8,11 @@ from services.const import DEFAULT_JOB_OWNER_LIUM
 from services.gpu_power_limit import (
     MIN_POWER_LIMIT_RATIO,
     STALE_CAP_GRACE_SECONDS,
+    GpuPowerCapRevert,
     GpuPowerRestoreRecord,
+    detect_cap_revert,
     read_gpu_power_restore_records,
+    record_cap_reverts,
     restore_tracked_gpu_power_limits,
 )
 
@@ -63,6 +66,10 @@ class GpuPowerLimitCheck:
             rented_data.get_default_job_owner(ctx.executor.uuid) if rented_data else None
         )
         if default_job_owner == DEFAULT_JOB_OWNER_LIUM:
+            # DAH-2786: this is the only moment we can tell a host that raises our cap back
+            # WHILE our job runs from one that merely resets the limit after the job ends. The
+            # first kills the job it is paid to host; the second harms nothing.
+            await self._record_reverts_of_our_live_cap(ctx)
             event = render_message(
                 Msg.SKIPPED_ACTIVE_LIUM_FILLER,
                 ctx=ctx,
@@ -149,6 +156,51 @@ class GpuPowerLimitCheck:
             },
         )
         return CheckResult(passed=True, event=event)
+
+    async def _record_reverts_of_our_live_cap(self, ctx: Context) -> None:
+        """Note every GPU of this executor whose live limit sits above the cap we applied and
+        verified for the Lium job running right now (DAH-2786).
+
+        Read-only towards the host: it changes no limit, it only records what it saw, so the
+        filler keeps running either way. The unrented incentive gate counts these later.
+        """
+        # same reason the stale-cap rescue is gated: the dry-run pipeline must not write shared state
+        if not self.restore_stale_caps:
+            return
+        live_watts_by_uuid: dict[str, GpuPowerMeasurement] = {
+            str(detail.get("uuid")): GpuPowerMeasurement(
+                index=index,
+                name=detail.get("name"),
+                uuid=str(detail.get("uuid")),
+                power_limit=_to_float(detail.get("power_limit")),
+                power_default_limit=_to_float(detail.get("power_default_limit")),
+                power_max_limit=_to_float(detail.get("power_max_limit")),
+            )
+            for index, detail in enumerate(ctx.state.gpu_details or [])
+            if detail.get("uuid")
+        }
+        if not live_watts_by_uuid:
+            return
+        read_result = await read_gpu_power_restore_records(
+            ctx.services.redis, list(live_watts_by_uuid), log_extra=ctx.default_extra
+        )
+        observed_at = time.time()
+        reverts: list[GpuPowerCapRevert] = []
+        for record in read_result.records:
+            if record.executor_id != ctx.executor.uuid:
+                continue
+            measurement = live_watts_by_uuid.get(record.gpu_uuid)
+            if measurement is None or measurement.power_limit is None:
+                continue
+            revert = detect_cap_revert(
+                record, measurement.power_limit, measurement.power_default_limit, observed_at
+            )
+            if revert is not None:
+                reverts.append(revert)
+        if reverts:
+            await record_cap_reverts(
+                ctx.services.redis, ctx.executor.uuid, reverts, ctx.default_extra
+            )
 
     async def _rescue_stale_lium_caps(
         self, ctx: Context, rejected: list[GpuPowerMeasurement]

--- a/neurons/validators/tests/test_gpu_power_cap_revert.py
+++ b/neurons/validators/tests/test_gpu_power_cap_revert.py
@@ -25,6 +25,7 @@ from services.gpu_power_limit import (
     GpuPowerCapRevert,
     GpuPowerCapRevertHistory,
     GpuPowerRestoreRecord,
+    GpuPowerState,
     _restore_key,
     _revert_key,
     _reverted_cap_target,
@@ -52,40 +53,78 @@ def _restore_record(watts: int, capped_to_watts: int | None) -> GpuPowerRestoreR
     )
 
 
-def test_limit_back_at_the_pre_cap_value_is_a_revert() -> None:
-    # The prod shape: 103 of 113 reverts land exactly on the miner's own pre-cap value.
-    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=409) == 315
+def _state(current_watts: int, default_watts: int | None = 450) -> GpuPowerState:
+    return GpuPowerState(
+        current_watts=current_watts, min_watts=100, max_watts=600, default_watts=default_watts
+    )
+
+
+# RTX 4090 numbers throughout: default 450 W, our cap 315 W (0.70), uncapped line 405 W (0.90).
+
+
+def test_limit_pinned_just_above_our_floor_is_a_revert() -> None:
+    # The prod shape: the host guard pins 409 W, one point above the 0.9 line we kill at.
+    record = _restore_record(watts=409, capped_to_watts=315)
+
+    assert _reverted_cap_target(record, watts_before=409, state=_state(409)) == 315
 
 
 def test_limit_back_at_the_card_default_is_a_revert() -> None:
-    # The other 10: above the pre-cap value, i.e. a driver reload or a reset by the host.
-    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=450) == 315
+    record = _restore_record(watts=409, capped_to_watts=315)
+
+    assert _reverted_cap_target(record, watts_before=450, state=_state(450)) == 315
+
+
+def test_host_floor_below_the_pre_cap_reading_is_still_a_revert() -> None:
+    # Guard script A restores the DEFAULT every 30 s during cold start, then pins 0.91 of it.
+    # The pre-cap reading is then the default and the live limit sits under it - still an
+    # uncapped run, and a pre-cap comparison alone would miss it.
+    record = _restore_record(watts=450, capped_to_watts=315)
+
+    assert _reverted_cap_target(record, watts_before=409, state=_state(409)) == 315
 
 
 def test_cap_that_still_holds_is_not_a_revert() -> None:
-    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=315) is None
+    record = _restore_record(watts=409, capped_to_watts=315)
+
+    assert _reverted_cap_target(record, watts_before=315, state=_state(315)) is None
 
 
-def test_partly_raised_limit_is_not_a_revert() -> None:
-    # Conservative on purpose: only a limit back at or above where the miner had it counts,
-    # so a frozen record from an earlier failed restore can never invent a breach.
-    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=350) is None
+def test_limit_below_the_uncapped_line_is_not_a_revert() -> None:
+    # The job still ran capped, so it did the work it is paid for. Drift is not a breach.
+    record = _restore_record(watts=409, capped_to_watts=315)
+
+    assert _reverted_cap_target(record, watts_before=350, state=_state(350)) is None
 
 
 def test_cap_that_never_lowered_the_limit_is_not_a_revert() -> None:
-    # A miner running below our target is capped upwards; the restore then reads our own
-    # target back and must not be read as the host raising it.
-    assert _reverted_cap_target(_restore_record(watts=250, capped_to_watts=315), watts_before=315) is None
+    # A miner running below our target is capped upwards; reading our own target back at
+    # restore time is not the host raising it.
+    record = _restore_record(watts=250, capped_to_watts=315)
+
+    assert _reverted_cap_target(record, watts_before=315, state=_state(315)) is None
 
 
 def test_record_without_a_cap_target_is_not_a_revert() -> None:
-    # Records written before this change carry no target: fail open, never penalize.
-    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=None), watts_before=409) is None
+    # Records written before this field existed: fail open, never penalize.
+    record = _restore_record(watts=409, capped_to_watts=None)
+
+    assert _reverted_cap_target(record, watts_before=409, state=_state(409)) is None
 
 
-def test_unknown_live_limit_is_not_a_revert() -> None:
-    # The state query failed, so there is no reading to judge.
-    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=None) is None
+def test_unknown_default_falls_back_to_the_pre_cap_limit() -> None:
+    # Some GPUs report "[N/A]" for the default limit. The miner's own pre-cap value is the line.
+    record = _restore_record(watts=409, capped_to_watts=315)
+    no_default = _state(409, default_watts=None)
+
+    assert _reverted_cap_target(record, watts_before=409, state=no_default) == 315
+    assert _reverted_cap_target(record, watts_before=380, state=no_default) is None
+
+
+def test_unknown_gpu_state_falls_back_to_the_pre_cap_limit() -> None:
+    record = _restore_record(watts=409, capped_to_watts=315)
+
+    assert _reverted_cap_target(record, watts_before=409, state=None) == 315
 
 
 # ---------------------------- recording at restore time ----------------------------
@@ -146,10 +185,13 @@ def _stored_restore_record(watts: int = 400, capped_to_watts: int | None = 280) 
     return _restore_record(watts=watts, capped_to_watts=capped_to_watts).model_dump_json()
 
 
+def _restore_record_for(gpu_uuid: str, executor_id: str) -> str:
+    record = _restore_record(watts=400, capped_to_watts=280)
+    return record.model_copy(update={"gpu_uuid": gpu_uuid, "executor_id": executor_id}).model_dump_json()
+
+
 @pytest.mark.asyncio
 async def test_restore_records_a_revert_when_the_limit_came_back() -> None:
-
-
     ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
     redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
 
@@ -166,8 +208,6 @@ async def test_restore_records_a_revert_when_the_limit_came_back() -> None:
 
 @pytest.mark.asyncio
 async def test_restore_records_nothing_when_the_cap_held() -> None:
-
-
     ssh = fake_ssh(FakeRun(stdout=HELD_STATE_CSV), *_set_ok(400))
     redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
 
@@ -177,9 +217,44 @@ async def test_restore_records_nothing_when_the_cap_held() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_whole_node_revert_counts_once() -> None:
+    # A host guard resets every GPU in the same tick. Counting eight of those as eight
+    # breaches would zero an 8x node on a single event.
+    state_csv = "GPU-a, 400, 400, 100, 400\nGPU-b, 400, 400, 100, 400\n"
+    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(400), *_set_ok(400))
+    redis = FakeRedis({
+        _restore_key("GPU-a"): _stored_restore_record(),
+        _restore_key("GPU-b"): _restore_record_for("GPU-b", EXECUTOR_ID),
+    })
+
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a", "GPU-b"])
+
+    history = _stored_history(redis)
+    assert len(history.reverts) == 1
+    assert history.reverts[0].reverted_gpu_count == 2
+
+
+@pytest.mark.asyncio
+async def test_two_executors_on_one_host_each_get_their_own_revert() -> None:
+    # A whole-host restore sweeps every executor on the box; one provider's breach must not
+    # land on its neighbour's record.
+    other_executor = "executor-2"
+    state_csv = "GPU-a, 400, 400, 100, 400\nGPU-b, 400, 400, 100, 400\n"
+    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(400), *_set_ok(400))
+    redis = FakeRedis({
+        _restore_key("GPU-a"): _stored_restore_record(),
+        _restore_key("GPU-b"): _restore_record_for("GPU-b", other_executor),
+    })
+
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a", "GPU-b"])
+
+    assert len(_stored_history(redis).reverts) == 1
+    other = GpuPowerCapRevertHistory.model_validate_json(redis.store[_revert_key(other_executor)])
+    assert [revert.gpu_uuid for revert in other.reverts] == ["GPU-b"]
+
+
+@pytest.mark.asyncio
 async def test_reverts_accumulate_and_old_ones_drop_out_of_the_window() -> None:
-
-
     stale = GpuPowerCapRevert(
         at=time.time() - CAP_REVERT_WINDOW_SECONDS - 60,
         gpu_uuid="GPU-a",
@@ -201,8 +276,6 @@ async def test_reverts_accumulate_and_old_ones_drop_out_of_the_window() -> None:
 
 @pytest.mark.asyncio
 async def test_history_is_bounded() -> None:
-
-
     now = time.time()
     reverts = [
         GpuPowerCapRevert(at=now - index, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)

--- a/neurons/validators/tests/test_gpu_power_cap_revert.py
+++ b/neurons/validators/tests/test_gpu_power_cap_revert.py
@@ -3,9 +3,12 @@
 Case 3 of the three power-cap problems: the cap applies, the validator reads it back, and
 then something on the provider's host raises the limit again. The PEARL filler is killed by
 the backend grace check, so the node runs no Lium job — and today it still collects the full
-unrented incentive. This suite covers the two halves: the validator records each revert it
-observes at restore time, and the incentive gate withholds the unrented incentive once the
-node has reverted often enough inside the window.
+unrented incentive.
+
+The revert is observed WHILE the Lium job runs, in the validation check that already skips the
+power-limit penalty for a live filler. That is the only moment it can be told apart from a host
+that leaves our cap alone and merely resets the limit after the job ends, which harms nothing.
+This suite covers the three halves: the rule, the recording, and the incentive gate.
 """
 
 import json
@@ -15,30 +18,38 @@ from unittest.mock import AsyncMock
 
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
+from helpers import build_services, build_state
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 
 from core.config import settings
 from incentive.config import IncentiveConfig
 from incentive.rental_price import MIN_POWER_CAP_REVERTS_TO_PENALIZE, RentalPriceIncentive
 from payload_models.payloads import GpuPowerLimit
+from services.const import DEFAULT_JOB_OWNER_LIUM
 from services.gpu_power_limit import (
     CAP_REVERT_WINDOW_SECONDS,
     MAX_TRACKED_CAP_REVERTS,
     GpuPowerCapRevert,
     GpuPowerCapRevertHistory,
+    GpuPowerRestoreReadResult,
     GpuPowerRestoreRecord,
-    GpuPowerState,
     _restore_key,
     _revert_key,
-    _detect_cap_revert,
     apply_filler_gpu_power_limits,
+    detect_cap_revert,
     read_gpu_power_cap_reverts,
     restore_tracked_gpu_power_limits,
 )
+from services.task.checks import gpu_power_limit as check_module
+from services.task.checks.gpu_power_limit import GpuPowerLimitCheck
+from services.task.pipeline import ContextState
 from services.task_service import JobResult
 
 EXECUTOR_ID = "executor-1"
 POD_ID = "pod-1"
 H200 = "NVIDIA H200"  # base model H200 is rental-eligible by default
+# matches default_executor().uuid in helpers.py — the executor context_factory builds
+CHECK_EXECUTOR_UUID = "executor-123"
 
 
 # ---------------------------- _detect_cap_revert (pure) ----------------------------
@@ -55,16 +66,15 @@ def _restore_record(watts: int, capped_to_watts: int | None) -> GpuPowerRestoreR
     )
 
 
-def _state(current_watts: int, default_watts: int | None = 450) -> GpuPowerState:
-    return GpuPowerState(
-        current_watts=current_watts, min_watts=100, max_watts=600, default_watts=default_watts
-    )
-
-
 def _observe(
     watts: int, capped_to_watts: int | None, found: int, default: int | None = 450
 ) -> GpuPowerCapRevert | None:
-    return _detect_cap_revert(_restore_record(watts, capped_to_watts), _state(found, default), observed_at=1.0)
+    return detect_cap_revert(
+        _restore_record(watts, capped_to_watts),
+        current_watts=found,
+        default_watts=default,
+        observed_at=1.0,
+    )
 
 
 # RTX 4090 numbers throughout: default 450 W, our cap 315 W (0.70), uncapped line 405 W (0.90).
@@ -125,7 +135,7 @@ def test_unknown_default_falls_back_to_the_pre_cap_limit() -> None:
     assert _observe(watts=409, capped_to_watts=315, found=380, default=None) is None
 
 
-# ---------------------------- recording at restore time ----------------------------
+# ---------------------------- recording while the Lium job runs ----------------------------
 
 
 class FakeRun:
@@ -170,13 +180,8 @@ class BrokenRedis(FakeRedis):
         raise ConnectionError("redis down")
 
 
-def _stored_history(redis: FakeRedis) -> GpuPowerCapRevertHistory:
-    return GpuPowerCapRevertHistory.model_validate_json(redis.store[_revert_key(EXECUTOR_ID)])
-
-
-# uuid, current, default, min, max — GPU-a sits back at its pre-cap 400W
-REVERTED_STATE_CSV = "GPU-a, 400, 400, 100, 400\n"
-HELD_STATE_CSV = "GPU-a, 280, 400, 100, 400\n"
+def _stored_history(redis: FakeRedis, executor_id: str = CHECK_EXECUTOR_UUID) -> GpuPowerCapRevertHistory:
+    return GpuPowerCapRevertHistory.model_validate_json(redis.store[_revert_key(executor_id)])
 
 
 def _stored_restore_record(
@@ -188,252 +193,258 @@ def _stored_restore_record(
     ).model_dump_json()
 
 
-@pytest.mark.asyncio
-async def test_restore_records_a_revert_when_the_limit_came_back() -> None:
-    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
-    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
+def _record(
+    gpu_uuid: str = "GPU-a",
+    executor_id: str = CHECK_EXECUTOR_UUID,
+    pod_id: str = POD_ID,
+    capped_to_watts: int | None = 280,
+) -> GpuPowerRestoreRecord:
+    return GpuPowerRestoreRecord(
+        gpu_uuid=gpu_uuid,
+        watts=400,
+        capped_to_watts=capped_to_watts,
+        pod_id=pod_id,
+        executor_id=executor_id,
+        capped_at=time.time(),
+    )
 
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+def _running_filler_state(*live_watts_by_uuid: tuple[str, float]) -> ContextState:
+    """Node state while a Lium filler runs: GPU readings plus the owner flag the check keys off."""
+    return build_state(
+        gpu_model="NVIDIA L40S",
+        gpu_count=len(live_watts_by_uuid),
+        gpu_details=[
+            {
+                "name": "NVIDIA L40S",
+                "uuid": gpu_uuid,
+                "power_limit": watts,
+                "power_default_limit": 400.0,
+                "power_max_limit": 450.0,
+            }
+            for gpu_uuid, watts in live_watts_by_uuid
+        ],
+        rented_data=RentedExecutorsResponse(
+            executors={},
+            default_job_owner_by_executor={CHECK_EXECUTOR_UUID: DEFAULT_JOB_OWNER_LIUM},
+        ),
+    )
+
+
+async def _run_check_while_filler_runs(
+    context_factory,
+    monkeypatch: pytest.MonkeyPatch,
+    redis: FakeRedis,
+    records: list[GpuPowerRestoreRecord],
+    live_watts_by_uuid: list[tuple[str, float]],
+) -> None:
+    monkeypatch.setattr(
+        check_module,
+        "read_gpu_power_restore_records",
+        AsyncMock(return_value=GpuPowerRestoreReadResult(records=records, read_failed=False)),
+    )
+    ctx = context_factory(
+        state=_running_filler_state(*live_watts_by_uuid),
+        services=build_services(redis=redis),
+    )
+    result = await GpuPowerLimitCheck().run(ctx)
+
+    # the check still passes: our own cap is why the limit is low, and a revert never uncaps
+    assert result.passed is True
+
+
+@pytest.mark.asyncio
+async def test_a_live_revert_is_recorded(context_factory, monkeypatch) -> None:
+    # The host raised our 280 W cap back to the card default while our job is still running.
+    redis = FakeRedis()
+
+    await _run_check_while_filler_runs(
+        context_factory, monkeypatch, redis, [_record()], [("GPU-a", 400.0)]
+    )
 
     history = _stored_history(redis)
     assert len(history.reverts) == 1
     assert history.reverts[0].gpu_uuid == "GPU-a"
     assert history.reverts[0].capped_to_watts == 280
     assert history.reverts[0].found_watts == 400
-    assert redis.expiries[_revert_key(EXECUTOR_ID)] == CAP_REVERT_WINDOW_SECONDS
+    assert redis.expiries[_revert_key(CHECK_EXECUTOR_UUID)] == CAP_REVERT_WINDOW_SECONDS
 
 
 @pytest.mark.asyncio
-async def test_restore_records_nothing_when_the_cap_held() -> None:
-    ssh = fake_ssh(FakeRun(stdout=HELD_STATE_CSV), *_set_ok(400))
-    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
+async def test_a_cap_that_holds_records_nothing(context_factory, monkeypatch) -> None:
+    redis = FakeRedis()
 
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+    await _run_check_while_filler_runs(
+        context_factory, monkeypatch, redis, [_record()], [("GPU-a", 280.0)]
+    )
 
-    assert _revert_key(EXECUTOR_ID) not in redis.store
-
-
-@pytest.mark.asyncio
-async def test_a_whole_node_revert_counts_once() -> None:
-    # A host guard resets every GPU in the same tick. Counting eight of those as eight
-    # breaches would zero an 8x node on a single event.
-    state_csv = "GPU-a, 400, 400, 100, 400\nGPU-b, 400, 400, 100, 400\n"
-    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(400), *_set_ok(400))
-    redis = FakeRedis({
-        _restore_key("GPU-a"): _stored_restore_record(),
-        _restore_key("GPU-b"): _stored_restore_record(gpu_uuid="GPU-b"),
-    })
-
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a", "GPU-b"])
-
-    history = _stored_history(redis)
-    assert len(history.reverts) == 1
-    assert history.reverts[0].pod_id == POD_ID
+    assert _revert_key(CHECK_EXECUTOR_UUID) not in redis.store
 
 
 @pytest.mark.asyncio
-async def test_two_executors_on_one_host_each_get_their_own_revert() -> None:
-    # A whole-host restore sweeps every executor on the box; one provider's breach must not
-    # land on its neighbour's record.
-    other_executor = "executor-2"
-    state_csv = "GPU-a, 400, 400, 100, 400\nGPU-b, 400, 400, 100, 400\n"
-    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(400), *_set_ok(400))
-    redis = FakeRedis({
-        _restore_key("GPU-a"): _stored_restore_record(),
-        _restore_key("GPU-b"): _stored_restore_record(gpu_uuid="GPU-b", executor_id=other_executor),
-    })
+async def test_a_reset_after_the_job_is_never_seen(context_factory, monkeypatch) -> None:
+    # The whole reason detection lives here: a host that leaves our cap alone while the job runs
+    # and only resets the limit once the container is gone has harmed nothing. With no Lium job
+    # on the node the check takes the normal path and never looks at the revert history.
+    redis = FakeRedis()
+    monkeypatch.setattr(
+        check_module,
+        "read_gpu_power_restore_records",
+        AsyncMock(return_value=GpuPowerRestoreReadResult(records=[_record()], read_failed=False)),
+    )
+    state = build_state(
+        gpu_model="NVIDIA L40S",
+        gpu_count=1,
+        gpu_details=[{
+            "name": "NVIDIA L40S", "uuid": "GPU-a",
+            "power_limit": 400.0, "power_default_limit": 400.0, "power_max_limit": 450.0,
+        }],
+        rented_data=RentedExecutorsResponse(executors={}, default_job_owner_by_executor={}),
+    )
+    ctx = context_factory(state=state, services=build_services(redis=redis))
 
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a", "GPU-b"])
+    await GpuPowerLimitCheck().run(ctx)
+
+    assert _revert_key(CHECK_EXECUTOR_UUID) not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_a_whole_node_revert_counts_once(context_factory, monkeypatch) -> None:
+    # A host guard resets every GPU in the same tick. Counting eight of those as eight breaches
+    # would zero an 8x node on a single event.
+    redis = FakeRedis()
+
+    await _run_check_while_filler_runs(
+        context_factory, monkeypatch, redis,
+        [_record(gpu_uuid="GPU-a"), _record(gpu_uuid="GPU-b")],
+        [("GPU-a", 400.0), ("GPU-b", 400.0)],
+    )
 
     assert len(_stored_history(redis).reverts) == 1
-    other = GpuPowerCapRevertHistory.model_validate_json(redis.store[_revert_key(other_executor)])
-    assert [revert.gpu_uuid for revert in other.reverts] == ["GPU-b"]
 
 
 @pytest.mark.asyncio
-async def test_reverts_accumulate_and_old_ones_drop_out_of_the_window() -> None:
+async def test_the_same_job_is_not_counted_on_every_cycle(context_factory, monkeypatch) -> None:
+    # The check runs every validation cycle for as long as the filler lives. One killed job is
+    # one breach, however many cycles observe it.
+    redis = FakeRedis()
+
+    for _ in range(3):
+        await _run_check_while_filler_runs(
+            context_factory, monkeypatch, redis, [_record()], [("GPU-a", 400.0)]
+        )
+
+    assert len(_stored_history(redis).reverts) == 1
+
+
+@pytest.mark.asyncio
+async def test_another_executors_record_is_never_charged_here(context_factory, monkeypatch) -> None:
+    # One host can carry several executors; a neighbour's record must not land on this one.
+    redis = FakeRedis()
+
+    await _run_check_while_filler_runs(
+        context_factory, monkeypatch, redis,
+        [_record(executor_id="executor-next-door")], [("GPU-a", 400.0)],
+    )
+
+    assert _revert_key(CHECK_EXECUTOR_UUID) not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_a_failed_read_never_overwrites_the_stored_history(context_factory, monkeypatch) -> None:
+    # A transient GET failure used to look like "this executor has no reverts", and the write
+    # that followed replaced the real history with just this job's reverts.
+    class ReadBlindRedis(FakeRedis):
+        async def get(self, key: str) -> str | None:
+            raise ConnectionError("redis down")
+
+    earlier = GpuPowerCapRevertHistory(
+        reverts=[
+            GpuPowerCapRevert(
+                observed_at=time.time() - 60, pod_id="pod-earlier", gpu_uuid="GPU-a",
+                capped_to_watts=280, found_watts=400,
+            )
+        ]
+    )
+    redis = ReadBlindRedis({_revert_key(CHECK_EXECUTOR_UUID): earlier.model_dump_json()})
+
+    await _run_check_while_filler_runs(
+        context_factory, monkeypatch, redis, [_record(pod_id="pod-now")], [("GPU-a", 400.0)]
+    )
+
+    kept = GpuPowerCapRevertHistory.model_validate_json(redis.store[_revert_key(CHECK_EXECUTOR_UUID)])
+    assert [revert.pod_id for revert in kept.reverts] == ["pod-earlier"]
+
+
+@pytest.mark.asyncio
+async def test_recording_survives_redis_being_down(context_factory, monkeypatch) -> None:
+    # Redis resilience: the check must still pass, and the filler must keep running.
+    await _run_check_while_filler_runs(
+        context_factory, monkeypatch, BrokenRedis(), [_record()], [("GPU-a", 400.0)]
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_dry_run_pipeline_writes_nothing(context_factory, monkeypatch) -> None:
+    redis = FakeRedis()
+    monkeypatch.setattr(
+        check_module,
+        "read_gpu_power_restore_records",
+        AsyncMock(return_value=GpuPowerRestoreReadResult(records=[_record()], read_failed=False)),
+    )
+    ctx = context_factory(
+        state=_running_filler_state(("GPU-a", 400.0)), services=build_services(redis=redis)
+    )
+
+    await GpuPowerLimitCheck(restore_stale_caps=False).run(ctx)
+
+    assert redis.store == {}
+
+
+@pytest.mark.asyncio
+async def test_old_reverts_drop_out_of_the_window(context_factory, monkeypatch) -> None:
     stale = GpuPowerCapRevert(
         observed_at=time.time() - CAP_REVERT_WINDOW_SECONDS - 60,
-        pod_id="pod-stale",
-        gpu_uuid="GPU-a",
-        capped_to_watts=280,
-        found_watts=400,
+        pod_id="pod-stale", gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400,
     )
-    fresh = GpuPowerCapRevert(observed_at=time.time() - 60, pod_id="pod-fresh", gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)
-    history = GpuPowerCapRevertHistory(reverts=[stale, fresh])
-    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
+    fresh = GpuPowerCapRevert(
+        observed_at=time.time() - 60,
+        pod_id="pod-fresh", gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400,
+    )
     redis = FakeRedis({
-        _restore_key("GPU-a"): _stored_restore_record(),
-        _revert_key(EXECUTOR_ID): history.model_dump_json(),
+        _revert_key(CHECK_EXECUTOR_UUID): GpuPowerCapRevertHistory(reverts=[stale, fresh]).model_dump_json()
     })
 
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+    await _run_check_while_filler_runs(
+        context_factory, monkeypatch, redis, [_record(pod_id="pod-now")], [("GPU-a", 400.0)]
+    )
 
-    assert len(_stored_history(redis).reverts) == 2  # the stale one is dropped, the new one added
+    assert [revert.pod_id for revert in _stored_history(redis).reverts] == ["pod-fresh", "pod-now"]
 
 
 @pytest.mark.asyncio
-async def test_history_is_bounded() -> None:
+async def test_history_is_bounded(context_factory, monkeypatch) -> None:
     now = time.time()
-    reverts = [
-        GpuPowerCapRevert(
-            observed_at=now - index, pod_id=f"seed-{index}", gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400
-        )
-        for index in range(MAX_TRACKED_CAP_REVERTS + 10)
-    ]
-    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
     redis = FakeRedis({
-        _restore_key("GPU-a"): _stored_restore_record(),
-        _revert_key(EXECUTOR_ID): GpuPowerCapRevertHistory(reverts=reverts).model_dump_json(),
+        _revert_key(CHECK_EXECUTOR_UUID): GpuPowerCapRevertHistory(
+            reverts=[
+                GpuPowerCapRevert(
+                    observed_at=now - index, pod_id=f"seed-{index}", gpu_uuid="GPU-a",
+                    capped_to_watts=280, found_watts=400,
+                )
+                for index in range(MAX_TRACKED_CAP_REVERTS + 10)
+            ]
+        ).model_dump_json()
     })
 
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+    await _run_check_while_filler_runs(
+        context_factory, monkeypatch, redis, [_record(pod_id="pod-now")], [("GPU-a", 400.0)]
+    )
 
     assert len(_stored_history(redis).reverts) == MAX_TRACKED_CAP_REVERTS
 
 
-@pytest.mark.asyncio
-async def test_a_failed_apply_is_never_recorded_as_a_revert() -> None:
-    # The DAH-2715 population: the container cannot run nvidia-smi -pl at all. The failed apply
-    # is undone through the same restore path, and the undo reads the untouched pre-cap limit.
-    # Without the post-set stamp, every retry of a node that CANNOT cap would count as a node
-    # that WILL NOT cap, and two retries reach the threshold.
-    state_csv = "GPU-a, 400, 400, 100, 400\n"
-    ssh = fake_ssh(
-        FakeRun(stdout=state_csv),          # plan: state query
-        FakeRun(), FakeRun(exit_status=4),  # -pm, then -pl fails (no readback follows)
-        FakeRun(stdout=state_csv),          # undo: state query
-        *_set_ok(400),                      # undo: restore to the recorded 400 W
-    )
-    redis = FakeRedis()
-
-    applied = await apply_filler_gpu_power_limits(
-        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
-    )
-
-    assert applied is False
-    assert _revert_key(EXECUTOR_ID) not in redis.store
-
-
-@pytest.mark.asyncio
-async def test_a_failed_apply_clears_a_stale_claim_from_an_earlier_cap() -> None:
-    # A record frozen by an earlier FAILED restore still carries the watts that cap applied.
-    # If the next attempt cannot cap, the undo restores against an untouched high limit - and
-    # without clearing the claim first, that reads as the host reverting us.
-    state_csv = "GPU-a, 400, 400, 100, 400\n"
-    ssh = fake_ssh(
-        FakeRun(stdout=state_csv),          # plan: state query
-        FakeRun(), FakeRun(exit_status=4),  # -pm, then -pl fails (no readback follows)
-        FakeRun(stdout=state_csv),          # undo: state query
-        *_set_ok(400),                      # undo: restore to the frozen 400 W
-    )
-    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record(pod_id="pod-earlier")})
-
-    applied = await apply_filler_gpu_power_limits(
-        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
-    )
-
-    assert applied is False
-    assert _revert_key(EXECUTOR_ID) not in redis.store
-
-
-@pytest.mark.asyncio
-async def test_a_verified_cap_is_stamped_so_a_later_revert_is_attributable() -> None:
-    state_csv = "GPU-a, 400, 400, 100, 400\n"
-    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(280))
-    redis = FakeRedis()
-
-    applied = await apply_filler_gpu_power_limits(
-        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
-    )
-
-    assert applied is True
-    stored = GpuPowerRestoreRecord.model_validate_json(redis.store[_restore_key("GPU-a")])
-    assert stored.watts == 400  # the way back is still the miner's own limit
-    assert stored.capped_to_watts == 280
-
-
-@pytest.mark.asyncio
-async def test_a_cap_without_persistence_mode_is_never_stamped() -> None:
-    # DAH-2702: with persistence off the driver unloads on an idle GPU and the stock limit
-    # comes back on its own. At teardown that is indistinguishable from a provider raising it,
-    # so two healthy jobs on such a host would cost the provider the idle payout.
-    state_csv = "GPU-a, 400, 400, 100, 400\n"
-    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(280, persistence="Disabled"))
-    redis = FakeRedis()
-
-    applied = await apply_filler_gpu_power_limits(
-        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
-    )
-
-    assert applied is True  # the cap holds for now, so the filler still runs
-    stored = GpuPowerRestoreRecord.model_validate_json(redis.store[_restore_key("GPU-a")])
-    assert stored.capped_to_watts is None
-
-
-@pytest.mark.asyncio
-async def test_the_stamp_moves_a_frozen_record_onto_the_capping_pod() -> None:
-    # A record frozen by an earlier failed restore still names the pod that first capped the
-    # GPU. Reverts are deduplicated per job, so leaving the old pod on it would make every
-    # later reverted job look like one already counted.
-    state_csv = "GPU-a, 400, 400, 100, 400\n"
-    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(280))
-    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record(pod_id="pod-earlier")})
-
-    await apply_filler_gpu_power_limits(
-        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
-    )
-
-    stored = GpuPowerRestoreRecord.model_validate_json(redis.store[_restore_key("GPU-a")])
-    assert stored.pod_id == POD_ID
-    assert stored.watts == 400  # the frozen way back is untouched
-
-
-@pytest.mark.asyncio
-async def test_our_own_restore_is_never_read_as_a_host_revert() -> None:
-    # The restore raises the limit itself. If clearing the record afterwards fails, the record
-    # outlives it — and the next pass would read OUR raise as the provider raising it, taking
-    # the idle payout from a host whose cap held all along.
-    class DeleteBlindRedis(FakeRedis):
-        async def delete(self, key: str) -> None:
-            raise ConnectionError("redis down")
-
-    held_state_csv = "GPU-a, 280, 400, 100, 400\n"   # the cap held for the whole job
-    redis = DeleteBlindRedis({_restore_key("GPU-a"): _stored_restore_record()})
-    ssh = fake_ssh(FakeRun(stdout=held_state_csv), *_set_ok(400))
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
-
-    # second pass: the record survived and the GPU now sits at the 400 W we restored
-    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
-
-    assert _revert_key(EXECUTOR_ID) not in redis.store
-
-
-@pytest.mark.asyncio
-async def test_a_retried_restore_does_not_count_the_same_job_twice() -> None:
-    # A failed restore keeps its record on purpose so a safety net can retry it. The retry sees
-    # the same high limit and must not turn one killed job into two breaches.
-    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
-
-    for _ in range(2):
-        ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), FakeRun(), FakeRun(), FakeRun(stdout="399.00, Enabled\n"))
-        await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
-
-    assert _restore_key("GPU-a") in redis.store  # the failed restore kept its record
-    assert len(_stored_history(redis).reverts) == 1
-
-
-@pytest.mark.asyncio
-async def test_restore_still_succeeds_when_redis_cannot_store_the_revert() -> None:
-    # Teardown must never be blocked by the bookkeeping this gate needs.
-    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
-    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
-    redis.set = BrokenRedis().set
-
-    restored = await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
-
-    assert restored == 1
+# ---------------------------- the applied-cap stamp ----------------------------
 
 
 # ---------------------------- read_gpu_power_cap_reverts ----------------------------
@@ -458,36 +469,6 @@ async def test_read_returns_only_reverts_inside_the_window() -> None:
 @pytest.mark.asyncio
 async def test_read_is_empty_without_a_record() -> None:
     assert await read_gpu_power_cap_reverts(FakeRedis(), EXECUTOR_ID) == []
-
-
-@pytest.mark.asyncio
-async def test_a_failed_read_never_overwrites_the_stored_history() -> None:
-    # A transient GET failure used to look like "this executor has no reverts", and the write
-    # that followed replaced the real history with just this job's reverts.
-    class ReadBlindRedis(FakeRedis):
-        async def get(self, key: str) -> str | None:
-            if key == _revert_key(EXECUTOR_ID):
-                raise ConnectionError("redis down")
-            return self.store.get(key)
-
-    earlier = GpuPowerCapRevertHistory(
-        reverts=[
-            GpuPowerCapRevert(
-                observed_at=time.time() - 60, pod_id="pod-earlier", gpu_uuid="GPU-a",
-                capped_to_watts=280, found_watts=400,
-            )
-        ]
-    )
-    redis = ReadBlindRedis({
-        _restore_key("GPU-a"): _stored_restore_record(),
-        _revert_key(EXECUTOR_ID): earlier.model_dump_json(),
-    })
-    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
-
-    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
-
-    kept = GpuPowerCapRevertHistory.model_validate_json(redis.store[_revert_key(EXECUTOR_ID)])
-    assert [revert.pod_id for revert in kept.reverts] == ["pod-earlier"]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_gpu_power_cap_revert.py
+++ b/neurons/validators/tests/test_gpu_power_cap_revert.py
@@ -1,0 +1,408 @@
+"""DAH-2786 — a host that puts its own GPU power limit back loses the unrented incentive.
+
+Case 3 of the three power-cap problems: the cap applies, the validator reads it back, and
+then something on the provider's host raises the limit again. The PEARL filler is killed by
+the backend grace check, so the node runs no Lium job — and today it still collects the full
+unrented incentive. This suite covers the two halves: the validator records each revert it
+observes at restore time, and the incentive gate withholds the unrented incentive once the
+node has reverted often enough inside the window.
+"""
+
+import json
+import logging
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from core.config import settings
+from incentive.config import IncentiveConfig
+from incentive.rental_price import MIN_POWER_CAP_REVERTS_TO_PENALIZE, RentalPriceIncentive
+from services.gpu_power_limit import (
+    CAP_REVERT_WINDOW_SECONDS,
+    MAX_TRACKED_CAP_REVERTS,
+    GpuPowerCapRevert,
+    GpuPowerCapRevertHistory,
+    GpuPowerRestoreRecord,
+    _restore_key,
+    _revert_key,
+    _reverted_cap_target,
+    read_gpu_power_cap_reverts,
+    restore_tracked_gpu_power_limits,
+)
+from services.task_service import JobResult
+
+EXECUTOR_ID = "executor-1"
+POD_ID = "pod-1"
+H200 = "NVIDIA H200"  # base model H200 is rental-eligible by default
+
+
+# ---------------------------- _reverted_cap_target (pure) ----------------------------
+
+
+def _restore_record(watts: int, capped_to_watts: int | None) -> GpuPowerRestoreRecord:
+    return GpuPowerRestoreRecord(
+        gpu_uuid="GPU-a",
+        watts=watts,
+        capped_to_watts=capped_to_watts,
+        pod_id=POD_ID,
+        executor_id=EXECUTOR_ID,
+        capped_at=time.time(),
+    )
+
+
+def test_limit_back_at_the_pre_cap_value_is_a_revert() -> None:
+    # The prod shape: 103 of 113 reverts land exactly on the miner's own pre-cap value.
+    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=409) == 315
+
+
+def test_limit_back_at_the_card_default_is_a_revert() -> None:
+    # The other 10: above the pre-cap value, i.e. a driver reload or a reset by the host.
+    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=450) == 315
+
+
+def test_cap_that_still_holds_is_not_a_revert() -> None:
+    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=315) is None
+
+
+def test_partly_raised_limit_is_not_a_revert() -> None:
+    # Conservative on purpose: only a limit back at or above where the miner had it counts,
+    # so a frozen record from an earlier failed restore can never invent a breach.
+    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=350) is None
+
+
+def test_cap_that_never_lowered_the_limit_is_not_a_revert() -> None:
+    # A miner running below our target is capped upwards; the restore then reads our own
+    # target back and must not be read as the host raising it.
+    assert _reverted_cap_target(_restore_record(watts=250, capped_to_watts=315), watts_before=315) is None
+
+
+def test_record_without_a_cap_target_is_not_a_revert() -> None:
+    # Records written before this change carry no target: fail open, never penalize.
+    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=None), watts_before=409) is None
+
+
+def test_unknown_live_limit_is_not_a_revert() -> None:
+    # The state query failed, so there is no reading to judge.
+    assert _reverted_cap_target(_restore_record(watts=409, capped_to_watts=315), watts_before=None) is None
+
+
+# ---------------------------- recording at restore time ----------------------------
+
+
+class FakeRun:
+    def __init__(self, stdout: str = "", stderr: str = "", exit_status: int = 0):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.exit_status = exit_status
+
+
+def fake_ssh(*responses: FakeRun) -> AsyncMock:
+    ssh = AsyncMock()
+    ssh.run.side_effect = responses
+    return ssh
+
+
+def _set_ok(readback_watts: int) -> list[FakeRun]:
+    return [FakeRun(), FakeRun(), FakeRun(stdout=f"{readback_watts}.00, Enabled\n")]
+
+
+class FakeRedis:
+    def __init__(self, initial: dict[str, str] | None = None):
+        self.store: dict[str, str] = dict(initial or {})
+        self.expiries: dict[str, int] = {}
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self.store[key] = value
+        if ex is not None:
+            self.expiries[key] = ex
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def delete(self, key: str) -> None:
+        self.store.pop(key, None)
+
+
+class BrokenRedis(FakeRedis):
+    async def get(self, key: str) -> str | None:
+        raise ConnectionError("redis down")
+
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
+        raise ConnectionError("redis down")
+
+
+def _stored_history(redis: FakeRedis) -> GpuPowerCapRevertHistory:
+    return GpuPowerCapRevertHistory.model_validate_json(redis.store[_revert_key(EXECUTOR_ID)])
+
+
+# uuid, current, default, min, max — GPU-a sits back at its pre-cap 400W
+REVERTED_STATE_CSV = "GPU-a, 400, 400, 100, 400\n"
+HELD_STATE_CSV = "GPU-a, 280, 400, 100, 400\n"
+
+
+def _stored_restore_record(watts: int = 400, capped_to_watts: int | None = 280) -> str:
+    return _restore_record(watts=watts, capped_to_watts=capped_to_watts).model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_restore_records_a_revert_when_the_limit_came_back() -> None:
+
+
+    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
+    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
+
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    history = _stored_history(redis)
+    assert history.executor_id == EXECUTOR_ID
+    assert len(history.reverts) == 1
+    assert history.reverts[0].gpu_uuid == "GPU-a"
+    assert history.reverts[0].capped_to_watts == 280
+    assert history.reverts[0].found_watts == 400
+    assert redis.expiries[_revert_key(EXECUTOR_ID)] == CAP_REVERT_WINDOW_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_restore_records_nothing_when_the_cap_held() -> None:
+
+
+    ssh = fake_ssh(FakeRun(stdout=HELD_STATE_CSV), *_set_ok(400))
+    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
+
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    assert _revert_key(EXECUTOR_ID) not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_reverts_accumulate_and_old_ones_drop_out_of_the_window() -> None:
+
+
+    stale = GpuPowerCapRevert(
+        at=time.time() - CAP_REVERT_WINDOW_SECONDS - 60,
+        gpu_uuid="GPU-a",
+        capped_to_watts=280,
+        found_watts=400,
+    )
+    fresh = GpuPowerCapRevert(at=time.time() - 60, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)
+    history = GpuPowerCapRevertHistory(executor_id=EXECUTOR_ID, reverts=[stale, fresh])
+    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
+    redis = FakeRedis({
+        _restore_key("GPU-a"): _stored_restore_record(),
+        _revert_key(EXECUTOR_ID): history.model_dump_json(),
+    })
+
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    assert len(_stored_history(redis).reverts) == 2  # the stale one is dropped, the new one added
+
+
+@pytest.mark.asyncio
+async def test_history_is_bounded() -> None:
+
+
+    now = time.time()
+    reverts = [
+        GpuPowerCapRevert(at=now - index, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)
+        for index in range(MAX_TRACKED_CAP_REVERTS + 10)
+    ]
+    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
+    redis = FakeRedis({
+        _restore_key("GPU-a"): _stored_restore_record(),
+        _revert_key(EXECUTOR_ID): GpuPowerCapRevertHistory(
+            executor_id=EXECUTOR_ID, reverts=reverts
+        ).model_dump_json(),
+    })
+
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    assert len(_stored_history(redis).reverts) == MAX_TRACKED_CAP_REVERTS
+
+
+@pytest.mark.asyncio
+async def test_restore_still_succeeds_when_redis_cannot_store_the_revert(caplog) -> None:
+    # Teardown must never be blocked by the bookkeeping this gate needs.
+
+
+    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
+    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
+    redis.set = BrokenRedis().set
+
+    with caplog.at_level(logging.ERROR):
+        restored = await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    assert restored == 1
+
+
+# ---------------------------- read_gpu_power_cap_reverts ----------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_returns_only_reverts_inside_the_window() -> None:
+    now = time.time()
+    history = GpuPowerCapRevertHistory(
+        executor_id=EXECUTOR_ID,
+        reverts=[
+            GpuPowerCapRevert(at=now - CAP_REVERT_WINDOW_SECONDS - 1, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400),
+            GpuPowerCapRevert(at=now - 10, gpu_uuid="GPU-b", capped_to_watts=280, found_watts=400),
+        ],
+    )
+    redis = FakeRedis({_revert_key(EXECUTOR_ID): history.model_dump_json()})
+
+    reverts = await read_gpu_power_cap_reverts(redis, EXECUTOR_ID)
+
+    assert [revert.gpu_uuid for revert in reverts] == ["GPU-b"]
+
+
+@pytest.mark.asyncio
+async def test_read_is_empty_without_a_record() -> None:
+    assert await read_gpu_power_cap_reverts(FakeRedis(), EXECUTOR_ID) == []
+
+
+@pytest.mark.asyncio
+async def test_read_fails_open_when_redis_is_down() -> None:
+    # Redis resilience: our own outage must never zero an innocent provider's incentive.
+    assert await read_gpu_power_cap_reverts(BrokenRedis(), EXECUTOR_ID) == []
+
+
+@pytest.mark.asyncio
+async def test_read_fails_open_on_a_corrupt_record() -> None:
+    redis = FakeRedis({_revert_key(EXECUTOR_ID): json.dumps({"nonsense": True})})
+
+    assert await read_gpu_power_cap_reverts(redis, EXECUTOR_ID) == []
+
+
+# ---------------------------- the incentive gate ----------------------------
+
+
+def _build_incentive(redis) -> RentalPriceIncentive:
+    return RentalPriceIncentive(IncentiveConfig(), redis, {}, {})
+
+
+def _redis_with_reverts(count: int) -> FakeRedis:
+    now = time.time()
+    history = GpuPowerCapRevertHistory(
+        executor_id=EXECUTOR_ID,
+        reverts=[
+            GpuPowerCapRevert(at=now - 60 * index, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)
+            for index in range(count)
+        ],
+    )
+    return FakeRedis({_revert_key(EXECUTOR_ID): history.model_dump_json()})
+
+
+def _make_job(is_rented: bool = False) -> JobResult:
+    return JobResult(
+        spec={"container_cap_eff": "000001ffffffffff", "nvidiactl_owner_uid": 0},
+        executor_info=ExecutorSSHInfo(
+            uuid=EXECUTOR_ID,
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+            price_per_gpu=1.0,
+        ),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch",
+        log_status="success",
+        log_text="ok",
+        gpu_model=H200,
+        gpu_count=8,
+        is_rented=is_rented,
+        collateral_deposited=True,
+        sysbox_runtime=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_one_revert_does_not_reach_the_threshold() -> None:
+    # A driver reset can raise a limit on its own, so a single observation is not a breach.
+    incentive = _build_incentive(_redis_with_reverts(1))
+
+    assert await incentive._power_cap_reverted(_make_job()) is None
+
+
+@pytest.mark.asyncio
+async def test_repeated_reverts_are_flagged() -> None:
+    incentive = _build_incentive(_redis_with_reverts(MIN_POWER_CAP_REVERTS_TO_PENALIZE))
+
+    reverted = await incentive._power_cap_reverted(_make_job())
+
+    assert reverted is not None
+    assert reverted.revert_count == MIN_POWER_CAP_REVERTS_TO_PENALIZE
+    assert reverted.capped_to_watts == 280
+    assert reverted.found_watts == 400
+
+
+@pytest.mark.asyncio
+async def test_gate_fails_open_when_redis_is_down() -> None:
+    incentive = _build_incentive(BrokenRedis())
+
+    assert await incentive._power_cap_reverted(_make_job()) is None
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_keeps_rental_eligibility(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT", False)
+    incentive = _build_incentive(_redis_with_reverts(MIN_POWER_CAP_REVERTS_TO_PENALIZE))
+
+    result = await incentive.calculate_executor_score(_make_job())
+
+    assert result.eligible_for_rental_share is True
+    assert "reverts_gpu_power_cap" not in "\n".join(result.incentive_logs)
+
+
+@pytest.mark.asyncio
+async def test_shadow_mode_emits_the_measurement_log(monkeypatch, caplog) -> None:
+    # The shadow numbers are the whole deliverable of the first deploy.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT", False)
+    incentive = _build_incentive(_redis_with_reverts(MIN_POWER_CAP_REVERTS_TO_PENALIZE))
+
+    with caplog.at_level(logging.INFO):
+        await incentive.calculate_executor_score(_make_job())
+
+    breach = next(
+        record.msg for record in caplog.records
+        if hasattr(record.msg, "extra") and record.msg.extra.get("reason") == "reverts_gpu_power_cap"
+    )
+    assert "shadow only - flag off" in breach.message
+    assert breach.extra["power_cap_revert_count"] == MIN_POWER_CAP_REVERTS_TO_PENALIZE
+    assert breach.extra["enforced"] is False
+    assert breach.extra["pool"] == "rental_kept_shadow"
+
+
+@pytest.mark.asyncio
+async def test_enforced_drops_rental_eligibility(monkeypatch) -> None:
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT", True)
+    incentive = _build_incentive(_redis_with_reverts(MIN_POWER_CAP_REVERTS_TO_PENALIZE))
+
+    result = await incentive.calculate_executor_score(_make_job())
+
+    assert result.eligible_for_rental_share is False
+    assert result.mining_score == 0
+    assert "reverts_gpu_power_cap" in "\n".join(result.incentive_logs)
+
+
+@pytest.mark.asyncio
+async def test_rented_executor_is_never_gated(monkeypatch) -> None:
+    # The gate only withholds the UNRENTED incentive; a rented node earns from the mining pool.
+    monkeypatch.setattr(settings, "ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT", True)
+    incentive = _build_incentive(_redis_with_reverts(MIN_POWER_CAP_REVERTS_TO_PENALIZE))
+
+    assert await incentive._power_cap_reverted(_make_job(is_rented=True)) is not None  # gate is state-only
+    result = await incentive.calculate_executor_score(_make_job(is_rented=True))
+
+    assert "reverts_gpu_power_cap" not in "\n".join(result.incentive_logs)
+
+
+@pytest.mark.asyncio
+async def test_enforcement_ships_off() -> None:
+    # Rollout contract: this gate infers provider intent, so it starts in shadow.
+    default = type(settings).model_fields["ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT"].default
+
+    assert default is False

--- a/neurons/validators/tests/test_gpu_power_cap_revert.py
+++ b/neurons/validators/tests/test_gpu_power_cap_revert.py
@@ -19,6 +19,7 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 from core.config import settings
 from incentive.config import IncentiveConfig
 from incentive.rental_price import MIN_POWER_CAP_REVERTS_TO_PENALIZE, RentalPriceIncentive
+from payload_models.payloads import GpuPowerLimit
 from services.gpu_power_limit import (
     CAP_REVERT_WINDOW_SECONDS,
     MAX_TRACKED_CAP_REVERTS,
@@ -28,7 +29,8 @@ from services.gpu_power_limit import (
     GpuPowerState,
     _restore_key,
     _revert_key,
-    _reverted_cap_target,
+    _detect_cap_revert,
+    apply_filler_gpu_power_limits,
     read_gpu_power_cap_reverts,
     restore_tracked_gpu_power_limits,
 )
@@ -39,7 +41,7 @@ POD_ID = "pod-1"
 H200 = "NVIDIA H200"  # base model H200 is rental-eligible by default
 
 
-# ---------------------------- _reverted_cap_target (pure) ----------------------------
+# ---------------------------- _detect_cap_revert (pure) ----------------------------
 
 
 def _restore_record(watts: int, capped_to_watts: int | None) -> GpuPowerRestoreRecord:
@@ -59,72 +61,66 @@ def _state(current_watts: int, default_watts: int | None = 450) -> GpuPowerState
     )
 
 
+def _observe(watts: int, capped_to_watts: int | None, found: int, default: int | None = 450):
+    return _detect_cap_revert(_restore_record(watts, capped_to_watts), _state(found, default), observed_at=1.0)
+
+
 # RTX 4090 numbers throughout: default 450 W, our cap 315 W (0.70), uncapped line 405 W (0.90).
 
 
 def test_limit_pinned_just_above_our_floor_is_a_revert() -> None:
     # The prod shape: the host guard pins 409 W, one point above the 0.9 line we kill at.
-    record = _restore_record(watts=409, capped_to_watts=315)
+    observation = _observe(watts=409, capped_to_watts=315, found=409)
 
-    assert _reverted_cap_target(record, watts_before=409, state=_state(409)) == 315
+    assert observation is not None
+    assert observation.capped_to_watts == 315
+    assert observation.found_watts == 409
+    assert observation.pod_id == POD_ID
 
 
 def test_limit_back_at_the_card_default_is_a_revert() -> None:
-    record = _restore_record(watts=409, capped_to_watts=315)
-
-    assert _reverted_cap_target(record, watts_before=450, state=_state(450)) == 315
+    assert _observe(watts=409, capped_to_watts=315, found=450) is not None
 
 
 def test_host_floor_below_the_pre_cap_reading_is_still_a_revert() -> None:
     # Guard script A restores the DEFAULT every 30 s during cold start, then pins 0.91 of it.
     # The pre-cap reading is then the default and the live limit sits under it - still an
     # uncapped run, and a pre-cap comparison alone would miss it.
-    record = _restore_record(watts=450, capped_to_watts=315)
-
-    assert _reverted_cap_target(record, watts_before=409, state=_state(409)) == 315
+    assert _observe(watts=450, capped_to_watts=315, found=409) is not None
 
 
 def test_cap_that_still_holds_is_not_a_revert() -> None:
-    record = _restore_record(watts=409, capped_to_watts=315)
-
-    assert _reverted_cap_target(record, watts_before=315, state=_state(315)) is None
+    assert _observe(watts=409, capped_to_watts=315, found=315) is None
 
 
 def test_limit_below_the_uncapped_line_is_not_a_revert() -> None:
     # The job still ran capped, so it did the work it is paid for. Drift is not a breach.
-    record = _restore_record(watts=409, capped_to_watts=315)
+    assert _observe(watts=409, capped_to_watts=315, found=350) is None
 
-    assert _reverted_cap_target(record, watts_before=350, state=_state(350)) is None
+
+def test_the_line_is_not_rounded_below_the_backend_kill_ratio() -> None:
+    # 5090: 0.9 x 575 = 517.5. A limit of 517 W is 0.8991 of default, which the backend guard
+    # lets live - penalizing a run nobody killed would be a rule of our own.
+    assert _observe(watts=518, capped_to_watts=402, found=517, default=575) is None
+    assert _observe(watts=518, capped_to_watts=402, found=518, default=575) is not None
 
 
 def test_cap_that_never_lowered_the_limit_is_not_a_revert() -> None:
     # A miner running below our target is capped upwards; reading our own target back at
     # restore time is not the host raising it.
-    record = _restore_record(watts=250, capped_to_watts=315)
-
-    assert _reverted_cap_target(record, watts_before=315, state=_state(315)) is None
+    assert _observe(watts=250, capped_to_watts=315, found=315) is None
 
 
-def test_record_without_a_cap_target_is_not_a_revert() -> None:
-    # Records written before this field existed: fail open, never penalize.
-    record = _restore_record(watts=409, capped_to_watts=None)
-
-    assert _reverted_cap_target(record, watts_before=409, state=_state(409)) is None
+def test_a_cap_that_never_landed_is_not_a_revert() -> None:
+    # The whole DAH-2715 population: the container cannot cap at all, so the failed apply is
+    # undone through the same restore path. No stamped target, no accusation.
+    assert _observe(watts=409, capped_to_watts=None, found=409) is None
 
 
 def test_unknown_default_falls_back_to_the_pre_cap_limit() -> None:
     # Some GPUs report "[N/A]" for the default limit. The miner's own pre-cap value is the line.
-    record = _restore_record(watts=409, capped_to_watts=315)
-    no_default = _state(409, default_watts=None)
-
-    assert _reverted_cap_target(record, watts_before=409, state=no_default) == 315
-    assert _reverted_cap_target(record, watts_before=380, state=no_default) is None
-
-
-def test_unknown_gpu_state_falls_back_to_the_pre_cap_limit() -> None:
-    record = _restore_record(watts=409, capped_to_watts=315)
-
-    assert _reverted_cap_target(record, watts_before=409, state=None) == 315
+    assert _observe(watts=409, capped_to_watts=315, found=409, default=None) is not None
+    assert _observe(watts=409, capped_to_watts=315, found=380, default=None) is None
 
 
 # ---------------------------- recording at restore time ----------------------------
@@ -181,13 +177,13 @@ REVERTED_STATE_CSV = "GPU-a, 400, 400, 100, 400\n"
 HELD_STATE_CSV = "GPU-a, 280, 400, 100, 400\n"
 
 
-def _stored_restore_record(watts: int = 400, capped_to_watts: int | None = 280) -> str:
-    return _restore_record(watts=watts, capped_to_watts=capped_to_watts).model_dump_json()
-
-
-def _restore_record_for(gpu_uuid: str, executor_id: str) -> str:
+def _stored_restore_record(
+    gpu_uuid: str = "GPU-a", executor_id: str = EXECUTOR_ID, pod_id: str = POD_ID
+) -> str:
     record = _restore_record(watts=400, capped_to_watts=280)
-    return record.model_copy(update={"gpu_uuid": gpu_uuid, "executor_id": executor_id}).model_dump_json()
+    return record.model_copy(
+        update={"gpu_uuid": gpu_uuid, "executor_id": executor_id, "pod_id": pod_id}
+    ).model_dump_json()
 
 
 @pytest.mark.asyncio
@@ -198,7 +194,6 @@ async def test_restore_records_a_revert_when_the_limit_came_back() -> None:
     await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
 
     history = _stored_history(redis)
-    assert history.executor_id == EXECUTOR_ID
     assert len(history.reverts) == 1
     assert history.reverts[0].gpu_uuid == "GPU-a"
     assert history.reverts[0].capped_to_watts == 280
@@ -224,14 +219,14 @@ async def test_a_whole_node_revert_counts_once() -> None:
     ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(400), *_set_ok(400))
     redis = FakeRedis({
         _restore_key("GPU-a"): _stored_restore_record(),
-        _restore_key("GPU-b"): _restore_record_for("GPU-b", EXECUTOR_ID),
+        _restore_key("GPU-b"): _stored_restore_record(gpu_uuid="GPU-b"),
     })
 
     await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a", "GPU-b"])
 
     history = _stored_history(redis)
     assert len(history.reverts) == 1
-    assert history.reverts[0].reverted_gpu_count == 2
+    assert history.reverts[0].pod_id == POD_ID
 
 
 @pytest.mark.asyncio
@@ -243,7 +238,7 @@ async def test_two_executors_on_one_host_each_get_their_own_revert() -> None:
     ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(400), *_set_ok(400))
     redis = FakeRedis({
         _restore_key("GPU-a"): _stored_restore_record(),
-        _restore_key("GPU-b"): _restore_record_for("GPU-b", other_executor),
+        _restore_key("GPU-b"): _stored_restore_record(gpu_uuid="GPU-b", executor_id=other_executor),
     })
 
     await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a", "GPU-b"])
@@ -256,13 +251,14 @@ async def test_two_executors_on_one_host_each_get_their_own_revert() -> None:
 @pytest.mark.asyncio
 async def test_reverts_accumulate_and_old_ones_drop_out_of_the_window() -> None:
     stale = GpuPowerCapRevert(
-        at=time.time() - CAP_REVERT_WINDOW_SECONDS - 60,
+        observed_at=time.time() - CAP_REVERT_WINDOW_SECONDS - 60,
+        pod_id="pod-stale",
         gpu_uuid="GPU-a",
         capped_to_watts=280,
         found_watts=400,
     )
-    fresh = GpuPowerCapRevert(at=time.time() - 60, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)
-    history = GpuPowerCapRevertHistory(executor_id=EXECUTOR_ID, reverts=[stale, fresh])
+    fresh = GpuPowerCapRevert(observed_at=time.time() - 60, pod_id="pod-fresh", gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)
+    history = GpuPowerCapRevertHistory(reverts=[stale, fresh])
     ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
     redis = FakeRedis({
         _restore_key("GPU-a"): _stored_restore_record(),
@@ -278,15 +274,15 @@ async def test_reverts_accumulate_and_old_ones_drop_out_of_the_window() -> None:
 async def test_history_is_bounded() -> None:
     now = time.time()
     reverts = [
-        GpuPowerCapRevert(at=now - index, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)
+        GpuPowerCapRevert(
+            observed_at=now - index, pod_id=f"seed-{index}", gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400
+        )
         for index in range(MAX_TRACKED_CAP_REVERTS + 10)
     ]
     ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
     redis = FakeRedis({
         _restore_key("GPU-a"): _stored_restore_record(),
-        _revert_key(EXECUTOR_ID): GpuPowerCapRevertHistory(
-            executor_id=EXECUTOR_ID, reverts=reverts
-        ).model_dump_json(),
+        _revert_key(EXECUTOR_ID): GpuPowerCapRevertHistory(reverts=reverts).model_dump_json(),
     })
 
     await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
@@ -295,16 +291,88 @@ async def test_history_is_bounded() -> None:
 
 
 @pytest.mark.asyncio
-async def test_restore_still_succeeds_when_redis_cannot_store_the_revert(caplog) -> None:
+async def test_a_failed_apply_is_never_recorded_as_a_revert() -> None:
+    # The DAH-2715 population: the container cannot run nvidia-smi -pl at all. The failed apply
+    # is undone through the same restore path, and the undo reads the untouched pre-cap limit.
+    # Without the post-set stamp, every retry of a node that CANNOT cap would count as a node
+    # that WILL NOT cap, and two retries reach the threshold.
+    state_csv = "GPU-a, 400, 400, 100, 400\n"
+    ssh = fake_ssh(
+        FakeRun(stdout=state_csv),          # plan: state query
+        FakeRun(), FakeRun(exit_status=4),  # -pm, then -pl fails (no readback follows)
+        FakeRun(stdout=state_csv),          # undo: state query
+        *_set_ok(400),                      # undo: restore to the recorded 400 W
+    )
+    redis = FakeRedis()
+
+    applied = await apply_filler_gpu_power_limits(
+        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
+    )
+
+    assert applied is False
+    assert _revert_key(EXECUTOR_ID) not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_a_failed_apply_clears_a_stale_claim_from_an_earlier_cap() -> None:
+    # A record frozen by an earlier FAILED restore still carries the watts that cap applied.
+    # If the next attempt cannot cap, the undo restores against an untouched high limit - and
+    # without clearing the claim first, that reads as the host reverting us.
+    state_csv = "GPU-a, 400, 400, 100, 400\n"
+    ssh = fake_ssh(
+        FakeRun(stdout=state_csv),          # plan: state query
+        FakeRun(), FakeRun(exit_status=4),  # -pm, then -pl fails (no readback follows)
+        FakeRun(stdout=state_csv),          # undo: state query
+        *_set_ok(400),                      # undo: restore to the frozen 400 W
+    )
+    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record(pod_id="pod-earlier")})
+
+    applied = await apply_filler_gpu_power_limits(
+        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
+    )
+
+    assert applied is False
+    assert _revert_key(EXECUTOR_ID) not in redis.store
+
+
+@pytest.mark.asyncio
+async def test_a_verified_cap_is_stamped_so_a_later_revert_is_attributable() -> None:
+    state_csv = "GPU-a, 400, 400, 100, 400\n"
+    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(280))
+    redis = FakeRedis()
+
+    applied = await apply_filler_gpu_power_limits(
+        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
+    )
+
+    assert applied is True
+    stored = GpuPowerRestoreRecord.model_validate_json(redis.store[_restore_key("GPU-a")])
+    assert stored.watts == 400  # the way back is still the miner's own limit
+    assert stored.capped_to_watts == 280
+
+
+@pytest.mark.asyncio
+async def test_a_retried_restore_does_not_count_the_same_job_twice() -> None:
+    # A failed restore keeps its record on purpose so a safety net can retry it. The retry sees
+    # the same high limit and must not turn one killed job into two breaches.
+    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
+
+    for _ in range(2):
+        ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), FakeRun(), FakeRun(), FakeRun(stdout="399.00, Enabled\n"))
+        await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    assert _restore_key("GPU-a") in redis.store  # the failed restore kept its record
+    assert len(_stored_history(redis).reverts) == 1
+
+
+@pytest.mark.asyncio
+async def test_restore_still_succeeds_when_redis_cannot_store_the_revert() -> None:
     # Teardown must never be blocked by the bookkeeping this gate needs.
-
-
     ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
     redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record()})
     redis.set = BrokenRedis().set
 
-    with caplog.at_level(logging.ERROR):
-        restored = await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+    restored = await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
 
     assert restored == 1
 
@@ -316,10 +384,9 @@ async def test_restore_still_succeeds_when_redis_cannot_store_the_revert(caplog)
 async def test_read_returns_only_reverts_inside_the_window() -> None:
     now = time.time()
     history = GpuPowerCapRevertHistory(
-        executor_id=EXECUTOR_ID,
         reverts=[
-            GpuPowerCapRevert(at=now - CAP_REVERT_WINDOW_SECONDS - 1, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400),
-            GpuPowerCapRevert(at=now - 10, gpu_uuid="GPU-b", capped_to_watts=280, found_watts=400),
+            GpuPowerCapRevert(observed_at=now - CAP_REVERT_WINDOW_SECONDS - 1, pod_id="pod-old", gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400),
+            GpuPowerCapRevert(observed_at=now - 10, pod_id="pod-new", gpu_uuid="GPU-b", capped_to_watts=280, found_watts=400),
         ],
     )
     redis = FakeRedis({_revert_key(EXECUTOR_ID): history.model_dump_json()})
@@ -357,9 +424,11 @@ def _build_incentive(redis) -> RentalPriceIncentive:
 def _redis_with_reverts(count: int) -> FakeRedis:
     now = time.time()
     history = GpuPowerCapRevertHistory(
-        executor_id=EXECUTOR_ID,
         reverts=[
-            GpuPowerCapRevert(at=now - 60 * index, gpu_uuid="GPU-a", capped_to_watts=280, found_watts=400)
+            GpuPowerCapRevert(
+                observed_at=now - 60 * index, pod_id=f"pod-{index}", gpu_uuid="GPU-a",
+                capped_to_watts=280, found_watts=400,
+            )
             for index in range(count)
         ],
     )

--- a/neurons/validators/tests/test_gpu_power_cap_revert.py
+++ b/neurons/validators/tests/test_gpu_power_cap_revert.py
@@ -61,7 +61,9 @@ def _state(current_watts: int, default_watts: int | None = 450) -> GpuPowerState
     )
 
 
-def _observe(watts: int, capped_to_watts: int | None, found: int, default: int | None = 450):
+def _observe(
+    watts: int, capped_to_watts: int | None, found: int, default: int | None = 450
+) -> GpuPowerCapRevert | None:
     return _detect_cap_revert(_restore_record(watts, capped_to_watts), _state(found, default), observed_at=1.0)
 
 
@@ -127,7 +129,7 @@ def test_unknown_default_falls_back_to_the_pre_cap_limit() -> None:
 
 
 class FakeRun:
-    def __init__(self, stdout: str = "", stderr: str = "", exit_status: int = 0):
+    def __init__(self, stdout: str = "", stderr: str = "", exit_status: int = 0) -> None:
         self.stdout = stdout
         self.stderr = stderr
         self.exit_status = exit_status
@@ -144,7 +146,7 @@ def _set_ok(readback_watts: int, persistence: str = "Enabled") -> list[FakeRun]:
 
 
 class FakeRedis:
-    def __init__(self, initial: dict[str, str] | None = None):
+    def __init__(self, initial: dict[str, str] | None = None) -> None:
         self.store: dict[str, str] = dict(initial or {})
         self.expiries: dict[str, int] = {}
 
@@ -523,7 +525,7 @@ async def test_read_fails_open_on_a_corrupt_record() -> None:
 # ---------------------------- the incentive gate ----------------------------
 
 
-def _build_incentive(redis) -> RentalPriceIncentive:
+def _build_incentive(redis: FakeRedis) -> RentalPriceIncentive:
     return RentalPriceIncentive(IncentiveConfig(), redis, {}, {})
 
 

--- a/neurons/validators/tests/test_gpu_power_cap_revert.py
+++ b/neurons/validators/tests/test_gpu_power_cap_revert.py
@@ -388,6 +388,27 @@ async def test_the_stamp_moves_a_frozen_record_onto_the_capping_pod() -> None:
 
 
 @pytest.mark.asyncio
+async def test_our_own_restore_is_never_read_as_a_host_revert() -> None:
+    # The restore raises the limit itself. If clearing the record afterwards fails, the record
+    # outlives it — and the next pass would read OUR raise as the provider raising it, taking
+    # the idle payout from a host whose cap held all along.
+    class DeleteBlindRedis(FakeRedis):
+        async def delete(self, key: str) -> None:
+            raise ConnectionError("redis down")
+
+    held_state_csv = "GPU-a, 280, 400, 100, 400\n"   # the cap held for the whole job
+    redis = DeleteBlindRedis({_restore_key("GPU-a"): _stored_restore_record()})
+    ssh = fake_ssh(FakeRun(stdout=held_state_csv), *_set_ok(400))
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    # second pass: the record survived and the GPU now sits at the 400 W we restored
+    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    assert _revert_key(EXECUTOR_ID) not in redis.store
+
+
+@pytest.mark.asyncio
 async def test_a_retried_restore_does_not_count_the_same_job_twice() -> None:
     # A failed restore keeps its record on purpose so a safety net can retry it. The retry sees
     # the same high limit and must not turn one killed job into two breaches.

--- a/neurons/validators/tests/test_gpu_power_cap_revert.py
+++ b/neurons/validators/tests/test_gpu_power_cap_revert.py
@@ -139,8 +139,8 @@ def fake_ssh(*responses: FakeRun) -> AsyncMock:
     return ssh
 
 
-def _set_ok(readback_watts: int) -> list[FakeRun]:
-    return [FakeRun(), FakeRun(), FakeRun(stdout=f"{readback_watts}.00, Enabled\n")]
+def _set_ok(readback_watts: int, persistence: str = "Enabled") -> list[FakeRun]:
+    return [FakeRun(), FakeRun(), FakeRun(stdout=f"{readback_watts}.00, {persistence}\n")]
 
 
 class FakeRedis:
@@ -349,6 +349,42 @@ async def test_a_verified_cap_is_stamped_so_a_later_revert_is_attributable() -> 
     stored = GpuPowerRestoreRecord.model_validate_json(redis.store[_restore_key("GPU-a")])
     assert stored.watts == 400  # the way back is still the miner's own limit
     assert stored.capped_to_watts == 280
+
+
+@pytest.mark.asyncio
+async def test_a_cap_without_persistence_mode_is_never_stamped() -> None:
+    # DAH-2702: with persistence off the driver unloads on an idle GPU and the stock limit
+    # comes back on its own. At teardown that is indistinguishable from a provider raising it,
+    # so two healthy jobs on such a host would cost the provider the idle payout.
+    state_csv = "GPU-a, 400, 400, 100, 400\n"
+    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(280, persistence="Disabled"))
+    redis = FakeRedis()
+
+    applied = await apply_filler_gpu_power_limits(
+        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
+    )
+
+    assert applied is True  # the cap holds for now, so the filler still runs
+    stored = GpuPowerRestoreRecord.model_validate_json(redis.store[_restore_key("GPU-a")])
+    assert stored.capped_to_watts is None
+
+
+@pytest.mark.asyncio
+async def test_the_stamp_moves_a_frozen_record_onto_the_capping_pod() -> None:
+    # A record frozen by an earlier failed restore still names the pod that first capped the
+    # GPU. Reverts are deduplicated per job, so leaving the old pod on it would make every
+    # later reverted job look like one already counted.
+    state_csv = "GPU-a, 400, 400, 100, 400\n"
+    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(280))
+    redis = FakeRedis({_restore_key("GPU-a"): _stored_restore_record(pod_id="pod-earlier")})
+
+    await apply_filler_gpu_power_limits(
+        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
+    )
+
+    stored = GpuPowerRestoreRecord.model_validate_json(redis.store[_restore_key("GPU-a")])
+    assert stored.pod_id == POD_ID
+    assert stored.watts == 400  # the frozen way back is untouched
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_gpu_power_cap_revert.py
+++ b/neurons/validators/tests/test_gpu_power_cap_revert.py
@@ -438,6 +438,55 @@ async def test_read_is_empty_without_a_record() -> None:
 
 
 @pytest.mark.asyncio
+async def test_a_failed_read_never_overwrites_the_stored_history() -> None:
+    # A transient GET failure used to look like "this executor has no reverts", and the write
+    # that followed replaced the real history with just this job's reverts.
+    class ReadBlindRedis(FakeRedis):
+        async def get(self, key: str) -> str | None:
+            if key == _revert_key(EXECUTOR_ID):
+                raise ConnectionError("redis down")
+            return self.store.get(key)
+
+    earlier = GpuPowerCapRevertHistory(
+        reverts=[
+            GpuPowerCapRevert(
+                observed_at=time.time() - 60, pod_id="pod-earlier", gpu_uuid="GPU-a",
+                capped_to_watts=280, found_watts=400,
+            )
+        ]
+    )
+    redis = ReadBlindRedis({
+        _restore_key("GPU-a"): _stored_restore_record(),
+        _revert_key(EXECUTOR_ID): earlier.model_dump_json(),
+    })
+    ssh = fake_ssh(FakeRun(stdout=REVERTED_STATE_CSV), *_set_ok(400))
+
+    await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-a"])
+
+    kept = GpuPowerCapRevertHistory.model_validate_json(redis.store[_revert_key(EXECUTOR_ID)])
+    assert [revert.pod_id for revert in kept.reverts] == ["pod-earlier"]
+
+
+@pytest.mark.asyncio
+async def test_the_stamp_moves_a_frozen_record_onto_the_capping_executor() -> None:
+    # A GPU whose record was frozen under an earlier executor must not file its next breach
+    # against that executor - the provider running it now is the one being judged.
+    state_csv = "GPU-a, 400, 400, 100, 400\n"
+    ssh = fake_ssh(FakeRun(stdout=state_csv), *_set_ok(280))
+    redis = FakeRedis({
+        _restore_key("GPU-a"): _stored_restore_record(executor_id="executor-earlier", pod_id="pod-earlier")
+    })
+
+    await apply_filler_gpu_power_limits(
+        ssh, [GpuPowerLimit(gpu_uuid="GPU-a", watts=280)], redis, POD_ID, EXECUTOR_ID
+    )
+
+    stored = GpuPowerRestoreRecord.model_validate_json(redis.store[_restore_key("GPU-a")])
+    assert stored.executor_id == EXECUTOR_ID
+    assert stored.pod_id == POD_ID
+
+
+@pytest.mark.asyncio
 async def test_read_fails_open_when_redis_is_down() -> None:
     # Redis resilience: our own outage must never zero an innocent provider's incentive.
     assert await read_gpu_power_cap_reverts(BrokenRedis(), EXECUTOR_ID) == []

--- a/neurons/validators/tests/test_gpu_power_limit.py
+++ b/neurons/validators/tests/test_gpu_power_limit.py
@@ -87,7 +87,7 @@ class FakeRedis:
     def __init__(self, initial: dict[str, str] | None = None):
         self.store: dict[str, str] = dict(initial or {})
 
-    async def set(self, key: str, value: str) -> None:
+    async def set(self, key: str, value: str, ex: int | None = None) -> None:
         self.store[key] = value
 
     async def get(self, key: str) -> str | None:

--- a/neurons/validators/tests/test_gpu_power_limit_check.py
+++ b/neurons/validators/tests/test_gpu_power_limit_check.py
@@ -143,7 +143,9 @@ async def test_power_limit_skipped_when_lium_default_job_active(context_factory,
     result = await GpuPowerLimitCheck().run(ctx)
     assert result.passed is True
     assert result.event.reason_code == "GPU_POWER_LIMIT_SKIPPED_LIUM_FILLER"
-    read_records_mock.assert_not_awaited()  # never touch records under a live filler
+    # DAH-2786: the records ARE read here now — a live filler is the only moment we can catch
+    # the host raising our cap back. Reading them never changes this verdict.
+    read_records_mock.assert_awaited()
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -11,6 +11,7 @@ from incentive.rental_price import (
     InsufficientDisk,
     MissingFlagshipCapability,
     PowerCapIncapable,
+    PowerCapReverted,
     RentalPriceIncentive,
 )
 from services.task_service import JobResult
@@ -35,6 +36,7 @@ def test_reason_enum_pins_the_stable_code_contract():
         "insufficient_disk_for_vram",
         "flagship_without_ncu_or_split",
         "cannot_apply_gpu_power_cap",
+        "reverts_gpu_power_cap",
     }
 
 
@@ -142,6 +144,16 @@ def _job(**overrides) -> JobResult:
             ),
             "cannot_apply_gpu_power_cap",
             "CAP_SYS_ADMIN",
+        ),
+        (
+            lambda job: MinerLogLine.no_payout_because_reverts_gpu_power_cap(
+                job,
+                PowerCapReverted(
+                    revert_count=3, window_hours=24, capped_to_watts=280, found_watts=400
+                ),
+            ),
+            "reverts_gpu_power_cap",
+            "nvidia-smi -pl",
         ),
     ],
 )


### PR DESCRIPTION
Case 3 of the three power-cap problems: the cap applies, the validator reads it back, and then the host raises the limit again. The backend grace check kills the PEARL filler, the node runs no Lium job — and it still collects the full unrented incentive. Measured on 2026-08-18: 113 of 536 cap/restore pairs, 103 of them landing exactly on the miner's own pre-cap value.

## Signal
`services/gpu_power_limit.py`. The restore path already reads the live limit before it writes the miner's value back.

- `GpuPowerRestoreRecord` gains `capped_to_watts` — the clamped watts we really applied. Old records carry `None` and never accuse.
- `_reverted_cap_target()` flags a revert only when the cap really lowered the limit AND the live limit is back at or above the miner's own value. The first bound covers a miner who already ran below our target; the second stops a frozen record (older cap target after a failed restore) from inventing a breach.
- Each observation goes to Redis `gpu_power_cap_revert:<executor_id>`, 24 h window, bounded history. Best-effort — teardown never fails over it.

## Gate
`incentive/rental_price.py`, fifth unrented gate, same pattern as DAH-2520 / 2546 / 2715.

- Flags at 3 reverts in 24 h. One revert is not enough: a driver reload can undo a cap on its own.
- `ENABLE_UNRENTED_POWER_CAP_REVERT_LIMIT`, **default False** — shadow only. This gate reads provider behaviour, not a capability, so the prod numbers get read first.
- Miner-facing reason `reverts_gpu_power_cap` with the count, the window and both watt readings. No backend change: the portal humanizes the code generically.
- Fail-open on every unknown — Redis down, corrupt record, missing cap target, missing live reading.

## Tests
`tests/test_gpu_power_cap_revert.py`, 24 cases: the pure discriminator (both prod shapes plus the three false-positive traps), recording at restore time, the reader, and the gate. Full validator suite 1790 passed; the 3 `test_sshd_bootstrap_script.py` failures also fail on clean `main`.

Docs: Datura-ai/lium-docs#132.

## Before the flag flip
1. `default_job/strategies.py` has no incentive input, so a flagged node still gets PEARL fillers it will revert. Same shape as the DAH-2715 finding — grade the sanction first.
2. Shadow mode tells the provider nothing, so the docs and the announcement must land before enforcement.
3. Not verified on staging yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)