### PR TITLE
DAH-2794: send machine_scrape as source over stdin instead of a 12 MB upload

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -197,6 +197,9 @@ class Settings(BaseSettings):
     ENABLE_NO_COLLATERAL: bool = True
     ENABLE_VERIFYX: bool = True
     ENABLE_INSPECTOR: bool = True
+    # DAH-2794: feed the obfuscated scrape to the executor's own interpreter over stdin
+    # instead of freezing it into a ~13 MB onefile and uploading that every cycle.
+    ENABLE_SCRAPE_SOURCE_DELIVERY: bool = Field(env="ENABLE_SCRAPE_SOURCE_DELIVERY", default=False)
     INSPECTOR_ENSURE_COLLECTOR_ON_RENTED_CHECK: bool = Field(
         env="INSPECTOR_ENSURE_COLLECTOR_ON_RENTED_CHECK",
         default=True,

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -156,9 +156,9 @@ class MinerJobEnryptedFiles(BaseModel):
     all_keys: dict
     tmp_directory: str
     machine_scrape_file_name: str
-    # DAH-2794: the same obfuscated source the binary was frozen from, carried alongside it so
-    # an executor that can run it needs no upload and one that cannot still gets the binary.
-    machine_scrape_source: str | None = None
+    # DAH-2794: the same obfuscated source the binary was frozen from, so a pipeline that can
+    # deliver it over stdin needs no upload and one that cannot still has the binary.
+    machine_scrape_source: str
     # score_file_name: str
 
 

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -156,6 +156,9 @@ class MinerJobEnryptedFiles(BaseModel):
     all_keys: dict
     tmp_directory: str
     machine_scrape_file_name: str
+    # DAH-2794: the same obfuscated source the binary was frozen from, carried alongside it so
+    # an executor that can run it needs no upload and one that cannot still gets the binary.
+    machine_scrape_source: str | None = None
     # score_file_name: str
 
 

--- a/neurons/validators/src/services/file_encrypt_service.py
+++ b/neurons/validators/src/services/file_encrypt_service.py
@@ -12,6 +12,7 @@ import PyInstaller.__main__
 from fastapi import Depends
 from payload_models.payloads import MinerJobEnryptedFiles
 
+from core.config import settings
 from services.ssh_service import SSHService
 
 # ORDER IS LOAD-BEARING: machine_scrape derives its encryption key from the literal key order of
@@ -411,4 +412,8 @@ class FileEncryptService:
             all_keys=all_keys,
             tmp_directory=str(tmp_directory),
             machine_scrape_file_name=machine_scrape_file_name,
+            # DAH-2794: an executor that can run this source needs no upload at all. The binary
+            # stays built because the miner picks the executor image, and one that predates a
+            # dependency the scrape imports has to keep the self-contained path.
+            machine_scrape_source=obfuscated_content if settings.ENABLE_SCRAPE_SOURCE_DELIVERY else None,
         )

--- a/neurons/validators/src/services/file_encrypt_service.py
+++ b/neurons/validators/src/services/file_encrypt_service.py
@@ -12,7 +12,6 @@ import PyInstaller.__main__
 from fastapi import Depends
 from payload_models.payloads import MinerJobEnryptedFiles
 
-from core.config import settings
 from services.ssh_service import SSHService
 
 # ORDER IS LOAD-BEARING: machine_scrape derives its encryption key from the literal key order of
@@ -412,8 +411,5 @@ class FileEncryptService:
             all_keys=all_keys,
             tmp_directory=str(tmp_directory),
             machine_scrape_file_name=machine_scrape_file_name,
-            # DAH-2794: an executor that can run this source needs no upload at all. The binary
-            # stays built because the miner picks the executor image, and one that predates a
-            # dependency the scrape imports has to keep the self-contained path.
-            machine_scrape_source=obfuscated_content if settings.ENABLE_SCRAPE_SOURCE_DELIVERY else None,
+            machine_scrape_source=obfuscated_content,
         )

--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import json
 import shlex
-from dataclasses import replace
+from collections.abc import Iterator
+from dataclasses import dataclass, fields, replace
 from typing import Any, Literal
 
 from ..messages import MachineSpecMessages as Msg, render_message
@@ -11,14 +12,14 @@ from ..runner import SSHCommandResult
 from services.file_encrypt_service import ORIGINAL_KEYS
 from services.gpu_spec_table import normalize_gpu_model
 from .network_ema import compute_ema
-from .upload_files import UploadFailed, upload_validation_files
+from .upload_files import UploadFailed, upload_validation_files_to_fresh_remote_dir
 
 # DAH-2794: how long a failed stdin attempt may have taken and still be worth retrying with the
 # binary. Above a full scrape (~15 s on a real box, so a payload that will not decrypt is only
 # knowable around then), below the point where the retry stops fitting: 60 s here + 300 s upload
 # + 300 s scrape = 660 s against the 780 s per-executor timeout. The upload gets one attempt for
 # exactly that reason.
-FALLBACK_MAX_STDIN_DURATION_MS = 60_000
+STDIN_FAILURE_RETRY_WINDOW_MS = 60_000
 FALLBACK_UPLOAD_ATTEMPTS = 1
 
 # The scrape says only two things on stdout: a Fernet token when it worked, and a JSON object
@@ -27,10 +28,22 @@ FALLBACK_UPLOAD_ATTEMPTS = 1
 FERNET_TOKEN_PREFIX = "gAAAAA"
 
 # How much stdout the miner puts in front of the scrape's own line is his choice, not a bounded
-# amount, so only the tail is searched and only so many candidates are decrypted — both run
-# synchronously on the event loop shared with every other executor in the cycle.
+# amount, so only the last lines are searched and only so many candidates are decrypted — both
+# run synchronously on the event loop shared with every other executor in the cycle.
 STDOUT_SEARCH_TAIL_BYTES = 256 * 1024
 MAX_PAYLOAD_DECRYPT_ATTEMPTS = 20
+
+
+def _lines_from_the_end(stdout: str) -> Iterator[str]:
+    # whole lines, newest first, until the window is spent — a token that is itself longer than
+    # the window would lose its prefix to a byte-wise cut and be dropped by every reader below
+    end = len(stdout)
+    scanned = 0
+    while end > 0 and scanned < STDOUT_SEARCH_TAIL_BYTES:
+        start = stdout.rfind("\n", 0, end)
+        yield stdout[start + 1 : end]
+        scanned += end - start
+        end = start
 
 
 def _update_keys(data: Any, key_mapping: dict[str, str]) -> Any:
@@ -76,7 +89,7 @@ def _decrypt_payload(ctx: Context, stdout: str) -> str:
 
     last_exc: Exception | None = None
     attempts = 0
-    for line in reversed(stdout[-STDOUT_SEARCH_TAIL_BYTES:].splitlines()):
+    for line in _lines_from_the_end(stdout):
         candidate = line.strip()
         if not candidate.startswith(FERNET_TOKEN_PREFIX):
             continue
@@ -94,14 +107,47 @@ def _decrypt_payload(ctx: Context, stdout: str) -> str:
 def _scrape_reported_its_own_failure(stdout: str) -> bool:
     # the scrape prints {"error": ...} as its last line and exits non-zero when it ran but found
     # nothing to report; a source the interpreter could not run prints nothing of ours at all
-    lines = [line for line in stdout[-STDOUT_SEARCH_TAIL_BYTES:].splitlines() if line.strip()]
-    if not lines:
+    last_line = next((line for line in _lines_from_the_end(stdout) if line.strip()), None)
+    if last_line is None:
         return False
     try:
-        report = json.loads(lines[-1])
+        report = json.loads(last_line)
     except ValueError:
         return False
     return isinstance(report, dict) and "error" in report
+
+
+@dataclass(frozen=True)
+class StdinAttempt:
+    """Why the stdin delivery failed, carried into the event of the binary retry.
+
+    The retry discards the stdin attempt's own event, and a run that exited 0 with an unreadable
+    payload says nothing in ``exit_code`` or ``stderr`` — so the reason travels with it.
+    """
+
+    reason: str
+    command_id: str | None = None
+    exit_code: int | None = None
+    duration_ms: int | None = None
+    stderr_tail: str | None = None
+    exception: str | None = None
+    stdout_head: str | None = None
+
+    @classmethod
+    def from_failed_result(cls, result: CheckResult) -> StdinAttempt:
+        what_we_saw = result.event.what_we_saw
+        carried = {field.name for field in fields(cls)} - {"reason"}
+        return cls(
+            reason=result.event.reason_code,
+            **{name: what_we_saw.get(name) for name in carried},
+        )
+
+    def as_event_field(self) -> dict[str, Any]:
+        return {
+            field.name: getattr(self, field.name)
+            for field in fields(self)
+            if getattr(self, field.name) is not None
+        }
 
 
 def _binary_command(remote_dir: str, script_filename: str) -> str:
@@ -149,10 +195,10 @@ class MachineSpecScrapeCheck:
 
         # The source did not run here: wrong interpreter, no psutil, or a cryptography too old
         # to produce a token this validator can read. The binary carries its own interpreter and
-        # every dependency, so retry with it — but past FALLBACK_MAX_STDIN_DURATION_MS the scrape
+        # every dependency, so retry with it — but past STDIN_FAILURE_RETRY_WINDOW_MS the scrape
         # hung rather than failed to start, and the binary runs the very same code.
         if (
-            scrape_run.duration_ms > FALLBACK_MAX_STDIN_DURATION_MS
+            scrape_run.duration_ms > STDIN_FAILURE_RETRY_WINDOW_MS
             or not ctx.config.machine_scrape_filename
         ):
             return result
@@ -162,12 +208,16 @@ class MachineSpecScrapeCheck:
         if scrape_run.exit_code != 0 and _scrape_reported_its_own_failure(scrape_run.stdout):
             return result
 
-        # The stdin attempt's own event is discarded with the retry, so carry it whole: a run that
-        # exited 0 and produced an unreadable payload says nothing in exit_code or stderr.
-        fallback_from = {"reason": result.event.reason_code, **result.event.what_we_saw}
+        return await self._retry_scrape_with_uploaded_binary(
+            ctx, timeout, fallback_from=StdinAttempt.from_failed_result(result)
+        )
 
+    async def _retry_scrape_with_uploaded_binary(
+        self, ctx: Context, timeout: int, *, fallback_from: StdinAttempt
+    ) -> CheckResult:
+        # upload the frozen scrape and run it, after the stdin delivery failed to start
         try:
-            remote_dir = await upload_validation_files(ctx, attempts=FALLBACK_UPLOAD_ATTEMPTS)
+            remote_dir = await upload_validation_files_to_fresh_remote_dir(ctx, attempts=FALLBACK_UPLOAD_ATTEMPTS)
         except UploadFailed as exc:
             event = render_message(
                 Msg.SCRAPE_FAILED,
@@ -175,7 +225,7 @@ class MachineSpecScrapeCheck:
                 check_id=self.check_id,
                 what={
                     "delivery": "stdin",
-                    "fallback_from": fallback_from,
+                    "fallback_from": fallback_from.as_event_field(),
                     "fallback_upload_error": str(exc),
                 },
             )
@@ -222,11 +272,11 @@ class MachineSpecScrapeCheck:
         scrape_run: SSHCommandResult,
         *,
         delivery: Literal["stdin", "upload"],
-        fallback_from: dict[str, Any] | None = None,
+        fallback_from: StdinAttempt | None = None,
     ) -> CheckResult:
         what: dict[str, Any] = {"delivery": delivery}
         if fallback_from:
-            what["fallback_from"] = fallback_from
+            what["fallback_from"] = fallback_from.as_event_field()
 
         if not scrape_run.success or not scrape_run.stdout.strip():
             event = render_message(

--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import shlex
 from dataclasses import replace
 from typing import Any
 
@@ -60,30 +61,42 @@ class MachineSpecScrapeCheck:
     async def run(self, ctx: Context) -> CheckResult:
         runner: SSHCommandRunner = ctx.runner
 
-        remote_dir = ctx.state.remote_dir
-
-        if not remote_dir:
-            event = render_message(
-                Msg.REMOTE_DIR_MISSING,
-                ctx=ctx,
-                check_id=self.check_id,
-            )
-            return CheckResult(passed=False, event=event)
-
-        script_filename = ctx.config.machine_scrape_filename
-        if not script_filename:
-            event = render_message(
-                Msg.CONFIG_MISSING,
-                ctx=ctx,
-                check_id=self.check_id,
-                what={"machine_scrape_filename": script_filename},
-            )
-            return CheckResult(passed=False, event=event)
-
-        script_path = f"{remote_dir.rstrip('/')}/{script_filename.lstrip('/')}"
         timeout = ctx.config.machine_scrape_timeout or self.DEFAULT_TIMEOUT
+        source = ctx.config.machine_scrape_source if ctx.state.scrape_over_stdin else None
 
-        res = await runner.run(f"chmod +x {script_path} && {script_path}", timeout=timeout, retryable=False)
+        if source:
+            # DAH-2794: nothing was uploaded — the source goes down stdin instead. `-I` implies
+            # -E -s -P, which drops PYTHONPATH, the user site-dir and the cwd entry from
+            # sys.path, so a file left next to the SSH login shell cannot shadow psutil or json.
+            # It does not disable site processing: a .pth or sitecustomize inside the image still
+            # runs, which is why the payload is read off the last line rather than the first.
+            command = f"{shlex.quote(ctx.executor.python_path)} -I -"
+        else:
+            remote_dir = ctx.state.remote_dir
+
+            if not remote_dir:
+                event = render_message(
+                    Msg.REMOTE_DIR_MISSING,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                )
+                return CheckResult(passed=False, event=event)
+
+            script_filename = ctx.config.machine_scrape_filename
+            if not script_filename:
+                event = render_message(
+                    Msg.CONFIG_MISSING,
+                    ctx=ctx,
+                    check_id=self.check_id,
+                    what={"machine_scrape_filename": script_filename},
+                )
+                return CheckResult(passed=False, event=event)
+
+            script_path = f"{remote_dir.rstrip('/')}/{script_filename.lstrip('/')}"
+            command = f"chmod +x {script_path} && {script_path}"
+
+        delivery = "stdin" if source else "upload"
+        res = await runner.run(command, timeout=timeout, retryable=False, stdin_text=source)
 
         if not res.success or not res.stdout.strip():
             event = render_message(
@@ -94,13 +107,16 @@ class MachineSpecScrapeCheck:
                     "command_id": res.command_id,
                     "exit_code": res.exit_code,
                     "duration_ms": res.duration_ms,
+                    "delivery": delivery,
                     "stderr_tail": res.stderr[-400:],
                 },
             )
             return CheckResult(passed=False, event=event)
 
         try:
