### PR TITLE
DAH-2701: withhold incentive from executors running an outdated image

### DIFF
--- a/neurons/validators/src/cli.py
+++ b/neurons/validators/src/cli.py
@@ -10,10 +10,13 @@ from datura.requests.miner_requests import ExecutorSSHInfo
 from core.utils import configure_logs_of_other_modules, _m, get_extra_info, get_logger
 from core.validator import Validator
 from clients.subtensor_client import SubtensorClient
-from services.default_docker_image_digest_service import fetch_default_image_digests
+from services.default_docker_image_digest_service import (
+    fetch_default_image_digests,
+    fetch_executor_image_digest,
+)
+from services.executor_image_policy import build_expected_image_snapshot
 from services.ioc import ioc
 from services.miner_service import MinerService
-from services.docker_service import DockerService
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.file_encrypt_service import FileEncryptService
 from payload_models.payloads import (
@@ -138,6 +141,9 @@ async def _request_job_to_miner(miner_hotkey: str):
 
         encrypted_files = file_encrypt_service.ecrypt_miner_job_files()
 
+        executor_digest = await fetch_executor_image_digest()
+        executor_image_snapshot = build_expected_image_snapshot(executor_digest)
+
         result = await miner_service.request_job_to_miner(
             MinerJobRequestPayload(
                 job_batch_id='job_batch_id',
@@ -149,6 +155,7 @@ async def _request_job_to_miner(miner_hotkey: str):
             encrypted_files=encrypted_files,
             rented_data=RentedExecutorsResponse(executors={}),
             default_docker_image_digests=await fetch_default_image_digests(),
+            executor_image_snapshot=executor_image_snapshot,
         )
         print('job_result:', result)
     finally:

--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -346,6 +346,7 @@ class ComputeClient:
                             attestation_digest=data.get("attestation_digest"),
                             tdx_attestation_passed=data.get("tdx_attestation_passed"),
                             gpu_attestation_passed=data.get("gpu_attestation_passed"),
+                            executor_image=data.get("executor_image"),
                             sent_at=data.get("sent_at"),
                             batch_total=data.get("batch_total"),
                         )

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -274,6 +274,10 @@ class Settings(BaseSettings):
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")
     DUPLICATE_EXECUTOR_DRY_RUN: bool = Field(env="DUPLICATE_EXECUTOR_DRY_RUN", default=True, description="Observe mode: detect duplicate executors but don't penalize")
+    EXECUTOR_IMAGE_REF: str = Field(
+        env="EXECUTOR_IMAGE_REF",
+        default="daturaai/compute-subnet-executor:latest",
+    )
 
     # DAH-2272: when on, raise the asyncssh logger to DEBUG (debug level 2) so the
     # SSH handshake (banner / key exchange / auth) is logged per connection, and

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -12,8 +12,12 @@ from incentive.rental_price import precompute_all_estimates
 from payload_models.payloads import MinerJobRequestPayload
 from services.attestation_service import AttestationService
 from services.collateral_contract_service import CollateralContractService
-from services.default_docker_image_digest_service import fetch_default_image_digests
+from services.default_docker_image_digest_service import (
+    fetch_default_image_digests,
+    fetch_executor_image_digest,
+)
 from services.docker_service import DockerService
+from services.executor_image_policy import build_expected_image_snapshot
 from services.executor_connectivity.container_runner import ContainerRunner
 from services.executor_connectivity.dind_probe import DindProbe, DindVerifier
 from services.executor_connectivity.orchestrator import ConnectivityOrchestrator
@@ -286,6 +290,19 @@ class Validator:
                         ),
                     )
 
+                try:
+                    executor_digest = await fetch_executor_image_digest()
+                except Exception as exc:
+                    executor_digest = None
+                    logger.error(
+                        _m(
+                            "[sync] executor image digest fetch failed; image check skips this cycle",
+                            extra=get_extra_info({**self.default_extra, "error": str(exc)}),
+                        ),
+                    )
+
+                executor_image_snapshot = build_expected_image_snapshot(executor_digest)
+
                 # Fetch all rented executors from backend API
                 rented_executors = await self.backend_client.get_all_rented_executors()
                 if rented_executors is None:
@@ -335,6 +352,7 @@ class Validator:
                             encrypted_files=encrypted_files,
                             rented_data=rented_executors,
                             default_docker_image_digests=default_image_digests,
+                            executor_image_snapshot=executor_image_snapshot,
                         )
                     )
                     for miner in miners

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -13,7 +13,7 @@ from services.task_service import JobResult
 from core.config import get_total_burn_emission, settings
 from core.utils import _m, get_extra_info, get_logger
 from incentive.base import BaseIncentive
-from incentive.miner_incentive_log import MinerLogLine
+from incentive.miner_incentive_log import MinerLogLine, ZeroIncentiveReason
 
 logger = get_logger(__name__)
 
@@ -103,6 +103,20 @@ class DefaultIncentive(BaseIncentive):
             self.failed_executors += 1
         return result
 
+    @staticmethod
+    def _record_outdated_image_reason(result: JobResult) -> bool:
+        report = result.executor_image_report or {}
+        if report.get("status") != "OUTDATED":
+            return False
+        if not any(
+            reason.reason == ZeroIncentiveReason.OUTDATED_EXECUTOR_IMAGE.value
+            for reason in result.zero_incentive_reasons
+        ):
+            result.record_incentive_log(
+                MinerLogLine.no_payout_because_outdated_executor_image(result)
+            )
+        return True
+
     async def _post_process_job_result(self, hotkey: str, result: JobResult) -> JobResult:
         """Process a job result.
 
@@ -140,6 +154,10 @@ class DefaultIncentive(BaseIncentive):
         Returns:
             JobResult with calculated mining score
         """
+        if self._record_outdated_image_reason(job_result):
+            job_result.mining_score = 0
+            return job_result
+
         # Early exit check - if job score is 0, return immediately
         if not job_result.score:
             job_result.mining_score = 0

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -51,7 +51,9 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field
 
+from core.config import settings
 from core.utils import _m, _StructuredMessage, get_extra_info
+from services.executor_image_policy import outdated_image_remediation
 
 if TYPE_CHECKING:
     from incentive.rental_price import InsufficientDisk, MissingFlagshipCapability, PowerCapIncapable
