### PR TITLE
DAH-2780: supervise the CVM under systemd and keep the host from restarting it

### DIFF
--- a/neurons/executor/dstacktee/docs/host-setup.md
+++ b/neurons/executor/dstacktee/docs/host-setup.md
@@ -6,7 +6,8 @@ Provider guide for taking a TDX host from bare metal to an attested Lium CVM exe
 |---|---|---|
 | §1–§4 host bring-up (BIOS, kernel, QEMU, key provider) | once per host | ~1–2 h (dominated by BIOS + QEMU build) |
 | §5 executor deployment | once per executor | ~15 min |
-| §6 upgrades | per release | ~10 min |
+| §6 supervision and host hygiene | once per host | ~20 min |
+| §7 upgrades | per release | ~10 min |
 
 ## 1. Hardware and firmware
 
@@ -112,6 +113,8 @@ Two containers: `aesmd` (SGX architectural enclaves, host network) and `gramine-
    sudo ./lium-cvm.sh run my-executor
    ```
 
+   This `run` is a foreground first boot, not how the executor should stay up — hand it to systemd in §6.
+
    Everything attestation-related inside the guest — sysbox force-install, digest-pinned runner, quote generation — is baked into the measured compose; there is nothing to configure in the guest.
 
 3. Verify: the executor API answers on `EXTERNAL_PORT` and SSH banners on `SSH_PORT` within ~3–5 minutes of boot. `./lium-cvm.sh list` shows the VM.
@@ -120,17 +123,76 @@ Two containers: `aesmd` (SGX architectural enclaves, host network) and `gramine-
 
 **Do not modify** `app/docker-compose*.yml`, `app/pre_launch_script.sh`, or `app/init_script.sh`: they are measured into the compose hash the validator whitelists — any local change makes attestation fail.
 
-## 6. Upgrades
+## 6. Supervision and host hygiene
+
+`lium-cvm.sh run` does not daemonize: QEMU runs in the foreground of that command, and the guest's serial console — everything the guest prints while booting, including failures that happen before the executor answers — is QEMU's stdout. So whatever supervises that process owns your only window into the guest. Run it under systemd, not in a login shell and not in a terminal multiplexer.
+
+```ini
+# /etc/systemd/system/lium-cvm@.service
+[Unit]
+Description=Lium CVM %i
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/lium-io/neurons/executor/dstacktee
+ExecStart=/opt/lium-io/neurons/executor/dstacktee/lium-cvm.sh run %i
+# --timeout is not optional: `stop` waits 30 s by default, then returns success and leaves the
+# guest running, and systemd SIGTERMs QEMU — a hard power-off of a guest that is still writing.
+ExecStop=/opt/lium-io/neurons/executor/dstacktee/lium-cvm.sh stop %i --timeout 840
+# A multi-TB TDX guest does not finish shutting down in the default 90 s; keep this above the
+# ExecStop timeout so systemd's SIGKILL is never what ends the guest.
+TimeoutStopSec=15min
+Restart=on-failure
+# GPU passthrough is still being torn down when the unit restarts. Restarting immediately
+# fails with "vfio ... Device or resource busy" and burns the restart budget.
+RestartSec=60
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Point both paths at the checkout you deploy from — the unit must run the same tree §7 upgrades,
+or `systemctl start` will quietly boot the old one. Stop the foreground `run` from §5 first: a
+second QEMU on the same GPUs dies with `vfio ... Device or resource busy` and the unit then
+retries every 60 s.
+
+```bash
+sudo ./lium-cvm.sh stop my-executor        # the §5 foreground run, if it is still up
+sudo systemctl daemon-reload
+sudo systemctl enable --now lium-cvm@my-executor
+journalctl -u lium-cvm@my-executor -f     # the guest console, live
+```
+
+**Nothing may restart this unit behind your back.** A guest restart is never free: rentals running inside the guest go down with it, and an encrypted rental does not come back on its own — it waits for the renter or Datura to recreate the pod, and the miner accrues downtime penalties in the meantime. Drain rentals before any planned restart, and stop the automation that would do it unplanned:
+
+```bash
+# never auto-restart the CVM on a library upgrade
+printf '$nrconf{override_rc}{qr(^lium-cvm@)} = 0;\n' | sudo tee /etc/needrestart/conf.d/lium-cvm.conf
+
+# security updates yes, automatic reboots no
+sudo tee /etc/apt/apt.conf.d/99-lium-no-reboot >/dev/null <<'EOF'
+Unattended-Upgrade::Automatic-Reboot "false";
+EOF
+```
+
+**Pin whatever package owns the QEMU binary `client.conf` names.** RTMR0 only reproduces under the exact QEMU the verifier's oracle was built from (§3). Following §3 you build it into `/opt/qemu-dstack`, outside apt's reach, and there is nothing to hold. If your `client.conf` instead points at a distro binary, `apt-mark hold` that package — an ordinary upgrade would silently change the measurement and the guest would come back unable to open its data disk.
+
+## 7. Upgrades
 
 Per release:
 
 ```bash
-sudo ./lium-cvm.sh stop my-executor
-git pull                                   # the release tag
+sudo systemctl stop lium-cvm@my-executor   # or: sudo ./lium-cvm.sh stop my-executor
+git fetch --tags
+git checkout <release tag>                 # exactly the released tree — the compose is measured
 # update EXECUTOR_RUNNER_IMAGE_DIGEST in .env from the release notes
 sudo rm -rf run/vms/my-executor            # see warning below
 sudo ./lium-cvm.sh new my-executor
-sudo ./lium-cvm.sh run my-executor
+sudo systemctl start lium-cvm@my-executor  # or: sudo ./lium-cvm.sh run my-executor
 ```
 
 > **Warning — data disk.** The CVM's encrypted data disk key derives from the launch measurements. Any upgrade that changes measurements (OS image, host QEMU, OVMF, compose content) makes the existing `hda.img` undecryptable: the guest reboot-loops with `Failed to open encrypted data disk` even though the launcher reports success. Drain rentals before upgrading and recreate the VM directory. The new compose hash is whitelisted by Datura at release time — nothing to do on your side, but the compose must be exactly as released.
