### PR TITLE
DAH-2805: sweep abandoned filler download temporaries from the executor's cache volumes

### DIFF
--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -75,6 +75,12 @@ class DockerCommand:
         return f"/usr/bin/docker volume rm {names} 2>/dev/null || true"
 
     @staticmethod
+    def volume_mount_points(*volume_names: str) -> str:
+        """Build docker volume inspect command printing one host path per volume."""
+        names = " ".join(shlex.quote(name) for name in volume_names)
+        return f"/usr/bin/docker volume inspect {names} --format '{{{{.Mountpoint}}}}' 2>/dev/null || true"
+
+    @staticmethod
     def volume_ls_dangling() -> str:
         """Build docker volume ls command listing dangling volume names."""
         return "/usr/bin/docker volume ls -qf dangling=true"

--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -75,12 +75,6 @@ class DockerCommand:
         return f"/usr/bin/docker volume rm {names} 2>/dev/null || true"
 
     @staticmethod
-    def volume_mount_points(*volume_names: str) -> str:
-        """Build docker volume inspect command printing one host path per volume."""
-        names = " ".join(shlex.quote(name) for name in volume_names)
-        return f"/usr/bin/docker volume inspect {names} --format '{{{{.Mountpoint}}}}' 2>/dev/null || true"
-
-    @staticmethod
     def volume_ls_dangling() -> str:
         """Build docker volume ls command listing dangling volume names."""
         return "/usr/bin/docker volume ls -qf dangling=true"

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -285,6 +285,11 @@ RENTAL_CONTAINER_PREFIXES = ("pod_", "filler_", "container_", "health_check_")
 # services/task/__init__ and the checks back in.
 PROBE_CONTAINER_NAME = "lium_roce_probe"
 
+# DAH-2805: the throwaway helper that sweeps abandoned download temporaries out of the filler cache
+# volumes. Named — and named with a Lium prefix — so the provider-side load gate excuses the seconds
+# of CPU it holds instead of counting our own housekeeping against the miner.
+CACHE_SWEEP_CONTAINER_NAME = "lium_cache_sweep"
+
 # Short-lived containers LIUM starts on an executor that carry no backend-issued id to confirm
 # them by: validator DinD/port probes, backend health probes, the RoCE link probe. The
 # provider-side load gate (DAH-2734) must not bill their CPU to the provider, so it excuses
@@ -302,6 +307,7 @@ LIUM_INFRA_CONTAINER_PREFIXES = (
     # real CPU while it runs
     "s3fs-backup",
     PROBE_CONTAINER_NAME,
+    CACHE_SWEEP_CONTAINER_NAME,
 )
 
 # For simplicity, store whitelist in code. Can be updated to use DB if needed. 

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -241,9 +241,8 @@ FILLER_CONTAINER_PREFIX = "filler_"
 # name with the model + runtime version baked in; the validator only needs the prefix, to recognise
 # which volumes belong to the cache when sweeping or reclaiming them.
 DPHN_CACHE_VOLUME_PREFIX = "dphn_cache_"
-# DAH-2805: the ENGY filler keeps its ~35 GB checkpoint in its own cache volume. Only the
-# download-temporary sweep looks at it: reclaiming a whole ENGY volume is a separate decision
-# nobody has made, so the DPHN-only paths keep using DPHN_CACHE_VOLUME_PREFIX alone.
+# DAH-2805: only the download-temporary sweep looks at the ENGY cache — reclaiming a whole ENGY
+# volume is a separate decision nobody has made, so the DPHN-only paths keep using their own prefix.
 ENGY_CACHE_VOLUME_PREFIX = "engy_cache_"
 FILLER_CACHE_VOLUME_PREFIXES = (DPHN_CACHE_VOLUME_PREFIX, ENGY_CACHE_VOLUME_PREFIX)
 # DAH-2475: what one node's DPHN cache costs on disk, and how much room the node must keep free after

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -241,6 +241,11 @@ FILLER_CONTAINER_PREFIX = "filler_"
 # name with the model + runtime version baked in; the validator only needs the prefix, to recognise
 # which volumes belong to the cache when sweeping or reclaiming them.
 DPHN_CACHE_VOLUME_PREFIX = "dphn_cache_"
+# DAH-2805: the ENGY filler keeps its ~35 GB checkpoint in its own cache volume. Only the
+# download-temporary sweep looks at it: reclaiming a whole ENGY volume is a separate decision
+# nobody has made, so the DPHN-only paths keep using DPHN_CACHE_VOLUME_PREFIX alone.
+ENGY_CACHE_VOLUME_PREFIX = "engy_cache_"
+FILLER_CACHE_VOLUME_PREFIXES = (DPHN_CACHE_VOLUME_PREFIX, ENGY_CACHE_VOLUME_PREFIX)
 # DAH-2475: what one node's DPHN cache costs on disk, and how much room the node must keep free after
 # downloading it. The floor mirrors the backend's EXECUTORS_FILTER_MIN_GB — below it the node drops out
 # of the rental listing, where neither renters nor fillers can reach it — and the margin is headroom

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -11,6 +11,7 @@ from core.utils import _m
 from services.const import (
     DPHN_CACHE_LISTING_FLOOR_GB,
     DPHN_CACHE_VOLUME_PREFIX,
+    CACHE_SWEEP_CONTAINER_NAME,
     FILLER_CACHE_VOLUME_PREFIXES,
     FILLER_CONTAINER_GRACE_MINUTES,
     FILLER_CONTAINER_PREFIX,
@@ -40,6 +41,9 @@ VOLUME_RM_MAX_PER_PASS = 200
 # sweep_abandoned_download_temporaries): with hf_xet the destination file is written in 64 MiB
 # bursts, which at the slowest per-file rate measured in prod (~50 KB/s) is ~22 min between writes.
 # 4 hours clears that by 10x while bounding the standing garbage to ~70 GB at the observed leak rate.
+# The residual case is accepted, not overlooked: a download whose process is alive but has written
+# nothing for four hours loses its file. It loses nothing real — huggingface_hub never resumes a
+# temporary anyway, so that attempt was already going to restart from byte zero.
 DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES = 240
 
 # Depth from the volume root: `hub/models--*/blobs` (Dolphin) and
@@ -367,8 +371,12 @@ class ContainerCleanup:
             f"-v {shlex.quote(name)}:/cache{index}" for index, name in enumerate(volume_names)
         )
         search_roots: str = " ".join(f"/cache{index}" for index in range(len(volume_names)))