-            line = res.stdout.splitlines()[0].strip()
+            # Last line, not first: the payload is the scrape's final print, and a .pth or
+            # sitecustomize in the executor image can put its own line in front of it.
+            line = [ln for ln in res.stdout.splitlines() if ln.strip()][-1].strip()
             if not ctx.encrypt_key:
                 raise ValueError("Missing encrypt_key in context")
 
@@ -155,6 +171,7 @@ class MachineSpecScrapeCheck:
                 what={
                     "gpu_count": gpu_count,
                     "gpu_model": gpu_model,
+                    "delivery": delivery,
                     "network": specs.get("network"),
                 },
                 extra=extra_info,

--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -7,10 +7,15 @@ from typing import Any
 
 from ..messages import MachineSpecMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
-from ..runner import SSHCommandRunner
+from ..runner import SSHCommandResult
 from services.file_encrypt_service import ORIGINAL_KEYS
 from services.gpu_spec_table import normalize_gpu_model
 from .network_ema import compute_ema
+from .upload_files import UploadFailed, upload_validation_files
+
+# DAH-2794: how fast the stdin attempt must fail for the binary fallback to still fit the
+# 780 s per-executor budget. An interpreter that cannot run the source rejects it in ~2 s.
+FALLBACK_AFTER_MS = 60_000
 
 
 def _update_keys(data: Any, key_mapping: dict[str, str]) -> Any:
