### PR TITLE
DAH-2811, validate one miner on demand

### DIFF
--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -31,6 +31,7 @@ from payload_models.payloads import (
     DuplicateExecutorsResponse,
     FailedContainerRequest,
     ExecutorRentFinishedRequest,
+    ForcedMinerValidationRequest,
     ForcedValidationCycleRequest,
     GetEstimateRequest,
     GetPodLogsRequestFromServer,
@@ -685,6 +686,14 @@ class ComputeClient:
             return
 
         try:
+            request = pydantic.TypeAdapter(ForcedMinerValidationRequest).validate_json(raw_msg)
+        except pydantic.ValidationError:
+            pass
+        else:
+            await self.handle_forced_miner_validation(request)
+            return
+
+        try:
             job_request = self.accepted_request_type().parse(raw_msg)
         except Exception as ex:
             error_msg = "Invalid message received from backend"
@@ -783,6 +792,23 @@ class ComputeClient:
             return
 
         await self.miner_service.request_validation_cycle_now()
+
+    async def handle_forced_miner_validation(self, request: ForcedMinerValidationRequest) -> None:
+        """Validate one miner now instead of waiting for the next block window.
+
+        Staging only. The backend gates the request too; this is the second gate, so a message
+        that reaches a production validator does nothing.
+        """
+        if settings.DEPLOY_ENV == "PROD":
+            logger.warning(
+                _m(
+                    "Forced miner validation is disabled in production",
+                    extra=get_extra_info(self.logging_extra),
+                ),
+            )
+            return
+
+        await self.miner_service.validate_one_miner_now(request.miner_hotkey)
 
     async def get_miner_axon_info(self, hotkey: str) -> bittensor.AxonInfo:
         miner = await self.subtensor_client.get_miner(hotkey)

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -99,6 +99,8 @@ class Validator:
             ssh_service=ssh_service,
             redis_service=self.redis_service,
             attestation_service=self.attestation_service,
+            backend_client=self.backend_client,
+            file_encrypt_service=self.file_encrypt_service,
         )
         task_service = TaskService(
             ssh_service=ssh_service,

--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -206,6 +206,17 @@ class ForcedValidationCycleRequest(BaseModel):
     message_type: Literal["ForcedValidationCycleRequest"]
 
 
+class ForcedMinerValidationRequest(BaseModel):
+    """Ask the validator to validate one miner now, not at the next block window.
+
+    A staging development tool. The whole cycle waits on every registered miner, and most of
+    them never answer, so a run aimed at one miner returns in seconds instead of minutes.
+    """
+
+    message_type: Literal["ForcedMinerValidationRequest"]
+    miner_hotkey: str
+
+
 class WorkloadKind(enum.Enum):
     CUSTOMER_RENTAL = "CUSTOMER_RENTAL"
     FILLER = "FILLER"

--- a/neurons/validators/src/services/ioc.py
+++ b/neurons/validators/src/services/ioc.py
@@ -75,6 +75,8 @@ async def initiate_services():
         task_service=ioc["TaskService"],
         redis_service=ioc["RedisService"],
         attestation_service=ioc["AttestationService"],
+        backend_client=ioc["BackendClient"],
+        file_encrypt_service=ioc["FileEncryptService"],
     )
 
 

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -11,7 +11,9 @@ import aiohttp
 from asyncssh import SSHKey
 import asyncssh
 import bittensor
+from clients.backend_client import BackendClient
 from clients.miner_client import MinerClient