@@ -80,6 +82,7 @@ class ZeroIncentiveReason(StrEnum):
     SYSBOX_NOT_ENABLED = "sysbox_not_enabled"
     FLAGSHIP_WITHOUT_NCU_OR_SPLIT = "flagship_without_ncu_or_split"
     CANNOT_APPLY_GPU_POWER_CAP = "cannot_apply_gpu_power_cap"
+    OUTDATED_EXECUTOR_IMAGE = "outdated_executor_image"
 
 
 class IncentiveReason(BaseModel):
@@ -230,6 +233,23 @@ class MinerLogLine(BaseModel):
                 "of a Lium job, and executors on your own job do not earn subnet incentive."
             ),
             internal_message="Executor excluded from both pools - running miner's own default job",
+        )
+
+    @staticmethod
+    def no_payout_because_outdated_executor_image(result: JobResult) -> MinerLogLine:
+        report = result.executor_image_report or {}
+        expected_ref = report.get("expected_ref") or settings.EXECUTOR_IMAGE_REF
+        return MinerLogLine._no_payout(
+            result,
+            reason=ZeroIncentiveReason.OUTDATED_EXECUTOR_IMAGE,
+            message=outdated_image_remediation(str(expected_ref)),
+            extra_fields={
+                "executor_image_status": report.get("status"),
+                "observed_digest": report.get("observed_digest"),
+                "expected_digest": report.get("expected_digest"),
+                "expected_ref": expected_ref,
+            },
+            internal_message="Executor excluded from both pools because a required image is outdated",
         )
 
     # ── Group B: idle but not qualified for the unrented pool ─────────────────

--- a/neurons/validators/src/incentive/rental_price.py
+++ b/neurons/validators/src/incentive/rental_price.py
@@ -630,6 +630,7 @@ class RentalPriceIncentive(DefaultIncentive):
         reassignment happens later in `_reassign_split_candidates`, once every
         bucket's fill is known.
         """
+        self._record_outdated_image_reason(result)
         if not result.is_successful:
             return
 
@@ -908,6 +909,11 @@ class RentalPriceIncentive(DefaultIncentive):
         Returns:
             Calculated score (0 for unrented eligible GPUs, normal score otherwise)
         """
+        if self._record_outdated_image_reason(job_result):
+            job_result.mining_score = 0
+            job_result.eligible_for_rental_share = False
+            return job_result
+
         # Hard exclusions: reasons a validated executor earns 0 from BOTH pools.
         # One evaluator so the internal log, the customer-facing incentive log, and the
         # scoring decision all read from the same source and cannot drift (DAH-2327).

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -93,6 +93,7 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     attestation_digest: str | None = None
     tdx_attestation_passed: bool | None = None
     gpu_attestation_passed: bool | None = None
+    executor_image: dict[str, Any] | None = None
     # None = publisher did not report the field; [] = no catalogued reason was recorded.
     incentive_reasons: list[IncentiveReason] | None = None
     # DAH-2792: specs the validator scored for this miner in this job_batch_id, counting the ones

--- a/neurons/validators/src/services/default_docker_image_digest_service.py
+++ b/neurons/validators/src/services/default_docker_image_digest_service.py
@@ -18,6 +18,8 @@ import logging
 
 import aiohttp
 
+from core.config import settings
+
 logger = logging.getLogger(__name__)
 
 _MANIFEST_ACCEPT = (
@@ -115,3 +117,10 @@ async def fetch_default_image_digests() -> dict[str, str]:
             len(digests),
         )
     return digests
+
+
+async def fetch_executor_image_digest() -> str | None:
+    ref = settings.EXECUTOR_IMAGE_REF
+    timeout = aiohttp.ClientTimeout(total=30)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        return await fetch_registry_digest(session, ref)

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -6349,62 +6349,6 @@ class DockerService:
                 error_code=FailedContainerErrorCodes.UnknownError,
             )
 
