### PR TITLE
DAH-2801 drop the dead docker logout block on the rental create path

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -4186,14 +4186,10 @@ class DockerService:
                         pod_id=payload.pod_id,
                     )
                 )
-                # command = f"/usr/bin/docker logout"
-                # await self.execute_and_stream_logs(
-                #     ssh_client=ssh_client,
-                #     command=command,
-                #     log_tag=log_tag,
-                #     log_text=f"Logging out of Docker registry",
-                #     log_extra=default_extra,
-                # )
+                # No logout counterpart below: the SDK login is a POST /auth to the executor's
+                # Docker daemon and the credential stays in this validator's client, so nothing is
+                # written to the executor's ~/.docker/config.json for a `docker logout` to clear.
+                #
                 # The default cache-template images are public Docker Hub refs, so a
                 # registry login buys nothing for them — the pull needs no auth and is
                 # itself almost always skipped (the image is pre-cached on the executor).


### PR DESCRIPTION
## Describe your changes

Comment-only change on the rental create path.

`create_container` carried a commented-out `docker logout` over SSH, left there long
enough that it reads like an unfinished security measure — the credential is sent in
cleartext, so wiping it after the pull looks overdue.

It is not: the rental login is `APIClient.login()` (`rental_docker_sdk.py:157`), a
`POST /auth` to the executor's Docker daemon over the `ssh://` connection. The daemon
only verifies the credential against the registry; `~/.docker/config.json` is written by
the CLI, which we never invoke. docker-py keeps the credential in the validator's own
`_auth_configs`, and `_build_pull_headers` reads it from there to set `X-Registry-Auth`
on `/images/create`. Nothing lands on the executor's disk.

So enabling that block would clear nothing of ours and would delete the *provider's* own
`~/.docker/config.json` under their root. Dropped the block and replaced it with three
lines stating why there is no logout here.

The real exposure — the provider is root and can read `X-Registry-Auth` off their own
docker.sock during the pull — is unchanged by this PR and is only closed by not sending
the password at all (read-only access token, short-lived token, or a pull-through proxy).
Tracked separately.

## Issue ticket number and link

[DAH-2801 check credential ownership on read, update and delete](https://www.notion.so/Compute-SN-c27d35dd084e4c4d92374f55cdd293f2)

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [ ] I wrote tests. — comment-only change, no behaviour to cover
- [x] Need to take care of performance? — no runtime effect
