### PR TITLE
DAH-2793, log what the provider-side load second look measured

### DIFF
--- a/neurons/validators/src/services/task/checks/provider_side_load.py
+++ b/neurons/validators/src/services/task/checks/provider_side_load.py
@@ -122,10 +122,9 @@ def provider_cores_outside_lium(
     host_cores: float, rows: list[ContainerRow], lium_container_keys: set[str]
 ) -> float:
     """The host's cores minus the containers Lium itself put there."""
-    lium_percent: float = lium_cores_among(rows, lium_container_keys) * 100
     # Floor, not round: 1.96 cores must not become 2.0 and cross the limit on its own. The
     # inner round absorbs float noise first, so an exact 1.6 does not floor to 1.5.
-    provider_cores = max(0.0, host_cores - lium_percent / 100)
+    provider_cores = max(0.0, host_cores - lium_cores_among(rows, lium_container_keys))
     return math.floor(round(provider_cores, 3) * 10) / 10
 
 
@@ -135,7 +134,8 @@ class SecondLook:
 
     The verdict alone cannot be argued with: a provider mining beside a renter and a renter pod
     that was never subtracted both come out as "N provider cores". These three numbers separate
-    them - they add up to `provider_cores` by construction.
+    them: `host_cores - lium_container_cores - dockerd_cores` is `provider_cores` before the
+    final floor to one decimal, so they are kept at two so the subtraction reconciles.
     """
 
     host_cores: float
@@ -417,9 +417,9 @@ def parse_second_look(
     excused_dockerd_cores = min(max(0.0, dockerd_cores), CLAIMED_EXCUSE_CORES)
     host_cores = (total_delta - (last_idle - first_idle)) / total_delta * kernel_cores
     return SecondLook(
-        host_cores=round(host_cores, 1),
-        lium_container_cores=round(lium_cores_among(stats_rows, lium_container_keys), 1),
-        dockerd_cores=round(excused_dockerd_cores, 1),
+        host_cores=round(host_cores, 2),
+        lium_container_cores=round(lium_cores_among(stats_rows, lium_container_keys), 2),
+        dockerd_cores=round(excused_dockerd_cores, 2),
         provider_cores=provider_cores_outside_lium(
             host_cores - excused_dockerd_cores, stats_rows, lium_container_keys
         ),

--- a/neurons/validators/src/services/task/checks/provider_side_load.py
+++ b/neurons/validators/src/services/task/checks/provider_side_load.py
@@ -101,24 +101,54 @@ class ContainerRow:
         return self.cpu_percent
 
 
-def provider_cores_outside_lium(
-    host_cores: float, rows: list[ContainerRow], lium_container_keys: set[str]
-) -> float:
-    """The host's cores minus the containers Lium itself put there.
+def lium_cores_among(rows: list[ContainerRow], lium_container_keys: set[str]) -> float:
+    """What Lium's own containers burn, in cores.
 
     Matching by both id and name, because the scrape reports full ids and `docker stats`
     reports the first 12 characters.
     """
     lium_short_ids: set[str] = {key[:12] for key in lium_container_keys}