-    async def get_docker_hub_digests(self, repositories) -> dict[str, str]:
-        """Retrieve all tags and their corresponding digests from Docker Hub."""
-        all_digests = {}  # Initialize a dictionary to store all tag-digest pairs
-
-        async with aiohttp.ClientSession() as session:
-            for repo in repositories:
-                try:
-                    # Split repository and tag if specified
-                    if ":" in repo:
-                        repository, specified_tag = repo.split(":", 1)
-                    else:
-                        repository, specified_tag = repo, None
-
-                    # Get authorization token
-                    async with session.get(
-                        f"https://auth.docker.io/token?service=registry.docker.io&scope=repository:{repository}:pull"
-                    ) as token_response:
-                        token_response.raise_for_status()
-                        token = await token_response.json()
-                        token = token.get("token")
-
-                    # Find all tags if no specific tag is specified
-                    if specified_tag is None:
-                        async with session.get(
-                            f"https://index.docker.io/v2/{repository}/tags/list",
-                            headers={"Authorization": f"Bearer {token}"},
-                        ) as tags_response:
-                            tags_response.raise_for_status()
-                            tags_data = await tags_response.json()
-                            all_tags = tags_data.get("tags", [])
-                    else:
-                        all_tags = [specified_tag]
-
-                    # Dictionary to store tag-digest pairs for the current repository
-                    tag_digests = {}
-                    for tag in all_tags:
-                        # Get image digest
-                        async with session.head(
-                            f"https://index.docker.io/v2/{repository}/manifests/{tag}",
-                            headers={
-                                "Authorization": f"Bearer {token}",
-                                "Accept": "application/vnd.docker.distribution.manifest.v2+json",
-                            },
-                        ) as manifest_response:
-                            manifest_response.raise_for_status()
-                            digest = manifest_response.headers.get("Docker-Content-Digest")
-                            tag_digests[f"{repository}:{tag}"] = digest
-
-                    # Update the all_digests dictionary with the current repository's tag-digest pairs
-                    all_digests.update(tag_digests)
-
-                except aiohttp.ClientError as e:
-                    print(f"Error retrieving data for {repo}: {e}")
-
-        return all_digests
-
     def _get_preferred_ports(self, initial_port_count: int | None) -> list[int]:
         """Calculate preferred ports based on initial_port_count.
 

--- a/neurons/validators/src/services/executor_image_policy.py
+++ b/neurons/validators/src/services/executor_image_policy.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+
+from core.config import settings
+
+_SHA256_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+
+
+class ImageVerdict(StrEnum):
+    CURRENT = "CURRENT"
+    OUTDATED = "OUTDATED"
+
+
+@dataclass(frozen=True)
+class ExpectedImage:
+    ref: str
+    digest: str
+
+    def __post_init__(self) -> None:
+        if not _SHA256_DIGEST.fullmatch(self.digest):
+            raise ValueError(f"Invalid image digest: {self.digest}")
+
+
+@dataclass(frozen=True)
+class ExecutorImageReport:
+    status: ImageVerdict
+    observed_digest: str | None
+    expected_ref: str
+    expected_digest: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status.value,
+            "observed_digest": self.observed_digest,
+            "expected_ref": self.expected_ref,
+            "expected_digest": self.expected_digest,
+        }
+
+
+@dataclass(frozen=True)
+class ExpectedImageSnapshot:
+    executor: ExpectedImage | None
+    executor_ref: str
+
+    def report(self, observed_digest: str | None) -> ExecutorImageReport:
+        if self.executor is None:
+            raise ValueError("Cannot report without an expected executor digest")
+        status = (
+            ImageVerdict.CURRENT
+            if observed_digest == self.executor.digest
+            else ImageVerdict.OUTDATED
+        )
+        return ExecutorImageReport(
+            status=status,
+            observed_digest=observed_digest,
+            expected_ref=self.executor_ref,
+            expected_digest=self.executor.digest,
+        )
+
+
+def normalize_sha256_digest(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    digest = value.strip().lower()
+    return digest if _SHA256_DIGEST.fullmatch(digest) else None
+
+
+def build_expected_image_snapshot(digest: str | None) -> ExpectedImageSnapshot:
+    ref = settings.EXECUTOR_IMAGE_REF
+    normalized = normalize_sha256_digest(digest)
+    executor = ExpectedImage(ref=ref, digest=normalized) if normalized else None
+    return ExpectedImageSnapshot(executor=executor, executor_ref=ref)
+
+
+def outdated_image_remediation(expected_ref: str) -> str:
+    return (
+        f"This node is not running the current {expected_ref} image. "
+        "On a standard stack, confirm executor-executor-runner-1 and executor-watchtower-1 "
+        "are running so Watchtower can pull and redeploy the latest executor automatically. "
+        "If auto-update stopped, follow "
+        "https://docs.lium.io/providers/nodes/gpu-power-cap#the-standard-stack-which-stopped-updating. "
+        "The node earns no incentive until the executor image matches the current release."
+    )

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -63,6 +63,7 @@ from core.utils import _m, _StructuredMessage, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.attestation_service import AttestationService
 from services.docker_service import DockerService, inflight_creates
+from services.executor_image_policy import ExpectedImageSnapshot
 from services.redis_service import MACHINE_SPEC_CHANNEL, RedisService
 from services.roce_link_probe import measure_and_attach
 from services.ssh_service import SSHService
@@ -222,6 +223,7 @@ class MinerService:
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
         default_docker_image_digests: dict[str, str],
+        executor_image_snapshot: ExpectedImageSnapshot | None = None,
     ):
         """Request job to miner - uses REST API if configured, otherwise WebSocket."""
         if settings.USE_REST_API:
@@ -235,7 +237,11 @@ class MinerService:
                 ),
             )
             return await self._request_job_to_miner(
-                payload, encrypted_files, rented_data, default_docker_image_digests
+                payload,
+                encrypted_files,
+                rented_data,
+                default_docker_image_digests,
+                executor_image_snapshot,
             )
         else:
             logger.info(
@@ -363,6 +369,7 @@ class MinerService:
                                     encrypted_files=encrypted_files,
                                     rented_data=rented_data,
                                     default_docker_image_digests=default_docker_image_digests,
+                                    executor_image_snapshot=executor_image_snapshot,
                                     attestation_nonce=attestation_nonce,
                                 ),
                                 timeout=settings.JOB_TIME_OUT - 120
@@ -805,6 +812,7 @@ class MinerService:
                         "tee_type": result.tee_type,
                         "tdx_attestation_passed": result.tdx_attestation_passed,
                         "gpu_attestation_passed": result.gpu_attestation_passed,
+                        "executor_image": result.executor_image_report,
                         "sent_at": time.time(),
                         "batch_total": batch_total,
                     },
@@ -1869,6 +1877,7 @@ class MinerService:
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
         default_docker_image_digests: dict[str, str],
+        executor_image_snapshot: ExpectedImageSnapshot | None = None,
     ):
         """REST API version of request_job_to_miner."""
         # DAH-2667: see the WebSocket path — the RoCE probe measures the cycle's remaining time
@@ -1959,6 +1968,7 @@ class MinerService:
                                 encrypted_files=encrypted_files,
                                 rented_data=rented_data,
                                 default_docker_image_digests=default_docker_image_digests,
+                                executor_image_snapshot=executor_image_snapshot,
                                 attestation_nonce=attestation_nonce,
                             ),
                             timeout=settings.JOB_TIME_OUT - 120

--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -6,6 +6,7 @@ from .collateral import CollateralCheck
 from .cpu_truth import CpuTruthCheck
 from .custom_build_orphan_sweep import CustomBuildOrphanSweepCheck
 from .duplicate_executor import DuplicateExecutorCheck
+from .executor_image import ExecutorImageCheck
 from .finalize import FinalizeCheck
 from .gpu_count import GpuCountCheck
 from .gpu_fingerprint import GpuFingerprintCheck
@@ -39,6 +40,7 @@ __all__ = [
     "CpuTruthCheck",
     "CustomBuildOrphanSweepCheck",
     "DuplicateExecutorCheck",
+    "ExecutorImageCheck",
     "FinalizeCheck",
     "GpuCountCheck",
     "GpuFingerprintCheck",

--- a/neurons/validators/src/services/task/checks/executor_image.py
+++ b/neurons/validators/src/services/task/checks/executor_image.py
@@ -59,6 +59,15 @@ class ExecutorImageCheck:
     fatal = True
 
     async def run(self, ctx: Context) -> CheckResult:
+        if ctx.tdx_attestation_passed:
+            event = render_message(
+                Msg.SKIPPED,
+                ctx=ctx,
+                check_id=self.check_id,
+                extra={"skip_reason": "cvm", "tdx_attestation_passed": True},
+            )
+            return CheckResult(passed=True, event=event)
+
         snapshot = ctx.config.executor_image_snapshot
         if snapshot is None or snapshot.executor is None:
             event = render_message(Msg.SKIPPED, ctx=ctx, check_id=self.check_id)

--- a/neurons/validators/src/services/task/checks/executor_image.py
+++ b/neurons/validators/src/services/task/checks/executor_image.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from dataclasses import replace
+
+from services.executor_image_policy import (
+    ImageVerdict,
+    normalize_sha256_digest,
+    outdated_image_remediation,
+)
+
+from ..messages import ExecutorImageMessages as Msg
+from ..messages import render_message
+from ..pipeline import CheckResult, Context
+
+_EXECUTOR_NAME = re.compile(r"(?:^|-)executor-\d+$")
+
+
+def _single_digest(
+    containers: list[object],
+    matches: Callable[[dict[str, object]], bool],
+) -> str | None:
+    matched = [
+        container for container in containers if isinstance(container, dict) and matches(container)
+    ]
+    if len(matched) != 1:
+        return None
+    return normalize_sha256_digest(matched[0].get("digest"))
+
+
+def observed_executor_digest(specs: dict[str, object]) -> str | None:
+    docker = specs.get("docker")
+    if not isinstance(docker, dict):
+        return None
+    containers = docker.get("containers")
+    if not isinstance(containers, list):
+        return None
+
+    executor_container_id = docker.get("container_id")
+    if isinstance(executor_container_id, str) and executor_container_id:
+        digest = _single_digest(
+            containers,
+            lambda container: container.get("container_id") == executor_container_id,
+        )
+        if digest is not None:
+            return digest
+
+    return _single_digest(
+        containers,
+        lambda container: bool(
+            isinstance(container.get("name"), str) and _EXECUTOR_NAME.search(container["name"])
+        ),
+    )
+
+
+class ExecutorImageCheck:
+    check_id = "executor.validate.image_version"
+    fatal = True
+
+    async def run(self, ctx: Context) -> CheckResult:
+        snapshot = ctx.config.executor_image_snapshot
+        if snapshot is None or snapshot.executor is None:
+            event = render_message(Msg.SKIPPED, ctx=ctx, check_id=self.check_id)
+            return CheckResult(passed=True, event=event)
+
+        report = snapshot.report(observed_executor_digest(ctx.state.specs))
+        updated_state = replace(ctx.state, executor_image_report=report)
+        what = report.as_dict()
+
+        if report.status is ImageVerdict.CURRENT:
+            event = render_message(Msg.CURRENT, ctx=ctx, check_id=self.check_id, what=what)
+            passed = True
+        else:
+            rented_data = ctx.state.rented_data
+            rented_executor = rented_data.executors.get(ctx.executor.uuid) if rented_data else None
+            is_rented = rented_executor is not None and len(rented_executor.pods) > 0
+            passed = is_rented
+            event = render_message(
+                Msg.OUTDATED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what=what,
+                impact=(
+                    "Rental can continue, but no incentive until the image is current"
+                    if is_rented
+                    else "Validation failed - executor unavailable for rent until the image is current"
+                ),
+                remediation=outdated_image_remediation(report.expected_ref),
+                extra={"executor_image_status": report.status.value},
+            )
+        return CheckResult(
+            passed=passed,
+            event=event,
+            updates={
+                "state": updated_state,
+                "default_extra": {
+                    **ctx.default_extra,
+                    "executor_image_status": report.status.value,
+                },
+            },
+        )

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -411,6 +411,30 @@ class BannedProviderMessages:
     )
 
 
+class ExecutorImageMessages:
+    CURRENT = MessageTemplate(
+        event="Executor image is current",
+        reason="EXECUTOR_IMAGE_CURRENT",
+        severity="info",
+        category="policy",
+        impact="Proceed",
+    )
+    SKIPPED = MessageTemplate(
+        event="Executor image check skipped",
+        reason="EXECUTOR_IMAGE_SKIPPED",
+        severity="info",
+        category="policy",
+        impact="No image penalty this cycle",
+    )
+    OUTDATED = MessageTemplate(
+        event="Executor image is outdated",
+        reason="EXECUTOR_IMAGE_OUTDATED",
+        severity="error",
+        category="policy",
+        impact="Score set to 0 until the image is current",
+    )
+
+
 class SysboxRequiredMessages:
     SYSBOX_MISSING = MessageTemplate(
         event="Sysbox required for unrented executor",

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -66,6 +66,7 @@ class JobResult(BaseModel):
     tdx_attestation_passed: bool = False
     # G1 — NVIDIA CC GPU attestation outcome (None = not performed)
     gpu_attestation_passed: bool | None = None
+    executor_image_report: dict[str, Any] | None = None
 
     inspector_outcome: str = "SKIPPED"
 

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -16,6 +16,7 @@ from services.collateral_contract_service import CollateralContractService
 from services.matrix_validation_service import ValidationService
 from services.verifyx_validation_service import VerifyXValidationService
 from services.executor_connectivity_service import ExecutorConnectivityService
+from services.executor_image_policy import ExecutorImageReport, ExpectedImageSnapshot
 from services.interactive_shell_service import InteractiveShellService
 from services.inspector_validation_service import InspectorValidationService
 from services.container_cleanup import ContainerCleanup
@@ -71,6 +72,7 @@ class ContextConfig:
     # DAH-2380: per-cycle snapshot of default cache-template image_ref -> bare digest,
     # fetched from Docker Hub at job-cycle start. Empty => digest check skips (fail-open).
     default_docker_image_digests: dict[str, str]
+    executor_image_snapshot: ExpectedImageSnapshot | None = None
     validator_keypair: Optional[Any] = None
     max_gpu_count: Optional[int] = None
     gpu_model_rates: Optional[dict[str, Any]] = None
@@ -117,6 +119,7 @@ class ContextState:
     # serves STALE content under an unchanged tag); None = not compared this cycle
     # (not cached / no backend digest / unreadable RepoDigest — strict fail-open).
     recommended_image_digest_match: bool | None = None
+    executor_image_report: ExecutorImageReport | None = None
 
 
 class CheckResult(BaseModel):

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -19,6 +19,7 @@ from services.collateral_contract_service import CollateralContractService
 from services.const import GPU_MODEL_RATES, LIB_NVIDIA_ML_DIGESTS, MAX_GPU_COUNT
 from services.container_cleanup import ContainerCleanup
 from services.executor_connectivity_service import ExecutorConnectivityService
+from services.executor_image_policy import ExpectedImageSnapshot
 from services.inspector_validation_service import InspectorValidationService
 from services.interactive_shell_service import InteractiveShellService
 from services.matrix_validation_service import ValidationService
@@ -35,6 +36,7 @@ from .checks import (
     CpuTruthCheck,
     CustomBuildOrphanSweepCheck,
     DuplicateExecutorCheck,
+    ExecutorImageCheck,
     FinalizeCheck,
     GpuCountCheck,
     GpuFingerprintCheck,
@@ -134,6 +136,7 @@ class PipelineFactory:
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
         default_docker_image_digests: dict[str, str],
+        executor_image_snapshot: ExpectedImageSnapshot | None = None,
         tdx_attestation_passed: bool = False,
         gpu_attestation_passed: bool | None = None,
     ) -> Context:
@@ -221,6 +224,7 @@ class PipelineFactory:
                 machine_scrape_timeout=JOB_LENGTH,
                 obfuscation_keys=encrypted_files.all_keys,
                 default_docker_image_digests=default_docker_image_digests,
+                executor_image_snapshot=executor_image_snapshot,
                 validator_keypair=keypair,
                 max_gpu_count=MAX_GPU_COUNT,
                 gpu_model_rates=GPU_MODEL_RATES,
@@ -302,6 +306,7 @@ class PipelineFactory:
                 # Runs after PortConnectivityCheck, which overwrites ctx.state.sysbox_runtime with
                 # the authoritative probe result used for scoring (not the earlier scrape hint).
                 SysboxRequiredCheck(),
+                ExecutorImageCheck(),
                 InspectorRentedCheck(),
                 TenantEnforcementCheck(),
                 GpuUsageCheck(),
@@ -362,6 +367,7 @@ class PipelineFactory:
                 # Runs after PortConnectivityCheck, which overwrites ctx.state.sysbox_runtime with
                 # the authoritative probe result used for scoring (not the earlier scrape hint).
                 SysboxRequiredCheck(),
+                ExecutorImageCheck(),
                 # recover_stale_pods=False: dry run still reports a pod as down, but must not rmdir
                 # a stale mountpoint on the host or start a customer's container (DAH-2306).
                 TenantEnforcementCheck(recover_stale_pods=False),

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -177,6 +177,14 @@ class ResultHandler:
         if context.state.recommended_image_digest_match is not None:
             specs["recommended_image_digest_match"] = context.state.recommended_image_digest_match
 
+        executor_image_report = (
+            context.state.executor_image_report.as_dict()
+            if context.state.executor_image_report
+            else None
+        )
+        if executor_image_report is not None:
+            specs["executor_image"] = executor_image_report
+
         # NVIDIA driver version string reported by NVML (e.g. "580.95.05"). Used by the
         # minimum-driver requirement gate.
         nvidia_driver_version = str(specs.get("gpu", {}).get("driver") or "")
@@ -213,6 +221,7 @@ class ResultHandler:
             default_job_owner=default_job_owner,
             tdx_attestation_passed=context.tdx_attestation_passed,
             gpu_attestation_passed=context.gpu_attestation_passed,
+            executor_image_report=executor_image_report,
             inspector_outcome=inspector_outcome,
         )
 

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -7,6 +7,7 @@ based on collateral status, rental state, and contract versions.
 from typing import Tuple
 
 from core.config import settings, shared_client
+from services.executor_image_policy import ImageVerdict
 from services.task.pipeline import Context
 
 
@@ -37,6 +38,12 @@ def calculate_scores(
     warning_messages = []
     job_score = 1.0
     actual_score = 1.0
+
+    image_report = getattr(ctx.state, "executor_image_report", None)
+    if image_report and image_report.status is ImageVerdict.OUTDATED:
+        actual_score = 0.0
+        job_score = 0.0
+        warning_messages.append("Required executor image is outdated")
 
     # Machine price check
     base_price = shared_client.config.machine_prices.get(gpu_model, 0)

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -10,6 +10,7 @@ from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.attestation_service import AttestationError, AttestationNonce, AttestationService
 from services.collateral_contract_service import CollateralContractService
 from services.executor_connectivity_service import ExecutorConnectivityService
+from services.executor_image_policy import ExpectedImageSnapshot
 from services.interactive_shell_service import InteractiveShellService
 from services.matrix_validation_service import ValidationService
 from services.redis_service import RedisService
@@ -66,6 +67,7 @@ class TaskService:
         encrypted_files: MinerJobEnryptedFiles,
         rented_data: RentedExecutorsResponse,
         default_docker_image_digests: dict[str, str],
+        executor_image_snapshot: ExpectedImageSnapshot | None = None,
         attestation_nonce: AttestationNonce | None = None,
     ):
         """New pipeline-based validation task implementation."""
@@ -122,6 +124,7 @@ class TaskService:
                     encrypted_files=encrypted_files,
                     rented_data=rented_data,
                     default_docker_image_digests=default_docker_image_digests,
+                    executor_image_snapshot=executor_image_snapshot,
                     tdx_attestation_passed=attestation_passed,
                     gpu_attestation_passed=gpu_attestation_passed,
                 )

--- a/neurons/validators/tests/test_default_docker_image_digest_service.py
+++ b/neurons/validators/tests/test_default_docker_image_digest_service.py
@@ -7,6 +7,7 @@ import pytest
 from neurons.validators.src.services.default_docker_image_digest_service import (
     _shared_config_image_refs,
     fetch_default_image_digests,
+    fetch_executor_image_digest,
     fetch_registry_digest,
 )
 
@@ -118,3 +119,16 @@ async def test_fetch_default_image_digests_reads_refs_from_shared_config():
         digests = await fetch_default_image_digests()
 
     assert digests == {"daturaai/pytorch:shared": "sha256:shared"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_executor_image_digest_uses_executor_image_ref():
+    with patch(
+        f"{_MODULE}.fetch_registry_digest",
+        new=AsyncMock(return_value=f"sha256:{'a' * 64}"),
+    ) as fetch_registry:
+        digest = await fetch_executor_image_digest()
+
+    assert digest == f"sha256:{'a' * 64}"
+    fetch_registry.assert_awaited_once()
+    assert fetch_registry.await_args.args[1] == "daturaai/compute-subnet-executor:latest"

--- a/neurons/validators/tests/test_executor_image_check.py
+++ b/neurons/validators/tests/test_executor_image_check.py
@@ -161,6 +161,25 @@ async def test_unobservable_executor_digest_is_outdated():
 
 
 @pytest.mark.asyncio
+async def test_cvm_outdated_executor_skips_image_check():
+    context = make_context(
+        config=build_context_config(executor_image_snapshot=policy()),
+        state=build_state(
+            specs=specs(executor_digest=STALE_DIGEST),
+            rented_data=SimpleNamespace(executors={}),
+        ),
+        tdx_attestation_passed=True,
+    )
+
+    result = await ExecutorImageCheck().run(context)
+
+    assert result.passed is True
+    assert result.updates == {}
+    assert result.event.reason_code == "EXECUTOR_IMAGE_SKIPPED"
+    assert result.event.context.get("skip_reason") == "cvm"
+
+
+@pytest.mark.asyncio
 async def test_missing_expected_state_skips_without_penalty():
     unknown_policy = ExpectedImageSnapshot(
         executor=None,

--- a/neurons/validators/tests/test_executor_image_check.py
+++ b/neurons/validators/tests/test_executor_image_check.py
@@ -1,0 +1,240 @@
+from types import SimpleNamespace
+
+import pytest
+from protocol.vc_protocol.compute_requests import (
+    RentedExecutor,
+    RentedExecutorsResponse,
+    RentedPod,
+)
+from services.executor_image_policy import (
+    ExpectedImage,
+    ExpectedImageSnapshot,
+    ImageVerdict,
+)
+from services.task.checks.executor_image import ExecutorImageCheck, observed_executor_digest
+from services.task.checks.rented_machine import TenantEnforcementCheck
+from services.task.pipeline_factory import PipelineFactory
+from services.task.result_handler import ResultHandler
+from services.task.score_calculator import calculate_scores
+
+from tests.helpers import build_context_config, build_state, make_context
+
+EXECUTOR_DIGEST = f"sha256:{'a' * 64}"
+STALE_DIGEST = f"sha256:{'c' * 64}"
+
+
+def policy() -> ExpectedImageSnapshot:
+    return ExpectedImageSnapshot(
+        executor=ExpectedImage("executor:latest", EXECUTOR_DIGEST),
+        executor_ref="executor:latest",
+    )
+
+
+def rented_data() -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(
+        executors={
+            "executor-123": RentedExecutor(
+                miner_hotkey="test-miner",
+                executor_ip_address="127.0.0.1",
+                executor_ip_port="22",
+                pods=[RentedPod(pod_id="pod-1", container_name="container_test", rented_ports=[8080, 8081])],
+            )
+        },
+    )
+
+
+def specs(*, executor_digest: str = EXECUTOR_DIGEST) -> dict:
+    return {
+        "docker": {
+            "container_id": "executor-id",
+            "containers": [
+                {
+                    "container_id": "executor-id",
+                    "digest": executor_digest,
+                    "name": "executor-executor-1",
+                },
+            ],
+        }
+    }
+
+
+def test_observation_uses_container_id_then_name():
+    assert observed_executor_digest(specs()) == EXECUTOR_DIGEST
+    assert (
+        observed_executor_digest(
+            {
+                "docker": {
+                    "containers": [
+                        {
+                            "container_id": "other-id",
+                            "digest": EXECUTOR_DIGEST,
+                            "name": "provider-stack-executor-1",
+                        }
+                    ]
+                }
+            }
+        )
+        == EXECUTOR_DIGEST
+    )
+
+
+def test_observation_returns_none_when_ambiguous():
+    assert (
+        observed_executor_digest(
+            {
+                "docker": {
+                    "containers": [
+                        {"digest": EXECUTOR_DIGEST, "name": "executor-executor-1"},
+                        {"digest": EXECUTOR_DIGEST, "name": "provider-executor-1"},
+                    ]
+                }
+            }
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_unrented_outdated_executor_fails_validation():
+    context = make_context(
+        config=build_context_config(executor_image_snapshot=policy()),
+        state=build_state(
+            specs=specs(executor_digest=STALE_DIGEST),
+            rented_data=SimpleNamespace(executors={}),
+        ),
+    )
+
+    result = await ExecutorImageCheck().run(context)
+
+    assert result.passed is False
+    assert result.updates["state"].executor_image_report.status is ImageVerdict.OUTDATED
+    assert "unavailable for rent" in result.event.impact
+
+
+@pytest.mark.asyncio
+async def test_rented_outdated_executor_passes_validation():
+    context = make_context(
+        config=build_context_config(executor_image_snapshot=policy()),
+        state=build_state(
+            specs=specs(executor_digest=STALE_DIGEST),
+            rented_data=rented_data(),
+        ),
+    )
+
+    result = await ExecutorImageCheck().run(context)
+
+    assert result.passed is True
+    assert result.updates["state"].executor_image_report.status is ImageVerdict.OUTDATED
+
+
+@pytest.mark.asyncio
+async def test_current_executor_passes_validation():
+    context = make_context(
+        config=build_context_config(executor_image_snapshot=policy()),
+        state=build_state(
+            specs=specs(executor_digest=EXECUTOR_DIGEST),
+            rented_data=SimpleNamespace(executors={}),
+        ),
+    )
+
+    result = await ExecutorImageCheck().run(context)
+
+    assert result.passed is True
+    assert result.updates["state"].executor_image_report.status is ImageVerdict.CURRENT
+
+
+@pytest.mark.asyncio
+async def test_unobservable_executor_digest_is_outdated():
+    context = make_context(
+        config=build_context_config(executor_image_snapshot=policy()),
+        state=build_state(
+            specs={"docker": {"containers": []}},
+            rented_data=rented_data(),
+        ),
+    )
+
+    result = await ExecutorImageCheck().run(context)
+
+    assert result.passed is True
+    assert result.updates["state"].executor_image_report.status is ImageVerdict.OUTDATED
+    assert result.event.reason_code == "EXECUTOR_IMAGE_OUTDATED"
+
+
+@pytest.mark.asyncio
+async def test_missing_expected_state_skips_without_penalty():
+    unknown_policy = ExpectedImageSnapshot(
+        executor=None,
+        executor_ref="executor:latest",
+    )
+    context = make_context(
+        config=build_context_config(executor_image_snapshot=unknown_policy),
+        state=build_state(
+            specs=specs(executor_digest=STALE_DIGEST),
+            rented_data=SimpleNamespace(executors={}),
+        ),
+    )
+
+    result = await ExecutorImageCheck().run(context)
+
+    assert result.passed is True
+    assert result.updates == {}
+    assert result.event.reason_code == "EXECUTOR_IMAGE_SKIPPED"
+
+
+def test_image_check_is_fatal():
+    assert ExecutorImageCheck.fatal is True
+
+
+def test_image_check_precedes_tenant_enforcement_in_both_pipelines():
+    for checks in (PipelineFactory.build_checks(), PipelineFactory.build_dry_run_checks()):
+        image_index = next(
+            index for index, check in enumerate(checks) if isinstance(check, ExecutorImageCheck)
+        )
+        tenant_index = next(
+            index for index, check in enumerate(checks) if isinstance(check, TenantEnforcementCheck)
+        )
+        assert image_index < tenant_index
+
+
+@pytest.mark.parametrize(
+    ("rented", "expected_job_score"),
+    [(False, 0.0), (True, 1.0)],
+)
+def test_score_calculator_zeroes_outdated_executor(
+    rented: bool,
+    expected_job_score: float,
+):
+    report = policy().report(STALE_DIGEST)
+    context = make_context(
+        state=build_state(
+            gpu_model="NVIDIA H200",
+            executor_image_report=report,
+        ),
+        collateral_deposited=True,
+    )
+
+    actual_score, job_score, warning = calculate_scores(context, rented)
+
+    assert actual_score == 0.0
+    assert job_score == expected_job_score
+    assert "Required executor image is outdated" in warning
+
+
+@pytest.mark.asyncio
+async def test_result_handler_publishes_report_on_job_result_and_specs():
+    report = policy().report(EXECUTOR_DIGEST)
+    context = make_context(
+        state=build_state(specs={"gpu": {}}, executor_image_report=report),
+    )
+
+    result = await ResultHandler(redis_service=None, dry_run=True).handle_result(
+        context=context,
+        miner_info=SimpleNamespace(miner_hotkey="miner", job_batch_id="batch"),
+        executor_info=context.executor,
+        verified_job_info={},
+        log_text="ok",
+        success=True,
+    )
+
+    assert result.executor_image_report == report.as_dict()
+    assert result.spec["executor_image"] == report.as_dict()

--- a/neurons/validators/tests/test_executor_image_incentive.py
+++ b/neurons/validators/tests/test_executor_image_incentive.py
@@ -1,0 +1,92 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+from incentive.config import IncentiveConfig
+from incentive.default import DefaultIncentive
+from incentive.miner_incentive_log import ZeroIncentiveReason
+from incentive.rental_price import RentalPriceIncentive
+from services.task.models import JobResult
+
+
+def failed_idle_result() -> JobResult:
+    return JobResult(
+        executor_info=ExecutorSSHInfo(
+            uuid="outdated-executor",
+            address="10.0.0.1",
+            port=8080,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="/usr/bin/python3",
+            root_dir="/tmp",
+        ),
+        score=0,
+        job_score=0,
+        job_batch_id="batch",
+        log_status="error",
+        log_text="validation failed",
+        executor_image_report={
+            "status": "OUTDATED",
+            "observed_digest": f"sha256:{'b' * 64}",
+            "expected_digest": f"sha256:{'a' * 64}",
+            "expected_ref": "daturaai/compute-subnet-executor:latest",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_default_incentive_records_outdated_reason_before_score_early_return():
+    result = failed_idle_result()
+    incentive = DefaultIncentive(
+        IncentiveConfig(),
+        AsyncMock(),
+        {"miner": [result]},
+        {},
+    )
+
+    await incentive._pre_process_job_result("miner", result)
+
+    assert result.mining_score == 0
+    assert [reason.reason for reason in result.zero_incentive_reasons] == [
+        ZeroIncentiveReason.OUTDATED_EXECUTOR_IMAGE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rental_price_incentive_records_reason_before_unsuccessful_filter():
+    result = failed_idle_result()
+    incentive = RentalPriceIncentive(
+        IncentiveConfig(),
+        AsyncMock(),
+        {"miner": [result]},
+        {},
+    )
+
+    await incentive._pre_process_job_result("miner", result)
+
+    assert [reason.reason for reason in result.zero_incentive_reasons] == [
+        ZeroIncentiveReason.OUTDATED_EXECUTOR_IMAGE
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rented_outdated_executor_keeps_job_result_but_gets_zero_mining_score():
+    result = failed_idle_result().model_copy(
+        update={
+            "job_score": 1.0,
+            "is_rented": True,
+            "gpu_model": "NVIDIA H200",
+            "gpu_count": 8,
+        }
+    )
+    incentive = RentalPriceIncentive(
+        IncentiveConfig(),
+        AsyncMock(),
+        {"miner": [result]},
+        {"NVIDIA H200": 8},
+    )
+
+    await incentive._pre_process_job_result("miner", result)
+
+    assert result.mining_score == 0
+    assert result.zero_incentive_reasons[0].reason == "outdated_executor_image"

--- a/neurons/validators/tests/test_executor_image_policy.py
+++ b/neurons/validators/tests/test_executor_image_policy.py
@@ -1,0 +1,59 @@
+import pytest
+from services.executor_image_policy import (
+    ExpectedImage,
+    ExpectedImageSnapshot,
+    ImageVerdict,
+    build_expected_image_snapshot,
+)
+
+EXECUTOR_DIGEST = f"sha256:{'a' * 64}"
+
+
+def policy() -> ExpectedImageSnapshot:
+    return ExpectedImageSnapshot(
+        executor=ExpectedImage("daturaai/compute-subnet-executor:latest", EXECUTOR_DIGEST),
+        executor_ref="daturaai/compute-subnet-executor:latest",
+    )
+
+
+def test_matching_digest_is_current():
+    assert policy().report(EXECUTOR_DIGEST).status is ImageVerdict.CURRENT
+
+
+def test_mismatch_is_outdated():
+    assert policy().report(f"sha256:{'c' * 64}").status is ImageVerdict.OUTDATED
+
+
+def test_missing_local_digest_is_outdated():
+    report = policy().report(None)
+
+    assert report.status is ImageVerdict.OUTDATED
+    assert report.observed_digest is None
+
+
+def test_missing_expected_digest_cannot_report():
+    empty = ExpectedImageSnapshot(
+        executor=None,
+        executor_ref="daturaai/compute-subnet-executor:latest",
+    )
+
+    with pytest.raises(ValueError, match="expected executor digest"):
+        empty.report(EXECUTOR_DIGEST)
+
+
+def test_expected_image_rejects_non_sha256_digest():
+    with pytest.raises(ValueError, match="Invalid image digest"):
+        ExpectedImage("repo:tag", "sha256:short")
+
+
+def test_build_expected_image_snapshot_from_digest():
+    snapshot = build_expected_image_snapshot(EXECUTOR_DIGEST)
+
+    assert snapshot.executor is not None
+    assert snapshot.executor.digest == EXECUTOR_DIGEST
+
+
+def test_build_snapshot_skips_missing_digest():
+    snapshot = build_expected_image_snapshot(None)
+
+    assert snapshot.executor is None

--- a/neurons/validators/tests/test_executor_image_spec_bridge.py
+++ b/neurons/validators/tests/test_executor_image_spec_bridge.py
@@ -1,0 +1,63 @@
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from clients.compute_client import ComputeClient
+from protocol.vc_protocol.validator_requests import ExecutorSpecRequest
+from services.redis_service import MACHINE_SPEC_CHANNEL
+
+_OUTDATED_IMAGE = {
+    "status": "OUTDATED",
+    "observed_digest": "sha256:deadbeef",
+    "expected_ref": "daturaai/compute-subnet-executor:latest",
+    "expected_digest": "sha256:feedface",
+}
+
+
+async def _bridge_machine_spec(payload: dict[str, Any]) -> ExecutorSpecRequest:
+    async def listen() -> AsyncIterator[dict[str, bytes]]:
+        yield {"channel": MACHINE_SPEC_CHANNEL.encode(), "data": json.dumps(payload).encode()}
+        raise asyncio.CancelledError
+
+    pubsub = MagicMock(listen=listen, aclose=AsyncMock())
+    client = ComputeClient.__new__(ComputeClient)
+    client.keypair = MagicMock(ss58_address="validator-hotkey")
+    client.lock = asyncio.Lock()
+    client.message_queue = []
+    client.logging_extra = {"validator_hotkey": "validator-hotkey"}
+    client.compute_app_uri = "wss://backend.example/validator"
+    client.miner_service = MagicMock()
+    client.miner_service.redis_service.subscribe = AsyncMock(return_value=pubsub)
+    with pytest.raises(asyncio.CancelledError):
+        await client.subscribe_mesages_from_redis()
+    return client.message_queue[0]
+
+
+@pytest.mark.asyncio
+async def test_bridge_carries_executor_image() -> None:
+    payload = {
+        "specs": {"gpu": {"count": 1}},
+        "score": 0.0,
+        "synthetic_job_score": 0.0,
+        "log_status": "error",
+        "job_batch_id": "2026-08-31 08:00:00",
+        "log_text": "outdated",
+        "miner_hotkey": "hk",
+        "miner_coldkey": "ck",
+        "executor_uuid": "exec-1",
+        "executor_ip": "127.0.0.1",
+        "executor_port": 8000,
+        "executor_ssh_port": 22,
+        "price_per_gpu": 0.5,
+        "collateral_deposited": True,
+        "ssh_pub_keys": [],
+        "executor_image": _OUTDATED_IMAGE,
+    }
+
+    spec = await _bridge_machine_spec(payload)
+
+    assert spec.executor_image == _OUTDATED_IMAGE

--- a/neurons/validators/tests/test_incentive_flow.py
+++ b/neurons/validators/tests/test_incentive_flow.py
@@ -84,7 +84,13 @@ async def _run_set_weights_and_capture(
 
 
 async def _run_sync_with_jobs(validator, miners, job_results_by_hotkey, *, job_batch_id="2024-01-01 00:00:00"):
-    async def request_job_side_effect(payload, encrypted_files, rented_data, default_docker_image_digests):
+    async def request_job_side_effect(
+        payload,
+        encrypted_files,
+        rented_data,
+        default_docker_image_digests,
+        executor_image_snapshot,
+    ):
         hotkey = payload.miner_hotkey
         results = job_results_by_hotkey.get(hotkey, [])
         return {
@@ -101,9 +107,15 @@ async def _run_sync_with_jobs(validator, miners, job_results_by_hotkey, *, job_b
     # DAH-2380: sync() fetches default docker image digests from Docker Hub at job-cycle
     # start. Stub it here so these unit tests never hit the network (the real fetch would
     # open aiohttp connections to auth.docker.io / registry-1.docker.io per cycle).
-    with patch(
-        "core.validator.fetch_default_image_digests",
-        new=AsyncMock(return_value={}),
+    with (
+        patch(
+            "core.validator.fetch_default_image_digests",
+            new=AsyncMock(return_value={}),
+        ),
+        patch(
+            "core.validator.fetch_executor_image_digest",
+            new=AsyncMock(return_value=None),
+        ),
     ):
         await validator.sync()
 

--- a/neurons/validators/tests/test_miner_incentive_log.py
+++ b/neurons/validators/tests/test_miner_incentive_log.py
@@ -35,6 +35,7 @@ def test_reason_enum_pins_the_stable_code_contract():
         "insufficient_disk_for_vram",
         "flagship_without_ncu_or_split",
         "cannot_apply_gpu_power_cap",
+        "outdated_executor_image",
     }
 
 


### PR DESCRIPTION
## Describe your changes

Requires every executor to run the latest `compute-subnet-executor` image and withholds subnet incentive from nodes that don't. Outdated nodes will fail the validation checks.

- The sync fetches the current image digest from Docker Hub once per cycle; on failure the check is skipped for the whole cycle) and builds an expected-image snapshot that flows into each executor's validation context.
- New `ExecutorImageCheck` compares the executor container's scraped digest against the snapshot. A concrete digest mismatch scores `OUTDATED`.
- No-verdict cases are never penalized: when the registry digest is unavailable, or the local container digest can't be observed from the scrape, the check is skipped and both cases are logged for lookup.

## Issue ticket number and link

[DAH-2701](https://app.notion.com/p/Make-miners-run-the-latest-executor-image-3c0b8bfdbde981a58751ceab07d9132b?v=34ab8bfdbde980eb8c88000c8ab9f75f&source=copy_link)