### PR TITLE
DAH-2780: stop docker from restarting encrypted pods behind the volume mount

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1052,8 +1052,10 @@ class DockerService:
             # DAH-2780: an encrypted pod must never be restarted by docker. The gocryptfs mount
             # lives inside the container and dies with it, and nothing remounts it on a docker-side
             # restore -- so the container comes back with the plaintext path as an ordinary
-            # directory and the renter's writes land unencrypted on the miner's disk. Recovery goes
-            # through the validator, which mounts before it starts.
+            # directory and the renter's writes land unencrypted on the miner's disk. The cost is
+            # real: DAH-2306 recovery only fires on the State.Error docker writes after a restart it
+            # attempted itself, so an encrypted pod that exits now stays down until it is recreated
+            # -- a host reboot included.
             restart_policy=None if encrypted_local_volume else "unless-stopped",
             runtime="sysbox-runc" if payload.is_sysbox else None,
             cap_add=self._capabilities_for(devices),
@@ -4486,7 +4488,7 @@ class DockerService:
 
                 # Must run before the cleanup below removes the container it inspects.
                 current_step = "volume_encryption_precheck"
-                await self._assert_no_encryption_downgrade(
+                existing_volume_encrypted = await self._assert_no_encryption_downgrade(
                     ssh_client=ssh_client,
                     payload=payload,
                     local_volume=local_volume,
@@ -4607,6 +4609,17 @@ class DockerService:
                         ssh_client,
                         payload.docker_image,
                     ):
+                        if existing_volume_encrypted:
+                            # DAH-2780: falling back to plain here would mount the ciphertext of a
+                            # volume the renter already has data in straight at their path. An edit
+                            # that swaps in an unlabelled image is the one way to reach it, and by
+                            # now the container that proved the volume encrypted is gone -- so the
+                            # answer taken before the cleanup is the only one left.
+                            raise RentalDockerOperationError(
+                                f"{container_name} runs an encrypted volume but "
+                                f"{payload.docker_image} carries no {_ENCRYPTED_VOLUME_IMAGE_LABEL} "
+                                "label; refusing rather than mounting it as plain"
+                            )
                         use_encrypted_volume = False
                         volume_encryption_status = VolumeEncryptionStatus.UNSUPPORTED_IMAGE
                         await self.stream_log(
@@ -5725,21 +5738,26 @@ class DockerService:
         local_volume: str | None,
         container_name: str,
         log_extra: dict[str, Any],
-    ) -> None:
-        # a recreate that would mount an already-encrypted rental volume as plaintext
+    ) -> bool:
+        # whether the pod being replaced already holds an encrypted volume; raises when this
+        # request would mount that volume as plaintext
         #
         # DAH-2780: the payload decides encryption from `is_sysbox`, which the backend reads off
         # executor specs -- and specs freeze whenever a validation cycle scores zero. A pod created
         # while the machine was known to be sysbox can therefore be recreated with is_sysbox=False,
         # and the ciphertext tree would be mounted straight at the renter's path: they would see
         # gocryptfs internals and write plaintext next to them. The container being replaced is the
-        # only place that knows the truth, so ask it before it is removed. A first create has no
-        # such container, the inspect answers UNKNOWN, and nothing here fires.
+        # only place that knows the truth, so ask it before it is removed, and carry the answer to
+        # the image-label check further down, which is the other way this deploy can end up plain.
         #
         # A rental whose volume this validator is about to create has no history to lose, so it
         # skips the inspect rather than paying for it on every deploy.
         if not local_volume:
-            return
+            return False
+
+        state = await self._local_volume_encryption_state(ssh_client, container_name)
+        if state is not _VolumeEncryptionState.ENCRYPTED:
+            return False
 
         if _should_encrypt_local_volume(
             local_volume,
@@ -5747,11 +5765,7 @@ class DockerService:
             payload.is_sysbox,
             payload.enable_volume_encryption,
         ):
-            return
-
-        state = await self._local_volume_encryption_state(ssh_client, container_name)
-        if state is not _VolumeEncryptionState.ENCRYPTED:
-            return
+            return True
 
         logger.error(
             _m(
@@ -5761,12 +5775,17 @@ class DockerService:
                     "container_name": container_name,
                     "is_sysbox": payload.is_sysbox,
                     "enable_volume_encryption": payload.enable_volume_encryption,
+                    "volume_encryption_enabled_setting": settings.ENABLE_VOLUME_ENCRYPTION,
                 }),
             )
         )
