### PR TITLE
DAH-2814: wait 180 s for a cancelled create, not 30 s

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -447,9 +447,11 @@ class _InflightCreateRegistry:
 inflight_creates = _InflightCreateRegistry()
 
 # How long a delete waits for the create it just cancelled. The create reads the flag at its next
-# checkpoint, and the only checkpoint gap that can orphan a container is the short one before
-# `docker run` — a pull-length wait would hold the customer's delete for nothing.
-CANCELLED_CREATE_ABORT_TIMEOUT_SECONDS = 30.0
+# checkpoint, and the long gap is the one AFTER `docker run` — ssh bootstrap, keys, jupyter — where
+# the container already holds the host ports. DAH-2814: prod measured 35-180 s from the cancel to the
+# create stopping, so the first 30 s limit ran out on 4 of 7 races in a day and the delete tore the
+# pod down beside a create that was still working.
+CANCELLED_CREATE_ABORT_TIMEOUT_SECONDS = 180.0
 
 
 def _is_missing_docker_container_error(exc: Exception) -> bool:


### PR DESCRIPTION
DAH-2814. Follow-up on DAH-2728 (in prod since 2026-08-25).

## Problem

A delete that meets an in-flight create for the same pod cancels that create and waits for it to
tear itself down. The wait was 30 s. In the 24 hours to 2026-09-01 the race happened 7 times and the
wait ran out 4 of them. When it runs out, the delete does its own teardown and answers "deleted"
while the create is still working on the host — the orphan container DAH-2728 was made to prevent.

## Why 30 s was too short

The 30 s came from an assumption: the only dangerous gap is the short one before `docker run`. The
prod log says the opposite. In every timed-out case the container was already created and the create
was in the step after `docker run` — ssh bootstrap, public keys, jupyter. That step holds the host
ports and takes minutes.

Time from the cancel to the create actually stopping (`{namespace="subnet"} |= "The cancelled create
is still running"`, then the pod id):

| pod | cancel → create stopped | kind |
|---|---|---|
| 0e221bd0 | 35 s | CUSTOMER_RENTAL |
| 6e7550be | 40 s | FILLER |
| 9dc45bbc | 178 s | CUSTOMER_RENTAL |
| c66a35b3 | 39 s | FILLER |
| 30ad9d9f | 57 s | CUSTOMER_RENTAL |

30 s is below every measured value. 180 s covers all of them.

## Change

One constant, 30.0 → 180.0, and a comment that names the real gap.

## Cost

A delete that races a create can now take up to 3 minutes instead of 30 s. That only happens on the
7-per-day race, and it is the correct trade: the delete waits for the actor that holds the ports.
The DAH-2728 watch already reports any pod that stays in DELETING longer than 10 minutes.

## Not in this PR

A checkpoint inside the bootstrap step would let the create stop sooner and cut the wait. Worth it
only if 180 s turns out to feel slow.

## Test

`pytest neurons/validators/tests/test_delete_cancels_inflight_create.py` — 13 passed.

## After deploy

The daily DAH-2728 watch runs to 2026-09-15. Expect "The cancelled create is still running" at 0 per
day, PORT_ALREADY_ALLOCATED_RETRY near 27 per day, and no pod stuck in DELETING.
