### PR TITLE
DAH-2718: carry structured validation events to backend

### DIFF
--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -330,6 +330,7 @@ class ComputeClient:
                             incentive_formula_version=data.get("incentive_formula_version"),
                             incentive_formula_inputs=data.get("incentive_formula_inputs"),
                             log_text=data["log_text"],
+                            validation_event=data.get("validation_event"),
                             incentive_reasons=data.get("incentive_reasons"),
                             miner_hotkey=data["miner_hotkey"],
                             miner_coldkey=data["miner_coldkey"],

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -1,13 +1,13 @@
 import enum
 import json
 import time
+import uuid
 from datetime import datetime
 from typing import Any
 
 import bittensor
 import pydantic
 from datura.requests.base import BaseRequest
-
 from incentive.miner_incentive_log import IncentiveReason
 from payload_models.payloads import DeliveryStamps
 
@@ -58,6 +58,32 @@ class AuthenticateRequest(BaseValidatorRequest):
         return cls(payload=payload, signature=f"0x{keypair.sign(payload.blob_for_signing()).hex()}")
 
 
+AVAILABILITY_CATEGORY = "availability"
+
+
+class ValidationEvent(pydantic.BaseModel):
+    event: str
+    reason_code: str
+    severity: str
+    category: str = "runtime"
+    impact: str
+    remediation: str | None = None
+    what_we_saw: dict[str, Any] = pydantic.Field(default_factory=dict)
+    warnings: list[str] = pydantic.Field(default_factory=list)
+    help_uri: str | None = None
+    check_id: str | None = None
+    pipeline_id: str | None = None
+    trace_id: str = pydantic.Field(default_factory=lambda: str(uuid.uuid4()))
+    when: datetime
+    context: dict[str, Any] = pydantic.Field(default_factory=dict)
+
+    model_config = pydantic.ConfigDict(extra="allow")
+
+    @property
+    def is_availability_error(self) -> bool:
+        return self.category == AVAILABILITY_CATEGORY
+
+
 class ExecutorSpecRequest(BaseValidatorRequest):
     message_type: RequestType = RequestType.ExecutorSpecRequest
     miner_hotkey: str
@@ -73,6 +99,7 @@ class ExecutorSpecRequest(BaseValidatorRequest):
     synthetic_job_score: float | None
     log_text: str | None
     log_status: str | None
+    validation_event: ValidationEvent | None = None
     job_batch_id: str
     netuid: int | None = None
     scored_at: datetime | None = None

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -897,6 +897,9 @@ class MinerService:
                         "incentive_formula_inputs": result.incentive_formula_inputs,
                         "log_status": result.log_status,
                         "log_text": result.full_log_text,