+        # name both causes -- a payload that lost `is_sysbox` to frozen specs, and the global kill
+        # switch being off. They need opposite answers, and this line is all the operator gets.
         raise RentalDockerOperationError(
             f"{container_name} runs an encrypted volume but this request would mount it as plain "
-            f"(is_sysbox={payload.is_sysbox}, enable_volume_encryption={payload.enable_volume_encryption}); "
+            f"(workload_kind={payload.workload_kind.value}, is_sysbox={payload.is_sysbox}, "
+            f"enable_volume_encryption={payload.enable_volume_encryption}, "
+            f"ENABLE_VOLUME_ENCRYPTION={settings.ENABLE_VOLUME_ENCRYPTION}); "
             "refusing rather than exposing the renter's data"
         )
 

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1049,7 +1049,12 @@ class DockerService:
             environment=environment,
             ports=_published_ports(port_maps, cluster_udp_ports),
             volumes=tuple(volumes),
-            restart_policy="unless-stopped",
+            # DAH-2780: an encrypted pod must never be restarted by docker. The gocryptfs mount
+            # lives inside the container and dies with it, and nothing remounts it on a docker-side
+            # restore -- so the container comes back with the plaintext path as an ordinary
+            # directory and the renter's writes land unencrypted on the miner's disk. Recovery goes
+            # through the validator, which mounts before it starts.
+            restart_policy=None if encrypted_local_volume else "unless-stopped",
             runtime="sysbox-runc" if payload.is_sysbox else None,
             cap_add=self._capabilities_for(devices),
             sysctls={"net.ipv4.conf.all.src_valid_mark": "1"},
@@ -4479,6 +4484,16 @@ class DockerService:
                 if local_volume:
                     protected_volume_names.add(local_volume)
 
+                # Must run before the cleanup below removes the container it inspects.
+                current_step = "volume_encryption_precheck"
+                await self._assert_no_encryption_downgrade(
+                    ssh_client=ssh_client,
+                    payload=payload,
+                    local_volume=local_volume,
+                    container_name=container_name,
+                    log_extra=default_extra,
+                )
+
                 current_step = "container_cleanup"
                 # DAH-1524: the GC below (force-removing stale pod_/filler_
                 # containers + their volumes that aren't in active_*) stays on the
@@ -5701,6 +5716,59 @@ class DockerService:
         if _LIUM_CIPHER_MOUNT in (inspect_result.stdout or "").split():
             return _VolumeEncryptionState.ENCRYPTED
         return _VolumeEncryptionState.PLAIN
+
+    async def _assert_no_encryption_downgrade(
+        self,
+        *,
+        ssh_client: asyncssh.SSHClientConnection,
+        payload: ContainerCreateRequest,
+        local_volume: str | None,
+        container_name: str,
+        log_extra: dict[str, Any],
+    ) -> None:
+        # a recreate that would mount an already-encrypted rental volume as plaintext
+        #
+        # DAH-2780: the payload decides encryption from `is_sysbox`, which the backend reads off
+        # executor specs -- and specs freeze whenever a validation cycle scores zero. A pod created
+        # while the machine was known to be sysbox can therefore be recreated with is_sysbox=False,
+        # and the ciphertext tree would be mounted straight at the renter's path: they would see
+        # gocryptfs internals and write plaintext next to them. The container being replaced is the
+        # only place that knows the truth, so ask it before it is removed. A first create has no
+        # such container, the inspect answers UNKNOWN, and nothing here fires.
+        #
+        # A rental whose volume this validator is about to create has no history to lose, so it
+        # skips the inspect rather than paying for it on every deploy.
+        if not local_volume:
+            return
+
+        if _should_encrypt_local_volume(
+            local_volume,
+            payload.workload_kind,
+            payload.is_sysbox,
+            payload.enable_volume_encryption,
+        ):
+            return
+
+        state = await self._local_volume_encryption_state(ssh_client, container_name)
+        if state is not _VolumeEncryptionState.ENCRYPTED:
+            return
+
+        logger.error(
+            _m(
+                "POD_ENCRYPTION_DOWNGRADE_REFUSED",
+                extra=get_extra_info({
+                    **log_extra,
+                    "container_name": container_name,
+                    "is_sysbox": payload.is_sysbox,
+                    "enable_volume_encryption": payload.enable_volume_encryption,
+                }),
+            )
+        )
+        raise RentalDockerOperationError(
+            f"{container_name} runs an encrypted volume but this request would mount it as plain "
+            f"(is_sysbox={payload.is_sysbox}, enable_volume_encryption={payload.enable_volume_encryption}); "
+            "refusing rather than exposing the renter's data"
+        )
 
     async def _repair_stale_mountpoint_of_container_volume(
         self,

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -5185,12 +5185,11 @@ def test_should_encrypt_local_volume_requires_local_sysbox_customer_volume(monke
     )
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "encrypted, expected_policy",
     [(True, None), (False, "unless-stopped")],
 )