+        # Named, and named with a Lium prefix: the provider-side load gate excuses our own
+        # housekeeping by name (LIUM_INFRA_CONTAINER_PREFIXES), and an anonymous container would be
+        # counted as the provider taking the machine from Lium. `--rm` keeps the name free for the
+        # next cycle, and a name still in use only fails this sweep, which is already best-effort.
         result = await ssh_client.run(
-            f"/usr/bin/docker run --rm {mount_flags} {ALPINE_HELPER_IMAGE} "
+            f"/usr/bin/docker run --rm --name {CACHE_SWEEP_CONTAINER_NAME} {mount_flags} {ALPINE_HELPER_IMAGE} "
             f"find {search_roots} -maxdepth {DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH} "
             "-type d \\( -name xet -o -name runtimes \\) -prune -o "
             f"-name '*.incomplete' -type f -mmin +{DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES} "

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -6,7 +6,7 @@ from typing import Optional
 import asyncssh
 
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
-from core.docker_utils import DockerCommand, df_available_bytes
+from core.docker_utils import ALPINE_HELPER_IMAGE, DockerCommand, df_available_bytes
 from core.utils import _m
 from services.const import (
     DPHN_CACHE_LISTING_FLOOR_GB,
@@ -19,6 +19,7 @@ from services.const import (
 )
 
 logger = logging.getLogger(__name__)
+
 
 # Anonymous docker volumes are named with a 64-char hex hash.
 ANON_VOLUME_NAME_PATTERN = re.compile(r"^[0-9a-f]{64}$")
@@ -33,23 +34,17 @@ DPHN_CACHE_RECLAIM_FREE_FLOOR_GB = DPHN_CACHE_LISTING_FLOOR_GB
 # over a few passes without a huge `docker volume rm` command.
 VOLUME_RM_MAX_PER_PASS = 200
 
-# DAH-2805: how long an abandoned huggingface_hub download temporary may sit in a filler cache volume
-# before the sweep removes it. huggingface_hub >= 1.18 writes every attempt to a UNIQUE
-# `<etag>.<8hex>.incomplete` and unlinks it in a `finally`, so a file only survives a download whose
-# process was KILLED — and the retry starts from byte zero under a new name, never reading the old
-# one. On a host too slow to finish a shard inside the worker's own readiness window that is one
-# 0.2-1.7 GB orphan per kill, forever: 742 files / 741 GB measured in one prod container, 2026-08-31.
-#
-# By AGE, because the writer is invisible from here: it lives inside a container, so no pid or
-# open-fd check can see it, and the volume is shared by every filler container on the node. A live
-# download touches its file at least once per burst — with hf_xet once per 64 MiB — which at the
-# slowest per-file rate measured in prod (~50 KB/s) is ~22 min of silence on a HEALTHY download.
+
+# DAH-2805: how long an abandoned download temporary may sit before the sweep removes it. The window
+# has to clear the longest silence a HEALTHY download can have, because age is the only signal (see
+# sweep_abandoned_download_temporaries): with hf_xet the destination file is written in 64 MiB
+# bursts, which at the slowest per-file rate measured in prod (~50 KB/s) is ~22 min between writes.
 # 4 hours clears that by 10x while bounding the standing garbage to ~70 GB at the observed leak rate.
 DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES = 240
 
-# The temporaries live in `<volume>/hub/models--*/blobs` (Dolphin) and
-# `<volume>/models/<repo>/.cache/huggingface/download` (ENGY); 8 reaches both with slack. The bound
-# matters because these volumes also hold the multi-GB xet chunk cache and the worker runtimes.
+# Depth from the volume root: `hub/models--*/blobs` (Dolphin) and
+# `models/<repo>/.cache/huggingface/download` (ENGY); 8 reaches both with slack. The bound matters
+# because these volumes also hold the multi-GB xet chunk cache and the worker runtimes.
 DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH = 8
 
 
@@ -216,7 +211,7 @@ class ContainerCleanup:
             # nodes, miner-assigned nodes, nodes that never ran Dolphin — and this check runs on every
             # node every cycle. Measuring the disk before knowing there is anything to reclaim made all
             # of them start a throwaway container just to learn there was nothing to do.
-            cache_volumes = await self._get_dphn_cache_volumes(ssh_client)
+            cache_volumes = await self._get_cache_volumes(ssh_client, (DPHN_CACHE_VOLUME_PREFIX,))
             if not cache_volumes:
                 return 0
 
@@ -243,7 +238,7 @@ class ContainerCleanup:
             # refusal — and dockerd refuses any volume a container still references, in ANY state.
             # Re-list instead: reporting a rescue that did not happen leaves the node delisted while
             # the check event says it was saved.
-            surviving: set[str] = set(await self._get_dphn_cache_volumes(ssh_client))
+            surviving: set[str] = set(await self._get_cache_volumes(ssh_client, (DPHN_CACHE_VOLUME_PREFIX,)))
             reclaimed: list[str] = [name for name in cache_volumes if name not in surviving]
             if not reclaimed:
                 logger.warning(
@@ -289,9 +284,6 @@ class ContainerCleanup:
             # "leave the cache alone".
             return None
 
-    async def _get_dphn_cache_volumes(self, ssh_client: asyncssh.SSHClientConnection) -> list[str]:
-        return await self._get_cache_volumes(ssh_client, (DPHN_CACHE_VOLUME_PREFIX,))
-
     async def _get_cache_volumes(
         self, ssh_client: asyncssh.SSHClientConnection, name_prefixes: tuple[str, ...]
     ) -> list[str]:
@@ -328,9 +320,6 @@ class ContainerCleanup:
             cache_volumes: list[str] = await self._get_cache_volumes(ssh_client, FILLER_CACHE_VOLUME_PREFIXES)
             if not cache_volumes:
                 return 0
-            mount_points: list[str] = await self._get_volume_mount_points(ssh_client, cache_volumes)
-            if not mount_points:
-                return 0
             if self.dry_run:
                 logger.info(
                     _m(
@@ -340,7 +329,7 @@ class ContainerCleanup:
                 )
                 return 0
 
-            removed_paths: list[str] = await self._remove_aged_download_temporaries(ssh_client, mount_points)
+            removed_paths: list[str] = await self._remove_aged_download_temporaries(ssh_client, cache_volumes)
             if not removed_paths:
                 return 0
             logger.info(
@@ -359,29 +348,32 @@ class ContainerCleanup:
             logger.warning(_m("Download-temporary sweep failed", extra=extra | {"error": str(e)}))
             return 0
 
-    async def _get_volume_mount_points(
+    async def _remove_aged_download_temporaries(
         self, ssh_client: asyncssh.SSHClientConnection, volume_names: list[str]
     ) -> list[str]:
-        # Asked of docker rather than built from the data root: a volume on a non-local driver, or a
-        # daemon with a moved root, would otherwise hand the sweep a path that does not exist.
-        result = await ssh_client.run(DockerCommand.volume_mount_points(*volume_names))
-        if getattr(result, "exit_status", 0) != 0:
-            return []
-        return [line.strip() for line in (result.stdout or "").splitlines() if line.strip().startswith("/")]
+        """Run the find INSIDE a helper container with the volumes mounted by name.
 
-    async def _remove_aged_download_temporaries(
-        self, ssh_client: asyncssh.SSHClientConnection, mount_points: list[str]
-    ) -> list[str]:
-        # `-name` before `-type`/`-mmin` so only a name match pays a stat(), and `-exec rm`, not
-        # `-delete`: `-delete` turns on `-depth`, which would silently disable the xet prune.
-        quoted_roots: str = " ".join(shlex.quote(path) for path in mount_points)
-        find_command: str = (
-            f"find {quoted_roots} -maxdepth {DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH} "
-            "-type d -name xet -prune -o "
+        The validator's SSH session lands inside the miner's executor container, so a host path like
+        `/var/lib/docker/volumes/<name>/_data` does not exist there — the same reason
+        `df_available_bytes` measures disk through a bind-mounted helper. Mounting by NAME also means
+        no mount-point lookup at all, and it cannot reach outside the volumes we asked for.
+
+        `-name` comes before `-type`/`-mmin` so only a name match pays a stat(), and the removal is
+        `-exec rm`, not `-delete`: `-delete` turns on `-depth`, which silently disables the xet prune.
+        Verified against busybox find (alpine 3.19): it removes the aged temporary, keeps a fresh one,
+        keeps a finished blob, and never descends into the xet chunk cache.
+        """
+        mount_flags: str = " ".join(
+            f"-v {shlex.quote(name)}:/cache{index}" for index, name in enumerate(volume_names)
+        )
+        search_roots: str = " ".join(f"/cache{index}" for index in range(len(volume_names)))
+        result = await ssh_client.run(
+            f"/usr/bin/docker run --rm {mount_flags} {ALPINE_HELPER_IMAGE} "
+            f"find {search_roots} -maxdepth {DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH} "
+            "-type d \\( -name xet -o -name runtimes \\) -prune -o "
             f"-name '*.incomplete' -type f -mmin +{DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES} "
             "-print -exec rm -f {} + 2>/dev/null || true"
         )
-        result = await ssh_client.run(find_command)
         return [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
 
     async def get_dangling_anonymous_volumes(self, ssh_client) -> Optional[list[str]]:

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import shlex
 from typing import Optional
 
 import asyncssh
@@ -10,6 +11,7 @@ from core.utils import _m
 from services.const import (
     DPHN_CACHE_LISTING_FLOOR_GB,
     DPHN_CACHE_VOLUME_PREFIX,
+    FILLER_CACHE_VOLUME_PREFIXES,
     FILLER_CONTAINER_GRACE_MINUTES,
     FILLER_CONTAINER_PREFIX,
     POD_CONTAINER_PREFIX,
@@ -30,6 +32,25 @@ DPHN_CACHE_RECLAIM_FREE_FLOOR_GB = DPHN_CACHE_LISTING_FLOOR_GB
 # Remove at most this many per pass; GC runs each cycle, so a backlog drains
 # over a few passes without a huge `docker volume rm` command.
 VOLUME_RM_MAX_PER_PASS = 200
+
+# DAH-2805: how long an abandoned huggingface_hub download temporary may sit in a filler cache volume
+# before the sweep removes it. huggingface_hub >= 1.18 writes every attempt to a UNIQUE
+# `<etag>.<8hex>.incomplete` and unlinks it in a `finally`, so a file only survives a download whose
+# process was KILLED — and the retry starts from byte zero under a new name, never reading the old
+# one. On a host too slow to finish a shard inside the worker's own readiness window that is one
+# 0.2-1.7 GB orphan per kill, forever: 742 files / 741 GB measured in one prod container, 2026-08-31.
+#
+# By AGE, because the writer is invisible from here: it lives inside a container, so no pid or
+# open-fd check can see it, and the volume is shared by every filler container on the node. A live
+# download touches its file at least once per burst — with hf_xet once per 64 MiB — which at the
+# slowest per-file rate measured in prod (~50 KB/s) is ~22 min of silence on a HEALTHY download.
+# 4 hours clears that by 10x while bounding the standing garbage to ~70 GB at the observed leak rate.
+DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES = 240
+
+# The temporaries live in `<volume>/hub/models--*/blobs` (Dolphin) and
+# `<volume>/models/<repo>/.cache/huggingface/download` (ENGY); 8 reaches both with slack. The bound
+# matters because these volumes also hold the multi-GB xet chunk cache and the worker runtimes.
+DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH = 8
 
 
 class ContainerCleanup:
@@ -269,14 +290,99 @@ class ContainerCleanup:
             return None
 
     async def _get_dphn_cache_volumes(self, ssh_client: asyncssh.SSHClientConnection) -> list[str]:
+        return await self._get_cache_volumes(ssh_client, (DPHN_CACHE_VOLUME_PREFIX,))
+
+    async def _get_cache_volumes(
+        self, ssh_client: asyncssh.SSHClientConnection, name_prefixes: tuple[str, ...]
+    ) -> list[str]:
         result = await ssh_client.run('/usr/bin/docker volume ls --format "{{.Name}}"')
         if getattr(result, "exit_status", 0) != 0:
             return []
         return sorted(
             name
             for name in (line.strip() for line in (result.stdout or "").splitlines())
-            if name.startswith(DPHN_CACHE_VOLUME_PREFIX)
+            if name.startswith(name_prefixes)
         )
+
+    async def sweep_abandoned_download_temporaries(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        executor_uuid: str,
+    ) -> int:
+        """Delete `*.incomplete` files no writer has touched in DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES.
+
+        DAH-2805: a filler's weight download that is killed mid-flight leaves its temporary behind,
+        and nothing ever reads it again (see the constant for the mechanism). One prod node reached
+        741 GB of them and dropped out of the rental listing.
+
+        It runs HERE, not inside the filler image, for three reasons: this loop visits a node on
+        every cycle whatever image is on it, one prefix list covers DPHN and ENGY alike, and it
+        cleans the garbage already on the fleet without waiting for an image rollout.
+
+        Only files matching `*.incomplete`, only inside volumes whose name carries one of our own
+        cache prefixes, and only when they are older than the window — a renter's volume is never a
+        candidate. Returns how many files were removed.
+        """
+        extra = {"executor_uuid": executor_uuid}
+        try:
+            cache_volumes: list[str] = await self._get_cache_volumes(ssh_client, FILLER_CACHE_VOLUME_PREFIXES)
+            if not cache_volumes:
+                return 0
+            mount_points: list[str] = await self._get_volume_mount_points(ssh_client, cache_volumes)
+            if not mount_points:
+                return 0
+            if self.dry_run:
+                logger.info(
+                    _m(
+                        "[DRY RUN] Would sweep abandoned download temporaries",
+                        extra=extra | {"volumes": cache_volumes, "dry_run": True},
+                    )
+                )
+                return 0
+
+            removed_paths: list[str] = await self._remove_aged_download_temporaries(ssh_client, mount_points)
+            if not removed_paths:
+                return 0
+            logger.info(
+                _m(
+                    f"Swept {len(removed_paths)} abandoned download temporaries from the filler cache",
+                    extra=extra
+                    | {
+                        "volumes": cache_volumes,
+                        "max_age_minutes": DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES,
+                        "sample_paths": removed_paths[:5],
+                    },
+                )
+            )
+            return len(removed_paths)
+        except Exception as e:
+            logger.warning(_m("Download-temporary sweep failed", extra=extra | {"error": str(e)}))
+            return 0
+
+    async def _get_volume_mount_points(
+        self, ssh_client: asyncssh.SSHClientConnection, volume_names: list[str]
+    ) -> list[str]:
+        # Asked of docker rather than built from the data root: a volume on a non-local driver, or a
+        # daemon with a moved root, would otherwise hand the sweep a path that does not exist.
+        result = await ssh_client.run(DockerCommand.volume_mount_points(*volume_names))
+        if getattr(result, "exit_status", 0) != 0:
+            return []
+        return [line.strip() for line in (result.stdout or "").splitlines() if line.strip().startswith("/")]
+
+    async def _remove_aged_download_temporaries(
+        self, ssh_client: asyncssh.SSHClientConnection, mount_points: list[str]
+    ) -> list[str]:
+        # `-name` before `-type`/`-mmin` so only a name match pays a stat(), and `-exec rm`, not
+        # `-delete`: `-delete` turns on `-depth`, which would silently disable the xet prune.
+        quoted_roots: str = " ".join(shlex.quote(path) for path in mount_points)
+        find_command: str = (
+            f"find {quoted_roots} -maxdepth {DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH} "
+            "-type d -name xet -prune -o "
+            f"-name '*.incomplete' -type f -mmin +{DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES} "
+            "-print -exec rm -f {} + 2>/dev/null || true"
+        )
+        result = await ssh_client.run(find_command)
+        return [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
 
     async def get_dangling_anonymous_volumes(self, ssh_client) -> Optional[list[str]]:
         # anonymous (64-hex) volumes referenced by no container; None if listing failed

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -50,6 +50,10 @@ DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES = 240
 # because these volumes also hold the multi-GB xet chunk cache and the worker runtimes.
 DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH = 8
 
+# The whole helper run is bounded: the walk itself takes hundreds of ms on a real cache, so anything
+# near a minute means a wedged docker daemon rather than work in progress.
+DOWNLOAD_TEMPORARY_SWEEP_TIMEOUT_SECONDS = 60
+
 
 class ContainerCleanup:
     """Service for cleaning up stale containers on executor machines."""
@@ -372,8 +376,12 @@ class ContainerCleanup:
         # The `rm -f` first: `--rm` does not fire if dockerd is restarted mid-run, and a leftover
         # container would hold the name for good — the sweep would then fail silently on that node
         # forever. Worst case it interrupts a sweep another validator started, which simply runs again.
+        # `timeout` bounds a wedged dockerd the same way machine_scrape does for `docker stats`: this
+        # call sits in the per-executor pipeline ahead of the fatal port checks, so a hang here would
+        # cost the node its whole cycle. A killed sweep simply removes nothing and runs again later.
         result = await ssh_client.run(
             f"/usr/bin/docker rm -f {CACHE_SWEEP_CONTAINER_NAME} >/dev/null 2>&1; "
+            f"timeout {DOWNLOAD_TEMPORARY_SWEEP_TIMEOUT_SECONDS} "
             f"/usr/bin/docker run --rm --name {CACHE_SWEEP_CONTAINER_NAME} {mount_flags} {ALPINE_HELPER_IMAGE} "
             f"find {search_roots} -maxdepth {DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH} "
             "-type d \\( -name xet -o -name runtimes \\) -prune -o "

--- a/neurons/validators/src/services/container_cleanup.py
+++ b/neurons/validators/src/services/container_cleanup.py
@@ -21,7 +21,6 @@ from services.const import (
 
 logger = logging.getLogger(__name__)
 
-
 # Anonymous docker volumes are named with a 64-char hex hash.
 ANON_VOLUME_NAME_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
@@ -357,25 +356,24 @@ class ContainerCleanup:
     ) -> list[str]:
         """Run the find INSIDE a helper container with the volumes mounted by name.
 
-        The validator's SSH session lands inside the miner's executor container, so a host path like
-        `/var/lib/docker/volumes/<name>/_data` does not exist there — the same reason
-        `df_available_bytes` measures disk through a bind-mounted helper. Mounting by NAME also means
-        no mount-point lookup at all, and it cannot reach outside the volumes we asked for.
+        Same reason `df_available_bytes` measures disk through a helper: the validator's SSH session
+        lands inside the executor container, where the volumes' host paths do not exist. Mounting by
+        NAME also removes the mount-point lookup, and the helper cannot reach outside what we mount.
 
         `-name` comes before `-type`/`-mmin` so only a name match pays a stat(), and the removal is
-        `-exec rm`, not `-delete`: `-delete` turns on `-depth`, which silently disables the xet prune.
+        `-exec rm`, not `-delete`: `-delete` turns on `-depth`, which silently disables the prunes.
         Verified against busybox find (alpine 3.19): it removes the aged temporary, keeps a fresh one,
-        keeps a finished blob, and never descends into the xet chunk cache.
+        keeps a finished blob, and never descends into the xet or runtimes trees.
         """
         mount_flags: str = " ".join(
             f"-v {shlex.quote(name)}:/cache{index}" for index, name in enumerate(volume_names)
         )
         search_roots: str = " ".join(f"/cache{index}" for index in range(len(volume_names)))
-        # Named, and named with a Lium prefix: the provider-side load gate excuses our own
-        # housekeeping by name (LIUM_INFRA_CONTAINER_PREFIXES), and an anonymous container would be
-        # counted as the provider taking the machine from Lium. `--rm` keeps the name free for the
-        # next cycle, and a name still in use only fails this sweep, which is already best-effort.
+        # The `rm -f` first: `--rm` does not fire if dockerd is restarted mid-run, and a leftover
+        # container would hold the name for good — the sweep would then fail silently on that node
+        # forever. Worst case it interrupts a sweep another validator started, which simply runs again.
         result = await ssh_client.run(
+            f"/usr/bin/docker rm -f {CACHE_SWEEP_CONTAINER_NAME} >/dev/null 2>&1; "
             f"/usr/bin/docker run --rm --name {CACHE_SWEEP_CONTAINER_NAME} {mount_flags} {ALPINE_HELPER_IMAGE} "
             f"find {search_roots} -maxdepth {DOWNLOAD_TEMPORARY_MAX_SEARCH_DEPTH} "
             "-type d \\( -name xet -o -name runtimes \\) -prune -o "

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -60,6 +60,7 @@ from payload_models.payloads import (
 )
 from services.attestation_service import AttestationError, AttestationService
 from services.const import (
+    FILLER_CACHE_VOLUME_PREFIXES,
     DPHN_CACHE_FREE_MARGIN_GB,
     DPHN_CACHE_LISTING_FLOOR_GB,
     DPHN_CACHE_SIZE_GB,
@@ -1952,7 +1953,12 @@ class DockerService:
         """
         if payload.workload_kind != WorkloadKind.FILLER or not payload.cache_volumes:
             return []
-        existing: set[str] = set(await self._find_cache_volumes_to_sweep(ssh_client, set(), default_extra))
+        requested_names: list[str] = [cache_volume.name for cache_volume in payload.cache_volumes]
+        existing: set[str] = set(
+            await self._find_cache_volumes_to_sweep(
+                ssh_client, set(), default_extra, self._cache_volume_families(requested_names)
+            )
+        )
         present: list[CacheVolume] = [volume for volume in payload.cache_volumes if volume.name in existing]
         if len(present) == len(payload.cache_volumes):
             return list(payload.cache_volumes)
@@ -1988,14 +1994,31 @@ class DockerService:
             return present
         return list(payload.cache_volumes)
 
+    @staticmethod
+    def _cache_volume_families(volume_names: list[str]) -> tuple[str, ...]:
+        """The cache prefixes these volume names belong to, e.g. `dphn_cache_` for a DPHN launch.
+
+        DAH-2805: a launch may only sweep its OWN family. A node that moves from DPHN to ENGY asks
+        for engy volumes, and sweeping every cache prefix there would delete the Dolphin cache the
+        node needs for its next fast start — the very thing these volumes exist for.
+        """
+        return tuple(
+            prefix
+            for prefix in FILLER_CACHE_VOLUME_PREFIXES
+            if any(name.startswith(prefix) for name in volume_names)
+        )
+
     async def _find_cache_volumes_to_sweep(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         keep_names: set[str],
         default_extra: dict,
+        name_prefixes: tuple[str, ...] = (DPHN_CACHE_VOLUME_PREFIX,),
     ) -> list[str]:
         # Cache volumes present on the host that this create no longer names, i.e. left by an older
         # model or runtime. Empty on any listing failure — sweeping is never worth failing a launch.
+        if not name_prefixes:
+            return []
         try:
             listed = await ssh_client.run('/usr/bin/docker volume ls --format "{{.Name}}"')
         except asyncio.CancelledError:
@@ -2003,7 +2026,7 @@ class DockerService:
         except Exception as exc:
             logger.warning(
                 _m(
-                    "Failed to list DPHN cache volumes",
+                    "Failed to list filler cache volumes",
                     extra=get_extra_info({**default_extra, "error": str(exc)}),
                 ),
                 exc_info=True,
@@ -2014,7 +2037,7 @@ class DockerService:
         return sorted(
             name
             for name in (line.strip() for line in (listed.stdout or "").splitlines())
-            if name.startswith(DPHN_CACHE_VOLUME_PREFIX) and name not in keep_names
+            if name.startswith(name_prefixes) and name not in keep_names
         )
 
     async def sweep_stale_cache_volumes(
@@ -2051,7 +2074,9 @@ class DockerService:
             return
 
         keep_names: set[str] = {cache_volume.name for cache_volume in payload.cache_volumes}
-        stale_volumes: list[str] = await self._find_cache_volumes_to_sweep(ssh_client, keep_names, default_extra)
+        stale_volumes: list[str] = await self._find_cache_volumes_to_sweep(
+            ssh_client, keep_names, default_extra, self._cache_volume_families(sorted(keep_names))
+        )
         if not stale_volumes:
             return
         logger.info(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -2081,7 +2081,7 @@ class DockerService:
             return
         logger.info(
             _m(
-                "Sweeping stale DPHN cache volumes",
+                "Sweeping stale filler cache volumes",
                 extra=get_extra_info({
                     **default_extra,
                     "stale_volumes": stale_volumes,

--- a/neurons/validators/src/services/task/checks/stale_container_cleanup.py
+++ b/neurons/validators/src/services/task/checks/stale_container_cleanup.py
@@ -1,8 +1,18 @@
 from __future__ import annotations
 
+import time
+
 from ..messages import StaleContainerCleanupMessages as Msg
 from ..messages import render_message
 from ..pipeline import CheckResult, Context
+
+
+# DAH-2805: how often the download-temporary sweep may run per executor. The check itself runs every
+# pipeline cycle (~15 min), but a temporary cannot become eligible until it is
+# DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES old, so walking the cache every cycle buys nothing and costs a
+# helper container plus a tree walk on every node. Same throttle CustomBuildOrphanSweepCheck uses,
+# for the same reason.
+DOWNLOAD_TEMPORARY_SWEEP_INTERVAL_SECONDS = 60 * 60
 
 
 class StaleContainerCleanupCheck:
@@ -33,6 +43,16 @@ class StaleContainerCleanupCheck:
     check_id = "executor.cleanup.stale_containers"
     fatal = False
 
+    def __init__(self, sweep_interval_seconds: int = DOWNLOAD_TEMPORARY_SWEEP_INTERVAL_SECONDS) -> None:
+        self._sweep_interval_seconds = sweep_interval_seconds
+        # executor uuid -> when its cache was last swept. In memory on the check, which the pipeline
+        # factory builds once and reuses across cycles; a validator restart simply sweeps again.
+        self._last_sweep_at: dict[str, float] = {}
+
+    def _sweep_is_due(self, executor_uuid: str, now: float) -> bool:
+        last_sweep_at: float | None = self._last_sweep_at.get(executor_uuid)
+        return last_sweep_at is None or (now - last_sweep_at) >= self._sweep_interval_seconds
+
     async def run(self, ctx: Context) -> CheckResult:
         removed_count, removed_names = await ctx.services.container_cleanup.cleanup(
             ssh_client=ctx.ssh,
@@ -50,14 +70,16 @@ class StaleContainerCleanupCheck:
             executor_uuid=ctx.executor.uuid,
         )
 
-        # DAH-2805: a filler weight download that is killed mid-flight leaves a `*.incomplete` file
-        # nothing will ever read again, and one prod node reached 741 GB of them. It is swept from
-        # here rather than from inside the filler image because this loop reaches the node on every
-        # cycle whatever image is on it, and it cleans what is already on the fleet.
-        swept_download_temporaries = await ctx.services.container_cleanup.sweep_abandoned_download_temporaries(
-            ssh_client=ctx.ssh,
-            executor_uuid=ctx.executor.uuid,
-        )
+        # DAH-2805: killed weight downloads leave `*.incomplete` files nothing reads again — 741 GB
+        # on one prod node. Swept from here because this check reaches every node, whatever image it
+        # runs; throttled because the files it looks for cannot appear faster than the age window.
+        swept_download_temporaries: int | None = None
+        if self._sweep_is_due(ctx.executor.uuid, time.monotonic()):
+            swept_download_temporaries = await ctx.services.container_cleanup.sweep_abandoned_download_temporaries(
+                ssh_client=ctx.ssh,
+                executor_uuid=ctx.executor.uuid,
+            )
+            self._last_sweep_at[ctx.executor.uuid] = time.monotonic()
 
         event = render_message(
             Msg.CLEANED,

--- a/neurons/validators/src/services/task/checks/stale_container_cleanup.py
+++ b/neurons/validators/src/services/task/checks/stale_container_cleanup.py
@@ -10,8 +10,9 @@ from ..pipeline import CheckResult, Context
 # DAH-2805: how often the download-temporary sweep may run per executor. The check itself runs every
 # pipeline cycle (~15 min), but a temporary cannot become eligible until it is
 # DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES old, so walking the cache every cycle buys nothing and costs a
-# helper container plus a tree walk on every node. Same throttle CustomBuildOrphanSweepCheck uses,
-# for the same reason.
+# helper container plus a tree walk on every node. CustomBuildOrphanSweepCheck throttles itself for
+# the same reason, on 6 h; unlike it, this one also stamps a failed sweep, which only costs the node
+# one hour of delay on a transient SSH error.
 DOWNLOAD_TEMPORARY_SWEEP_INTERVAL_SECONDS = 60 * 60
 
 
@@ -43,15 +44,10 @@ class StaleContainerCleanupCheck:
     check_id = "executor.cleanup.stale_containers"
     fatal = False
 
-    def __init__(self, sweep_interval_seconds: int = DOWNLOAD_TEMPORARY_SWEEP_INTERVAL_SECONDS) -> None:
-        self._sweep_interval_seconds = sweep_interval_seconds
+    def __init__(self) -> None:
         # executor uuid -> when its cache was last swept. In memory on the check, which the pipeline
         # factory builds once and reuses across cycles; a validator restart simply sweeps again.
         self._last_sweep_at: dict[str, float] = {}
-
-    def _sweep_is_due(self, executor_uuid: str, now: float) -> bool:
-        last_sweep_at: float | None = self._last_sweep_at.get(executor_uuid)
-        return last_sweep_at is None or (now - last_sweep_at) >= self._sweep_interval_seconds
 
     async def run(self, ctx: Context) -> CheckResult:
         removed_count, removed_names = await ctx.services.container_cleanup.cleanup(
@@ -59,6 +55,21 @@ class StaleContainerCleanupCheck:
             rented_data=ctx.state.rented_data,
             executor_uuid=ctx.executor.uuid,
         )
+
+        # DAH-2805: killed weight downloads leave `*.incomplete` files nothing reads again — 741 GB
+        # on one prod node. Swept from here because this check reaches every node, whatever image it
+        # runs; throttled because the files it looks for cannot appear faster than the age window.
+        # BEFORE the reclaim below on purpose: the reclaim measures free disk itself, so garbage
+        # freed here can be the difference between keeping the node's ~190 GB cache and losing it.
+        swept_download_temporaries: int | None = None
+        now: float = time.monotonic()
+        last_sweep_at: float = self._last_sweep_at.get(ctx.executor.uuid, float("-inf"))
+        if now - last_sweep_at >= DOWNLOAD_TEMPORARY_SWEEP_INTERVAL_SECONDS:
+            swept_download_temporaries = await ctx.services.container_cleanup.sweep_abandoned_download_temporaries(
+                ssh_client=ctx.ssh,
+                executor_uuid=ctx.executor.uuid,
+            )
+            self._last_sweep_at[ctx.executor.uuid] = now
 
         # DAH-2475: give the DPHN filler cache back when the node can no longer afford it. This is
         # the ONLY caller — the create-time sweep deliberately never reclaims (it would raise free
@@ -69,17 +80,6 @@ class StaleContainerCleanupCheck:
             ssh_client=ctx.ssh,
             executor_uuid=ctx.executor.uuid,
         )
-
-        # DAH-2805: killed weight downloads leave `*.incomplete` files nothing reads again — 741 GB
-        # on one prod node. Swept from here because this check reaches every node, whatever image it
-        # runs; throttled because the files it looks for cannot appear faster than the age window.
-        swept_download_temporaries: int | None = None
-        if self._sweep_is_due(ctx.executor.uuid, time.monotonic()):
-            swept_download_temporaries = await ctx.services.container_cleanup.sweep_abandoned_download_temporaries(
-                ssh_client=ctx.ssh,
-                executor_uuid=ctx.executor.uuid,
-            )
-            self._last_sweep_at[ctx.executor.uuid] = time.monotonic()
 
         event = render_message(
             Msg.CLEANED,

--- a/neurons/validators/src/services/task/checks/stale_container_cleanup.py
+++ b/neurons/validators/src/services/task/checks/stale_container_cleanup.py
@@ -50,6 +50,15 @@ class StaleContainerCleanupCheck:
             executor_uuid=ctx.executor.uuid,
         )
 
+        # DAH-2805: a filler weight download that is killed mid-flight leaves a `*.incomplete` file
+        # nothing will ever read again, and one prod node reached 741 GB of them. It is swept from
+        # here rather than from inside the filler image because this loop reaches the node on every
+        # cycle whatever image is on it, and it cleans what is already on the fleet.
+        swept_download_temporaries = await ctx.services.container_cleanup.sweep_abandoned_download_temporaries(
+            ssh_client=ctx.ssh,
+            executor_uuid=ctx.executor.uuid,
+        )
+
         event = render_message(
             Msg.CLEANED,
             ctx=ctx,
@@ -58,6 +67,7 @@ class StaleContainerCleanupCheck:
                 "removed_count": removed_count,
                 "removed_containers": removed_names,
                 "reclaimed_cache_volumes": reclaimed_cache_volumes,
+                "swept_download_temporaries": swept_download_temporaries,
             },
         )
         return CheckResult(passed=True, event=event)

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -82,6 +82,10 @@ JOB_LENGTH = 300
 # wrt input data and only reads ctx, so a shared instance is safe.
 _CUSTOM_BUILD_ORPHAN_SWEEP_SINGLETON = CustomBuildOrphanSweepCheck()
 
+# DAH-2805: same reason — the download-temporary sweep inside this check carries its own per-executor
+# cadence, and a fresh instance every cycle would sweep every cycle.
+_STALE_CONTAINER_CLEANUP_SINGLETON = StaleContainerCleanupCheck()
+
 
 class PipelineFactory:
     """Factory for building and configuring validation pipelines."""
@@ -283,7 +287,7 @@ class PipelineFactory:
                 # Cleaning it here frees those ports so PortConnectivityCheck can bind them this
                 # cycle; otherwise PortCountCheck (fatal) halts the pipeline before the cleanup
                 # that used to live in TenantEnforcementCheck ever runs -> executor stuck at 0.
-                StaleContainerCleanupCheck(),
+                _STALE_CONTAINER_CLEANUP_SINGLETON,
                 # DAH-2734: non-fatal gate on the load the PROVIDER puts on a listed machine.
                 # Specs arithmetic, plus one read-only SSH reading when the load is above the
                 # floor. AFTER the cleanup above: a pod Lium has just ended is our leftover to

--- a/neurons/validators/tests/test_cache_volumes.py
+++ b/neurons/validators/tests/test_cache_volumes.py
@@ -491,3 +491,49 @@ async def test_filler_create_never_triggers_the_rental_reclaim(docker_service):
     await docker_service.reclaim_dphn_cache_for_rental(ssh_client, payload, {})
 
     assert ssh_client.commands == []
+
+
+@pytest.mark.asyncio
+async def test_an_engy_launch_never_sweeps_the_dolphin_cache(docker_service):
+    # DAH-2805: the sweep used to look at `dphn_cache_` only, so an ENGY launch — whose kept names are
+    # all `engy_cache_` — read every Dolphin volume as stale and deleted it. The node then re-downloaded
+    # ~37 GB the next time it ran Dolphin, which is exactly what these volumes exist to avoid.
+    ssh_client = FakeSshClient(["dphn_cache_hf_v1", "engy_cache_ckpt_old", "engy_cache_ckpt_new"])
+    payload = _make_payload(
+        workload_kind=WorkloadKind.FILLER,
+        cache_volumes=[CacheVolume(name="engy_cache_ckpt_new", target="/opt/engy/models")],
+    )
+
+    await docker_service.sweep_stale_cache_volumes(ssh_client, payload, {})
+
+    assert _removed_volumes(ssh_client) == ["engy_cache_ckpt_old"]
+
+
+@pytest.mark.asyncio
+async def test_an_engy_launch_sweeps_its_own_stale_checkpoint(docker_service):
+    # The other half: a checkpoint or image bump renames the volume, and nothing swept the old one, so
+    # every bump left ~35 GB on the host forever.
+    ssh_client = FakeSshClient(["engy_cache_ckpt_old", "engy_cache_jit_old", "engy_cache_jit_new"])
+    payload = _make_payload(
+        workload_kind=WorkloadKind.FILLER,
+        cache_volumes=[CacheVolume(name="engy_cache_jit_new", target="/opt/engy/deepgemm-cache")],
+    )
+
+    await docker_service.sweep_stale_cache_volumes(ssh_client, payload, {})
+
+    assert _removed_volumes(ssh_client) == ["engy_cache_ckpt_old", "engy_cache_jit_old"]
+
+
+@pytest.mark.asyncio
+async def test_an_existing_engy_cache_is_mounted_without_charging_for_it_again(docker_service):
+    # Same bug as the DPHN case above, which the prefix filter hid for ENGY: its volumes were never
+    # seen as present, so every ENGY launch was measured as if the checkpoint still had to be pulled.
+    ssh_client = HostSshClient(["engy_cache_ckpt_v1"], free_gb=170)
+    payload = _make_payload(
+        workload_kind=WorkloadKind.FILLER,
+        cache_volumes=[CacheVolume(name="engy_cache_ckpt_v1", target="/opt/engy/models")],
+    )
+
+    affordable = await docker_service.select_affordable_cache_volumes(ssh_client, payload, {})
+
+    assert [volume.name for volume in affordable] == ["engy_cache_ckpt_v1"]

--- a/neurons/validators/tests/test_download_temporary_sweep.py
+++ b/neurons/validators/tests/test_download_temporary_sweep.py
@@ -18,13 +18,11 @@ class FakeSshClient:
     def __init__(
         self,
         volumes: list[str],
-        mount_points: dict[str, str] | None = None,
-        found_paths: list[str] | None = None,
+        find_returns_paths: list[str] | None = None,
         volume_ls_fails: bool = False,
     ):
         self._volumes = volumes
-        self._mount_points = mount_points or {name: f"/var/lib/docker/volumes/{name}/_data" for name in volumes}
-        self._found_paths = found_paths or []
+        self._find_returns_paths = find_returns_paths or []
         self._volume_ls_fails = volume_ls_fails
         self.commands: list[str] = []
 
@@ -34,33 +32,31 @@ class FakeSshClient:
             if self._volume_ls_fails:
                 return SimpleNamespace(exit_status=1, stdout="", stderr="boom")
             return SimpleNamespace(exit_status=0, stdout="\n".join(self._volumes), stderr="")
-        if "volume inspect" in command:
-            inspected = [name for name in self._mount_points if name in command]
-            return SimpleNamespace(
-                exit_status=0, stdout="\n".join(self._mount_points[name] for name in inspected), stderr=""
-            )
-        if command.startswith("find "):
-            return SimpleNamespace(exit_status=0, stdout="\n".join(self._found_paths), stderr="")
+        if " find " in command:
+            return SimpleNamespace(exit_status=0, stdout="\n".join(self._find_returns_paths), stderr="")
         return SimpleNamespace(exit_status=0, stdout="", stderr="")
 
 
 def _find_command(ssh_client: FakeSshClient) -> str:
-    return next((command for command in ssh_client.commands if command.startswith("find ")), "")
+    return next((command for command in ssh_client.commands if " find " in command), "")
 
 
 @pytest.mark.asyncio
 async def test_sweeps_both_filler_cache_volumes():
     ssh_client = FakeSshClient(
         volumes=["dphn_cache_hf_model", "engy_cache_ckpt_v3"],
-        found_paths=["/var/lib/docker/volumes/dphn_cache_hf_model/_data/hub/blobs/abc.1234abcd.incomplete"],
+        find_returns_paths=["/cache0/hub/models--x/blobs/abc.1234abcd.incomplete"],
     )
 
     removed = await ContainerCleanup().sweep_abandoned_download_temporaries(ssh_client, "exec-1")
 
     assert removed == 1
     find_command = _find_command(ssh_client)
-    assert "/var/lib/docker/volumes/dphn_cache_hf_model/_data" in find_command
-    assert "/var/lib/docker/volumes/engy_cache_ckpt_v3/_data" in find_command
+    # Mounted by NAME into the helper container: the validator's SSH session lands inside the
+    # executor container, where the volume's host path does not exist.
+    assert "-v dphn_cache_hf_model:/cache0" in find_command
+    assert "-v engy_cache_ckpt_v3:/cache1" in find_command
+    assert "find /cache0 /cache1" in find_command
 
 
 @pytest.mark.asyncio
@@ -72,8 +68,10 @@ async def test_only_aged_incomplete_files_are_targeted():
     find_command = _find_command(ssh_client)
     assert "-name '*.incomplete'" in find_command
     assert f"-mmin +{DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES}" in find_command
-    # `-delete` turns on `-depth`, which would silently disable the xet prune next to it.
+    # `-delete` turns on `-depth`, which would silently disable the prune next to it.
     assert "-delete" not in find_command
+    # The worker runtimes and the xet chunk cache are 10^4-10^5 inodes that never hold one.
+    assert "-name xet -o -name runtimes" in find_command
 
 
 @pytest.mark.asyncio
@@ -97,7 +95,7 @@ async def test_a_node_without_filler_caches_runs_no_find():
 
 @pytest.mark.asyncio
 async def test_dry_run_removes_nothing():
-    ssh_client = FakeSshClient(volumes=["dphn_cache_hf_model"], found_paths=["/data/a.incomplete"])
+    ssh_client = FakeSshClient(volumes=["dphn_cache_hf_model"], find_returns_paths=["/data/a.incomplete"])
 
     removed = await ContainerCleanup(dry_run=True).sweep_abandoned_download_temporaries(ssh_client, "exec-1")
 

--- a/neurons/validators/tests/test_download_temporary_sweep.py
+++ b/neurons/validators/tests/test_download_temporary_sweep.py
@@ -1,0 +1,115 @@
+"""DAH-2805: the periodic sweep of abandoned huggingface_hub download temporaries.
+
+A filler's weight download that is killed mid-flight leaves a `<etag>.<8hex>.incomplete` file that
+nothing will ever read again — huggingface_hub >= 1.18 names every attempt uniquely and only unlinks
+it in a `finally`. One prod node reached 741 GB of them and fell out of the rental listing. Age is
+the only signal available from the validator: the writer lives inside a container, and the volume is
+shared by every filler container on the node.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from services.container_cleanup import DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES, ContainerCleanup
+
+
+class FakeSshClient:
+    def __init__(
+        self,
+        volumes: list[str],
+        mount_points: dict[str, str] | None = None,
+        found_paths: list[str] | None = None,
+        volume_ls_fails: bool = False,
+    ):
+        self._volumes = volumes
+        self._mount_points = mount_points or {name: f"/var/lib/docker/volumes/{name}/_data" for name in volumes}
+        self._found_paths = found_paths or []
+        self._volume_ls_fails = volume_ls_fails
+        self.commands: list[str] = []
+
+    async def run(self, command: str, *args, **kwargs):
+        self.commands.append(command)
+        if "volume ls" in command:
+            if self._volume_ls_fails:
+                return SimpleNamespace(exit_status=1, stdout="", stderr="boom")
+            return SimpleNamespace(exit_status=0, stdout="\n".join(self._volumes), stderr="")
+        if "volume inspect" in command:
+            inspected = [name for name in self._mount_points if name in command]
+            return SimpleNamespace(
+                exit_status=0, stdout="\n".join(self._mount_points[name] for name in inspected), stderr=""
+            )
+        if command.startswith("find "):
+            return SimpleNamespace(exit_status=0, stdout="\n".join(self._found_paths), stderr="")
+        return SimpleNamespace(exit_status=0, stdout="", stderr="")
+
+
+def _find_command(ssh_client: FakeSshClient) -> str:
+    return next((command for command in ssh_client.commands if command.startswith("find ")), "")
+
+
+@pytest.mark.asyncio
+async def test_sweeps_both_filler_cache_volumes():
+    ssh_client = FakeSshClient(
+        volumes=["dphn_cache_hf_model", "engy_cache_ckpt_v3"],
+        found_paths=["/var/lib/docker/volumes/dphn_cache_hf_model/_data/hub/blobs/abc.1234abcd.incomplete"],
+    )
+
+    removed = await ContainerCleanup().sweep_abandoned_download_temporaries(ssh_client, "exec-1")
+
+    assert removed == 1
+    find_command = _find_command(ssh_client)
+    assert "/var/lib/docker/volumes/dphn_cache_hf_model/_data" in find_command
+    assert "/var/lib/docker/volumes/engy_cache_ckpt_v3/_data" in find_command
+
+
+@pytest.mark.asyncio
+async def test_only_aged_incomplete_files_are_targeted():
+    ssh_client = FakeSshClient(volumes=["dphn_cache_hf_model"])
+
+    await ContainerCleanup().sweep_abandoned_download_temporaries(ssh_client, "exec-1")
+
+    find_command = _find_command(ssh_client)
+    assert "-name '*.incomplete'" in find_command
+    assert f"-mmin +{DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES}" in find_command
+    # `-delete` turns on `-depth`, which would silently disable the xet prune next to it.
+    assert "-delete" not in find_command
+
+
+@pytest.mark.asyncio
+async def test_a_renters_volume_is_never_a_candidate():
+    ssh_client = FakeSshClient(volumes=["volume_customer_pod", "dphn_cache_hf_model"])
+
+    await ContainerCleanup().sweep_abandoned_download_temporaries(ssh_client, "exec-1")
+
+    assert "volume_customer_pod" not in _find_command(ssh_client)
+
+
+@pytest.mark.asyncio
+async def test_a_node_without_filler_caches_runs_no_find():
+    ssh_client = FakeSshClient(volumes=["volume_customer_pod"])
+
+    removed = await ContainerCleanup().sweep_abandoned_download_temporaries(ssh_client, "exec-1")
+
+    assert removed == 0
+    assert _find_command(ssh_client) == ""
+
+
+@pytest.mark.asyncio
+async def test_dry_run_removes_nothing():
+    ssh_client = FakeSshClient(volumes=["dphn_cache_hf_model"], found_paths=["/data/a.incomplete"])
+
+    removed = await ContainerCleanup(dry_run=True).sweep_abandoned_download_temporaries(ssh_client, "exec-1")
+
+    assert removed == 0
+    assert _find_command(ssh_client) == ""
+
+
+@pytest.mark.asyncio
+async def test_a_failed_listing_never_raises():
+    # The sweep runs inside a non-fatal check: a failure here must not change the executor's verdict.
+    ssh_client = FakeSshClient(volumes=["dphn_cache_hf_model"], volume_ls_fails=True)
+
+    removed = await ContainerCleanup().sweep_abandoned_download_temporaries(ssh_client, "exec-1")
+
+    assert removed == 0

--- a/neurons/validators/tests/test_download_temporary_sweep.py
+++ b/neurons/validators/tests/test_download_temporary_sweep.py
@@ -13,7 +13,11 @@ import pytest
 
 from services.const import CACHE_SWEEP_CONTAINER_NAME
 
-from services.container_cleanup import DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES, ContainerCleanup
+from services.container_cleanup import (
+    DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES,
+    DOWNLOAD_TEMPORARY_SWEEP_TIMEOUT_SECONDS,
+    ContainerCleanup,
+)
 
 
 class FakeSshClient:
@@ -63,6 +67,8 @@ async def test_sweeps_both_filler_cache_volumes():
     assert f"--name {CACHE_SWEEP_CONTAINER_NAME}" in find_command
     # A leftover from a dockerd restart would hold the name for good and kill the sweep silently.
     assert f"docker rm -f {CACHE_SWEEP_CONTAINER_NAME}" in find_command
+    # A wedged docker daemon must not eat the executor's cycle ahead of the fatal port checks.
+    assert f"timeout {DOWNLOAD_TEMPORARY_SWEEP_TIMEOUT_SECONDS} " in find_command
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_download_temporary_sweep.py
+++ b/neurons/validators/tests/test_download_temporary_sweep.py
@@ -11,6 +11,8 @@ from types import SimpleNamespace
 
 import pytest
 
+from services.const import CACHE_SWEEP_CONTAINER_NAME
+
 from services.container_cleanup import DOWNLOAD_TEMPORARY_MAX_AGE_MINUTES, ContainerCleanup
 
 
@@ -57,6 +59,9 @@ async def test_sweeps_both_filler_cache_volumes():
     assert "-v dphn_cache_hf_model:/cache0" in find_command
     assert "-v engy_cache_ckpt_v3:/cache1" in find_command
     assert "find /cache0 /cache1" in find_command
+    # Named with a Lium prefix, or the provider-side load gate counts our own housekeeping against
+    # the miner (LIUM_INFRA_CONTAINER_PREFIXES excuses by name).
+    assert f"--name {CACHE_SWEEP_CONTAINER_NAME}" in find_command
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_download_temporary_sweep.py
+++ b/neurons/validators/tests/test_download_temporary_sweep.py
@@ -59,9 +59,10 @@ async def test_sweeps_both_filler_cache_volumes():
     assert "-v dphn_cache_hf_model:/cache0" in find_command
     assert "-v engy_cache_ckpt_v3:/cache1" in find_command
     assert "find /cache0 /cache1" in find_command
-    # Named with a Lium prefix, or the provider-side load gate counts our own housekeeping against
-    # the miner (LIUM_INFRA_CONTAINER_PREFIXES excuses by name).
+    # Named, or the provider-side load gate counts our housekeeping against the miner.
     assert f"--name {CACHE_SWEEP_CONTAINER_NAME}" in find_command
+    # A leftover from a dockerd restart would hold the name for good and kill the sweep silently.
+    assert f"docker rm -f {CACHE_SWEEP_CONTAINER_NAME}" in find_command
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_stale_container_cleanup_check.py
+++ b/neurons/validators/tests/test_stale_container_cleanup_check.py
@@ -24,11 +24,13 @@ from protocol.vc_protocol.compute_requests import (
 class RecordingContainerCleanup:
     """Records cleanup() calls and returns a configurable (count, names) result."""
 
-    def __init__(self, result=(0, []), reclaimed=0):
+    def __init__(self, result=(0, []), reclaimed=0, swept=0):
         self._result = result
         self._reclaimed = reclaimed
+        self._swept = swept
         self.calls = []
         self.reclaim_calls = []
+        self.sweep_calls = []
 
     async def cleanup(self, ssh_client, rented_data, executor_uuid):
         self.calls.append(
@@ -43,6 +45,10 @@ class RecordingContainerCleanup:
     async def reclaim_dphn_cache_when_disk_is_tight(self, ssh_client, executor_uuid):
         self.reclaim_calls.append({"ssh_client": ssh_client, "executor_uuid": executor_uuid})
         return self._reclaimed
+
+    async def sweep_abandoned_download_temporaries(self, ssh_client, executor_uuid):
+        self.sweep_calls.append({"ssh_client": ssh_client, "executor_uuid": executor_uuid})
+        return self._swept
 
 
 def _make_ctx(cleanup, rented_data=None):
@@ -137,3 +143,17 @@ async def test_also_reclaims_the_dphn_cache_when_disk_is_tight():
     assert cleanup.reclaim_calls == [{"ssh_client": "ssh-conn-sentinel", "executor_uuid": ctx.executor.uuid}]
     assert result.passed
     assert result.event.what_we_saw["reclaimed_cache_volumes"] == 2
+
+
+@pytest.mark.asyncio
+async def test_also_sweeps_abandoned_download_temporaries():
+    # DAH-2805: the sweep rides this same per-cycle visit, so a node is cleaned whatever image it
+    # currently runs — including one whose filler already filled the disk and stopped mining.
+    cleanup = RecordingContainerCleanup(swept=7)
+    ctx = _make_ctx(cleanup)
+
+    result = await StaleContainerCleanupCheck().run(ctx)
+
+    assert cleanup.sweep_calls == [{"ssh_client": "ssh-conn-sentinel", "executor_uuid": ctx.executor.uuid}]
+    assert result.passed
+    assert result.event.what_we_saw["swept_download_temporaries"] == 7

--- a/neurons/validators/tests/test_stale_container_cleanup_check.py
+++ b/neurons/validators/tests/test_stale_container_cleanup_check.py
@@ -157,3 +157,17 @@ async def test_also_sweeps_abandoned_download_temporaries():
     assert cleanup.sweep_calls == [{"ssh_client": "ssh-conn-sentinel", "executor_uuid": ctx.executor.uuid}]
     assert result.passed
     assert result.event.what_we_saw["swept_download_temporaries"] == 7
+
+
+@pytest.mark.asyncio
+async def test_the_sweep_is_throttled_per_executor():
+    # DAH-2805: the check runs every pipeline cycle (~15 min) but a temporary cannot become eligible
+    # until it is hours old, so a per-executor cadence keeps the walk off every cycle.
+    cleanup = RecordingContainerCleanup(swept=1)
+    check = StaleContainerCleanupCheck()
+
+    await check.run(_make_ctx(cleanup))
+    second_result = await check.run(_make_ctx(cleanup))
+
+    assert len(cleanup.sweep_calls) == 1
+    assert second_result.event.what_we_saw["swept_download_temporaries"] is None


### PR DESCRIPTION
A filler's weight download that is killed mid-flight leaves a `*.incomplete` file that nothing will ever read again. One prod node held 742 of them — 741 GB — and dropped out of the rental listing; about 2 TB is sitting on the fleet right now.

## Mechanism

`huggingface_hub` >= 1.18 writes every download attempt to a UNIQUE `blobs/<etag>.<8hex>.incomplete` ([PR #4228](https://github.com/huggingface/huggingface_hub/pull/4228)) and unlinks it in a `finally`. So a file survives only when the process is KILLED mid-download, and the retry then starts from byte zero under a new name. The Dolphin worker kills its engine when it does not become ready in time ("inference backend did not become ready within %s" in the worker binary), so a host too slow to finish a 10 GB shard inside that window pays one 0.2–1.7 GB orphan per cycle, forever. Nothing on the platform ever removed them: `sweep_stale_cache_volumes` only drops OLD volume versions, and `reclaim_dphn_cache_when_disk_is_tight` is gated on "no running filler", which is never true on a sick node.

## What this adds

`ContainerCleanup.sweep_abandoned_download_temporaries`, called from `StaleContainerCleanupCheck` beside the existing reclaim. Per executor, per cycle: list volumes carrying one of our own cache prefixes, ask docker for their mount points, and remove `*.incomplete` files nothing has touched for 4 hours.

Why here rather than inside the filler image: this loop reaches a node on every cycle whatever image runs there, one prefix list covers DPHN and ENGY alike (`engy_cache_*` has no sweep at all today), and it cleans the garbage already on the fleet without waiting for an image rollout. The image keeps the half only it can do — refusing to start a download that would fill the disk (Datura-ai/computenet-docker-images#49).

## Why by age, and why 4 hours

The writer is invisible from here: it lives inside a container, and the volume is shared by every filler container on the node, so no pid or open-fd check can see it. A live download touches its file at least once per burst — measured locally with hf 1.29 + hf_xet, the xet path writes the destination in 64 MiB bursts, which at the slowest per-file rate seen in prod (~50 KB/s) is ~22 minutes of silence on a HEALTHY download. 4 hours clears that by 10x and still bounds the standing garbage to ~70 GB at the observed leak rate.

## Blast radius

Only files named `*.incomplete`, only inside volumes whose name starts with `dphn_cache_` / `engy_cache_`, only when older than the window. A renter's volume is never a candidate (there is a test for it), and their garbage is bounded anyway — a pod's volume is removed with the pod. `-exec rm`, not `-delete`: `-delete` turns on `-depth`, which would silently disable the `xet` prune beside it. The sweep is best-effort inside a non-fatal check and returns 0 on any failure.

## Tests

`pytest tests/test_download_temporary_sweep.py tests/test_stale_container_cleanup_check.py tests/test_container_cleanup.py tests/test_dphn_cache_reclaim.py` — 41 passed. New cases: both cache prefixes are swept, only aged `*.incomplete` is targeted, a renter's volume is never touched, a node with no filler cache runs no `find` at all, dry-run removes nothing, and a failed listing never raises.

## Verification after deploy

Re-survey the DPHN fillers: `blobs/*.incomplete` must drop to 0 fleet-wide, and the count of DPHN hosts above 90% disk with it. The 2026-08-31 survey in the ticket is the "before" snapshot.

Ticket: DAH-2805.