@@ -147,3 +209,4 @@ The host QEMU from §3 is **not** touched by executor releases; leave it alone u
 | QEMU launch error mentioning `iommufd` / `VFIO_DEVICE_BIND_IOMMUFD` EINVAL | launcher predates the QEMU-version-gated VFIO backend | update to the current release — `dstack.py` now selects type1 automatically for QEMU < 10 |
 | Validation fails `CHECK_SYSBOX_COMPATIBILITY` inside the guest | compose not the released one (pre-launch sysbox force-install missing or altered) | redeploy with the unmodified released compose (§5) |
 | `lium-cvm.sh check` reports QEMU missing although §3 is done | `check` looks for `qemu-system-x86_64` on PATH; the launcher itself uses `client.conf` | add the §3 symlink, or ignore this one check line |
+| Guest is up and the executor answers, but a rental container is down | something inside the guest failed after boot, and the executor does not check it | read the guest console in the host journal: `journalctl -u lium-cvm@<name> --since '-1h'` (§6) — the guest prints boot failures there and nowhere else |


### PR DESCRIPTION
### Task Link

[DAH-2780 — A CVM guest restart leaves the rental container down for hours, and only the customer notices](https://app.notion.com/p/A-CVM-guest-restart-leaves-the-rental-container-down-for-hours-and-only-the-customer-notices-3c8b8bfdbde981fdb2a6f4b3962faf1b)

---

Part 1 of 3 for DAH-2780. Provider documentation only — no code.

## Why

On 26 August a provider restarted a CVM guest. Inside the guest sysbox came back only half-way, the executor reported the node healthy anyway, and the rental container stayed down for nine hours until the customer complained. Two nodes, \$695.036512022889 in penalties, the whole miner fleet demoted to SPOT.

Two of the three fixes are code and land in their own PRs. This one closes the part that needs no code and is the only one that lowers the odds of a repeat *before* any provider recreates a VM: the host must not restart the guest behind the provider's back, and when the guest does break, someone must be able to see it.

## What changes

New §6 "Supervision and host hygiene":

- **Run the CVM under a systemd unit.** `lium-cvm.sh run` does not daemonize — QEMU runs in that command's foreground with `-nographic -chardev stdio,id=ser0 -serial chardev:ser0` (`scripts/dstack.py:711-716`, launched at `:745`). The guest writes with `StandardOutput=journal+console` and the console is that serial port, so the guest console *is* QEMU's stdout. Under systemd it lands in the host journal, and `journalctl -u lium-cvm@<name>` becomes the only window into a guest that failed before the executor could answer. The unit carries `TimeoutStopSec=15min` (a multi-TB TDX guest does not stop in the default 90 s) and `RestartSec=60` (GPU passthrough is still tearing down; restarting immediately fails with `vfio ... Device or resource busy`).
- **Nothing may restart the unit unattended**: a `needrestart` `override_rc` rule and `Unattended-Upgrade::Automatic-Reboot "false"`. Says plainly what a restart costs — rentals go down with the guest, an encrypted rental does not come back on its own, and the miner accrues penalties meanwhile.
- **Pin whatever package owns the QEMU binary `client.conf` names.** Worded around the actual threat: following §3 the fork lives in `/opt/qemu-dstack`, outside apt's reach, so there is nothing to hold — but a `client.conf` pointing at a distro binary needs `apt-mark hold`, or an ordinary upgrade changes RTMR0 and the guest comes back unable to open its data disk. This removes the contradiction between §6's old "host QEMU is not touched by executor releases" and the measurement warning two lines above it.

§7 Upgrades: `git pull  # the release tag` never selected a tag — now `git fetch --tags && git checkout <release tag>`. Start/stop go through the unit.

Troubleshooting: one new row for the exact shape of this incident — guest up, executor answering, rental container down — pointing at the host journal.

## Verification

Prose only; nothing here executes in CI. The bar is that a provider who has never seen the incident can follow §6 end to end without asking us anything. Both providers should acknowledge it before the first VM is recreated for the measured-file change in the third PR.