-async def test_run_spec_restart_policy_only_for_plain_volumes(
+def test_run_spec_restart_policy_only_for_plain_volumes(
     docker_service, encrypted, expected_policy
 ):
     # Arrange
@@ -5220,6 +5219,16 @@ async def test_run_spec_restart_policy_only_for_plain_volumes(
 
     # Assert
     assert run_spec.restart_policy == expected_policy
+
+
+def _encrypted_container_ssh_run(command, **kwargs):
+    # the container being replaced answers `docker inspect` with the gocryptfs ciphertext mount, and
+    # any image asked about carries no volume-encryption label
+    if "docker image inspect" in command:
+        return _make_ssh_command_result()
+    if "docker inspect" in command:
+        return _make_ssh_command_result(stdout=f"{_LIUM_CIPHER_MOUNT}\n")
+    return _make_ssh_command_result()
 
 
 @pytest.mark.asyncio
@@ -5260,39 +5269,8 @@ async def test_create_container_refuses_encryption_downgrade_before_removing_the
     land while it still exists -- a recreate that removed it first would leave the operator with a
     deleted pod and no evidence."""
     # Arrange: recreate of an encrypted pod, payload arrives with a stale is_sysbox=False
-    def ssh_run(command, **kwargs):
-        if "docker inspect" in command:
-            return _make_ssh_command_result(stdout=f"{_LIUM_CIPHER_MOUNT}\n")
-        return _make_ssh_command_result()
-
-    ssh_client = AsyncMock()
-    ssh_client.run = AsyncMock(side_effect=ssh_run)
-    monkeypatch.setattr(
-        "services.docker_service.asyncssh.connect",
-        Mock(return_value=DummySSHConnectionManager(ssh_client)),
-    )
-    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
-    monkeypatch.setattr(
-        "services.docker_service.build_gpu_docker_config_for_executor",
-        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
-    )
-
-    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
-    docker_service.redis_service.add_pending_pod = AsyncMock()
-    docker_service.redis_service.remove_pending_pod = AsyncMock()
-    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
-    monkeypatch.setattr(
-        docker_service,
-        "generate_portMappings",
-        AsyncMock(return_value=([(22, 20001, 20001)], None)),
-    )
-    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock())
-    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
-    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
-    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
-    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
-    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
-    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+    ssh_client = _patch_create_container_happy_path(docker_service, monkeypatch)
+    ssh_client.run = AsyncMock(side_effect=_encrypted_container_ssh_run)
 
     payload = ContainerCreateRequest(
         miner_hotkey="miner",
@@ -5334,9 +5312,60 @@ async def test_create_container_refuses_encryption_downgrade_before_removing_the
 
 
 @pytest.mark.asyncio
-async def test_encryption_downgrade_allows_fresh_rental_on_non_sysbox_machine(docker_service):
-    # Arrange: the default payload asks for encryption on a machine that cannot do it, and there is
-    # no previous container to inspect -- the ordinary shape of most of the fleet
+async def test_create_container_refuses_an_unlabelled_image_on_an_encrypted_volume(
+    docker_service,
+    monkeypatch,
+):
+    """The other way a recreate ends up plain: the payload does ask for encryption, but the image it
+    switches to carries no label, and the fallback would mount the ciphertext at the renter's path
+    -- by which point the container that proved the volume encrypted is already gone."""
+    # Arrange: recreate of an encrypted pod onto an image without the volume-encryption label
+    monkeypatch.setattr(docker_service_module.settings, "ENABLE_VOLUME_ENCRYPTION", True)
+    ssh_client = _patch_create_container_happy_path(docker_service, monkeypatch)
+    ssh_client.run = AsyncMock(side_effect=_encrypted_container_ssh_run)
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:unlabelled",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        local_volume="volume_test",
+        is_sysbox=True,
+        enable_volume_encryption=True,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    # Act
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    assert result.failure_step == "encrypted_volume_image_inspect"
+
+
+@pytest.mark.asyncio
+async def test_encryption_downgrade_allows_a_recreate_whose_container_is_gone(docker_service):
+    # Arrange: the payload asks for encryption on a machine that cannot do it -- the ordinary shape
+    # of most of the fleet -- and no container is left to contradict it
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(return_value=_make_ssh_command_result(exit_status=1))
     payload = ContainerCreateRequest(
@@ -5351,13 +5380,42 @@ async def test_encryption_downgrade_allows_fresh_rental_on_non_sysbox_machine(do
     )
 
     # Act / Assert: no exception
-    await docker_service._assert_no_encryption_downgrade(
+    assert await docker_service._assert_no_encryption_downgrade(
         ssh_client=ssh_client,
         payload=payload,
         local_volume="volume_test",
         container_name="pod_test",
         log_extra={},
+    ) is False
+
+
+@pytest.mark.asyncio
+async def test_encryption_downgrade_skips_the_inspect_on_a_first_create(docker_service):
+    # Arrange: a rental whose volume this validator is about to create has no history to lose
+    ssh_client = AsyncMock()
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        is_sysbox=True,
+        enable_volume_encryption=True,
     )
+
+    # Act
+    downgrade_risk = await docker_service._assert_no_encryption_downgrade(
+        ssh_client=ssh_client,
+        payload=payload,
+        local_volume=None,
+        container_name="pod_test",
+        log_extra={},
+    )
+
+    # Assert
+    assert downgrade_risk is False
+    ssh_client.run.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -5186,6 +5186,181 @@ def test_should_encrypt_local_volume_requires_local_sysbox_customer_volume(monke
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "encrypted, expected_policy",
+    [(True, None), (False, "unless-stopped")],
+)
+async def test_run_spec_restart_policy_only_for_plain_volumes(
+    docker_service, encrypted, expected_policy
+):
+    # Arrange
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+    )
+
+    # Act
+    run_spec = docker_service._build_rental_container_run_spec(
+        payload=payload,
+        container_name="pod_test",
+        custom_options=CustomOptions(),
+        port_maps=[],
+        local_volume="volume_test",
+        local_volume_path="/root",
+        encrypted_local_volume=encrypted,
+        external_volume_name=None,
+        gpu_devices=build_gpu_docker_config(["GPU-test"]),
+        effective_storage_limit_gb=None,
+        cpu_count=None,
+    )
+
+    # Assert
+    assert run_spec.restart_policy == expected_policy
+
+
+@pytest.mark.asyncio
+async def test_encryption_downgrade_refused_when_old_container_is_encrypted(docker_service):
+    # Arrange: the pod being replaced holds a gocryptfs volume, the payload says plain
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        return_value=_make_ssh_command_result(stdout=f"{_LIUM_CIPHER_MOUNT}\n/mnt\n")
+    )
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        is_sysbox=False,
+        enable_volume_encryption=True,
+    )
+
+    # Act / Assert
+    with pytest.raises(RentalDockerOperationError):
+        await docker_service._assert_no_encryption_downgrade(
+            ssh_client=ssh_client,
+            payload=payload,
+            local_volume="volume_test",
+            container_name="pod_test",
+            log_extra={},
+        )
+
+
+@pytest.mark.asyncio
+async def test_create_container_refuses_encryption_downgrade_before_removing_the_pod(
+    docker_service,
+    monkeypatch,
+):
+    """The old container is the only witness to the volume being encrypted, so the refusal has to
+    land while it still exists -- a recreate that removed it first would leave the operator with a
+    deleted pod and no evidence."""
+    # Arrange: recreate of an encrypted pod, payload arrives with a stale is_sysbox=False
+    def ssh_run(command, **kwargs):
+        if "docker inspect" in command:
+            return _make_ssh_command_result(stdout=f"{_LIUM_CIPHER_MOUNT}\n")
+        return _make_ssh_command_result()
+
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(side_effect=ssh_run)
+    monkeypatch.setattr(
+        "services.docker_service.asyncssh.connect",
+        Mock(return_value=DummySSHConnectionManager(ssh_client)),
+    )
+    monkeypatch.setattr("services.docker_service.asyncssh.import_private_key", Mock())
+    monkeypatch.setattr(
+        "services.docker_service.build_gpu_docker_config_for_executor",
+        AsyncMock(return_value=build_gpu_docker_config(["GPU-test"])),
+    )
+
+    docker_service.ssh_service.decrypt_payload = Mock(return_value="private-key")
+    docker_service.redis_service.add_pending_pod = AsyncMock()
+    docker_service.redis_service.remove_pending_pod = AsyncMock()
+    monkeypatch.setattr(docker_service, "_prepare_known_hosts_policy", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        docker_service,
+        "generate_portMappings",
+        AsyncMock(return_value=([(22, 20001, 20001)], None)),
+    )
+    monkeypatch.setattr(docker_service, "execute_and_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_existing_containers", AsyncMock())
+    monkeypatch.setattr(docker_service, "clean_stale_vloopback_volumes", AsyncMock())
+    monkeypatch.setattr(docker_service, "create_local_volume", AsyncMock())
+    monkeypatch.setattr(docker_service, "stream_log", AsyncMock())
+    monkeypatch.setattr(docker_service, "finish_stream_logs", AsyncMock())
+    monkeypatch.setattr(docker_service, "handle_stream_logs", AsyncMock())
+
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        local_volume="volume_test",
+        is_sysbox=False,
+        enable_volume_encryption=True,
+        available_ports=[PayloadPortMapping(internal_port=20001, external_port=20001)],
+        pod_mapping=[],
+        active_container_names=[],
+        active_volume_names=[],
+    )
+    executor_info = ExecutorSSHInfo(
+        uuid=payload.executor_id,
+        address="127.0.0.1",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python",
+        root_dir="/root/app",
+        ssh_host_key=FAKE_SSH_HOST_KEY,
+    )
+
+    # Act
+    result = await docker_service.create_container(
+        payload=payload,
+        executor_info=executor_info,
+        keypair=Mock(ss58_address="validator-hotkey"),
+        private_key="encrypted",
+    )
+
+    # Assert
+    assert result.failure_step == "volume_encryption_precheck"
+    docker_service.clean_existing_containers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_encryption_downgrade_allows_fresh_rental_on_non_sysbox_machine(docker_service):
+    # Arrange: the default payload asks for encryption on a machine that cannot do it, and there is
+    # no previous container to inspect -- the ordinary shape of most of the fleet
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(return_value=_make_ssh_command_result(exit_status=1))
+    payload = ContainerCreateRequest(
+        miner_hotkey="miner",
+        executor_id=str(uuid4()),
+        pod_id=str(uuid4()),
+        docker_image="daturaai/pytorch:test",
+        user_public_keys=["ssh-ed25519 test-key"],
+        gpu_uuids=["GPU-test"],
+        is_sysbox=False,
+        enable_volume_encryption=True,
+    )
+
+    # Act / Assert: no exception
+    await docker_service._assert_no_encryption_downgrade(
+        ssh_client=ssh_client,
+        payload=payload,
+        local_volume="volume_test",
+        container_name="pod_test",
+        log_extra={},
+    )
+
+
+@pytest.mark.asyncio
 async def test_image_has_encrypted_volume_label(docker_service):
     ssh_client = AsyncMock()
 


### PR DESCRIPTION
### Task Link

[DAH-2780 — A CVM guest restart leaves the rental container down for hours, and only the customer notices](https://app.notion.com/p/A-CVM-guest-restart-leaves-the-rental-container-down-for-hours-and-only-the-customer-notices-3c8b8bfdbde981fdb2a6f4b3962faf1b)

---

Part 2 of 3 for DAH-2780. Depends on nothing; safe to merge on its own.

## Why

When a host or a CVM guest restarts, dockerd restores every container carrying `unless-stopped` before anything else runs. For an encrypted pod that restore is wrong by construction: the gocryptfs mount is made by a `docker exec` *inside* the container and dies with it, and nothing on the docker-side restore path remounts it. The container comes back with the renter's path as an ordinary directory, and everything they write lands unencrypted on the miner's disk.

## What changes

**1. No `restart_policy` for encrypted pods** (`docker_service.py:1036`). The policy was unconditional; it is now `None` when the run spec carries an encrypted local volume. `_restart_policy()` in the SDK already maps `None` to "no policy" (`rental_docker_sdk.py:856-859`), but the dataclass default is `"unless-stopped"` (`:111`), so the call site passes `None` explicitly rather than omitting the argument.

What this costs, stated plainly: `unless-stopped` restarts on *any* exit, not only at daemon boot, so an OOM-killed or crashed encrypted pod now stays exited and reports `POD_NOT_RUNNING` until the pod is recreated. On a crash the restart it loses never worked anyway — it produced the plaintext window above. **After a host reboot it did work, and this PR takes it away:** DAH-2306 recovery is entered only when `container_error` (docker's `State.Error`) carries the stale-vloopback signature, and docker fills that field only when it attempted the restart itself. With no policy the container exits with an empty `State.Error`, `recover_pod_after_stale_vloopback_mount` returns at its first line, and the encrypted pod stays down — and the miner penalised — for the rest of the rental. Closing that needs a second recovery signal that does not come from `State.Error` (container exited before the current `boot_id`); it is not in this PR, so this is a leak-versus-downtime trade to sign off on, not a free win.

Fillers are unaffected in both directions: they never encrypt (`_should_encrypt_local_volume` excludes `WorkloadKind.FILLER`) and they keep their policy.

**2. Refuse a recreate that would mount an encrypted volume as plaintext.** The payload decides encryption from `is_sysbox`, which the backend reads off executor specs — and specs freeze whenever a validation cycle scores zero. A pod created while the machine was known to be sysbox can therefore be recreated with `is_sysbox=False`, and the ciphertext tree gets mounted straight at the renter's path: gocryptfs internals in view, plaintext written next to them.

The wire carries no field for the pod's established encryption state, and the backend column that does (`pod.volume_encryption_status`) is nulled on exactly this path, so the truth has to come from the machine. `_local_volume_encryption_state` already derives it from `docker inspect` mounts and is used by the recovery path; the new `_assert_no_encryption_downgrade` asks the container that is about to be replaced, **before** the cleanup removes it, and refuses on a mismatch. A first create has no such container and no volume to lose — it returns before the inspect, so the deploy path pays nothing on a fresh rental.

The same answer is carried down to the image-label check, which is the second way a recreate ends up plain: an edit that swaps in an image without `lium.volume_encryption.enable=1` used to fall back to a plain mount — of a volume that already holds gocryptfs ciphertext — and by then the container that could have proved it is gone. That fallback now refuses too.

Note the deliberate direction: with `ENABLE_VOLUME_ENCRYPTION` globally off, a recreate of an already-encrypted pod now fails instead of silently exposing it. Failing is the safe side of that trade. The refusal message names every input that decided it — `workload_kind`, `is_sysbox`, `enable_volume_encryption` and the global setting — so an operator can tell frozen specs from the kill switch.

## Tests

`tests/test_docker_service.py`:
- run spec drops the policy for an encrypted volume and keeps `unless-stopped` for a plain one;
- an encrypted old container plus a plain-computing payload raises;
- **the refusal lands before `clean_existing_containers` is awaited** — the old container is the only witness, so a recreate that removed it first would leave the operator with a deleted pod and no evidence;
- an unlabelled image on an encrypted volume fails at `encrypted_volume_image_inspect` instead of falling back to plain;
- a first create (no `local_volume`) never even runs the inspect;
- a recreate whose container is already gone does **not** raise. This one matters: `enable_volume_encryption` defaults to `True` for every rental while `is_sysbox` is `False` on most of the fleet, so a guard written as a naive payload-vs-payload comparison would have refused every ordinary rental.

`pdm run pytest tests/` — 1945 passed, 15 skipped. `tests/test_sshd_bootstrap_script.py` fails 3 tests on this machine both with and without these changes (pre-existing, untouched here).

## Not in this PR

The migration that strips `unless-stopped` from already-running encrypted pods; there is no restart-policy mutation path in the validator today. So this protects new pods only, and an existing encrypted pod keeps both halves of the incident mechanism until its rental churns. The recovery matcher and `RECOVER_ENCRYPTED_VOLUMES` are untouched.