+from clients.subtensor_client import SubtensorClient
 from datura.requests.miner_requests import (
     AcceptJobRequest,
     AcceptSSHKeyRequest,
@@ -58,7 +60,11 @@ from payload_models.payloads import (
 )
 from tenacity import RetryError
 
+from pydantic import BaseModel
+
 from core.config import settings
+from services.default_docker_image_digest_service import fetch_default_image_digests
+from services.file_encrypt_service import FileEncryptService
 from core.utils import _m, _StructuredMessage, get_extra_info
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.attestation_service import AttestationService
@@ -184,6 +190,15 @@ REST_SSH_REMOVE_TIMEOUT = 10  # Timeout for SSH key removal requests
 MANUAL_RENTAL_FORCED_PASS_EVENT = "Executor force-passed as special manual rental (not validated)"
 
 
+class ForcedValidationInputs(BaseModel):
+    """Everything one validation run needs, gathered before the miner is contacted."""
+
+    payload: MinerJobRequestPayload
+    encrypted_files: MinerJobEnryptedFiles
+    rented_executors: RentedExecutorsResponse
+    default_docker_image_digests: dict[str, str]
+
+
 class MinerService:
     def __init__(
         self,
@@ -191,11 +206,18 @@ class MinerService:
         task_service: Annotated[TaskService, Depends(TaskService)],
         redis_service: Annotated[RedisService, Depends(RedisService)],
         attestation_service: Annotated[AttestationService, Depends(AttestationService)],
+        backend_client: Annotated[BackendClient, Depends(BackendClient)],
+        file_encrypt_service: Annotated[FileEncryptService, Depends(FileEncryptService)],
     ):
         self.ssh_service = ssh_service
         self.task_service = task_service
         self.redis_service = redis_service
         self.attestation_service = attestation_service
+        self.backend_client = backend_client
+        self.file_encrypt_service = file_encrypt_service
+        # ecrypt_miner_job_files wipes and rebuilds one fixed temp directory, so two forced
+        # runs at once would delete each other's binaries mid-run.
+        self.forced_validation_lock = asyncio.Lock()
 
     @staticmethod
     def _normalize_public_key(public_key: bytes | str) -> str:
@@ -741,6 +763,131 @@ class MinerService:
         """
         await self.redis_service.request_forced_validation_cycle()
         logger.info(_m("Forced validation cycle requested", extra=get_extra_info({})))
+
+    async def validate_one_miner_now(self, miner_hotkey: str) -> None:
+        """Validate every executor of one miner now, and publish the result.
+
+        This is one iteration of the scheduled cycle, aimed at a single miner. The cycle waits
+        on all registered miners and most of them never answer, so it costs minutes; one miner
+        returns in seconds. Staging only -- the caller gates on the environment.
+        """
+        log_context: dict[str, str | int | None] = {"miner_hotkey": miner_hotkey}
+        async with self.forced_validation_lock:
+            job_inputs = await self._gather_forced_validation_inputs(miner_hotkey, log_context)
+            if job_inputs is None:
+                return
+            job = await self.request_job_to_miner(
+                payload=job_inputs.payload,
+                encrypted_files=job_inputs.encrypted_files,
+                rented_data=job_inputs.rented_executors,
+                default_docker_image_digests=job_inputs.default_docker_image_digests,
+            )
+
+        results: list[JobResult] = job["results"]
+        logger.info(
+            _m(
+                "Forced miner validation finished",
+                extra=get_extra_info({
+                    **log_context,
+                    "job_batch_id": job_inputs.payload.job_batch_id,
+                    "results": len(results),
+                    "log_text": results[0].log_text if results else "",
+                }),
+            ),
+        )
+        await self.publish_machine_specs(
+            results, job_inputs.payload.miner_hotkey, job_inputs.payload.miner_coldkey
+        )
+
+    async def _gather_forced_validation_inputs(
+        self, miner_hotkey: str, log_context: dict[str, str | int | None]
+    ) -> "ForcedValidationInputs | None":
+        """Collect everything one validation run needs, or None when the run must not start.
+
+        The four calls are independent, and three of them block the loop: the chain reads, and
+        the PyInstaller build inside ecrypt_miner_job_files. The connector process also serves
+        container create and delete traffic, so the blocking ones go to threads.
+        """
+        subtensor_client = SubtensorClient.get_instance()
+        miners = await subtensor_client.get_miners()
+        matches = [miner for miner in miners if miner.hotkey == miner_hotkey]
+        if not matches:
+            logger.error(
+                _m(
+                    "Forced miner validation stopped: miner is not in the metagraph",
+                    extra=get_extra_info(log_context),
+                ),
+            )
+            return None
+        miner = matches[0]
+
+        (
+            job_batch_id,
+            rented_executors,
+            encrypted_files,
+            default_docker_image_digests,
+        ) = await asyncio.gather(
+            self._current_cycle_batch_id(subtensor_client),
+            self.backend_client.get_all_rented_executors(),
+            asyncio.to_thread(self.file_encrypt_service.ecrypt_miner_job_files),
+            self._fetch_default_docker_image_digests_or_empty(log_context),
+        )
+
+        # The scheduled cycle skips its whole iteration when this fetch fails
+        # (core/validator.py), because an empty rental map reads every rented machine as free:
+        # the run would then disturb a customer's box and score it by the wrong rule set.
+        if rented_executors is None:
+            logger.error(
+                _m(
+                    "Forced miner validation stopped: could not fetch rented executors",
+                    extra=get_extra_info(log_context),
+                ),
+            )
+            return None
+
+        return ForcedValidationInputs(
+            payload=MinerJobRequestPayload(
+                job_batch_id=job_batch_id,
+                miner_hotkey=miner_hotkey,
+                miner_coldkey=miner.coldkey,
+                miner_address=miner.axon_info.ip,
+                miner_port=miner.axon_info.port,
+            ),
+            encrypted_files=encrypted_files,
+            rented_executors=rented_executors,
+            default_docker_image_digests=default_docker_image_digests,
+        )
+
+    @staticmethod
+    async def _current_cycle_batch_id(subtensor_client: SubtensorClient) -> str:
+        """The batch id of the cycle running now, in the shape the scheduled cycle sends.
+
+        The backend parses this field as a "%Y-%m-%d %H:%M:%S" cycle timestamp, so a forced run
+        cannot invent its own id -- it would fail the spec ingestion.
+        """
+        current_block: int = await asyncio.to_thread(subtensor_client.get_current_block)
+        cycle_block: int = (current_block // settings.BLOCKS_FOR_JOB) * settings.BLOCKS_FOR_JOB
+        return await subtensor_client.get_time_from_block(cycle_block)
+
+    @staticmethod
+    async def _fetch_default_docker_image_digests_or_empty(
+        log_context: dict[str, str | int | None],
+    ) -> dict[str, str]:
+        """The digest snapshot the scheduled cycle validates against, empty when Docker Hub fails.
+
+        Fail-open like the cycle: an empty snapshot skips the digest check. Without the fetch a
+        forced run would score the miner by a weaker rule set than the cycle does.
+        """
+        try:
+            return await fetch_default_image_digests()
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "Forced miner validation could not fetch image digests; digest checks skip",
+                    extra=get_extra_info({**log_context, "error": str(exc)}),
+                ),
+            )
+            return {}
 
     async def publish_machine_specs(
         self, results: list[JobResult], miner_hotkey: str, miner_coldkey: str

--- a/neurons/validators/tests/test_delete_cancels_inflight_create.py
+++ b/neurons/validators/tests/test_delete_cancels_inflight_create.py
@@ -8,7 +8,7 @@ the next paying rental.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 from uuid import uuid4
 
 import pytest
@@ -39,6 +39,8 @@ def miner_service() -> MinerService:
         task_service=Mock(),
         redis_service=Mock(),
         attestation_service=Mock(),
+        backend_client=MagicMock(),
+        file_encrypt_service=MagicMock(),
     )
 
 

--- a/neurons/validators/tests/test_failure_reason_split.py
+++ b/neurons/validators/tests/test_failure_reason_split.py
@@ -7,7 +7,7 @@ filler_run.failure_reason and logs. Packing the full text into msg is what leake
 into renter dashboards.
 """
 
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from core.utils import _m
 from payload_models.payloads import (
@@ -24,6 +24,8 @@ def _miner_service() -> MinerService:
         task_service=Mock(),
         redis_service=Mock(),
         attestation_service=Mock(),
+        backend_client=MagicMock(),
+        file_encrypt_service=MagicMock(),
     )
 
 

--- a/neurons/validators/tests/test_forced_miner_validation.py
+++ b/neurons/validators/tests/test_forced_miner_validation.py
@@ -1,0 +1,204 @@
+"""DAH-2811: validate one miner on demand, instead of the whole fleet."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from datura.requests.miner_requests import ExecutorSSHInfo
+
+from clients.compute_client import ComputeClient
+from payload_models.payloads import (
+    ForcedMinerValidationRequest,
+    MinerJobEnryptedFiles,
+)
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.miner_service import MinerService
+from services.task_service import JobResult
+
+MINER_HOTKEY = "5F7X5UpKSr26KU3jKfpLmT8kuKtBNyHhEnfS8xtxPCqCb13p"
+EXECUTOR_ID = "11111111-2222-3333-4444-555555555555"
+CYCLE_BATCH_ID = "2026-08-31 12:00:00"
+ENCRYPTED_FILES = MinerJobEnryptedFiles(
+    encrypt_key="key",
+    all_keys={},
+    tmp_directory="/tmp/forced",
+    machine_scrape_file_name="machine_scrape",
+)
+
+# The exact bytes the backend puts on the websocket. Reproduce with
+# ForcedMinerValidationRequest(miner_hotkey=...).model_dump_json() in lium-io-backend.
+BACKEND_MESSAGE = (
+    '{"message_type":"ForcedMinerValidationRequest","miner_hotkey":"' + MINER_HOTKEY + '"}'
+)
+
+
+def _make_service(monkeypatch) -> MinerService:
+    import services.miner_service as module
+
+    service = MinerService.__new__(MinerService)
+    service.forced_validation_lock = asyncio.Lock()
+    service.backend_client = MagicMock(
+        get_all_rented_executors=AsyncMock(return_value=RentedExecutorsResponse(executors={}))
+    )
+    service.file_encrypt_service = MagicMock(
+        ecrypt_miner_job_files=MagicMock(return_value=ENCRYPTED_FILES)
+    )
+    service.request_job_to_miner = AsyncMock()
+    service.publish_machine_specs = AsyncMock()
+
+    subtensor_client = MagicMock()
+    subtensor_client.get_miners = AsyncMock(
+        return_value=[
+            MagicMock(
+                hotkey=MINER_HOTKEY,
+                coldkey="coldkey",
+                axon_info=MagicMock(ip="1.2.3.4", port=8091),
+            )
+        ]
+    )
+    subtensor_client.get_current_block = MagicMock(return_value=1_000_042)
+    subtensor_client.get_time_from_block = AsyncMock(return_value=CYCLE_BATCH_ID)
+    monkeypatch.setattr(
+        module.SubtensorClient, "get_instance", MagicMock(return_value=subtensor_client)
+    )
+    monkeypatch.setattr(module, "fetch_default_image_digests", AsyncMock(return_value={}))
+    return service
+
+
+def _make_result() -> JobResult:
+    return JobResult(
+        spec={},
+        executor_info=ExecutorSSHInfo(
+            uuid=EXECUTOR_ID,
+            address="1.2.3.4",
+            port=8091,
+            ssh_username="root",
+            ssh_port=22,
+            python_path="",
+            root_dir="",
+        ),
+        score=1.0,
+        job_score=1.0,
+        collateral_deposited=False,
+        job_batch_id=CYCLE_BATCH_ID,
+        log_status="info",
+        log_text="ok",
+        gpu_model="H100",
+        gpu_count=1,
+        sysbox_runtime=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_it_validates_only_the_named_miner_and_publishes(monkeypatch) -> None:
+    service = _make_service(monkeypatch)
+    service.request_job_to_miner.return_value = {
+        "miner_hotkey": MINER_HOTKEY,
+        "miner_coldkey": "coldkey",
+        "results": [_make_result()],
+    }
+
+    await service.validate_one_miner_now(MINER_HOTKEY)
+
+    payload = service.request_job_to_miner.await_args.kwargs["payload"]
+    assert payload.miner_hotkey == MINER_HOTKEY
+    assert payload.miner_address == "1.2.3.4"
+    # The backend parses job_batch_id as the cycle timestamp, so a forced run reuses the
+    # running cycle's id instead of inventing one.
+    assert payload.job_batch_id == CYCLE_BATCH_ID
+    assert service.publish_machine_specs.await_args.args[0] == [service.request_job_to_miner.return_value["results"][0]]
+
+
+@pytest.mark.asyncio
+async def test_a_miner_outside_the_metagraph_is_refused(monkeypatch) -> None:
+    service = _make_service(monkeypatch)
+    import services.miner_service as module
+
+    module.SubtensorClient.get_instance().get_miners = AsyncMock(return_value=[])
+
+    await service.validate_one_miner_now("5UnknownHotkey")
+
+    service.request_job_to_miner.assert_not_awaited()
+    service.publish_machine_specs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unreachable_rental_data_stops_the_run(monkeypatch) -> None:
+    """The scheduled cycle skips its iteration here; an empty map reads rented boxes as free."""
+    service = _make_service(monkeypatch)
+    service.backend_client.get_all_rented_executors = AsyncMock(return_value=None)
+
+    await service.validate_one_miner_now(MINER_HOTKEY)
+
+    service.request_job_to_miner.assert_not_awaited()
+    service.publish_machine_specs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_two_runs_do_not_overlap(monkeypatch) -> None:
+    """ecrypt_miner_job_files wipes one fixed temp directory, so overlap destroys both runs."""
+    service = _make_service(monkeypatch)
+    concurrent_runs = 0
+    peak_concurrent_runs = 0
+
+    async def slow_job(**kwargs):
+        nonlocal concurrent_runs, peak_concurrent_runs
+        concurrent_runs += 1
+        peak_concurrent_runs = max(peak_concurrent_runs, concurrent_runs)
+        await asyncio.sleep(0)
+        concurrent_runs -= 1
+        return {"miner_hotkey": MINER_HOTKEY, "miner_coldkey": "c", "results": []}
+
+    service.request_job_to_miner = AsyncMock(side_effect=slow_job)
+
+    await asyncio.gather(
+        service.validate_one_miner_now(MINER_HOTKEY),
+        service.validate_one_miner_now(MINER_HOTKEY),
+    )
+
+    assert peak_concurrent_runs == 1
+
+
+def _make_client(monkeypatch, deploy_env: str) -> ComputeClient:
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "DEPLOY_ENV", deploy_env)
+    client = ComputeClient.__new__(ComputeClient)
+    client.logging_extra = {}
+    client.miner_service = MagicMock(validate_one_miner_now=AsyncMock())
+    client.lock = asyncio.Lock()
+    return client
+
+
+@pytest.mark.asyncio
+async def test_the_backend_message_reaches_the_service(monkeypatch) -> None:
+    """handle_message tries many models in turn, so the branch order is worth pinning."""
+    client = _make_client(monkeypatch, "STAGE")
+
+    await client.handle_message(BACKEND_MESSAGE)
+
+    client.miner_service.validate_one_miner_now.assert_awaited_once_with(MINER_HOTKEY)
+
+
+@pytest.mark.asyncio
+async def test_production_ignores_the_backend_message(monkeypatch) -> None:
+    client = _make_client(monkeypatch, "PROD")
+
+    await client.handle_message(BACKEND_MESSAGE)
+
+    client.miner_service.validate_one_miner_now.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_container_message_is_not_read_as_a_forced_run(monkeypatch) -> None:
+    client = _make_client(monkeypatch, "STAGE")
+    client.miner_drivers = asyncio.Queue()
+    client.miner_driver = MagicMock(return_value=asyncio.sleep(0))
+    delete_request = (
+        '{"message_type":"ContainerDeleteRequest","miner_hotkey":"h",'
+        '"executor_id":"e","pod_id":"p","container_name":"c","volume_name":"v"}'
+    )
+
+    await client.handle_message(delete_request)
+
+    client.miner_service.validate_one_miner_now.assert_not_awaited()

--- a/neurons/validators/tests/test_incentive_reasons_payload.py
+++ b/neurons/validators/tests/test_incentive_reasons_payload.py
@@ -81,6 +81,8 @@ async def test_publisher_carries_reason_codes_as_data_not_just_log_text(
         task_service=MagicMock(),
         redis_service=redis_service,
         attestation_service=MagicMock(),
+        backend_client=MagicMock(),
+        file_encrypt_service=MagicMock(),
     )
 
     await service.publish_machine_specs([job], miner_hotkey="hk", miner_coldkey="ck")
@@ -107,6 +109,8 @@ async def test_publisher_reports_empty_list_when_no_catalogued_reason_exists(
         task_service=MagicMock(),
         redis_service=redis_service,
         attestation_service=MagicMock(),
+        backend_client=MagicMock(),
+        file_encrypt_service=MagicMock(),
     )
 
     await service.publish_machine_specs([job], miner_hotkey="hk", miner_coldkey="ck")

--- a/neurons/validators/tests/test_manual_rental_results.py
+++ b/neurons/validators/tests/test_manual_rental_results.py
@@ -19,7 +19,7 @@ See .omc/plans/special-manual-rental.md sections T3, T4 and 5 for the full ratio
 exercised directly here rather than by driving the full websocket/REST flow.
 """
 
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from datura.requests.miner_requests import ExecutorSSHInfo
@@ -89,6 +89,8 @@ def make_miner_service() -> MinerService:
         task_service=Mock(),
         redis_service=Mock(),
         attestation_service=Mock(),
+        backend_client=MagicMock(),
+        file_encrypt_service=MagicMock(),
     )
 
 