+                        "validation_event": (
+                            result.validation_event.model_dump(mode="json") if result.validation_event else None
+                        ),
                         # [] means this cycle reported no catalogued zero-incentive reason.
                         "incentive_reasons": [
                             reason.model_dump(mode="json") for reason in result.zero_incentive_reasons

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -4,7 +4,10 @@ from typing import TYPE_CHECKING, Any
 
 from datura.requests.miner_requests import ExecutorSSHInfo
 from incentive.miner_incentive_log import IncentiveReason
-from protocol.vc_protocol.validator_requests import AVAILABILITY_CATEGORY, ValidationEvent
+from protocol.vc_protocol.validator_requests import (
+    AVAILABILITY_CATEGORY as AVAILABILITY_CATEGORY,
+    ValidationEvent,
+)
 from pydantic import BaseModel, Field, PrivateAttr
 
 if TYPE_CHECKING:

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -2,11 +2,10 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, Field, PrivateAttr
-
 from datura.requests.miner_requests import ExecutorSSHInfo
-
 from incentive.miner_incentive_log import IncentiveReason
+from protocol.vc_protocol.validator_requests import AVAILABILITY_CATEGORY, ValidationEvent
+from pydantic import BaseModel, Field, PrivateAttr
 
 if TYPE_CHECKING:
     from incentive.miner_incentive_log import MinerLogLine
@@ -35,6 +34,7 @@ class JobResult(BaseModel):
     job_batch_id: str
     log_status: str
     log_text: str
+    validation_event: ValidationEvent | None = None
     # One timestamp shared by every executor finalized in this validator cycle.
     # It is assigned after final weights are calculated and is the accounting/day key.
     scored_at: datetime | None = None
@@ -245,36 +245,6 @@ class JobResult(BaseModel):
     @property
     def is_successful(self):
         return (self.score > 0 or self.job_score > 0) and self.gpu_model and self.gpu_count > 0
-
-
-# DAH-2748: the category of an error that means "someone could not reach something".
-AVAILABILITY_CATEGORY = "availability"
-
-
-class ValidationEvent(BaseModel):
-    event: str
-    reason_code: str
-    severity: str
-    category: str = "runtime"
-    impact: str
-    remediation: str | None = None
-    what_we_saw: dict[str, Any] = Field(default_factory=dict)
-    warnings: list[str] = Field(default_factory=list)
-    help_uri: str | None = None
-    check_id: str | None = None
-    pipeline_id: str | None = None
-    trace_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    when: datetime
-    context: dict[str, Any] = Field(default_factory=dict)
-
-    class Config:
-        json_encoders = {datetime: lambda v: v.isoformat()}
-        extra = "allow"
-
-    @property
-    def is_availability_error(self) -> bool:
-        """DAH-2748: this error means someone could not reach something, so the node is hidden."""
-        return self.category == AVAILABILITY_CATEGORY
 
 
 def build_msg(

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -8,12 +8,13 @@ import logging
 from datetime import datetime
 from typing import Optional
 
-from core.utils import _m, get_extra_info
-from payload_models.payloads import MinerJobRequestPayload
-from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason
 from datura.requests.miner_requests import ExecutorSSHInfo
+from payload_models.payloads import MinerJobRequestPayload
+from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason, ValidationEvent
 from services.gpu_spec_table import normalize_gpu_model
 from services.redis_service import INSPECTOR_EVENT_CHANNEL, RedisService
+
+from core.utils import _m, get_extra_info
 
 from .models import JobResult
 from .pipeline import Context
@@ -63,6 +64,7 @@ class ResultHandler:
         verified_job_info: dict,
         log_text: str,
         success: bool,
+        validation_event: ValidationEvent | None = None,
     ) -> JobResult:
         """Handle task result by persisting verification data and building JobResult.
 
@@ -73,6 +75,7 @@ class ResultHandler:
             verified_job_info: Previous verification job info from Redis
             log_text: Log message for this result
             success: Whether validation succeeded
+            validation_event: Structured final validation outcome
 
         Returns:
             JobResult containing all validation outcomes
@@ -204,6 +207,7 @@ class ResultHandler:
             job_batch_id=miner_info.job_batch_id,
             log_status=log_status,
             log_text=str(log_text),
+            validation_event=validation_event,
             gpu_model=gpu_model,
             gpu_count=gpu_count,
             sysbox_runtime=context.state.sysbox_runtime,

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -178,6 +178,7 @@ class TaskService:
                     verified_job_info=base_ctx.verified,  # From original context
                     log_text=log_text.to_full_string(),
                     success=success,
+                    validation_event=last_event,
                 )
                 result.attestation_digest = attestation_digest
                 result.tee_type = tee_type

--- a/neurons/validators/tests/test_result_handler_gpu_metrics.py
+++ b/neurons/validators/tests/test_result_handler_gpu_metrics.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
-
 from neurons.validators.src.services.task.result_handler import ResultHandler
+from protocol.vc_protocol.validator_requests import ValidationEvent
 
 from tests.helpers import build_state
 
@@ -45,6 +46,30 @@ async def test_handle_result_nests_gpu_metrics_in_spec(context_factory):
 
     assert result.spec["gpu_metrics"] == metrics
     assert result.spec["gpu_metrics"]["fp32_tflops"] == 51.2
+
+
+@pytest.mark.asyncio
+async def test_handle_result_preserves_structured_validation_event(context_factory):
+    ctx = _context(context_factory, gpu_metrics=None)
+    validation_event = ValidationEvent(
+        event="GPU mismatch",
+        reason_code="GPU_MISMATCH",
+        severity="critical",
+        impact="Node cannot be listed",
+        when=datetime(2026, 9, 1, tzinfo=UTC),
+    )
+
+    result = await ResultHandler(redis_service=None, dry_run=True).handle_result(
+        context=ctx,
+        miner_info=_miner_info(),
+        executor_info=ctx.executor,
+        verified_job_info={},
+        log_text="GPU mismatch",
+        success=False,
+        validation_event=validation_event,
+    )
+
+    assert result.validation_event == validation_event
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_ws_delivery_stamps.py
+++ b/neurons/validators/tests/test_ws_delivery_stamps.py
@@ -5,15 +5,19 @@ pong timeout long enough for the keepalive to survive a scoring-cycle burst.
 import asyncio
 import json
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import websockets
-from payload_models.payloads import ContainerCreated, DeliveryStamps
-
 from clients.compute_client import WS_PING_INTERVAL, WS_PING_TIMEOUT, ComputeClient
-from protocol.vc_protocol.validator_requests import ExecutorSpecRequest, RentedMachineRequest
+from payload_models.payloads import ContainerCreated, DeliveryStamps
+from protocol.vc_protocol.validator_requests import (
+    ExecutorSpecRequest,
+    RentedMachineRequest,
+    ValidationEvent,
+)
 from services.miner_service import MinerService
 from services.redis_service import MACHINE_SPEC_CHANNEL
 
@@ -96,6 +100,39 @@ async def test_bridge_tolerates_payload_without_stamps(create_job_result, mock_s
     # Assert
     assert spec.sent_at is None
     assert spec.batch_total is None
+
+
+@pytest.mark.asyncio
+async def test_bridge_carries_structured_validation_event(create_job_result, mock_settings) -> None:
+    job = create_job_result(log_text="GPU mismatch >>> legacy JSON")
+    job.validation_event = ValidationEvent(
+        event="GPU mismatch",
+        reason_code="GPU_MISMATCH",
+        severity="critical",
+        impact="Node cannot be listed",
+        remediation="Check the installed GPU",
+        what_we_saw={"expected": "A100", "actual": "T4"},
+        check_id="executor.validate.gpu",
+        when=datetime(2026, 9, 1, tzinfo=UTC),
+    )
+
+    [payload] = await _published_payloads([job])
+    spec = await _bridge_machine_spec(payload)
+
+    assert payload["validation_event"]["reason_code"] == "GPU_MISMATCH"
+    assert isinstance(spec.validation_event, ValidationEvent)
+    assert spec.validation_event.what_we_saw == {"expected": "A100", "actual": "T4"}
+    assert spec.validation_event.when == datetime(2026, 9, 1, tzinfo=UTC)
+
+
+@pytest.mark.asyncio
+async def test_bridge_tolerates_payload_without_validation_event(create_job_result, mock_settings) -> None:
+    [payload] = await _published_payloads([create_job_result()])
+    del payload["validation_event"]
+
+    spec = await _bridge_machine_spec(payload)
+
+    assert spec.validation_event is None
 
 
 async def _drain_send_loop(client: ComputeClient, expected_sends: int) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Describe your changes

The validator already builds a typed final `ValidationEvent`, but the existing spec transport flattened it into `log_text`. This PR adds that same object as an optional field on the existing `ExecutorSpecRequest` path:

`ValidationEvent` -> `JobResult` -> existing Redis `MACHINE_SPEC_CHANNEL` payload -> existing websocket `ExecutorSpecRequest`.

It does not add a new message type, queue, broker, websocket channel, or validation flow. Payloads without `validation_event` remain valid for rollout compatibility.

### Changes

- Move the existing `ValidationEvent` model into the validator request protocol and keep it re-exported to current pipeline/check users.
- Preserve the final structured validation result in `JobResult`.
- Serialize it into the existing machine-spec Redis payload.
- Forward it through the existing compute-client websocket request.
- Cover result handling, end-to-end publisher/bridge preservation, timestamp/metadata serialization, and old-payload compatibility.

## Issue ticket number and link

[DAH-2718 — Provider notifications system](https://app.notion.com/p/Provider-notifications-system-3c1b8bfdbde9803680ded0ca4fac7ca3)

## Related PRs

- Backend recipient-neutral event foundation: https://github.com/Datura-ai/lium-io-backend/pull/997
- Event-backed notification projection/delivery: https://github.com/Datura-ai/lium-io-backend/pull/1009

## Testing

- `PYTHONPATH=src:tests:../../datura .../pytest tests/test_ws_delivery_stamps.py tests/test_result_handler_gpu_metrics.py -q`
- Result: 19 passed.
- Focused Ruff check passed for the new protocol/model/test changes.
- `git diff --check` passed.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I wrote tests.
- [x] Performance considered: the field uses the existing serialized payload and transport; no extra request or queue hop is introduced.