-    lium_percent: float = sum(
-        row.measured_cpu_percent
-        for row in rows
-        if row.name in lium_container_keys or row.container_id[:12] in lium_short_ids
+    return (
+        sum(
+            row.measured_cpu_percent
+            for row in rows
+            if row.name in lium_container_keys or row.container_id[:12] in lium_short_ids
+        )
+        / 100
     )
+
+
+def provider_cores_outside_lium(
+    host_cores: float, rows: list[ContainerRow], lium_container_keys: set[str]
+) -> float:
+    """The host's cores minus the containers Lium itself put there."""
+    lium_percent: float = lium_cores_among(rows, lium_container_keys) * 100
     # Floor, not round: 1.96 cores must not become 2.0 and cross the limit on its own. The
     # inner round absorbs float noise first, so an exact 1.6 does not floor to 1.5.
     provider_cores = max(0.0, host_cores - lium_percent / 100)
     return math.floor(round(provider_cores, 3) * 10) / 10
+
+
+@dataclass(frozen=True)
+class SecondLook:
+    """What the ssh reading actually measured, so a shadow week can be judged.
+
+    The verdict alone cannot be argued with: a provider mining beside a renter and a renter pod
+    that was never subtracted both come out as "N provider cores". These three numbers separate
+    them - they add up to `provider_cores` by construction.
+    """
+
+    host_cores: float
+    lium_container_cores: float
+    dockerd_cores: float
+    provider_cores: float
+
+    def to_specs_fields(self) -> dict[str, float]:
+        return {
+            "host_cores": self.host_cores,
+            "lium_container_cores": self.lium_container_cores,
+            "dockerd_cores": self.dockerd_cores,
+        }
 
 
 @dataclass(frozen=True)
@@ -130,6 +160,7 @@ class ProviderSideLoad:
 
     cpu_cores: float | None
     disk_kb: int | None
+    second_look: SecondLook | None = None
 
     @property
     def is_measured(self) -> bool:
@@ -154,6 +185,8 @@ class ProviderSideLoad:
             fields["cpu_cores"] = self.cpu_cores
         if self.disk_kb is not None:
             fields["disk_kb"] = self.disk_kb
+        if self.second_look is not None:
+            fields.update(self.second_look.to_specs_fields())
         return fields
 
 
@@ -342,13 +375,13 @@ def lium_named_cores_outside_snapshot(
     return round(cores / 100, 1)
 
 
-def parse_resampled_cpu_cores(
+def parse_second_look(
     sample_before: str,
     container_rows: str,
     sample_after: str,
     lium_container_keys: set[str],
-) -> float | None:
-    """Provider-side cores from the second reading, or None if it is not readable.
+) -> SecondLook | None:
+    """What the second reading measured, or None if it is not readable.
 
     Host busy time comes from the /proc/stat jiffies taken on either side of `docker stats`, so
     both cover the same seconds - the pairing the whole subtraction rests on. Out of that come
@@ -383,8 +416,13 @@ def parse_resampled_cpu_cores(
     # `dockerd` is a process name anyone can copy, so its excuse is capped like the name tier
     excused_dockerd_cores = min(max(0.0, dockerd_cores), CLAIMED_EXCUSE_CORES)
     host_cores = (total_delta - (last_idle - first_idle)) / total_delta * kernel_cores
-    return provider_cores_outside_lium(
-        host_cores - excused_dockerd_cores, stats_rows, lium_container_keys
+    return SecondLook(
+        host_cores=round(host_cores, 1),
+        lium_container_cores=round(lium_cores_among(stats_rows, lium_container_keys), 1),
+        dockerd_cores=round(excused_dockerd_cores, 1),
+        provider_cores=provider_cores_outside_lium(
+            host_cores - excused_dockerd_cores, stats_rows, lium_container_keys
+        ),
     )
 
 
@@ -409,9 +447,9 @@ class ProviderSideLoadCheck:
     check_id = "host.validate.provider_side_load"
     fatal = False
 
-    async def _resample_cpu_cores(
+    async def _take_a_second_look(
         self, ctx: Context, lium_container_keys: set[str] | None
-    ) -> float | None:
+    ) -> SecondLook | None:
         """Read the load once more over ssh. None on anything unreadable, which withholds nothing.
 
         Through `ctx.runner`, like the twin gate's second look at the card: the runner owns the
@@ -428,7 +466,7 @@ class ProviderSideLoadCheck:
         if len(sections) != 3:
             return None
         jiffies_before, container_rows, jiffies_after = sections
-        return parse_resampled_cpu_cores(
+        return parse_second_look(
             jiffies_before, container_rows, jiffies_after, lium_container_keys
         )
 
@@ -458,6 +496,13 @@ class ProviderSideLoadCheck:
             "lium_named_outside_snapshot_cores": lium_named_cores_outside_snapshot(
                 ctx.state.specs or {}, lium_container_keys
             ),
+            # what the ssh reading measured, so the shadow week can tell a foreign workload from
+            # a Lium container that was never subtracted. None when the floor was never crossed.
+            "second_look": (
+                provider_side_load.second_look.to_specs_fields()
+                if provider_side_load.second_look is not None
+                else None
+            ),
         }
 
     async def measure_provider_side_load(
@@ -470,9 +515,11 @@ class ProviderSideLoadCheck:
         )
         if (measured.cpu_cores or 0.0) < PROVIDER_SIDE_CPU_CORES_LIMIT:
             return measured
+        second_look = await self._take_a_second_look(ctx, lium_container_keys)
+        if second_look is None:
+            return replace(measured, cpu_cores=None)
         return replace(
-            measured,
-            cpu_cores=await self._resample_cpu_cores(ctx, lium_container_keys),
+            measured, cpu_cores=second_look.provider_cores, second_look=second_look
         )
 
     async def run(self, ctx: Context) -> CheckResult:

--- a/neurons/validators/src/services/task/checks/provider_side_load.py
+++ b/neurons/validators/src/services/task/checks/provider_side_load.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import replace
 from typing import Any
@@ -132,8 +133,8 @@ def provider_cores_outside_lium(
 
 
 @dataclass(frozen=True)
-class SecondLook:
-    """What the ssh reading actually measured, so a shadow week can be judged.
+class ConfirmedCpuReading:
+    """The CPU reading taken over ssh to confirm a load the scrape put above the limit.
 
     The verdict alone cannot be argued with: a provider mining beside a renter and a renter pod
     that was never subtracted both come out as "N provider cores". These three numbers separate
@@ -144,14 +145,16 @@ class SecondLook:
     host_cores: float
     lium_container_cores: float
     dockerd_cores: float
-    provider_cores: float
+
+    @property
+    def provider_cores(self) -> float:
+        """What is left for the provider. Derived, so the readings can never disagree with it."""
+        return floor_to_tenth(
+            max(0.0, self.host_cores - self.lium_container_cores - self.dockerd_cores)
+        )
 
     def to_specs_fields(self) -> dict[str, float]:
-        return {
-            "host_cores": self.host_cores,
-            "lium_container_cores": self.lium_container_cores,
-            "dockerd_cores": self.dockerd_cores,
-        }
+        return asdict(self)
 
 
 @dataclass(frozen=True)
@@ -163,7 +166,11 @@ class ProviderSideLoad:
 
     cpu_cores: float | None
     disk_kb: int | None
-    second_look: SecondLook | None = None
+    # the scrape reading that decided whether to look again. Kept beside the verdict so the
+    # shadow week can count how often the two disagree, the way cpu_truth reports `advertised`
+    # next to `present`.
+    cpu_cores_before_confirmation: float | None = None
+    confirmed_reading: ConfirmedCpuReading | None = None
 
     @property
     def is_measured(self) -> bool:
@@ -188,8 +195,8 @@ class ProviderSideLoad:
             fields["cpu_cores"] = self.cpu_cores
         if self.disk_kb is not None:
             fields["disk_kb"] = self.disk_kb
-        if self.second_look is not None:
-            fields.update(self.second_look.to_specs_fields())
+        if self.confirmed_reading is not None:
+            fields.update(self.confirmed_reading.to_specs_fields())
         return fields
 
 
@@ -378,12 +385,12 @@ def lium_named_cores_outside_snapshot(
     return round(cores / 100, 1)
 
 
-def parse_second_look(
+def parse_confirmed_cpu_reading(
     sample_before: str,
     container_rows: str,
     sample_after: str,
     lium_container_keys: set[str],
-) -> SecondLook | None:
+) -> ConfirmedCpuReading | None:
     """What the second reading measured, or None if it is not readable.
 
     Host busy time comes from the /proc/stat jiffies taken on either side of `docker stats`, so
@@ -419,16 +426,10 @@ def parse_second_look(
     # `dockerd` is a process name anyone can copy, so its excuse is capped like the name tier
     excused_dockerd_cores = min(max(0.0, dockerd_cores), CLAIMED_EXCUSE_CORES)
     host_cores = (total_delta - (last_idle - first_idle)) / total_delta * kernel_cores
-    reported_host_cores = round(host_cores, 2)
-    reported_lium_cores = round(lium_cores_among(stats_rows, lium_container_keys), 2)
-    reported_dockerd_cores = round(excused_dockerd_cores, 2)
-    return SecondLook(
-        host_cores=reported_host_cores,
-        lium_container_cores=reported_lium_cores,
-        dockerd_cores=reported_dockerd_cores,
-        provider_cores=floor_to_tenth(
-            max(0.0, reported_host_cores - reported_lium_cores - reported_dockerd_cores)
-        ),
+    return ConfirmedCpuReading(
+        host_cores=round(host_cores, 2),
+        lium_container_cores=round(lium_cores_among(stats_rows, lium_container_keys), 2),
+        dockerd_cores=round(excused_dockerd_cores, 2),
     )
 
 
@@ -453,9 +454,9 @@ class ProviderSideLoadCheck:
     check_id = "host.validate.provider_side_load"
     fatal = False
 
-    async def _take_a_second_look(
+    async def _confirm_the_cpu_reading_over_ssh(
         self, ctx: Context, lium_container_keys: set[str] | None
-    ) -> SecondLook | None:
+    ) -> ConfirmedCpuReading | None:
         """Read the load once more over ssh. None on anything unreadable, which withholds nothing.
 
         Through `ctx.runner`, like the twin gate's second look at the card: the runner owns the
@@ -472,7 +473,7 @@ class ProviderSideLoadCheck:
         if len(sections) != 3:
             return None
         jiffies_before, container_rows, jiffies_after = sections
-        return parse_second_look(
+        return parse_confirmed_cpu_reading(
             jiffies_before, container_rows, jiffies_after, lium_container_keys
         )
 
@@ -502,11 +503,13 @@ class ProviderSideLoadCheck:
             "lium_named_outside_snapshot_cores": lium_named_cores_outside_snapshot(
                 ctx.state.specs or {}, lium_container_keys
             ),
-            # what the ssh reading measured, so the shadow week can tell a foreign workload from
-            # a Lium container that was never subtracted. None when the floor was never crossed.
-            "second_look": (
-                provider_side_load.second_look.to_specs_fields()
-                if provider_side_load.second_look is not None
+            # what the scrape saw before the confirmation, and what the ssh reading measured.
+            # Together they say how often the cheap screen and the paid-for verdict disagree.
+            # Both None when the floor was never crossed and no second look was taken.
+            "cpu_cores_before_confirmation": provider_side_load.cpu_cores_before_confirmation,
+            "confirmed_reading": (
+                asdict(provider_side_load.confirmed_reading)
+                if provider_side_load.confirmed_reading is not None
                 else None
             ),
         }
@@ -521,11 +524,14 @@ class ProviderSideLoadCheck:
         )
         if (measured.cpu_cores or 0.0) < PROVIDER_SIDE_CPU_CORES_LIMIT:
             return measured
-        second_look = await self._take_a_second_look(ctx, lium_container_keys)
-        if second_look is None:
-            return replace(measured, cpu_cores=None)
+        confirmed_reading = await self._confirm_the_cpu_reading_over_ssh(ctx, lium_container_keys)
         return replace(
-            measured, cpu_cores=second_look.provider_cores, second_look=second_look
+            measured,
+            # None when the second look could not be read: an unconfirmed reading withholds
+            # nothing, and `cpu_cores_before_confirmation` keeps that case countable.
+            cpu_cores=confirmed_reading.provider_cores if confirmed_reading else None,
+            cpu_cores_before_confirmation=measured.cpu_cores,
+            confirmed_reading=confirmed_reading,
         )
 
     async def run(self, ctx: Context) -> CheckResult:
@@ -540,7 +546,12 @@ class ProviderSideLoadCheck:
                 Msg.NOT_MEASURABLE,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={"executor_uuid": ctx.executor.uuid},
+                # a scrape reading with no verdict means the second look failed, not that the
+                # machine was never measured; the shadow week needs that rate
+                what={
+                    "executor_uuid": ctx.executor.uuid,
+                    "cpu_cores_before_confirmation": provider_side_load.cpu_cores_before_confirmation,
+                },
             )
             return CheckResult(passed=True, event=event)
 
@@ -555,10 +566,22 @@ class ProviderSideLoadCheck:
             event = render_message(Msg.LOAD_OK, ctx=ctx, check_id=self.check_id, what=what)
             return CheckResult(passed=True, event=event, updates=updates)
 
-        # Only the CPU half withholds money. A high disk figure is reported and never scored:
-        # it is read once, with no second look, and every docker category nobody enumerated
-        # (loopback volumes, json logs, BuildCache so far) lands in it and would zero an honest
-        # node. The shadow week measures the disk numbers before that half is armed.
+        return self._verdict_for_a_load_above_the_limits(ctx, provider_side_load, what, updates)
+
+    def _verdict_for_a_load_above_the_limits(
+        self,
+        ctx: Context,
+        provider_side_load: ProviderSideLoad,
+        what: dict[str, object],
+        updates: dict[str, object],
+    ) -> CheckResult:
+        """Render the verdict and, under enforcement, set the flag that zeroes the score.
+
+        Only the CPU half withholds money. A high disk figure is reported and never scored: it
+        is read once, with no second look, and every docker category nobody enumerated
+        (loopback volumes, json logs, BuildCache so far) lands in it and would zero an honest
+        node. The shadow week measures the disk numbers before that half is armed.
+        """
         enforce: bool = (
             settings.PROVIDER_SIDE_LOAD_ENFORCEMENT_ENABLED
             and provider_side_load.is_cpu_above_limit

--- a/neurons/validators/src/services/task/checks/provider_side_load.py
+++ b/neurons/validators/src/services/task/checks/provider_side_load.py
@@ -101,6 +101,12 @@ class ContainerRow:
         return self.cpu_percent
 
 
+def floor_to_tenth(cores: float) -> float:
+    """Floor, not round: 1.96 cores must not become 2.0 and cross the limit on its own. The
+    inner round absorbs float noise first, so an exact 1.6 does not floor to 1.5."""
+    return math.floor(round(cores, 3) * 10) / 10
+
+
 def lium_cores_among(rows: list[ContainerRow], lium_container_keys: set[str]) -> float:
     """What Lium's own containers burn, in cores.
 
@@ -122,10 +128,7 @@ def provider_cores_outside_lium(
     host_cores: float, rows: list[ContainerRow], lium_container_keys: set[str]
 ) -> float:
     """The host's cores minus the containers Lium itself put there."""
-    # Floor, not round: 1.96 cores must not become 2.0 and cross the limit on its own. The
-    # inner round absorbs float noise first, so an exact 1.6 does not floor to 1.5.
-    provider_cores = max(0.0, host_cores - lium_cores_among(rows, lium_container_keys))
-    return math.floor(round(provider_cores, 3) * 10) / 10
+    return floor_to_tenth(max(0.0, host_cores - lium_cores_among(rows, lium_container_keys)))
 
 
 @dataclass(frozen=True)
@@ -416,12 +419,15 @@ def parse_second_look(
     # `dockerd` is a process name anyone can copy, so its excuse is capped like the name tier
     excused_dockerd_cores = min(max(0.0, dockerd_cores), CLAIMED_EXCUSE_CORES)
     host_cores = (total_delta - (last_idle - first_idle)) / total_delta * kernel_cores
+    reported_host_cores = round(host_cores, 2)
+    reported_lium_cores = round(lium_cores_among(stats_rows, lium_container_keys), 2)
+    reported_dockerd_cores = round(excused_dockerd_cores, 2)
     return SecondLook(
-        host_cores=round(host_cores, 2),
-        lium_container_cores=round(lium_cores_among(stats_rows, lium_container_keys), 2),
-        dockerd_cores=round(excused_dockerd_cores, 2),
-        provider_cores=provider_cores_outside_lium(
-            host_cores - excused_dockerd_cores, stats_rows, lium_container_keys
+        host_cores=reported_host_cores,
+        lium_container_cores=reported_lium_cores,
+        dockerd_cores=reported_dockerd_cores,
+        provider_cores=floor_to_tenth(
+            max(0.0, reported_host_cores - reported_lium_cores - reported_dockerd_cores)
         ),
     )
 

--- a/neurons/validators/tests/test_provider_side_load.py
+++ b/neurons/validators/tests/test_provider_side_load.py
@@ -41,6 +41,11 @@ SN13_SPECS = {
 
 # the same machine with the disk part removed, to judge the CPU verdict on its own
 CPU_ONLY_SPECS = {key: value for key, value in SN13_SPECS.items() if key != "hard_disk"}
+# a quiet machine: the floor is never crossed, so no ssh reading is taken
+SN13_SPECS_BELOW_FLOOR = {
+    "cpu": {"count": 32},
+    "docker": {"host_cpu_percent": 4.0, "containers": [{"name": "pod_renter", "cpu_percent": 20.0}]},
+}
 
 
 def test_provider_side_load_attributes_cpu_and_disk():
@@ -183,10 +188,11 @@ async def test_enforcement_zeroes_the_score_on_a_rented_machine(context_factory)
     assert result.updates["provider_side_load_passed"] is False
     assert result.event.reason_code == Msg.LOAD_ABOVE_LIMIT.reason
     assert result.event.what_we_saw["provider_cpu_cores"] == 8.9
-    assert result.updates["state"].specs["provider_side_load"] == {
-        "cpu_cores": 8.9,
-        "disk_kb": 1528 * GB_KB,
-    }
+    stored = result.updates["state"].specs["provider_side_load"]
+    assert stored["cpu_cores"] == 8.9
+    assert stored["disk_kb"] == 1528 * GB_KB
+    # the readings behind the verdict travel with it
+    assert stored["host_cores"] == 10.6
 
 
 @pytest.mark.asyncio
@@ -639,3 +645,31 @@ async def test_a_miner_renamed_dockerd_is_capped_like_every_other_forged_name(co
 
     assert result.passed is False
     assert result.event.what_we_saw["provider_cpu_cores"] == 6.9  # 10.56 - 1.58 - 2.0 capped
+
+
+@pytest.mark.asyncio
+async def test_the_event_carries_what_the_second_look_measured(context_factory):
+    # The verdict alone cannot be argued with. These three numbers add up to it, so a shadow
+    # week can separate a foreign workload from a Lium container that was never subtracted.
+    ctx = context_factory(
+        state=_rented_state(CPU_ONLY_SPECS),
+        runner=confirming_runner(10.56, 32, [("c1", "pod_renter", 158.0)], dockerd_cores=1.0),
+    )
+
+    with provider_load_gate(enforce=True):
+        result = await ProviderSideLoadCheck().run(ctx)
+
+    second_look = result.event.what_we_saw["second_look"]
+    assert second_look == {"host_cores": 10.6, "lium_container_cores": 1.6, "dockerd_cores": 1.0}
+    assert result.event.what_we_saw["provider_cpu_cores"] == 7.9  # 10.56 - 1.58 - 1.0
+    assert result.updates["state"].specs["provider_side_load"]["host_cores"] == 10.6
+
+
+@pytest.mark.asyncio
+async def test_a_node_below_the_floor_carries_no_second_look(context_factory):
+    ctx = context_factory(state=_rented_state(SN13_SPECS_BELOW_FLOOR))
+
+    with provider_load_gate(enforce=True):
+        result = await ProviderSideLoadCheck().run(ctx)
+
+    assert result.event.what_we_saw["second_look"] is None

--- a/neurons/validators/tests/test_provider_side_load.py
+++ b/neurons/validators/tests/test_provider_side_load.py
@@ -1,5 +1,4 @@
 """DAH-2734: provider-side CPU/disk gate — the twin of the DAH-2735 foreign-GPU gate."""
-import math
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -15,6 +14,8 @@ from neurons.validators.src.services.task.checks.provider_side_load import (
     ProviderSideLoad,
     ProviderSideLoadCheck,
     compute_provider_side_load,
+    floor_to_tenth,
+    parse_confirmed_cpu_reading,
 )
 from neurons.validators.src.services.task.pipeline import ContextState
 from neurons.validators.src.services.task.messages import ProviderSideLoadMessages as Msg
@@ -43,7 +44,7 @@ SN13_SPECS = {
 # the same machine with the disk part removed, to judge the CPU verdict on its own
 CPU_ONLY_SPECS = {key: value for key, value in SN13_SPECS.items() if key != "hard_disk"}
 # a quiet machine: the floor is never crossed, so no ssh reading is taken
-SN13_SPECS_BELOW_FLOOR = {
+SPECS_BELOW_THE_LIMITS = {
     "cpu": {"count": 32},
     "docker": {"host_cpu_percent": 4.0, "containers": [{"name": "pod_renter", "cpu_percent": 20.0}]},
 }
@@ -397,7 +398,7 @@ async def test_the_monitor_container_shares_the_executor_image_and_is_ours(conte
 
 
 @pytest.mark.asyncio
-async def test_a_spike_that_is_gone_on_the_second_look_costs_nothing(context_factory):
+async def test_a_spike_that_is_gone_on_the_confirmed_reading_costs_nothing(context_factory):
     # Lium's own watchtower pulling an image can hold two cores for a second. It is gone by the
     # second reading, and an honest machine keeps its score.
     ctx = context_factory(
@@ -414,7 +415,7 @@ async def test_a_spike_that_is_gone_on_the_second_look_costs_nothing(context_fac
 
 
 @pytest.mark.asyncio
-async def test_an_unreadable_second_look_withholds_nothing(context_factory):
+async def test_an_unreadable_confirmed_reading_withholds_nothing(context_factory):
     # ssh is down, so the load cannot be confirmed. The CPU verdict voids.
     ctx = context_factory(state=_rented_state(CPU_ONLY_SPECS))  # runner defaults to None
 
@@ -426,7 +427,7 @@ async def test_an_unreadable_second_look_withholds_nothing(context_factory):
 
 
 @pytest.mark.asyncio
-async def test_a_docker_that_does_not_answer_the_second_look_withholds_nothing(context_factory):
+async def test_a_docker_that_does_not_answer_the_confirmed_reading_withholds_nothing(context_factory):
     # An empty container section means docker did not answer. Reading it as "Lium runs nothing
     # here" would charge the machine's whole load to the provider.
     runner = AsyncMock()
@@ -649,7 +650,7 @@ async def test_a_miner_renamed_dockerd_is_capped_like_every_other_forged_name(co
 
 
 @pytest.mark.asyncio
-async def test_the_event_carries_what_the_second_look_measured(context_factory):
+async def test_the_event_carries_what_the_confirmed_reading_measured(context_factory):
     # The verdict alone cannot be argued with. These three numbers add up to it, so a shadow
     # week can separate a foreign workload from a Lium container that was never subtracted.
     ctx = context_factory(
@@ -660,42 +661,71 @@ async def test_the_event_carries_what_the_second_look_measured(context_factory):
     with provider_load_gate(enforce=True):
         result = await ProviderSideLoadCheck().run(ctx)
 
-    second_look = result.event.what_we_saw["second_look"]
-    assert second_look == {"host_cores": 10.56, "lium_container_cores": 1.58, "dockerd_cores": 1.0}
+    confirmed_reading = result.event.what_we_saw["confirmed_reading"]
+    assert confirmed_reading == {"host_cores": 10.56, "lium_container_cores": 1.58, "dockerd_cores": 1.0}
     verdict = result.event.what_we_saw["provider_cpu_cores"]
     assert verdict == 7.9
     # the readings reconstruct the verdict: the only step between them is the final floor
-    reconstructed = (
-        second_look["host_cores"]
-        - second_look["lium_container_cores"]
-        - second_look["dockerd_cores"]
+    readings_difference = (
+        confirmed_reading["host_cores"]
+        - confirmed_reading["lium_container_cores"]
+        - confirmed_reading["dockerd_cores"]
     )
-    assert math.floor(round(reconstructed, 3) * 10) / 10 == verdict
+    assert floor_to_tenth(readings_difference) == verdict
     assert result.updates["state"].specs["provider_side_load"]["host_cores"] == 10.56
 
 
 @pytest.mark.asyncio
-async def test_a_node_below_the_floor_carries_no_second_look(context_factory):
-    ctx = context_factory(state=_rented_state(SN13_SPECS_BELOW_FLOOR))
+async def test_a_node_below_the_floor_carries_no_confirmed_reading(context_factory):
+    ctx = context_factory(state=_rented_state(SPECS_BELOW_THE_LIMITS))
 
     with provider_load_gate(enforce=True):
         result = await ProviderSideLoadCheck().run(ctx)
 
-    assert result.event.what_we_saw["second_look"] is None
+    assert result.event.what_we_saw["confirmed_reading"] is None
 
 
 def test_the_readings_always_reconstruct_the_verdict():
     # Codex found a boundary where independently rounded readings and the verdict disagreed by
     # a tenth. The verdict is derived from the readings now, so the two cannot drift apart.
-    from neurons.validators.src.services.task.checks.provider_side_load import (
-        floor_to_tenth,
-        parse_second_look,
-    )
-
     for busy_jiffies in range(1, 400):
         before = "0 0 32 0"
         after = f"6400 {6400 - busy_jiffies} 32 0"
-        look = parse_second_look(before, "c1|pod_renter|0.50%", after, {"pod_renter"})
+        look = parse_confirmed_cpu_reading(before, "c1|pod_renter|0.50%", after, {"pod_renter"})
         assert look is not None
-        reconstructed = look.host_cores - look.lium_container_cores - look.dockerd_cores
-        assert floor_to_tenth(max(0.0, reconstructed)) == look.provider_cores
+        readings_difference = look.host_cores - look.lium_container_cores - look.dockerd_cores
+        assert floor_to_tenth(max(0.0, readings_difference)) == look.provider_cores
+
+
+@pytest.mark.asyncio
+async def test_a_confirmation_that_could_not_be_read_still_reports_the_scrape_reading(
+    context_factory,
+):
+    # Without the scrape reading this looks exactly like a machine nobody measured, and the
+    # shadow week has to count how often the confirmation itself fails.
+    runner = AsyncMock()
+    runner.run = AsyncMock(return_value=MagicMock(success=False, stdout=""))
+    ctx = context_factory(state=_rented_state(CPU_ONLY_SPECS), runner=runner)
+
+    with provider_load_gate(enforce=True):
+        result = await ProviderSideLoadCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.NOT_MEASURABLE.reason
+    assert result.event.what_we_saw["cpu_cores_before_confirmation"] == 8.9
+
+
+@pytest.mark.asyncio
+async def test_the_event_keeps_both_readings_side_by_side(context_factory):
+    # The scrape screams and the confirmation disagrees: that gap is what calibrates the floor.
+    ctx = context_factory(
+        state=_rented_state(CPU_ONLY_SPECS),
+        runner=confirming_runner(2.0, 32, [("c1", "pod_renter", 158.0)]),
+    )
+
+    with provider_load_gate(enforce=True):
+        result = await ProviderSideLoadCheck().run(ctx)
+
+    what = result.event.what_we_saw
+    assert what["cpu_cores_before_confirmation"] == 8.9
+    assert what["provider_cpu_cores"] == 0.4  # 2.0 host - 1.58 the renter's pod

--- a/neurons/validators/tests/test_provider_side_load.py
+++ b/neurons/validators/tests/test_provider_side_load.py
@@ -682,3 +682,20 @@ async def test_a_node_below_the_floor_carries_no_second_look(context_factory):
         result = await ProviderSideLoadCheck().run(ctx)
 
     assert result.event.what_we_saw["second_look"] is None
+
+
+def test_the_readings_always_reconstruct_the_verdict():
+    # Codex found a boundary where independently rounded readings and the verdict disagreed by
+    # a tenth. The verdict is derived from the readings now, so the two cannot drift apart.
+    from neurons.validators.src.services.task.checks.provider_side_load import (
+        floor_to_tenth,
+        parse_second_look,
+    )
+
+    for busy_jiffies in range(1, 400):
+        before = "0 0 32 0"
+        after = f"6400 {6400 - busy_jiffies} 32 0"
+        look = parse_second_look(before, "c1|pod_renter|0.50%", after, {"pod_renter"})
+        assert look is not None
+        reconstructed = look.host_cores - look.lium_container_cores - look.dockerd_cores
+        assert floor_to_tenth(max(0.0, reconstructed)) == look.provider_cores

--- a/neurons/validators/tests/test_provider_side_load.py
+++ b/neurons/validators/tests/test_provider_side_load.py
@@ -729,3 +729,34 @@ async def test_the_event_keeps_both_readings_side_by_side(context_factory):
     what = result.event.what_we_saw
     assert what["cpu_cores_before_confirmation"] == 8.9
     assert what["provider_cpu_cores"] == 0.4  # 2.0 host - 1.58 the renter's pod
+
+
+def test_a_real_shell_sample_parses():
+    """Recorded from CPU_RESAMPLE_COMMAND run unchanged inside a linux container, with a real
+    binary named `dockerd` burning a core and a stub `docker` printing two stats rows. Proves
+    the awk, the pgrep walk and the section markers survive a real shell, which no mock does."""
+    reading = parse_confirmed_cpu_reading(
+        "231533405 225982883 10 210",
+        "aaaaaaaaaaaa|pod_renter|150.00%\nbbbbbbbbbbbb|sn13_miner|300.00%",
+        "231533508 225982964 10 221",
+        {"pod_renter"},
+    )
+
+    assert reading is not None
+    assert reading.host_cores == 2.14  # 22 busy jiffies of 103, over 10 cores
+    assert reading.lium_container_cores == 1.5  # the renter's pod, the miner is not ours
+    assert reading.dockerd_cores == 1.07  # 11 jiffies over a 0.103 s window
+
+
+def test_a_shell_that_printed_an_extra_line_is_refused():
+    """The sample line must hold exactly four numbers. Anything else means the command did not
+    run as written, and guessing at a partial reading is how an honest node gets zeroed."""
+    assert (
+        parse_confirmed_cpu_reading(
+            "130 \n231533405 225982883 10 210",
+            "aaaaaaaaaaaa|pod_renter|150.00%",
+            "231533508 225982964 10 221",
+            {"pod_renter"},
+        )
+        is None
+    )

--- a/neurons/validators/tests/test_provider_side_load.py
+++ b/neurons/validators/tests/test_provider_side_load.py
@@ -1,4 +1,5 @@
 """DAH-2734: provider-side CPU/disk gate — the twin of the DAH-2735 foreign-GPU gate."""
+import math
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -192,7 +193,7 @@ async def test_enforcement_zeroes_the_score_on_a_rented_machine(context_factory)
     assert stored["cpu_cores"] == 8.9
     assert stored["disk_kb"] == 1528 * GB_KB
     # the readings behind the verdict travel with it
-    assert stored["host_cores"] == 10.6
+    assert stored["host_cores"] == 10.56
 
 
 @pytest.mark.asyncio
@@ -660,9 +661,17 @@ async def test_the_event_carries_what_the_second_look_measured(context_factory):
         result = await ProviderSideLoadCheck().run(ctx)
 
     second_look = result.event.what_we_saw["second_look"]
-    assert second_look == {"host_cores": 10.6, "lium_container_cores": 1.6, "dockerd_cores": 1.0}
-    assert result.event.what_we_saw["provider_cpu_cores"] == 7.9  # 10.56 - 1.58 - 1.0
-    assert result.updates["state"].specs["provider_side_load"]["host_cores"] == 10.6
+    assert second_look == {"host_cores": 10.56, "lium_container_cores": 1.58, "dockerd_cores": 1.0}
+    verdict = result.event.what_we_saw["provider_cpu_cores"]
+    assert verdict == 7.9
+    # the readings reconstruct the verdict: the only step between them is the final floor
+    reconstructed = (
+        second_look["host_cores"]
+        - second_look["lium_container_cores"]
+        - second_look["dockerd_cores"]
+    )
+    assert math.floor(round(reconstructed, 3) * 10) / 10 == verdict
+    assert result.updates["state"].specs["provider_side_load"]["host_cores"] == 10.56
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to DAH-2734, from its first hour in prod.

The gate flagged 40 executors in an hour: 30 on disk alone (that half never scores) and 12 on CPU, 10 of them rented. Whether those 12 are real is not answerable from the logs. On one node the scrape arithmetic gives 4.8 provider cores while the event says 10.1, because the verdict comes from the ssh second look and its components are not recorded. A provider mining beside a renter and a renter pod that was never subtracted look identical in the log.

This ships the readings with the verdict: `host_cores`, `lium_container_cores` and `dockerd_cores`, in the event and in `specs.provider_side_load`. They add up to the verdict by construction, so the shadow week can tell the two cases apart before anyone arms enforcement.

`second_look` is null when the floor was never crossed, because no ssh reading is taken then.

Backend companion: https://github.com/Datura-ai/lium-io-backend/pull/982 declares the three fields, otherwise `MachineSpecs` strips them.

Tests: 1796 passed.