--- a/neurons/validators/tests/test_miner_service.py
+++ b/neurons/validators/tests/test_miner_service.py
@@ -11,7 +11,7 @@ PortConnectivityCheck's renting_in_progress tolerate. This test therefore pins
 that a ContainerCreateRequest is delegated to create_container and that
 miner_service no longer makes an early wait_for_port_check_containers call.
 """
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock
 from uuid import uuid4
 
 import pytest
@@ -75,6 +75,8 @@ def miner_service(mocker):
         task_service=mocker.Mock(),
         redis_service=redis_service,
         attestation_service=mocker.Mock(),
+        backend_client=MagicMock(),
+        file_encrypt_service=MagicMock(),
     )
     return svc
 

--- a/neurons/validators/tests/test_ws_delivery_stamps.py
+++ b/neurons/validators/tests/test_ws_delivery_stamps.py
@@ -52,6 +52,8 @@ async def _published_payloads(jobs: list[Any]) -> list[dict[str, Any]]:
         task_service=MagicMock(),
         redis_service=redis_service,
         attestation_service=MagicMock(),
+        backend_client=MagicMock(),
+        file_encrypt_service=MagicMock(),
     )
     await service.publish_machine_specs(jobs, miner_hotkey="hk", miner_coldkey="ck")
     return [call.args[1] for call in redis_service.publish.await_args_list]


### PR DESCRIPTION
DAH-2090 gave staging a way to start the whole validation cycle now. It works, but the cycle takes about four minutes on staging, and almost none of that is validation: the run contacts all 36 registered miners, only two executors answer, and about 25 requests sit out a 30 second timeout because nobody is behind those axon addresses.

Aiming at one miner skips all of that. It is one iteration of the same cycle, for the miner you care about, so it returns in seconds.

`ForcedMinerValidationRequest` carries the miner hotkey. The connector runs `request_job_to_miner` once and publishes through the usual machine-spec path. Nothing is filtered afterwards: for a whole miner the manual-rental results and the failure sentinel are already the right answer, which is what made the earlier per-executor attempt awkward.

`MinerService` gains the two dependencies the run needs (`BackendClient`, `FileEncryptService`), so every construction site is updated. The rented-executor fetch failing stops the run, exactly as it stops the scheduled cycle, and one lock keeps two runs from wiping each other's encryption temp directory.

Production is closed the same way as DAH-2090: the backend flag is off, and the validator refuses the message when `DEPLOY_ENV` is `PROD`.

Needs Datura-ai/lium-io-backend#TBD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)