@@ -45,6 +50,11 @@ def _normalize_gpu_details(gpu_details: list[dict[str, Any]]) -> list[dict[str, 
     ]
 
 
+def _binary_command(remote_dir: str, script_filename: str) -> str:
+    script_path = f"{remote_dir.rstrip('/')}/{script_filename.lstrip('/')}"
+    return f"chmod +x {script_path} && {script_path}"
+
+
 class MachineSpecScrapeCheck:
     """Run the obfuscated scrape script and unpack the executor's hardware profile.
 
@@ -59,44 +69,108 @@ class MachineSpecScrapeCheck:
     DEFAULT_TIMEOUT = 300
 
     async def run(self, ctx: Context) -> CheckResult:
-        runner: SSHCommandRunner = ctx.runner
-
         timeout = ctx.config.machine_scrape_timeout or self.DEFAULT_TIMEOUT
-        source = ctx.config.machine_scrape_source if ctx.state.scrape_over_stdin else None
 
-        if source:
-            # DAH-2794: nothing was uploaded — the source goes down stdin instead. `-I` implies
-            # -E -s -P, which drops PYTHONPATH, the user site-dir and the cwd entry from
-            # sys.path, so a file left next to the SSH login shell cannot shadow psutil or json.
-            # It does not disable site processing: a .pth or sitecustomize inside the image still
-            # runs, which is why the payload is read off the last line rather than the first.
-            command = f"{shlex.quote(ctx.executor.python_path)} -I -"
-        else:
-            remote_dir = ctx.state.remote_dir
+        if ctx.state.scrape_over_stdin:
+            return await self._scrape_from_source(ctx, timeout)
+        return await self._scrape_uploaded_binary(ctx, timeout)
 
-            if not remote_dir:
-                event = render_message(
-                    Msg.REMOTE_DIR_MISSING,
-                    ctx=ctx,
-                    check_id=self.check_id,
-                )
-                return CheckResult(passed=False, event=event)
+    async def _scrape_from_source(self, ctx: Context, timeout: int) -> CheckResult:
+        # pipe the obfuscated source into the executor's own interpreter; binary on failure
+        #
+        # `-I` implies -E -s -P, which drops PYTHONPATH, the user site-dir and the cwd entry
+        # from sys.path, so a file left next to the SSH login shell cannot shadow psutil or
+        # json. It does not disable site processing: a .pth or sitecustomize inside the image
+        # still runs, which is why the payload is read off the last line rather than the first.
+        command = f"{shlex.quote(ctx.executor.python_path)} -I -"
+        res = await ctx.runner.run(
+            command,
+            timeout=timeout,
+            retryable=False,
+            stdin_text=ctx.config.machine_scrape_source,
+        )
+        result = self._result(ctx, res, delivery="stdin")
+        if result.passed:
+            return result
 
-            script_filename = ctx.config.machine_scrape_filename
-            if not script_filename:
-                event = render_message(
-                    Msg.CONFIG_MISSING,
-                    ctx=ctx,
-                    check_id=self.check_id,
-                    what={"machine_scrape_filename": script_filename},
-                )
-                return CheckResult(passed=False, event=event)
+        # The source did not run here: wrong interpreter, no psutil, or a cryptography too old
+        # to produce a token this validator can read. The binary carries its own interpreter and
+        # every dependency, so retry with it. Only after a fast failure, though — a slow one
+        # means the scrape got past its cheap part, and a second full attempt plus the upload
+        # would not fit the per-executor budget.
+        if res.duration_ms > FALLBACK_AFTER_MS or not ctx.config.machine_scrape_filename:
+            return result
 
-            script_path = f"{remote_dir.rstrip('/')}/{script_filename.lstrip('/')}"
-            command = f"chmod +x {script_path} && {script_path}"
+        fallback_from = {
+            "reason": result.event.reason_code,
+            "exit_code": res.exit_code,
+            "duration_ms": res.duration_ms,
+            "stderr_tail": res.stderr[-200:],
+        }
 
-        delivery = "stdin" if source else "upload"
-        res = await runner.run(command, timeout=timeout, retryable=False, stdin_text=source)
+        try:
+            remote_dir = await upload_validation_files(ctx)
+        except UploadFailed as exc:
+            event = render_message(
+                Msg.SCRAPE_FAILED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={
+                    "delivery": "stdin",
+                    "fallback_from": fallback_from,
+                    "fallback_upload_error": str(exc),
+                },
+            )
+            return CheckResult(passed=False, event=event)
+
+        res = await ctx.runner.run(
+            _binary_command(remote_dir, ctx.config.machine_scrape_filename),
+            timeout=timeout,
+            retryable=False,
+        )
+        return self._result(
+            ctx, res, delivery="upload", remote_dir=remote_dir, fallback_from=fallback_from
+        )
+
+    async def _scrape_uploaded_binary(self, ctx: Context, timeout: int) -> CheckResult:
+        # run the frozen scrape that UploadFilesCheck put on the executor
+        remote_dir = ctx.state.remote_dir
+        if not remote_dir:
+            event = render_message(
+                Msg.REMOTE_DIR_MISSING,
+                ctx=ctx,
+                check_id=self.check_id,
+            )
+            return CheckResult(passed=False, event=event)
+
+        script_filename = ctx.config.machine_scrape_filename
+        if not script_filename:
+            event = render_message(
+                Msg.CONFIG_MISSING,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={"machine_scrape_filename": script_filename},
+            )
+            return CheckResult(passed=False, event=event)
+
+        res = await ctx.runner.run(
+            _binary_command(remote_dir, script_filename), timeout=timeout, retryable=False
+        )
+        return self._result(ctx, res, delivery="upload")
+
+    def _result(
+        self,
+        ctx: Context,
+        res: SSHCommandResult,
+        *,
+        delivery: str,
+        remote_dir: str | None = None,
+        fallback_from: dict[str, Any] | None = None,
+    ) -> CheckResult:
+        # turn one scrape run into specs on the state, or into the event that says why not
+        what: dict[str, Any] = {"delivery": delivery}
+        if fallback_from:
+            what["fallback_from"] = fallback_from
 
         if not res.success or not res.stdout.strip():
             event = render_message(
@@ -104,10 +178,10 @@ class MachineSpecScrapeCheck:
                 ctx=ctx,
                 check_id=self.check_id,
                 what={
+                    **what,
                     "command_id": res.command_id,
                     "exit_code": res.exit_code,
                     "duration_ms": res.duration_ms,
-                    "delivery": delivery,
                     "stderr_tail": res.stderr[-400:],
                 },
             )
@@ -169,9 +243,9 @@ class MachineSpecScrapeCheck:
                 ctx=ctx,
                 check_id=self.check_id,
                 what={
+                    **what,
                     "gpu_count": gpu_count,
                     "gpu_model": gpu_model,
-                    "delivery": delivery,
                     "network": specs.get("network"),
                 },
                 extra=extra_info,
@@ -189,6 +263,10 @@ class MachineSpecScrapeCheck:
                 gpu_model_count=gpu_model_count,
                 gpu_uuids=gpu_uuids,
             )
+            if remote_dir:
+                updated_state = replace(
+                    updated_state, remote_dir=remote_dir, upload_remote_dir=remote_dir
+                )
 
             updates: dict[str, object] = {"state": updated_state, "default_extra": {**ctx.default_extra, **extra_info}}
             return CheckResult(passed=True, event=event, updates=updates)
@@ -198,6 +276,6 @@ class MachineSpecScrapeCheck:
                 Msg.SCRAPE_PARSE_FAILED,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={"exception": str(exc)[:300], "stdout_head": res.stdout[:200]},
+                what={**what, "exception": str(exc)[:300], "stdout_head": res.stdout[:200]},
             )
             return CheckResult(passed=False, event=event)

--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -13,9 +13,10 @@ from services.gpu_spec_table import normalize_gpu_model
 from .network_ema import compute_ema
 from .upload_files import UploadFailed, upload_validation_files
 
-# DAH-2794: how fast the stdin attempt must fail for the binary fallback to still fit the
-# 780 s per-executor budget. An interpreter that cannot run the source rejects it in ~2 s.
-FALLBACK_AFTER_MS = 60_000
+# DAH-2794: how fast the stdin attempt must fail for the binary fallback to still be worth it.
+# An interpreter that cannot run the source rejects it in ~2 s, so this ceiling keeps the fallback
+# path within the flag-off path plus 10 s — and that one already runs against the 780 s budget.
+FALLBACK_AFTER_MS = 10_000
 
 
 def _update_keys(data: Any, key_mapping: dict[str, str]) -> Any:
@@ -50,6 +51,26 @@ def _normalize_gpu_details(gpu_details: list[dict[str, Any]]) -> list[dict[str, 
     ]
 
 
+def _decrypt_payload(ctx: Context, stdout: str) -> str:
+    # find the scrape's ciphertext among the executor's stdout lines and decrypt it
+    #
+    # The payload is the scrape's own print, but the image decides what else lands on stdout: a
+    # .pth or sitecustomize prints before it, an atexit handler after it. Fernet authenticates, so
+    # a wrong line raises instead of decoding — trying them newest-first costs nothing and beats
+    # betting on a fixed position.
+    if not ctx.encrypt_key:
+        raise ValueError("Missing encrypt_key in context")
+
+    last_exc: Exception | None = None
+    for line in reversed([ln.strip() for ln in stdout.splitlines() if ln.strip()]):
+        try:
+            return ctx.services.ssh.decrypt_payload(ctx.encrypt_key, line)
+        except Exception as exc:
+            last_exc = exc
+
+    raise last_exc or ValueError("Scrape produced no output to decrypt")
+
+
 def _binary_command(remote_dir: str, script_filename: str) -> str:
     script_path = f"{remote_dir.rstrip('/')}/{script_filename.lstrip('/')}"
     return f"chmod +x {script_path} && {script_path}"
@@ -81,7 +102,7 @@ class MachineSpecScrapeCheck:
         # `-I` implies -E -s -P, which drops PYTHONPATH, the user site-dir and the cwd entry
         # from sys.path, so a file left next to the SSH login shell cannot shadow psutil or
         # json. It does not disable site processing: a .pth or sitecustomize inside the image
-        # still runs, which is why the payload is read off the last line rather than the first.
+        # still runs and prints, which is what `_decrypt_payload` searches through.
         command = f"{shlex.quote(ctx.executor.python_path)} -I -"
         res = await ctx.runner.run(
             command,
@@ -101,12 +122,9 @@ class MachineSpecScrapeCheck:
         if res.duration_ms > FALLBACK_AFTER_MS or not ctx.config.machine_scrape_filename:
             return result
 
-        fallback_from = {
-            "reason": result.event.reason_code,
-            "exit_code": res.exit_code,
-            "duration_ms": res.duration_ms,
-            "stderr_tail": res.stderr[-200:],
-        }
+        # The stdin attempt's own event is discarded with the retry, so carry it whole: a run that
+        # exited 0 and produced an unreadable payload says nothing in exit_code or stderr.
+        fallback_from = {"reason": result.event.reason_code, **result.event.what_we_saw}
 
         try:
             remote_dir = await upload_validation_files(ctx)
@@ -188,13 +206,7 @@ class MachineSpecScrapeCheck:
             return CheckResult(passed=False, event=event)
 
         try:
-            # Last line, not first: the payload is the scrape's final print, and a .pth or
-            # sitecustomize in the executor image can put its own line in front of it.
-            line = [ln for ln in res.stdout.splitlines() if ln.strip()][-1].strip()
-            if not ctx.encrypt_key:
-                raise ValueError("Missing encrypt_key in context")
-
-            decrypted = ctx.services.ssh.decrypt_payload(ctx.encrypt_key, line)
+            decrypted = _decrypt_payload(ctx, res.stdout)
             raw = json.loads(decrypted)
             obfuscation_keys = ctx.config.obfuscation_keys
             specs = _deobfuscate(raw, obfuscation_keys)

--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import shlex
 from dataclasses import replace
-from typing import Any
+from typing import Any, Literal
 
 from ..messages import MachineSpecMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
@@ -13,12 +13,24 @@ from services.gpu_spec_table import normalize_gpu_model
 from .network_ema import compute_ema
 from .upload_files import UploadFailed, upload_validation_files
 
-# DAH-2794: how late a failed stdin attempt may still be retried with the binary. Above a full
-# scrape (~15 s on a real box, so a payload that will not decrypt is only knowable around then),
-# below the point where the retry stops fitting: 60 s here + 300 s upload + 300 s scrape = 660 s
-# against the 780 s per-executor timeout. The upload gets one attempt for exactly that reason.
-FALLBACK_AFTER_MS = 60_000
+# DAH-2794: how long a failed stdin attempt may have taken and still be worth retrying with the
+# binary. Above a full scrape (~15 s on a real box, so a payload that will not decrypt is only
+# knowable around then), below the point where the retry stops fitting: 60 s here + 300 s upload
+# + 300 s scrape = 660 s against the 780 s per-executor timeout. The upload gets one attempt for
+# exactly that reason.
+FALLBACK_MAX_STDIN_DURATION_MS = 60_000
 FALLBACK_UPLOAD_ATTEMPTS = 1
+
+# The scrape says only two things on stdout: a Fernet token when it worked, and a JSON object
+# with an "error" key when it ran but had nothing to report. Every Fernet token is base64url of
+# a 0x80 version byte, so this prefix separates ours from whatever the miner's image printed.
+FERNET_TOKEN_PREFIX = "gAAAAA"
+
+# How much stdout the miner puts in front of the scrape's own line is his choice, not a bounded
+# amount, so only the tail is searched and only so many candidates are decrypted — both run
+# synchronously on the event loop shared with every other executor in the cycle.
+STDOUT_SEARCH_TAIL_BYTES = 256 * 1024
+MAX_PAYLOAD_DECRYPT_ATTEMPTS = 20
 
 
 def _update_keys(data: Any, key_mapping: dict[str, str]) -> Any:
@@ -54,23 +66,42 @@ def _normalize_gpu_details(gpu_details: list[dict[str, Any]]) -> list[dict[str, 
 
 
 def _decrypt_payload(ctx: Context, stdout: str) -> str:
-    # find the scrape's ciphertext among the executor's stdout lines and decrypt it
+    # decrypt the scrape's Fernet token out of whatever else the executor printed
     #
-    # The payload is the scrape's own print, but the image decides what else lands on stdout: a
-    # .pth or sitecustomize prints before it, an atexit handler after it. Fernet authenticates, so
-    # a wrong line raises instead of decoding — trying them newest-first costs nothing and beats
+    # The token is the scrape's own print, but the image decides what surrounds it: a .pth or
+    # sitecustomize prints before it, an atexit handler after it. Searching newest-first beats
     # betting on a fixed position.
     if not ctx.encrypt_key:
         raise ValueError("Missing encrypt_key in context")
 
     last_exc: Exception | None = None
-    for line in reversed([ln.strip() for ln in stdout.splitlines() if ln.strip()]):
+    attempts = 0
+    for line in reversed(stdout[-STDOUT_SEARCH_TAIL_BYTES:].splitlines()):
+        candidate = line.strip()
+        if not candidate.startswith(FERNET_TOKEN_PREFIX):
+            continue
         try:
-            return ctx.services.ssh.decrypt_payload(ctx.encrypt_key, line)
+            return ctx.services.ssh.decrypt_payload(ctx.encrypt_key, candidate)
         except Exception as exc:
             last_exc = exc
+        attempts += 1
+        if attempts == MAX_PAYLOAD_DECRYPT_ATTEMPTS:
+            break
 
-    raise last_exc or ValueError("Scrape produced no output to decrypt")
+    raise last_exc or ValueError("No scrape payload on stdout")
+
+
+def _scrape_reported_its_own_failure(stdout: str) -> bool:
+    # the scrape prints {"error": ...} as its last line and exits non-zero when it ran but found
+    # nothing to report; a source the interpreter could not run prints nothing of ours at all
+    lines = [line for line in stdout[-STDOUT_SEARCH_TAIL_BYTES:].splitlines() if line.strip()]
+    if not lines:
+        return False
+    try:
+        report = json.loads(lines[-1])
+    except ValueError:
+        return False
+    return isinstance(report, dict) and "error" in report
 
 
 def _binary_command(remote_dir: str, script_filename: str) -> str:
@@ -94,7 +125,7 @@ class MachineSpecScrapeCheck:
     async def run(self, ctx: Context) -> CheckResult:
         timeout = ctx.config.machine_scrape_timeout or self.DEFAULT_TIMEOUT
 
-        if ctx.state.scrape_over_stdin:
+        if ctx.config.machine_scrape_source:
             return await self._scrape_from_source(ctx, timeout)
         return await self._scrape_uploaded_binary(ctx, timeout)
 
@@ -106,21 +137,29 @@ class MachineSpecScrapeCheck:
         # json. It does not disable site processing: a .pth or sitecustomize inside the image
         # still runs and prints, which is what `_decrypt_payload` searches through.
         command = f"{shlex.quote(ctx.executor.python_path)} -I -"
-        res = await ctx.runner.run(
+        scrape_run = await ctx.runner.run(
             command,
             timeout=timeout,
             retryable=False,
             stdin_text=ctx.config.machine_scrape_source,
         )
-        result = self._result(ctx, res, delivery="stdin")
+        result = self._check_result_from_scrape_run(ctx, scrape_run, delivery="stdin")
         if result.passed:
             return result
 
         # The source did not run here: wrong interpreter, no psutil, or a cryptography too old
         # to produce a token this validator can read. The binary carries its own interpreter and
-        # every dependency, so retry with it. Only up to FALLBACK_AFTER_MS, though — past that the
-        # scrape hung rather than failed to start, and the binary runs the very same code.
-        if res.duration_ms > FALLBACK_AFTER_MS or not ctx.config.machine_scrape_filename:
+        # every dependency, so retry with it — but past FALLBACK_MAX_STDIN_DURATION_MS the scrape
+        # hung rather than failed to start, and the binary runs the very same code.
+        if (
+            scrape_run.duration_ms > FALLBACK_MAX_STDIN_DURATION_MS
+            or not ctx.config.machine_scrape_filename
+        ):
+            return result
+
+        # The scrape reporting its own failure (no GPU details, for one) means the interpreter
+        # ran it, so the binary would print the same thing for the price of a 13 MB upload.
+        if scrape_run.exit_code != 0 and _scrape_reported_its_own_failure(scrape_run.stdout):
             return result
 
         # The stdin attempt's own event is discarded with the retry, so carry it whole: a run that
@@ -142,13 +181,13 @@ class MachineSpecScrapeCheck:
             )
             return CheckResult(passed=False, event=event)
 
-        res = await ctx.runner.run(
+        scrape_run = await ctx.runner.run(
             _binary_command(remote_dir, ctx.config.machine_scrape_filename),
             timeout=timeout,
             retryable=False,
         )
-        return self._result(
-            ctx, res, delivery="upload", remote_dir=remote_dir, fallback_from=fallback_from
+        return self._check_result_from_scrape_run(
+            ctx, scrape_run, delivery="upload", fallback_from=fallback_from
         )
 
     async def _scrape_uploaded_binary(self, ctx: Context, timeout: int) -> CheckResult:
@@ -172,42 +211,40 @@ class MachineSpecScrapeCheck:
             )
             return CheckResult(passed=False, event=event)
 
-        res = await ctx.runner.run(
+        scrape_run = await ctx.runner.run(
             _binary_command(remote_dir, script_filename), timeout=timeout, retryable=False
         )
-        return self._result(ctx, res, delivery="upload")
+        return self._check_result_from_scrape_run(ctx, scrape_run, delivery="upload")
 
-    def _result(
+    def _check_result_from_scrape_run(
         self,
         ctx: Context,
-        res: SSHCommandResult,
+        scrape_run: SSHCommandResult,
         *,
-        delivery: str,
-        remote_dir: str | None = None,
+        delivery: Literal["stdin", "upload"],
         fallback_from: dict[str, Any] | None = None,
     ) -> CheckResult:
-        # turn one scrape run into specs on the state, or into the event that says why not
         what: dict[str, Any] = {"delivery": delivery}
         if fallback_from:
             what["fallback_from"] = fallback_from
 
-        if not res.success or not res.stdout.strip():
+        if not scrape_run.success or not scrape_run.stdout.strip():
             event = render_message(
                 Msg.SCRAPE_FAILED,
                 ctx=ctx,
                 check_id=self.check_id,
                 what={
                     **what,
-                    "command_id": res.command_id,
-                    "exit_code": res.exit_code,
-                    "duration_ms": res.duration_ms,
-                    "stderr_tail": res.stderr[-400:],
+                    "command_id": scrape_run.command_id,
+                    "exit_code": scrape_run.exit_code,
+                    "duration_ms": scrape_run.duration_ms,
+                    "stderr_tail": scrape_run.stderr[-400:],
                 },
             )
             return CheckResult(passed=False, event=event)
 
         try:
-            decrypted = _decrypt_payload(ctx, res.stdout)
+            decrypted = _decrypt_payload(ctx, scrape_run.stdout)
             raw = json.loads(decrypted)
             obfuscation_keys = ctx.config.obfuscation_keys
             specs = _deobfuscate(raw, obfuscation_keys)
@@ -276,11 +313,6 @@ class MachineSpecScrapeCheck:
                 gpu_model_count=gpu_model_count,
                 gpu_uuids=gpu_uuids,
             )
-            if remote_dir:
-                updated_state = replace(
-                    updated_state, remote_dir=remote_dir, upload_remote_dir=remote_dir
-                )
-
             updates: dict[str, object] = {"state": updated_state, "default_extra": {**ctx.default_extra, **extra_info}}
             return CheckResult(passed=True, event=event, updates=updates)
 
@@ -289,6 +321,6 @@ class MachineSpecScrapeCheck:
                 Msg.SCRAPE_PARSE_FAILED,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={**what, "exception": str(exc)[:300], "stdout_head": res.stdout[:200]},
+                what={**what, "exception": str(exc)[:300], "stdout_head": scrape_run.stdout[:200]},
             )
             return CheckResult(passed=False, event=event)

--- a/neurons/validators/src/services/task/checks/machine_spec_scrape.py
+++ b/neurons/validators/src/services/task/checks/machine_spec_scrape.py
@@ -13,10 +13,12 @@ from services.gpu_spec_table import normalize_gpu_model
 from .network_ema import compute_ema
 from .upload_files import UploadFailed, upload_validation_files
 
-# DAH-2794: how fast the stdin attempt must fail for the binary fallback to still be worth it.
-# An interpreter that cannot run the source rejects it in ~2 s, so this ceiling keeps the fallback
-# path within the flag-off path plus 10 s — and that one already runs against the 780 s budget.
-FALLBACK_AFTER_MS = 10_000
+# DAH-2794: how late a failed stdin attempt may still be retried with the binary. Above a full
+# scrape (~15 s on a real box, so a payload that will not decrypt is only knowable around then),
+# below the point where the retry stops fitting: 60 s here + 300 s upload + 300 s scrape = 660 s
+# against the 780 s per-executor timeout. The upload gets one attempt for exactly that reason.
+FALLBACK_AFTER_MS = 60_000
+FALLBACK_UPLOAD_ATTEMPTS = 1
 
 
 def _update_keys(data: Any, key_mapping: dict[str, str]) -> Any:
@@ -116,9 +118,8 @@ class MachineSpecScrapeCheck:
 
         # The source did not run here: wrong interpreter, no psutil, or a cryptography too old
         # to produce a token this validator can read. The binary carries its own interpreter and
-        # every dependency, so retry with it. Only after a fast failure, though — a slow one
-        # means the scrape got past its cheap part, and a second full attempt plus the upload
-        # would not fit the per-executor budget.
+        # every dependency, so retry with it. Only up to FALLBACK_AFTER_MS, though — past that the
+        # scrape hung rather than failed to start, and the binary runs the very same code.
         if res.duration_ms > FALLBACK_AFTER_MS or not ctx.config.machine_scrape_filename:
             return result
 
@@ -127,7 +128,7 @@ class MachineSpecScrapeCheck:
         fallback_from = {"reason": result.event.reason_code, **result.event.what_we_saw}
 
         try:
-            remote_dir = await upload_validation_files(ctx)
+            remote_dir = await upload_validation_files(ctx, attempts=FALLBACK_UPLOAD_ATTEMPTS)
         except UploadFailed as exc:
             event = render_message(
                 Msg.SCRAPE_FAILED,

--- a/neurons/validators/src/services/task/checks/upload_files.py
+++ b/neurons/validators/src/services/task/checks/upload_files.py
@@ -15,8 +15,8 @@ class UploadFailed(Exception):
     """The validation assets never reached the executor."""
 
 
-async def upload_validation_files(ctx: Context, *, attempts: int = MAX_RETRIES) -> str:
-    # copy the local validation assets into a fresh random directory on the executor
+async def upload_validation_files_to_fresh_remote_dir(ctx: Context, *, attempts: int = MAX_RETRIES) -> str:
+    # copy the local validation assets into a fresh random directory on the executor, and name it
     local_dir = ctx.state.upload_local_dir
     executor_root = ctx.config.executor_root
     if not local_dir or not executor_root:
@@ -80,7 +80,7 @@ class UploadFilesCheck:
             return CheckResult(passed=False, event=event)
 
         try:
-            remote_dir = await upload_validation_files(ctx)
+            remote_dir = await upload_validation_files_to_fresh_remote_dir(ctx)
         except UploadFailed as exc:
             event = render_message(
                 Msg.UPLOAD_FAILED,

--- a/neurons/validators/src/services/task/checks/upload_files.py
+++ b/neurons/validators/src/services/task/checks/upload_files.py
@@ -63,11 +63,7 @@ class UploadFilesCheck:
                 check_id=self.check_id,
                 what={"python_path": ctx.executor.python_path},
             )
-            return CheckResult(
-                passed=True,
-                event=event,
-                updates={"state": replace(ctx.state, scrape_over_stdin=True)},
-            )
+            return CheckResult(passed=True, event=event)
 
         local_dir = ctx.state.upload_local_dir
         executor_root = ctx.config.executor_root

--- a/neurons/validators/src/services/task/checks/upload_files.py
+++ b/neurons/validators/src/services/task/checks/upload_files.py
@@ -1,14 +1,45 @@
 from __future__ import annotations
 
 import asyncio
-import shlex
 import uuid
 from dataclasses import replace
 
 from ..messages import UploadFilesMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
-PROBE_TIMEOUT = 30
+UPLOAD_TIMEOUT = 300
+MAX_RETRIES = 2
+
+
+class UploadFailed(Exception):
+    """The validation assets never reached the executor."""
+
+
+async def upload_validation_files(ctx: Context) -> str:
+    # copy the local validation assets into a fresh random directory on the executor
+    local_dir = ctx.state.upload_local_dir
+    executor_root = ctx.config.executor_root
+    if not local_dir or not executor_root:
+        raise UploadFailed(f"missing upload config: local_dir={local_dir}, executor_root={executor_root}")
+
+    remote_dir = f"{executor_root.rstrip('/')}/{uuid.uuid4().hex}"
+    last_exc: Exception | None = None
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            async with asyncio.timeout(UPLOAD_TIMEOUT):
+                async with ctx.ssh.start_sftp_client() as sftp:
+                    await sftp.put(local_dir, remote_dir, recurse=True)
+            return remote_dir
+        except asyncio.TimeoutError:
+            # A retry would only re-spend the same 300 s against the same slow uplink.
+            raise UploadFailed(f"Upload timed out after {UPLOAD_TIMEOUT} seconds")
+        except Exception as exc:
+            last_exc = exc
+            if attempt < MAX_RETRIES:
+                await asyncio.sleep(1.0 * attempt)
+
+    raise UploadFailed(str(last_exc)[:200])
 
 
 class UploadFilesCheck:
@@ -22,14 +53,10 @@ class UploadFilesCheck:
     fatal = True
 
     async def run(self, ctx: Context) -> CheckResult:
-        local_dir = ctx.state.upload_local_dir
-        executor_root = ctx.config.executor_root
-        DEFAULT_TIMEOUT = 300
-
-        # DAH-2794: the scrape can travel down stdin instead of being uploaded, but only to an
-        # executor whose interpreter can actually run it. The miner picks the executor image, so
-        # that is a per-node question and it is asked here, not assumed from the flag.
-        if ctx.config.machine_scrape_source and await self._can_run_source(ctx):
+        # DAH-2794: with the source in hand there is nothing to upload — the scrape travels
+        # down stdin instead. Whether this executor's interpreter can actually run it is not
+        # guessed here: MachineSpecScrapeCheck tries, and uploads the binary itself if it cannot.
+        if ctx.config.machine_scrape_source:
             event = render_message(
                 Msg.UPLOAD_SKIPPED,
                 ctx=ctx,
@@ -42,6 +69,8 @@ class UploadFilesCheck:
                 updates={"state": replace(ctx.state, scrape_over_stdin=True)},
             )
 
+        local_dir = ctx.state.upload_local_dir
+        executor_root = ctx.config.executor_root
         if not local_dir or not executor_root:
             event = render_message(
                 Msg.CONFIG_MISSING,
@@ -54,62 +83,26 @@ class UploadFilesCheck:
             )
             return CheckResult(passed=False, event=event)
 
-        random_name = uuid.uuid4().hex
-        remote_dir = f"{executor_root.rstrip('/')}/{random_name}"
-
-        MAX_RETRIES = 2
-        last_exc: Exception | None = None
-
-        for attempt in range(1, MAX_RETRIES + 1):
-            try:
-                async with asyncio.timeout(DEFAULT_TIMEOUT):
-                    async with ctx.ssh.start_sftp_client() as sftp:
-                        await sftp.put(local_dir, remote_dir, recurse=True)
-
-                event = render_message(
-                    Msg.UPLOAD_OK,
-                    ctx=ctx,
-                    check_id=self.check_id,
-                    what={"remote_dir": remote_dir, "local_dir": local_dir},
-                )
-                updated_state = replace(
-                    ctx.state,
-                    upload_remote_dir=remote_dir,
-                    remote_dir=remote_dir,
-                )
-                return CheckResult(
-                    passed=True,
-                    event=event,
-                    updates={"state": updated_state},
-                )
-            except asyncio.TimeoutError:
-                event = render_message(
-                    Msg.UPLOAD_FAILED,
-                    ctx=ctx,
-                    check_id=self.check_id,
-                    what={"error": f"Upload timed out after {DEFAULT_TIMEOUT} seconds"},
-                )
-                return CheckResult(passed=False, event=event)
-            except Exception as exc:
-                last_exc = exc
-                if attempt < MAX_RETRIES:
-                    await asyncio.sleep(1.0 * attempt)
+        try:
+            remote_dir = await upload_validation_files(ctx)
+        except UploadFailed as exc:
+            event = render_message(
+                Msg.UPLOAD_FAILED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={"error": str(exc)},
+            )
+            return CheckResult(passed=False, event=event)
 
         event = render_message(
-            Msg.UPLOAD_FAILED,
+            Msg.UPLOAD_OK,
             ctx=ctx,
             check_id=self.check_id,
-            what={"error": str(last_exc)[:200]},
+            what={"remote_dir": remote_dir, "local_dir": local_dir},
         )
-        return CheckResult(passed=False, event=event)
-
-    async def _can_run_source(self, ctx: Context) -> bool:
-        # Cheap, per-cycle: one round trip, no bytes. Names exactly what the scrape imports —
-        # an image predating either dependency cannot run the source and must get the binary.
-        python_path = ctx.executor.python_path
-        if not python_path:
-            return False
-
-        probe = f"{shlex.quote(python_path)} -I -c 'import psutil, cryptography.fernet'"
-        res = await ctx.runner.run(probe, timeout=PROBE_TIMEOUT, retryable=False)
-        return res.success
+        updated_state = replace(
+            ctx.state,
+            upload_remote_dir=remote_dir,
+            remote_dir=remote_dir,
+        )
+        return CheckResult(passed=True, event=event, updates={"state": updated_state})

--- a/neurons/validators/src/services/task/checks/upload_files.py
+++ b/neurons/validators/src/services/task/checks/upload_files.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import asyncio
+import shlex
 import uuid
 from dataclasses import replace
 
 from ..messages import UploadFilesMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
+
+PROBE_TIMEOUT = 30
 
 
 class UploadFilesCheck:
@@ -22,6 +25,22 @@ class UploadFilesCheck:
         local_dir = ctx.state.upload_local_dir
         executor_root = ctx.config.executor_root
         DEFAULT_TIMEOUT = 300
+
+        # DAH-2794: the scrape can travel down stdin instead of being uploaded, but only to an
+        # executor whose interpreter can actually run it. The miner picks the executor image, so
+        # that is a per-node question and it is asked here, not assumed from the flag.
+        if ctx.config.machine_scrape_source and await self._can_run_source(ctx):
+            event = render_message(
+                Msg.UPLOAD_SKIPPED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={"python_path": ctx.executor.python_path},
+            )
+            return CheckResult(
+                passed=True,
+                event=event,
+                updates={"state": replace(ctx.state, scrape_over_stdin=True)},
+            )
 
         if not local_dir or not executor_root:
             event = render_message(
@@ -83,3 +102,14 @@ class UploadFilesCheck:
             what={"error": str(last_exc)[:200]},
         )
         return CheckResult(passed=False, event=event)
+
+    async def _can_run_source(self, ctx: Context) -> bool:
+        # Cheap, per-cycle: one round trip, no bytes. Names exactly what the scrape imports —
+        # an image predating either dependency cannot run the source and must get the binary.
+        python_path = ctx.executor.python_path
+        if not python_path:
+            return False
+
+        probe = f"{shlex.quote(python_path)} -I -c 'import psutil, cryptography.fernet'"
+        res = await ctx.runner.run(probe, timeout=PROBE_TIMEOUT, retryable=False)
+        return res.success

--- a/neurons/validators/src/services/task/checks/upload_files.py
+++ b/neurons/validators/src/services/task/checks/upload_files.py
@@ -15,7 +15,7 @@ class UploadFailed(Exception):
     """The validation assets never reached the executor."""
 
 
-async def upload_validation_files(ctx: Context) -> str:
+async def upload_validation_files(ctx: Context, *, attempts: int = MAX_RETRIES) -> str:
     # copy the local validation assets into a fresh random directory on the executor
     local_dir = ctx.state.upload_local_dir
     executor_root = ctx.config.executor_root
@@ -25,7 +25,7 @@ async def upload_validation_files(ctx: Context) -> str:
     remote_dir = f"{executor_root.rstrip('/')}/{uuid.uuid4().hex}"
     last_exc: Exception | None = None
 
-    for attempt in range(1, MAX_RETRIES + 1):
+    for attempt in range(1, attempts + 1):
         try:
             async with asyncio.timeout(UPLOAD_TIMEOUT):
                 async with ctx.ssh.start_sftp_client() as sftp:
@@ -36,7 +36,7 @@ async def upload_validation_files(ctx: Context) -> str:
             raise UploadFailed(f"Upload timed out after {UPLOAD_TIMEOUT} seconds")
         except Exception as exc:
             last_exc = exc
-            if attempt < MAX_RETRIES:
+            if attempt < attempts:
                 await asyncio.sleep(1.0 * attempt)
 
     raise UploadFailed(str(last_exc)[:200])

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -98,6 +98,13 @@ class UploadFilesMessages:
         category="prep",
         impact="Proceed to validation",
     )
+    UPLOAD_SKIPPED = MessageTemplate(
+        event="Validation files not uploaded",
+        reason="UPLOAD_SKIPPED",
+        severity="info",
+        category="prep",
+        impact="Proceed to validation",
+    )
     UPLOAD_FAILED = MessageTemplate(
         event="Failed to upload validation files",
         reason="UPLOAD_FAILED",

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -94,8 +94,8 @@ class ContextState:
     upload_local_dir: Optional[str] = None
     upload_remote_dir: Optional[str] = None
     remote_dir: Optional[str] = None
-    # DAH-2794: set by UploadFilesCheck once it has established that this executor's own
-    # interpreter can run the scrape. True => nothing was uploaded, the source goes over stdin.
+    # DAH-2794: set by UploadFilesCheck when the scrape source is available. True => nothing was
+    # uploaded; MachineSpecScrapeCheck pipes the source in and uploads the binary only if it fails.
     scrape_over_stdin: bool = False
     specs: dict[str, Any] = field(default_factory=dict)
     gpu_model: Optional[str] = None

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -94,9 +94,6 @@ class ContextState:
     upload_local_dir: Optional[str] = None
     upload_remote_dir: Optional[str] = None
     remote_dir: Optional[str] = None
-    # DAH-2794: set by UploadFilesCheck when the scrape source is available. True => nothing was
-    # uploaded; MachineSpecScrapeCheck pipes the source in and uploads the binary only if it fails.
-    scrape_over_stdin: bool = False
     specs: dict[str, Any] = field(default_factory=dict)
     gpu_model: Optional[str] = None
     gpu_count: Optional[int] = None

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -84,6 +84,9 @@ class ContextConfig:
     port_private_key: Optional[str] = None
     port_public_key: Optional[str] = None
     job_batch_id: Optional[str] = None
+    # DAH-2794: obfuscated scrape source, piped to the executor's interpreter over stdin.
+    # None => the legacy path, where the scrape is a binary uploaded by UploadFilesCheck.
+    machine_scrape_source: Optional[str] = None
 
 
 @dataclass(frozen=True)
@@ -91,6 +94,9 @@ class ContextState:
     upload_local_dir: Optional[str] = None
     upload_remote_dir: Optional[str] = None
     remote_dir: Optional[str] = None
+    # DAH-2794: set by UploadFilesCheck once it has established that this executor's own
+    # interpreter can run the scrape. True => nothing was uploaded, the source goes over stdin.
+    scrape_over_stdin: bool = False
     specs: dict[str, Any] = field(default_factory=dict)
     gpu_model: Optional[str] = None
     gpu_count: Optional[int] = None

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -210,6 +210,7 @@ class PipelineFactory:
                 compute_rest_app_url=settings.COMPUTE_REST_API_URL,
                 gpu_monitor_script_relative="src/gpus_utility.py",
                 machine_scrape_filename=encrypted_files.machine_scrape_file_name,
+                machine_scrape_source=encrypted_files.machine_scrape_source,
                 machine_scrape_timeout=JOB_LENGTH,
                 obfuscation_keys=encrypted_files.all_keys,
                 default_docker_image_digests=default_docker_image_digests,

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -210,7 +210,14 @@ class PipelineFactory:
                 compute_rest_app_url=settings.COMPUTE_REST_API_URL,
                 gpu_monitor_script_relative="src/gpus_utility.py",
                 machine_scrape_filename=encrypted_files.machine_scrape_file_name,
-                machine_scrape_source=encrypted_files.machine_scrape_source,
+                # DAH-2794: an executor that can run the source needs no upload at all. The
+                # binary stays built because the miner picks the executor image, and one that
+                # predates a dependency the scrape imports has to keep the self-contained path.
+                machine_scrape_source=(
+                    encrypted_files.machine_scrape_source
+                    if settings.ENABLE_SCRAPE_SOURCE_DELIVERY
+                    else None
+                ),
                 machine_scrape_timeout=JOB_LENGTH,
                 obfuscation_keys=encrypted_files.all_keys,
                 default_docker_image_digests=default_docker_image_digests,

--- a/neurons/validators/src/services/task/runner.py
+++ b/neurons/validators/src/services/task/runner.py
@@ -36,6 +36,7 @@ class SSHCommandRunner:
         timeout: int = 60,
         check: bool = False,
         retryable: bool = True,
+        stdin_text: str | None = None,
     ) -> SSHCommandResult:
         """Run a command and capture stdout/stderr safely."""
         attempt = 0
@@ -47,7 +48,7 @@ class SSHCommandRunner:
             start = datetime.now(UTC)
             t0 = time.perf_counter()
             try:
-                result = await asyncio.wait_for(self.ssh.run(cmd), timeout=timeout)
+                result = await asyncio.wait_for(self.ssh.run(cmd, input=stdin_text), timeout=timeout)
                 dt = int((time.perf_counter() - t0) * 1000)
                 stdout = str(result.stdout) or ""
                 stderr = str(result.stderr) or ""

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -61,8 +61,10 @@ class DummySFTPClient:
         self.should_raise = should_raise
         self.error_message = error_message
         self.put_called_with: dict | None = None
+        self.put_call_count = 0
 
     async def put(self, local_path: str, remote_path: str, recurse: bool = False):
+        self.put_call_count += 1
         self.put_called_with = {
             "local_path": local_path,
             "remote_path": remote_path,

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock
@@ -54,22 +55,30 @@ def dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
     raise AssertionError(f"{dict_name} dict literal not found")
 
 
+# Every Fernet token is base64url of a 0x80 version byte, so all of them start with "gAAAAA" —
+# and MachineSpecScrapeCheck only tries to decrypt the stdout lines shaped like that.
+FERNET_TOKEN = "gAAAAABscrape-payload"
+
+
+@dataclass(frozen=True)
+class SFTPPutCall:
+    local_path: str
+    remote_path: str
+    recurse: bool
+
+
 class DummySFTPClient:
     """Mock SFTP client that simulates file upload."""
 
     def __init__(self, *, should_raise: bool = False, error_message: str = ""):
         self.should_raise = should_raise
         self.error_message = error_message
-        self.put_called_with: dict | None = None
+        self.put_called_with: SFTPPutCall | None = None
         self.put_call_count = 0
 
-    async def put(self, local_path: str, remote_path: str, recurse: bool = False):
+    async def put(self, local_path: str, remote_path: str, recurse: bool = False) -> None:
         self.put_call_count += 1
-        self.put_called_with = {
-            "local_path": local_path,
-            "remote_path": remote_path,
-            "recurse": recurse,
-        }
+        self.put_called_with = SFTPPutCall(local_path, remote_path, recurse)
         if self.should_raise:
             raise RuntimeError(self.error_message)
 

--- a/neurons/validators/tests/helpers.py
+++ b/neurons/validators/tests/helpers.py
@@ -54,6 +54,43 @@ def dict_literal_keys(module: ast.Module, dict_name: str) -> list[str]:
     raise AssertionError(f"{dict_name} dict literal not found")
 
 
+class DummySFTPClient:
+    """Mock SFTP client that simulates file upload."""
+
+    def __init__(self, *, should_raise: bool = False, error_message: str = ""):
+        self.should_raise = should_raise
+        self.error_message = error_message
+        self.put_called_with: dict | None = None
+
+    async def put(self, local_path: str, remote_path: str, recurse: bool = False):
+        self.put_called_with = {
+            "local_path": local_path,
+            "remote_path": remote_path,
+            "recurse": recurse,
+        }
+        if self.should_raise:
+            raise RuntimeError(self.error_message)
+
+
+class DummySSHClient:
+    """Mock SSH client that provides SFTP access."""
+
+    def __init__(self, *, sftp_should_raise: bool = False, sftp_error: str = ""):
+        self.sftp_client = DummySFTPClient(
+            should_raise=sftp_should_raise,
+            error_message=sftp_error,
+        )
+
+    def start_sftp_client(self):
+        return self
+
+    async def __aenter__(self):
+        return self.sftp_client
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
 class DummyScoreCalc:
     def __call__(self, *args, **kwargs):  # pragma: no cover
         return 0.0, 0.0, ""

--- a/neurons/validators/tests/test_gpu_wedge_teardown_sweep.py
+++ b/neurons/validators/tests/test_gpu_wedge_teardown_sweep.py
@@ -45,7 +45,7 @@ async def test_sweep_cures_wedged_gpu(monkeypatch):
         "CUDA_VISIBLE_DEVICES=": _ssh_result("ctx open/close OK"),
     }
 
-    async def fake_run(cmd: str):
+    async def fake_run(cmd: str, **kwargs):
         for prefix, result in responses.items():
             if cmd.startswith(prefix):
                 return result
@@ -69,7 +69,7 @@ async def test_sweep_is_a_noop_on_healthy_gpus(monkeypatch):
         "neurons.validators.src.services.docker_service.GPU_WEDGE_SWEEP_SETTLE_SECONDS", 0
     )
 
-    async def fake_run(cmd: str):
+    async def fake_run(cmd: str, **kwargs):
         if cmd.startswith("nvidia-smi --query-gpu"):
             return _ssh_result(f"{HEALTHY_UUID}, 0, 0\n")
         if cmd.startswith("nvidia-smi --query-compute-apps"):
@@ -93,7 +93,7 @@ async def test_sweep_skips_the_settle_wait_when_nothing_looks_wedged():
     async def fake_sleep(seconds: float) -> None:
         slept.append(seconds)
 
-    async def fake_run(cmd: str):
+    async def fake_run(cmd: str, **kwargs):
         if cmd.startswith("nvidia-smi --query-gpu"):
             return _ssh_result(f"{HEALTHY_UUID}, 0, 0\n")
         if cmd.startswith("nvidia-smi --query-compute-apps"):
@@ -123,7 +123,7 @@ async def test_sweep_does_not_reset_a_card_that_settles_by_itself(monkeypatch):
         ]
     )
 
-    async def fake_run(cmd: str):
+    async def fake_run(cmd: str, **kwargs):
         if cmd.startswith("nvidia-smi --query-gpu"):
             return next(gpu_query_results)
         if cmd.startswith("nvidia-smi --query-compute-apps"):

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -1,5 +1,8 @@
 import json
+from dataclasses import dataclass
 from datetime import datetime, UTC
+from typing import Any
+
 import pytest
 
 from neurons.validators.src.services.task.checks.machine_spec_scrape import (
@@ -9,7 +12,16 @@ from neurons.validators.src.services.task.checks.machine_spec_scrape import (
 from neurons.validators.src.services.task.messages import MachineSpecMessages as Msg
 from neurons.validators.src.services.task.runner import SSHCommandResult
 
-from tests.helpers import DummySSHClient, build_context_config, build_services, build_state
+from tests.helpers import (
+    FERNET_TOKEN,
+    DummySSHClient,
+    build_context_config,
+    build_services,
+    build_state,
+)
+
+RAW_SPECS = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
+UNREADABLE_TOKEN = "gAAAAABnot-ours"
 
 
 # Mock SSH command result matching the real SSHCommandResult
@@ -36,17 +48,32 @@ def make_command_result(
     )
 
 
-# Mock SSHCommandRunner
+@dataclass(frozen=True)
+class RunCall:
+    command: str
+    timeout: int
+    retryable: bool
+    stdin_text: str | None
+
+
 class DummySSHCommandRunner:
-    def __init__(self, *, result: SSHCommandResult | None = None, results: list | None = None):
+    def __init__(
+        self,
+        *,
+        result: SSHCommandResult | None = None,
+        results: list[SSHCommandResult] | None = None,
+    ):
         """
         Args:
             result: The SSHCommandResult to return on every run() call
             results: One result per run() call, in order — for the stdin-then-binary fallback
         """
-        self.results = results if results is not None else [result]
-        self.calls: list[dict] = []
-        self.called_with: dict | None = None
+        self.results = results or [result]
+        self.calls: list[RunCall] = []
+
+    @property
+    def called_with(self) -> RunCall | None:
+        return self.calls[-1] if self.calls else None
 
     async def run(
         self,
@@ -55,21 +82,13 @@ class DummySSHCommandRunner:
         retryable: bool = False,
         stdin_text: str | None = None,
     ) -> SSHCommandResult:
-        """Mock method that mimics the real SSH command runner."""
-        # Track what parameters we were called with
-        self.called_with = {
-            "command": command,
-            "timeout": timeout,
-            "retryable": retryable,
-            "stdin_text": stdin_text,
-        }
-        self.calls.append(self.called_with)
+        self.calls.append(RunCall(command, timeout, retryable, stdin_text))
         return self.results[min(len(self.calls) - 1, len(self.results) - 1)]
 
 
 # Mock SSHService for decryption
 class DummySSHService:
-    def __init__(self, *, decrypted_data: dict, valid_payload: str | None = None):
+    def __init__(self, *, decrypted_data: dict[str, Any], valid_payload: str | None = None):
         """
         Args:
             decrypted_data: The decrypted machine specs to return
@@ -78,9 +97,11 @@ class DummySSHService:
         self.decrypted_data = decrypted_data
         self.valid_payload = valid_payload
         self.decrypt_called_with: dict | None = None
+        self.decrypt_call_count = 0
 
     def decrypt_payload(self, encrypt_key: str, payload: str) -> str:
         """Mock decrypt method - just returns JSON of our mock data."""
+        self.decrypt_call_count += 1
         self.decrypt_called_with = {
             "encrypt_key": encrypt_key,
             "payload": payload,
@@ -102,16 +123,10 @@ def test_normalize_gpu_details_canonicalizes_a10_alias():
 async def test_machine_spec_scrape_preserves_raw_a10_name_for_native_challenge(
     context_factory,
 ):
-    raw_specs = {
-        "gpu": {
-            "count": 1,
-            "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}],
-        },
-    }
     runner = DummySSHCommandRunner(
-        result=make_command_result(success=True, stdout="encrypted_payload_here")
+        result=make_command_result(success=True, stdout=FERNET_TOKEN)
     )
-    services = build_services(ssh=DummySSHService(decrypted_data=raw_specs))
+    services = build_services(ssh=DummySSHService(decrypted_data=RAW_SPECS))
     config = build_context_config(
         machine_scrape_filename="scrape.sh",
         machine_scrape_timeout=300,
@@ -147,9 +162,9 @@ async def test_machine_spec_scrape_preserves_raw_a10_name_for_native_challenge(
         # Scrape succeeds but empty stdout - should fail
         (True, True, True, "", True, False, Msg.SCRAPE_FAILED.reason),
         # Scrape succeeds with valid output - should pass
-        (True, True, True, "encrypted_payload_here", True, True, Msg.SCRAPE_OK.reason),
+        (True, True, True, FERNET_TOKEN, True, True, Msg.SCRAPE_OK.reason),
         # Scrape succeeds but no encrypt_key - should fail (parse error)
-        (True, True, True, "encrypted_payload_here", False, False, Msg.SCRAPE_PARSE_FAILED.reason),
+        (True, True, True, FERNET_TOKEN, False, False, Msg.SCRAPE_PARSE_FAILED.reason),
     ],
 )
 @pytest.mark.asyncio
@@ -225,9 +240,9 @@ async def test_machine_spec_scrape_check(
     # Verify runner was called correctly (if we got that far)
     if has_remote_dir and has_script_filename:
         assert runner.called_with is not None
-        assert "chmod +x /remote/path/scrape.sh && /remote/path/scrape.sh" in runner.called_with["command"]
-        assert runner.called_with["timeout"] == 300
-        assert runner.called_with["retryable"] is False
+        assert "chmod +x /remote/path/scrape.sh && /remote/path/scrape.sh" in runner.called_with.command
+        assert runner.called_with.timeout == 300
+        assert runner.called_with.retryable is False
 
     # Verify state update on success
     if expected_pass:
@@ -252,22 +267,21 @@ async def test_machine_spec_scrape_check(
         # Verify decryption was called
         assert ssh_service.decrypt_called_with is not None
         assert ssh_service.decrypt_called_with["encrypt_key"] == "test-encrypt-key"
-        assert ssh_service.decrypt_called_with["payload"] == "encrypted_payload_here"
+        assert ssh_service.decrypt_called_with["payload"] == FERNET_TOKEN
 
 
 @pytest.mark.asyncio
 async def test_machine_spec_scrape_pipes_source_to_the_executor_interpreter(context_factory):
     # Arrange
     source = "print('obfuscated scrape')"
-    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
     runner = DummySSHCommandRunner(
-        result=make_command_result(success=True, stdout="encrypted_payload_here")
+        result=make_command_result(success=True, stdout=FERNET_TOKEN)
     )
     ctx = context_factory(
-        services=build_services(ssh=DummySSHService(decrypted_data=raw_specs)),
+        services=build_services(ssh=DummySSHService(decrypted_data=RAW_SPECS)),
         config=build_context_config(machine_scrape_source=source),
         # No remote_dir: source delivery uploads nothing, so there is no directory to name.
-        state=build_state(scrape_over_stdin=True),
+        state=build_state(),
         runner=runner,
         encrypt_key="test-encrypt-key",
     )
@@ -277,25 +291,24 @@ async def test_machine_spec_scrape_pipes_source_to_the_executor_interpreter(cont
 
     # Assert
     assert result.passed is True
-    assert runner.called_with["command"] == "/usr/bin/python -I -"
-    assert runner.called_with["stdin_text"] == source
+    assert runner.called_with.command == "/usr/bin/python -I -"
+    assert runner.called_with.stdin_text == source
 
 
 @pytest.mark.asyncio
-async def test_machine_spec_scrape_runs_the_uploaded_binary_when_stdin_was_not_chosen(
+async def test_machine_spec_scrape_runs_the_uploaded_binary_when_no_source_was_delivered(
     context_factory,
 ):
-    # The source is built every cycle, but only a state that says so puts this executor on the
-    # stdin path — with the flag off, UploadFilesCheck uploaded the binary and it is what runs.
+    # With ENABLE_SCRAPE_SOURCE_DELIVERY off the config carries no source, so UploadFilesCheck
+    # uploaded the binary and it is what runs.
     # Arrange
-    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
     runner = DummySSHCommandRunner(
-        result=make_command_result(success=True, stdout="encrypted_payload_here")
+        result=make_command_result(success=True, stdout=FERNET_TOKEN)
     )
     ctx = context_factory(
-        services=build_services(ssh=DummySSHService(decrypted_data=raw_specs)),
-        config=build_context_config(machine_scrape_source="print('scrape')"),
-        state=build_state(remote_dir="/remote/path", scrape_over_stdin=False),
+        services=build_services(ssh=DummySSHService(decrypted_data=RAW_SPECS)),
+        config=build_context_config(machine_scrape_source=None),
+        state=build_state(remote_dir="/remote/path"),
         runner=runner,
         encrypt_key="test-encrypt-key",
     )
@@ -305,8 +318,8 @@ async def test_machine_spec_scrape_runs_the_uploaded_binary_when_stdin_was_not_c
 
     # Assert
     assert result.passed is True
-    assert runner.called_with["command"] == "chmod +x /remote/path/scrape.sh && /remote/path/scrape.sh"
-    assert runner.called_with["stdin_text"] is None
+    assert runner.called_with.command == "chmod +x /remote/path/scrape.sh && /remote/path/scrape.sh"
+    assert runner.called_with.stdin_text is None
 
 
 @pytest.mark.asyncio
@@ -316,7 +329,6 @@ async def test_machine_spec_scrape_uploads_the_binary_when_the_source_will_not_r
     # DAH-2794: nothing was uploaded, and this executor's interpreter rejects the source —
     # missing psutil, wrong Python, a cryptography too old. The binary carries all of it.
     # Arrange
-    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
     runner = DummySSHCommandRunner(
         results=[
             make_command_result(
@@ -325,14 +337,14 @@ async def test_machine_spec_scrape_uploads_the_binary_when_the_source_will_not_r
                 stderr="ModuleNotFoundError: No module named 'psutil'",
                 duration_ms=1600,
             ),
-            make_command_result(success=True, stdout="encrypted_payload_here"),
+            make_command_result(success=True, stdout=FERNET_TOKEN),
         ]
     )
     ssh_client = DummySSHClient()
     ctx = context_factory(
-        services=build_services(ssh=DummySSHService(decrypted_data=raw_specs)),
+        services=build_services(ssh=DummySSHService(decrypted_data=RAW_SPECS)),
         config=build_context_config(machine_scrape_source="print('scrape')"),
-        state=build_state(scrape_over_stdin=True, upload_local_dir="/local/validator/files"),
+        state=build_state(upload_local_dir="/local/validator/files"),
         runner=runner,
         ssh=ssh_client,
         encrypt_key="test-encrypt-key",
@@ -344,16 +356,15 @@ async def test_machine_spec_scrape_uploads_the_binary_when_the_source_will_not_r
     # Assert
     assert result.passed is True
     assert result.event.reason_code == Msg.SCRAPE_OK.reason
-    assert [call["command"] for call in runner.calls] == [
+    assert [call.command for call in runner.calls] == [
         "/usr/bin/python -I -",
-        f"chmod +x {ssh_client.sftp_client.put_called_with['remote_path']}/scrape.sh"
-        f" && {ssh_client.sftp_client.put_called_with['remote_path']}/scrape.sh",
+        f"chmod +x {ssh_client.sftp_client.put_called_with.remote_path}/scrape.sh"
+        f" && {ssh_client.sftp_client.put_called_with.remote_path}/scrape.sh",
     ]
     assert result.event.what_we_saw["delivery"] == "upload"
     # The stdin failure is only visible here — its own event was discarded with the retry.
     assert result.event.what_we_saw["fallback_from"]["reason"] == Msg.SCRAPE_FAILED.reason
     assert "psutil" in result.event.what_we_saw["fallback_from"]["stderr_tail"]
-    assert result.updates["state"].remote_dir == ssh_client.sftp_client.put_called_with["remote_path"]
 
 
 @pytest.mark.parametrize("duration_ms", [60_001, 240_000])
@@ -373,7 +384,7 @@ async def test_machine_spec_scrape_keeps_the_stdin_verdict_when_the_failure_was_
     ctx = context_factory(
         services=build_services(),
         config=build_context_config(machine_scrape_source="print('scrape')"),
-        state=build_state(scrape_over_stdin=True, upload_local_dir="/local/validator/files"),
+        state=build_state(upload_local_dir="/local/validator/files"),
         runner=runner,
         ssh=ssh_client,
         encrypt_key="test-encrypt-key",
@@ -390,28 +401,25 @@ async def test_machine_spec_scrape_keeps_the_stdin_verdict_when_the_failure_was_
     assert ssh_client.sftp_client.put_called_with is None
 
 
-@pytest.mark.parametrize("over_stdin", [True, False])
+@pytest.mark.parametrize("machine_scrape_source", ["print('scrape')", None])
 @pytest.mark.asyncio
 async def test_machine_spec_scrape_finds_the_payload_among_other_stdout_lines(
-    over_stdin, context_factory
+    machine_scrape_source, context_factory
 ):
     # The image decides what else lands on stdout — a .pth prints before the scrape, an atexit
     # handler after it. Neither the first nor the last line is a safe bet on either path.
     # Arrange
-    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
-    ssh_service = DummySSHService(
-        decrypted_data=raw_specs, valid_payload="encrypted_payload_here"
-    )
+    ssh_service = DummySSHService(decrypted_data=RAW_SPECS, valid_payload=FERNET_TOKEN)
     runner = DummySSHCommandRunner(
         result=make_command_result(
             success=True,
-            stdout="sitecustomize: loaded\nencrypted_payload_here\nExiting worker thread",
+            stdout=f"sitecustomize: loaded\n{FERNET_TOKEN}\nExiting worker thread",
         )
     )
     ctx = context_factory(
         services=build_services(ssh=ssh_service),
-        config=build_context_config(machine_scrape_source="print('scrape')"),
-        state=build_state(scrape_over_stdin=over_stdin, remote_dir="/remote/path"),
+        config=build_context_config(machine_scrape_source=machine_scrape_source),
+        state=build_state(remote_dir="/remote/path"),
         runner=runner,
         encrypt_key="test-encrypt-key",
     )
@@ -431,21 +439,20 @@ async def test_machine_spec_scrape_falls_back_when_the_stdin_payload_will_not_de
     # The failure mode a probe cannot see: the modules import, the scrape runs, and the token it
     # produces is not one this validator can read.
     # Arrange
-    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
     ssh_service = DummySSHService(
-        decrypted_data=raw_specs, valid_payload="encrypted_payload_here"
+        decrypted_data=RAW_SPECS, valid_payload=FERNET_TOKEN
     )
     runner = DummySSHCommandRunner(
         results=[
-            make_command_result(success=True, stdout="unreadable_token", duration_ms=15_000),
-            make_command_result(success=True, stdout="encrypted_payload_here"),
+            make_command_result(success=True, stdout=UNREADABLE_TOKEN, duration_ms=15_000),
+            make_command_result(success=True, stdout=FERNET_TOKEN),
         ]
     )
     ssh_client = DummySSHClient()
     ctx = context_factory(
         services=build_services(ssh=ssh_service),
         config=build_context_config(machine_scrape_source="print('scrape')"),
-        state=build_state(scrape_over_stdin=True, upload_local_dir="/local/validator/files"),
+        state=build_state(upload_local_dir="/local/validator/files"),
         runner=runner,
         ssh=ssh_client,
         encrypt_key="test-encrypt-key",
@@ -461,7 +468,7 @@ async def test_machine_spec_scrape_falls_back_when_the_stdin_payload_will_not_de
     fallback_from = result.event.what_we_saw["fallback_from"]
     # exit 0 and an empty stderr say nothing here — the exception and the output are the evidence.
     assert fallback_from["reason"] == Msg.SCRAPE_PARSE_FAILED.reason
-    assert fallback_from["stdout_head"] == "unreadable_token"
+    assert fallback_from["stdout_head"] == UNREADABLE_TOKEN
 
 
 @pytest.mark.asyncio
@@ -476,7 +483,7 @@ async def test_machine_spec_scrape_reports_the_stdin_failure_when_the_fallback_u
     ctx = context_factory(
         services=build_services(),
         config=build_context_config(machine_scrape_source="print('scrape')"),
-        state=build_state(scrape_over_stdin=True, upload_local_dir="/local/validator/files"),
+        state=build_state(upload_local_dir="/local/validator/files"),
         runner=runner,
         ssh=ssh_client,
         encrypt_key="test-encrypt-key",
@@ -493,3 +500,66 @@ async def test_machine_spec_scrape_reports_the_stdin_failure_when_the_fallback_u
     # One attempt, not two: the retry the legacy path spends is what keeps 60 s + 300 s + 300 s
     # inside the per-executor timeout.
     assert ssh_client.sftp_client.put_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_decrypts_nothing_but_the_token_on_a_spammed_stdout(
+    context_factory,
+):
+    # The miner decides how many lines land in front of the payload, and every decrypt runs on the
+    # event loop shared with the rest of the cycle — so only token-shaped lines are tried.
+    # Arrange
+    ssh_service = DummySSHService(decrypted_data=RAW_SPECS, valid_payload=FERNET_TOKEN)
+    noise = "\n".join(f"chatter {i}" for i in range(10_000))
+    runner = DummySSHCommandRunner(
+        result=make_command_result(success=True, stdout=f"{noise}\n{FERNET_TOKEN}")
+    )
+    ctx = context_factory(
+        services=build_services(ssh=ssh_service),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(),
+        runner=runner,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is True
+    assert ssh_service.decrypt_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_keeps_the_stdin_verdict_when_the_scrape_reported_its_own_error(
+    context_factory,
+):
+    # The scrape printed its own failure and exited 1: the interpreter ran it, so uploading the
+    # binary would buy 13 MB and a second full run to be told the same thing.
+    # Arrange
+    runner = DummySSHCommandRunner(
+        result=make_command_result(
+            success=False,
+            exit_code=1,
+            stdout='{"error": "no_gpu_details"}',
+            duration_ms=40_000,
+        )
+    )
+    ssh_client = DummySSHClient()
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(upload_local_dir="/local/validator/files"),
+        runner=runner,
+        ssh=ssh_client,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is False
+    assert result.event.what_we_saw["delivery"] == "stdin"
+    assert len(runner.calls) == 1
+    assert ssh_client.sftp_client.put_called_with is None

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -45,13 +45,20 @@ class DummySSHCommandRunner:
         self.result = result
         self.called_with: dict | None = None
 
-    async def run(self, command: str, timeout: int = 300, retryable: bool = False) -> SSHCommandResult:
+    async def run(
+        self,
+        command: str,
+        timeout: int = 300,
+        retryable: bool = False,
+        stdin_text: str | None = None,
+    ) -> SSHCommandResult:
         """Mock method that mimics the real SSH command runner."""
         # Track what parameters we were called with
         self.called_with = {
             "command": command,
             "timeout": timeout,
             "retryable": retryable,
+            "stdin_text": stdin_text,
         }
         return self.result
 
@@ -238,3 +245,57 @@ async def test_machine_spec_scrape_check(
         assert ssh_service.decrypt_called_with is not None
         assert ssh_service.decrypt_called_with["encrypt_key"] == "test-encrypt-key"
         assert ssh_service.decrypt_called_with["payload"] == "encrypted_payload_here"
+
+
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_pipes_source_to_the_executor_interpreter(context_factory):
+    # Arrange
+    source = "print('obfuscated scrape')"
+    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
+    runner = DummySSHCommandRunner(
+        result=make_command_result(success=True, stdout="encrypted_payload_here")
+    )
+    ctx = context_factory(
+        services=build_services(ssh=DummySSHService(decrypted_data=raw_specs)),
+        config=build_context_config(machine_scrape_source=source),
+        # No remote_dir: source delivery uploads nothing, so there is no directory to name.
+        state=build_state(scrape_over_stdin=True),
+        runner=runner,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is True
+    assert runner.called_with["command"] == "/usr/bin/python -I -"
+    assert runner.called_with["stdin_text"] == source
+
+
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_runs_the_uploaded_binary_when_stdin_was_not_chosen(
+    context_factory,
+):
+    # The source is built every cycle, but an executor whose interpreter failed the probe keeps
+    # the uploaded binary — the flag alone must not put it on the stdin path.
+    # Arrange
+    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
+    runner = DummySSHCommandRunner(
+        result=make_command_result(success=True, stdout="encrypted_payload_here")
+    )
+    ctx = context_factory(
+        services=build_services(ssh=DummySSHService(decrypted_data=raw_specs)),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(remote_dir="/remote/path", scrape_over_stdin=False),
+        runner=runner,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is True
+    assert runner.called_with["command"] == "chmod +x /remote/path/scrape.sh && /remote/path/scrape.sh"
+    assert runner.called_with["stdin_text"] is None

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -9,7 +9,7 @@ from neurons.validators.src.services.task.checks.machine_spec_scrape import (
 from neurons.validators.src.services.task.messages import MachineSpecMessages as Msg
 from neurons.validators.src.services.task.runner import SSHCommandResult
 
-from tests.helpers import build_context_config, build_services, build_state
+from tests.helpers import DummySSHClient, build_context_config, build_services, build_state
 
 
 # Mock SSH command result matching the real SSHCommandResult
@@ -19,6 +19,7 @@ def make_command_result(
     stderr: str = "",
     exit_code: int = 0,
     command: str = "test command",
+    duration_ms: int = 100,
 ) -> SSHCommandResult:
     """Helper to create mock SSH command results."""
     return SSHCommandResult(
@@ -27,7 +28,7 @@ def make_command_result(
         exit_code=exit_code,
         stdout=stdout,
         stderr=stderr,
-        duration_ms=100,
+        duration_ms=duration_ms,
         started_at=datetime.now(UTC),
         finished_at=datetime.now(UTC),
         success=success,
@@ -37,12 +38,14 @@ def make_command_result(
 
 # Mock SSHCommandRunner
 class DummySSHCommandRunner:
-    def __init__(self, *, result: SSHCommandResult):
+    def __init__(self, *, result: SSHCommandResult | None = None, results: list | None = None):
         """
         Args:
-            result: The SSHCommandResult to return when run() is called
+            result: The SSHCommandResult to return on every run() call
+            results: One result per run() call, in order — for the stdin-then-binary fallback
         """
-        self.result = result
+        self.results = results if results is not None else [result]
+        self.calls: list[dict] = []
         self.called_with: dict | None = None
 
     async def run(
@@ -60,7 +63,8 @@ class DummySSHCommandRunner:
             "retryable": retryable,
             "stdin_text": stdin_text,
         }
-        return self.result
+        self.calls.append(self.called_with)
+        return self.results[min(len(self.calls) - 1, len(self.results) - 1)]
 
 
 # Mock SSHService for decryption
@@ -277,8 +281,8 @@ async def test_machine_spec_scrape_pipes_source_to_the_executor_interpreter(cont
 async def test_machine_spec_scrape_runs_the_uploaded_binary_when_stdin_was_not_chosen(
     context_factory,
 ):
-    # The source is built every cycle, but an executor whose interpreter failed the probe keeps
-    # the uploaded binary — the flag alone must not put it on the stdin path.
+    # The source is built every cycle, but only a state that says so puts this executor on the
+    # stdin path — with the flag off, UploadFilesCheck uploaded the binary and it is what runs.
     # Arrange
     raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
     runner = DummySSHCommandRunner(
@@ -299,3 +303,81 @@ async def test_machine_spec_scrape_runs_the_uploaded_binary_when_stdin_was_not_c
     assert result.passed is True
     assert runner.called_with["command"] == "chmod +x /remote/path/scrape.sh && /remote/path/scrape.sh"
     assert runner.called_with["stdin_text"] is None
+
+
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_uploads_the_binary_when_the_source_will_not_run(
+    context_factory,
+):
+    # DAH-2794: nothing was uploaded, and this executor's interpreter rejects the source —
+    # missing psutil, wrong Python, a cryptography too old. The binary carries all of it.
+    # Arrange
+    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
+    runner = DummySSHCommandRunner(
+        results=[
+            make_command_result(
+                success=False,
+                exit_code=1,
+                stderr="ModuleNotFoundError: No module named 'psutil'",
+                duration_ms=1600,
+            ),
+            make_command_result(success=True, stdout="encrypted_payload_here"),
+        ]
+    )
+    ssh_client = DummySSHClient()
+    ctx = context_factory(
+        services=build_services(ssh=DummySSHService(decrypted_data=raw_specs)),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(scrape_over_stdin=True, upload_local_dir="/local/validator/files"),
+        runner=runner,
+        ssh=ssh_client,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is True
+    assert result.event.reason_code == Msg.SCRAPE_OK.reason
+    assert [call["command"] for call in runner.calls] == [
+        "/usr/bin/python -I -",
+        f"chmod +x {ssh_client.sftp_client.put_called_with['remote_path']}/scrape.sh"
+        f" && {ssh_client.sftp_client.put_called_with['remote_path']}/scrape.sh",
+    ]
+    assert result.event.what_we_saw["delivery"] == "upload"
+    # The stdin failure is only visible here — its own event was discarded with the retry.
+    assert result.event.what_we_saw["fallback_from"]["reason"] == Msg.SCRAPE_FAILED.reason
+    assert "psutil" in result.event.what_we_saw["fallback_from"]["stderr_tail"]
+    assert result.updates["state"].remote_dir == ssh_client.sftp_client.put_called_with["remote_path"]
+
+
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_keeps_the_stdin_verdict_when_the_failure_was_slow(
+    context_factory,
+):
+    # A scrape that dies deep in the run — past the network benchmark — is not an incompatible
+    # interpreter, and an upload plus a second full scrape would blow the per-executor budget.
+    # Arrange
+    runner = DummySSHCommandRunner(
+        result=make_command_result(success=False, exit_code=1, stderr="boom", duration_ms=240_000)
+    )
+    ssh_client = DummySSHClient()
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(scrape_over_stdin=True, upload_local_dir="/local/validator/files"),
+        runner=runner,
+        ssh=ssh_client,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is False
+    assert result.event.reason_code == Msg.SCRAPE_FAILED.reason
+    assert result.event.what_we_saw["delivery"] == "stdin"
+    assert len(runner.calls) == 1
+    assert ssh_client.sftp_client.put_called_with is None

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -356,15 +356,18 @@ async def test_machine_spec_scrape_uploads_the_binary_when_the_source_will_not_r
     assert result.updates["state"].remote_dir == ssh_client.sftp_client.put_called_with["remote_path"]
 
 
+@pytest.mark.parametrize("duration_ms", [60_001, 240_000])
 @pytest.mark.asyncio
 async def test_machine_spec_scrape_keeps_the_stdin_verdict_when_the_failure_was_slow(
-    context_factory,
+    duration_ms, context_factory
 ):
     # A scrape that dies deep in the run — past the network benchmark — is not an incompatible
     # interpreter, and an upload plus a second full scrape would blow the per-executor budget.
     # Arrange
     runner = DummySSHCommandRunner(
-        result=make_command_result(success=False, exit_code=1, stderr="boom", duration_ms=240_000)
+        result=make_command_result(
+            success=False, exit_code=1, stderr="boom", duration_ms=duration_ms
+        )
     )
     ssh_client = DummySSHClient()
     ctx = context_factory(
@@ -434,7 +437,7 @@ async def test_machine_spec_scrape_falls_back_when_the_stdin_payload_will_not_de
     )
     runner = DummySSHCommandRunner(
         results=[
-            make_command_result(success=True, stdout="unreadable_token", duration_ms=2000),
+            make_command_result(success=True, stdout="unreadable_token", duration_ms=15_000),
             make_command_result(success=True, stdout="encrypted_payload_here"),
         ]
     )
@@ -487,3 +490,6 @@ async def test_machine_spec_scrape_reports_the_stdin_failure_when_the_fallback_u
     assert result.event.reason_code == Msg.SCRAPE_FAILED.reason
     assert "Permission denied" in result.event.what_we_saw["fallback_upload_error"]
     assert result.event.what_we_saw["fallback_from"]["stderr_tail"] == "boom"
+    # One attempt, not two: the retry the legacy path spends is what keeps 60 s + 300 s + 300 s
+    # inside the per-executor timeout.
+    assert ssh_client.sftp_client.put_call_count == 1

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -531,6 +531,32 @@ async def test_machine_spec_scrape_decrypts_nothing_but_the_token_on_a_spammed_s
 
 
 @pytest.mark.asyncio
+async def test_machine_spec_scrape_reads_a_token_longer_than_the_search_window(
+    context_factory,
+):
+    # A byte-wise cut of the tail lands inside a big payload and takes the `gAAAAA` prefix with
+    # it, after which no reader recognises the line. Whole lines are searched instead.
+    # Arrange
+    long_token = FERNET_TOKEN + "x" * (400 * 1024)
+    ssh_service = DummySSHService(decrypted_data=RAW_SPECS, valid_payload=long_token)
+    runner = DummySSHCommandRunner(result=make_command_result(success=True, stdout=f"chatter\n{long_token}"))
+    ctx = context_factory(
+        services=build_services(ssh=ssh_service),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(),
+        runner=runner,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is True
+    assert ssh_service.decrypt_call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_machine_spec_scrape_keeps_the_stdin_verdict_when_the_scrape_reported_its_own_error(
     context_factory,
 ):

--- a/neurons/validators/tests/test_machine_spec_scrape_check.py
+++ b/neurons/validators/tests/test_machine_spec_scrape_check.py
@@ -69,12 +69,14 @@ class DummySSHCommandRunner:
 
 # Mock SSHService for decryption
 class DummySSHService:
-    def __init__(self, *, decrypted_data: dict):
+    def __init__(self, *, decrypted_data: dict, valid_payload: str | None = None):
         """
         Args:
             decrypted_data: The decrypted machine specs to return
+            valid_payload: The only line that authenticates, as Fernet would — anything else raises
         """
         self.decrypted_data = decrypted_data
+        self.valid_payload = valid_payload
         self.decrypt_called_with: dict | None = None
 
     def decrypt_payload(self, encrypt_key: str, payload: str) -> str:
@@ -83,6 +85,8 @@ class DummySSHService:
             "encrypt_key": encrypt_key,
             "payload": payload,
         }
+        if self.valid_payload is not None and payload != self.valid_payload:
+            raise ValueError("Invalid token")
         return json.dumps(self.decrypted_data)
 
 
@@ -381,3 +385,105 @@ async def test_machine_spec_scrape_keeps_the_stdin_verdict_when_the_failure_was_
     assert result.event.what_we_saw["delivery"] == "stdin"
     assert len(runner.calls) == 1
     assert ssh_client.sftp_client.put_called_with is None
+
+
+@pytest.mark.parametrize("over_stdin", [True, False])
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_finds_the_payload_among_other_stdout_lines(
+    over_stdin, context_factory
+):
+    # The image decides what else lands on stdout — a .pth prints before the scrape, an atexit
+    # handler after it. Neither the first nor the last line is a safe bet on either path.
+    # Arrange
+    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
+    ssh_service = DummySSHService(
+        decrypted_data=raw_specs, valid_payload="encrypted_payload_here"
+    )
+    runner = DummySSHCommandRunner(
+        result=make_command_result(
+            success=True,
+            stdout="sitecustomize: loaded\nencrypted_payload_here\nExiting worker thread",
+        )
+    )
+    ctx = context_factory(
+        services=build_services(ssh=ssh_service),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(scrape_over_stdin=over_stdin, remote_dir="/remote/path"),
+        runner=runner,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is True
+    assert result.updates["state"].gpu_count == 1
+
+
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_falls_back_when_the_stdin_payload_will_not_decrypt(
+    context_factory,
+):
+    # The failure mode a probe cannot see: the modules import, the scrape runs, and the token it
+    # produces is not one this validator can read.
+    # Arrange
+    raw_specs = {"gpu": {"count": 1, "details": [{"name": "NVIDIA A10", "uuid": "GPU-abc123"}]}}
+    ssh_service = DummySSHService(
+        decrypted_data=raw_specs, valid_payload="encrypted_payload_here"
+    )
+    runner = DummySSHCommandRunner(
+        results=[
+            make_command_result(success=True, stdout="unreadable_token", duration_ms=2000),
+            make_command_result(success=True, stdout="encrypted_payload_here"),
+        ]
+    )
+    ssh_client = DummySSHClient()
+    ctx = context_factory(
+        services=build_services(ssh=ssh_service),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(scrape_over_stdin=True, upload_local_dir="/local/validator/files"),
+        runner=runner,
+        ssh=ssh_client,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is True
+    assert len(runner.calls) == 2
+    assert ssh_client.sftp_client.put_called_with is not None
+    fallback_from = result.event.what_we_saw["fallback_from"]
+    # exit 0 and an empty stderr say nothing here — the exception and the output are the evidence.
+    assert fallback_from["reason"] == Msg.SCRAPE_PARSE_FAILED.reason
+    assert fallback_from["stdout_head"] == "unreadable_token"
+
+
+@pytest.mark.asyncio
+async def test_machine_spec_scrape_reports_the_stdin_failure_when_the_fallback_upload_fails(
+    context_factory,
+):
+    # Arrange
+    runner = DummySSHCommandRunner(
+        result=make_command_result(success=False, exit_code=1, stderr="boom", duration_ms=1600)
+    )
+    ssh_client = DummySSHClient(sftp_should_raise=True, sftp_error="Permission denied")
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(scrape_over_stdin=True, upload_local_dir="/local/validator/files"),
+        runner=runner,
+        ssh=ssh_client,
+        encrypt_key="test-encrypt-key",
+    )
+
+    # Act
+    result = await MachineSpecScrapeCheck().run(ctx)
+
+    # Assert
+    assert result.passed is False
+    assert result.event.reason_code == Msg.SCRAPE_FAILED.reason
+    assert "Permission denied" in result.event.what_we_saw["fallback_upload_error"]
+    assert result.event.what_we_saw["fallback_from"]["stderr_tail"] == "boom"

--- a/neurons/validators/tests/test_pipeline_default_scenarios.py
+++ b/neurons/validators/tests/test_pipeline_default_scenarios.py
@@ -119,7 +119,7 @@ class DummySSHCommandRunner:
         self.machine_specs_encrypted = machine_specs_encrypted
         self.commands_called = []
 
-    async def run(self, command: str, timeout: int = 300, retryable: bool = False):
+    async def run(self, command: str, timeout: int = 300, retryable: bool = False, stdin_text=None):
         self.commands_called.append(command)
 
         from neurons.validators.src.services.task.runner import SSHCommandResult

--- a/neurons/validators/tests/test_pipeline_default_scenarios.py
+++ b/neurons/validators/tests/test_pipeline_default_scenarios.py
@@ -35,7 +35,7 @@ from neurons.validators.src.services.task.checks import (
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse, RentedExecutor, RentedPod
 
 from datura.requests.miner_requests import ExecutorSSHInfo
-from helpers import build_context_config, build_services, build_state
+from helpers import FERNET_TOKEN, build_context_config, build_services, build_state
 
 
 class MockContainerCleanup:
@@ -115,7 +115,7 @@ class DummyLogger:
 class DummySSHCommandRunner:
     """Mock SSH command runner for successful operations."""
 
-    def __init__(self, machine_specs_encrypted: str = "encrypted_payload"):
+    def __init__(self, machine_specs_encrypted: str = FERNET_TOKEN):
         self.machine_specs_encrypted = machine_specs_encrypted
         self.commands_called = []
 
@@ -338,11 +338,8 @@ async def test_successful_unrented_pipeline_flow(context_factory):
     # Setup real executor (not Mock - to avoid Pydantic serialization issues)
     executor = make_executor("executor-123")
 
-    # Create encrypted payload
-    encrypted_payload = "encrypted_machine_specs_here"
-
     # Setup mocks
-    runner = DummySSHCommandRunner(machine_specs_encrypted=encrypted_payload)
+    runner = DummySSHCommandRunner(machine_specs_encrypted=FERNET_TOKEN)
     ssh_client = DummySSHClient()
     ssh_service = DummySSHService()
     redis_service = DummyRedisService()

--- a/neurons/validators/tests/test_scrape_source_delivery.py
+++ b/neurons/validators/tests/test_scrape_source_delivery.py
@@ -7,11 +7,9 @@ the new path: the validator produces runnable source, and the runner actually fo
 """
 
 import ast
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from core.config import settings
 from neurons.validators.src.services.file_encrypt_service import (
     KEYS_FOR_ENCRYPTION_KEY_GENERATION,
     FileEncryptService,
@@ -21,7 +19,6 @@ from neurons.validators.src.services.task.runner import SSHCommandRunner
 
 def test_source_delivery_carries_runnable_source_alongside_the_binary(monkeypatch):
     # Arrange
-    monkeypatch.setattr(settings, "ENABLE_SCRAPE_SOURCE_DELIVERY", True)
     # The obfuscator and the key substitution are the parts under test; freezing the result
     # costs ~40s of PyInstaller and is exercised by the flag-off path in production.
     monkeypatch.setattr(FileEncryptService, "make_binary_file", lambda self, tmp, path: "scrape")
@@ -42,17 +39,15 @@ def test_source_delivery_carries_runnable_source_alongside_the_binary(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_runner_forwards_stdin_text_to_the_remote_process():
+async def test_runner_forwards_stdin_text_to_the_remote_process(mock_ssh_client):
     # Arrange
-    ssh = MagicMock()
-    ssh.run = AsyncMock(
-        return_value=MagicMock(stdout="payload", stderr="", exit_status=0)
-    )
-    runner = SSHCommandRunner(ssh)
+    runner = SSHCommandRunner(mock_ssh_client)
 
     # Act
     result = await runner.run("/usr/bin/python -I -", stdin_text="print('scrape')")
 
     # Assert
     assert result.success is True
-    ssh.run.assert_awaited_once_with("/usr/bin/python -I -", input="print('scrape')")
+    mock_ssh_client.run.assert_awaited_once_with(
+        "/usr/bin/python -I -", input="print('scrape')"
+    )

--- a/neurons/validators/tests/test_scrape_source_delivery.py
+++ b/neurons/validators/tests/test_scrape_source_delivery.py
@@ -1,0 +1,58 @@
+"""DAH-2794: with ENABLE_SCRAPE_SOURCE_DELIVERY the scrape is not frozen and not uploaded —
+it is piped to the executor's own interpreter over the SSH channel's stdin.
+
+The old path builds a ~13 MB PyInstaller onefile every cycle and SFTP-puts it to every
+executor; behind one shared uplink that is what times out. These tests pin the two halves of
+the new path: the validator produces runnable source, and the runner actually forwards it.
+"""
+
+import ast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from core.config import settings
+from neurons.validators.src.services.file_encrypt_service import (
+    KEYS_FOR_ENCRYPTION_KEY_GENERATION,
+    FileEncryptService,
+)
+from neurons.validators.src.services.task.runner import SSHCommandRunner
+
+
+def test_source_delivery_carries_runnable_source_alongside_the_binary(monkeypatch):
+    # Arrange
+    monkeypatch.setattr(settings, "ENABLE_SCRAPE_SOURCE_DELIVERY", True)
+    # The obfuscator and the key substitution are the parts under test; freezing the result
+    # costs ~40s of PyInstaller and is exercised by the flag-off path in production.
+    monkeypatch.setattr(FileEncryptService, "make_binary_file", lambda self, tmp, path: "scrape")
+    service = FileEncryptService(ssh_service=None)
+
+    # Act
+    files = service.ecrypt_miner_job_files()
+
+    # Assert
+    ast.parse(files.machine_scrape_source)
+    # The key mapping is what makes every cycle's payload unique, and the encryption key is
+    # the concatenation of those random names — both must survive the shortcut.
+    assert files.encrypt_key == "".join(
+        files.all_keys[key] for key in KEYS_FOR_ENCRYPTION_KEY_GENERATION
+    )
+    for original_key in KEYS_FOR_ENCRYPTION_KEY_GENERATION:
+        assert original_key not in files.machine_scrape_source
+
+
+@pytest.mark.asyncio
+async def test_runner_forwards_stdin_text_to_the_remote_process():
+    # Arrange
+    ssh = MagicMock()
+    ssh.run = AsyncMock(
+        return_value=MagicMock(stdout="payload", stderr="", exit_status=0)
+    )
+    runner = SSHCommandRunner(ssh)
+
+    # Act
+    result = await runner.run("/usr/bin/python -I -", stdin_text="print('scrape')")
+
+    # Assert
+    assert result.success is True
+    ssh.run.assert_awaited_once_with("/usr/bin/python -I -", input="print('scrape')")

--- a/neurons/validators/tests/test_upload_files_check.py
+++ b/neurons/validators/tests/test_upload_files_check.py
@@ -67,12 +67,12 @@ async def test_upload_files_check(
     if has_local_dir and has_executor_root:
         # SFTP should have been called
         assert ssh_client.sftp_client.put_called_with is not None
-        assert ssh_client.sftp_client.put_called_with["local_path"] == "/local/validator/files"
+        assert ssh_client.sftp_client.put_called_with.local_path == "/local/validator/files"
         # Remote path should be executor_root + random hex (32 chars)
-        remote_path = ssh_client.sftp_client.put_called_with["remote_path"]
+        remote_path = ssh_client.sftp_client.put_called_with.remote_path
         assert remote_path.startswith("/root/app/")
         assert len(remote_path) == len("/root/app/") + 32  # UUID hex is 32 chars
-        assert ssh_client.sftp_client.put_called_with["recurse"] is True
+        assert ssh_client.sftp_client.put_called_with.recurse is True
 
         # Verify state update on success
         if expected_pass:
@@ -107,5 +107,4 @@ async def test_upload_files_check_uploads_nothing_when_the_scrape_can_travel_as_
     assert result.passed is True
     assert result.event.reason_code == Msg.UPLOAD_SKIPPED.reason
     assert ssh_client.sftp_client.put_called_with is None
-    assert result.updates["state"].scrape_over_stdin is True
-    assert result.updates["state"].remote_dir is None
+    assert result.updates == {}

--- a/neurons/validators/tests/test_upload_files_check.py
+++ b/neurons/validators/tests/test_upload_files_check.py
@@ -1,76 +1,9 @@
-from datetime import UTC, datetime
-
 import pytest
 
 from neurons.validators.src.services.task.checks.upload_files import UploadFilesCheck
 from neurons.validators.src.services.task.messages import UploadFilesMessages as Msg
-from neurons.validators.src.services.task.runner import SSHCommandResult
 
-from tests.helpers import build_context_config, build_services, build_state
-
-
-class DummySFTPClient:
-    """Mock SFTP client that simulates file upload."""
-
-    def __init__(self, *, should_raise: bool = False, error_message: str = ""):
-        self.should_raise = should_raise
-        self.error_message = error_message
-        self.put_called_with: dict | None = None
-
-    async def put(self, local_path: str, remote_path: str, recurse: bool = False):
-        """Mock method that simulates SFTP put operation."""
-        self.put_called_with = {
-            "local_path": local_path,
-            "remote_path": remote_path,
-            "recurse": recurse,
-        }
-
-        if self.should_raise:
-            raise RuntimeError(self.error_message)
-
-
-class DummyProbeRunner:
-    """Answers the interpreter probe UploadFilesCheck runs before it skips the upload."""
-
-    def __init__(self, *, success: bool):
-        self.success = success
-        self.commands: list[str] = []
-
-    async def run(self, command: str, timeout: int = 300, retryable: bool = False, stdin_text=None):
-        self.commands.append(command)
-        return SSHCommandResult(
-            command=command,
-            command_id="probe",
-            exit_code=0 if self.success else 1,
-            stdout="",
-            stderr="",
-            duration_ms=1,
-            started_at=datetime.now(UTC),
-            finished_at=datetime.now(UTC),
-            success=self.success,
-        )
-
-
-class DummySSHClient:
-    """Mock SSH client that provides SFTP access."""
-
-    def __init__(self, *, sftp_should_raise: bool = False, sftp_error: str = ""):
-        self.sftp_client = DummySFTPClient(
-            should_raise=sftp_should_raise,
-            error_message=sftp_error,
-        )
-
-    def start_sftp_client(self):
-        """Return an async context manager for SFTP."""
-        return self
-
-    async def __aenter__(self):
-        """Enter the async context - return the SFTP client."""
-        return self.sftp_client
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Exit the async context."""
-        pass
+from tests.helpers import DummySSHClient, build_context_config, build_services, build_state
 
 
 @pytest.mark.parametrize(
@@ -152,20 +85,18 @@ async def test_upload_files_check(
         assert ssh_client.sftp_client.put_called_with is None
 
 
-@pytest.mark.parametrize("probe_succeeds", [True, False])
 @pytest.mark.asyncio
-async def test_upload_files_check_uploads_only_when_the_executor_cannot_run_the_source(
-    probe_succeeds,
+async def test_upload_files_check_uploads_nothing_when_the_scrape_can_travel_as_source(
     context_factory,
 ):
+    # DAH-2794: no probe, no round trip — whether this executor can run the source is answered
+    # by MachineSpecScrapeCheck actually running it, and it uploads the binary if it cannot.
     # Arrange
     ssh_client = DummySSHClient()
-    runner = DummyProbeRunner(success=probe_succeeds)
     ctx = context_factory(
         services=build_services(),
         config=build_context_config(machine_scrape_source="print('scrape')"),
         state=build_state(upload_local_dir="/local/validator/files"),
-        runner=runner,
         ssh=ssh_client,
     )
 
@@ -174,14 +105,7 @@ async def test_upload_files_check_uploads_only_when_the_executor_cannot_run_the_
 
     # Assert
     assert result.passed is True
-    assert runner.commands == ["/usr/bin/python -I -c 'import psutil, cryptography.fernet'"]
-    if probe_succeeds:
-        assert result.event.reason_code == Msg.UPLOAD_SKIPPED.reason
-        assert ssh_client.sftp_client.put_called_with is None
-        assert result.updates["state"].scrape_over_stdin is True
-        assert result.updates["state"].remote_dir is None
-    else:
-        assert result.event.reason_code == Msg.UPLOAD_OK.reason
-        assert ssh_client.sftp_client.put_called_with is not None
-        assert result.updates["state"].scrape_over_stdin is False
-        assert result.updates["state"].remote_dir is not None
+    assert result.event.reason_code == Msg.UPLOAD_SKIPPED.reason
+    assert ssh_client.sftp_client.put_called_with is None
+    assert result.updates["state"].scrape_over_stdin is True
+    assert result.updates["state"].remote_dir is None

--- a/neurons/validators/tests/test_upload_files_check.py
+++ b/neurons/validators/tests/test_upload_files_check.py
@@ -1,7 +1,10 @@
+from datetime import UTC, datetime
+
 import pytest
 
 from neurons.validators.src.services.task.checks.upload_files import UploadFilesCheck
 from neurons.validators.src.services.task.messages import UploadFilesMessages as Msg
+from neurons.validators.src.services.task.runner import SSHCommandResult
 
 from tests.helpers import build_context_config, build_services, build_state
 
@@ -24,6 +27,28 @@ class DummySFTPClient:
 
         if self.should_raise:
             raise RuntimeError(self.error_message)
+
+
+class DummyProbeRunner:
+    """Answers the interpreter probe UploadFilesCheck runs before it skips the upload."""
+
+    def __init__(self, *, success: bool):
+        self.success = success
+        self.commands: list[str] = []
+
+    async def run(self, command: str, timeout: int = 300, retryable: bool = False, stdin_text=None):
+        self.commands.append(command)
+        return SSHCommandResult(
+            command=command,
+            command_id="probe",
+            exit_code=0 if self.success else 1,
+            stdout="",
+            stderr="",
+            duration_ms=1,
+            started_at=datetime.now(UTC),
+            finished_at=datetime.now(UTC),
+            success=self.success,
+        )
 
 
 class DummySSHClient:
@@ -125,3 +150,38 @@ async def test_upload_files_check(
     else:
         # SFTP should not have been called if config is missing
         assert ssh_client.sftp_client.put_called_with is None
+
+
+@pytest.mark.parametrize("probe_succeeds", [True, False])
+@pytest.mark.asyncio
+async def test_upload_files_check_uploads_only_when_the_executor_cannot_run_the_source(
+    probe_succeeds,
+    context_factory,
+):
+    # Arrange
+    ssh_client = DummySSHClient()
+    runner = DummyProbeRunner(success=probe_succeeds)
+    ctx = context_factory(
+        services=build_services(),
+        config=build_context_config(machine_scrape_source="print('scrape')"),
+        state=build_state(upload_local_dir="/local/validator/files"),
+        runner=runner,
+        ssh=ssh_client,
+    )
+
+    # Act
+    result = await UploadFilesCheck().run(ctx)
+
+    # Assert
+    assert result.passed is True
+    assert runner.commands == ["/usr/bin/python -I -c 'import psutil, cryptography.fernet'"]
+    if probe_succeeds:
+        assert result.event.reason_code == Msg.UPLOAD_SKIPPED.reason
+        assert ssh_client.sftp_client.put_called_with is None
+        assert result.updates["state"].scrape_over_stdin is True
+        assert result.updates["state"].remote_dir is None
+    else:
+        assert result.event.reason_code == Msg.UPLOAD_OK.reason
+        assert ssh_client.sftp_client.put_called_with is not None
+        assert result.updates["state"].scrape_over_stdin is False
+        assert result.updates["state"].remote_dir is not None


### PR DESCRIPTION
### Task Link

[DAH-2794 — Send machine_scrape to executors as source over stdin instead of a 13 MB binary](https://app.notion.com/p/Send-machine_scrape-to-executors-as-source-over-stdin-instead-of-a-13-MB-binary-3cab8bfdbde9816f8b66ced0c3ddfc03)

---

DAH-2794.

Every 15 minutes the validator freezes `machine_scrape.py` into a ~12 MB PyInstaller onefile and
SFTP-puts it into a fresh random directory on every executor. The binary is unique per cycle by
construction — `generate_key_mappings()` re-randomises 100+ dict key names and their concatenation
*is* the Fernet key — so no cache or signature can avoid the transfer. When several executors sit
behind one uplink, one link has to carry N x 12 MB inside the 300 s upload timeout, and they all
miss it together.

Measured on prod over 7 days (`prod_executors`), upload failure rate against executors per IP:

| executors on the IP | validations | UPLOAD_FAILED | rate |
|---|---|---|---|
| 1 | 276952 | 310 | 0.112% |
| 2-3 | 22345 | 108 | 0.483% |
| 4-6 | 32412 | 562 | 1.734% |
| 7+ | 24388 | 570 | 2.337% |

Monotonic, 21x spread. In the last 24 h of that window, 78% of all failures came from a single
IP carrying 26 executors. `UPLOAD_FAILED` is fatal, so those cycles score 0, so compute-app never
writes `Executor.updated_at`, so the staleness sweep can raise a false
`EXECUTOR_INACTIVE_MID_RENTAL` on a healthy machine.

## What this does

Sends the same obfuscated source down the SSH channel's stdin and runs it with the executor's own
interpreter: `{python_path} -I -`. **55 186 B instead of 12 054 784 B — 218x.**

With the flag on, `UploadFilesCheck` uploads nothing. `MachineSpecScrapeCheck` pipes the source in,
and if that run fails — non-zero exit, empty stdout, or a payload that will not decrypt — it uploads
the binary itself and re-runs the legacy path in the same check. So the question "can this executor
run the source?" is answered by running it, not by a probe: the miner picks the executor image, and
a probe can only prove the modules import, never that their API matches.

The fallback window is sized from two measurements. An interpreter that cannot run the source
rejects it in **1.6 s**, and a full scrape on a real box takes **15 s** — so a payload that will not
decrypt is only knowable around then, and the window has to clear a whole successful run.
`FALLBACK_AFTER_MS = 60_000` does, and stays inside the 780 s per-executor timeout:
60 s + 300 s upload + 300 s scrape = **660 s**. The fallback upload gets one attempt, not the
legacy path's two, for exactly that reason — that also makes the fallback path's worst case
*shorter* than the flag-off path's own (2 x 300 s upload + 300 s scrape).

Past 60 s the stdin verdict stands, and not only for the budget: a scrape that dies that late did
not fail to start, it hung somewhere in the middle, and the binary runs the very same code.

The binary keeps being built for that reason: it is one build per cycle for the whole fleet, and it
is the fallback. Behind `ENABLE_SCRAPE_SOURCE_DELIVERY`, default off.

## Notes on the details

- `-I` implies `-E -s -P`: PYTHONPATH, the user site-dir and the cwd entry leave `sys.path`, so a
  file dropped next to the SSH login shell cannot shadow `psutil` or `json`. It does **not** imply
  `-S`, so a `.pth` or `sitecustomize` inside the image still runs and prints. The payload is
  therefore no longer taken from a fixed stdout position: `_decrypt_payload` walks the non-empty
  lines newest-first until one authenticates. Fernet makes a wrong line raise rather than decode,
  so this is strictly more robust than the old `splitlines()[0]` on the binary path too.
- Confidentiality against a root miner is unchanged (PyInstaller onefile already unpacks itself to
  `/tmp/_MEIxxxxx`). Execution integrity gets cheaper to attack: `python_path` is reported by the
  executor, and a wrapper there sees plaintext source rather than a frozen binary. A root miner
  could already do both; this lowers the effort, not the trust boundary.
- `SCRAPE_OK` and `SCRAPE_FAILED` carry `delivery: stdin|upload`, and a run that fell back carries
  `fallback_from` with the stdin attempt's reason, exit code, duration and stderr tail — that event
  is the only trace of the first attempt, so the two paths and the fallback rate can be counted
  apart in Loki.
- The scrape's only third-party API surface is `psutil.cpu_percent`, `psutil.virtual_memory`,
  `Fernet(...)` and `Fernet.encrypt` — compatible across the validator's pins and the executor's.

## Verification

- Full validator suite green: no new failures against `origin/main` (pre-existing
  `test_port_mapping_dao` errors and `test_sshd_bootstrap_script` failures are unchanged).
- Four `fake_run(cmd)` doubles needed `**kwargs` because `SSHCommandRunner.run` now passes
  `input=` to `ssh.run` on every call.
- Parity gate outside the repo (`untracked/epics/scrape-binary-slimming/harness/executor_parity/`)
  runs the generated source inside the **published executor image**
  `daturaai/compute-subnet-executor@sha256:8dbf5395d9b6ead5d08c5a9ccc36963190aff6522321c040d0e76be6f77ef863`
  (python 3.11.11, psutil 6.1.1, cryptography 43.0.3) with an NVML stub bind-mounted, and asserts
  the payload decrypts and that gpu / cpu / ram / os / process / network are present and correctly
  typed. **PASS.**
- Same harness against a **live executor** (`149.36.1.151`, real NVML, RTX A4000, no stubs): source
  56 136 B vs binary 12 054 736 B, scrape exit 0 in 15.0 s, empty stderr, payload decrypts. **PASS.**
  The same box, given a python without `psutil`, fails in 1.56 s — that is where
  `FALLBACK_AFTER_MS` comes from.
- **Staging, flag on** (validator `0438aef`, both executors): `UPLOAD_SKIPPED` x2,
  `"delivery": "stdin"` x2, `SCRAPE_OK` x2, zero `UPLOAD_OK` / `UPLOAD_FAILED` / `SCRAPE_FAILED`.
  Scrape 13 956 ms and 12 895 ms, both `VALIDATION_COMPLETED` with score 1.0, full specs present
  (GPU uuid, driver, container digests, sysbox, ports, VerifyX speeds, md5 checksums).

## Deliberately not here

- `benchmark_network_speed()` runs on every node every cycle and `speedtest-cli` saturates the
  link — far more bytes than the binary ever was — while the validator only keeps an EMA of it.
- `UPLOAD_FAILED` -> `score=0` -> unwritten `updated_at` -> false penalty.
- `upload_files.py` returns immediately on timeout with no retry, unlike every other failure.
- Uploaded directories are never removed: `InteractiveShellService.upload_directory()` is dead
  code, so `shell.remote_dir` stays None and `clear_remote_directory()` is a no-op.
