### PR TITLE
DAH-2780: gate the CVM boot on sysbox actually serving, and stop rentals before the swap

### DIFF
--- a/neurons/executor/dstacktee/app/pre_launch_script.sh
+++ b/neurons/executor/dstacktee/app/pre_launch_script.sh
@@ -1,4 +1,39 @@
 chmod +x /usr/bin/containerd-shim-runc-v2
+
+# This file is sourced by /bin/app-compose.sh (bash) before it starts the compose. Sourced means
+# `exit` here would kill the boot before the executor ever starts, and any `set -e` would change
+# how the rest of app-compose.sh behaves -- so this script never does either, and cleans up the
+# names it defines at the end.
+
+lium_not_ready_marker=/dstack/sysbox-not-ready
+lium_say() {
+    # both the guest journal and the serial console, which is the host's only window in
+    echo "lium: $*" >&2
+}
+
+# DAH-2780: docker.service is ordered before app-compose.service, so dockerd has already restored
+# every `unless-stopped` container by the time this runs -- including customer rentals. Pulling the
+# sysbox daemons out from under a live rental is what left a customer's container dead for nine
+# hours on 26 August: it keeps handles on the old runtime and dies with exit 128. Stop rentals
+# first: a container stopped here is not brought back by the docker restart below, and the
+# validator will not start it either -- its only auto-recovery covers the DAH-2306 stale-mount
+# signature -- so the pod stays down until the customer starts it and the node takes
+# POD_NOT_RUNNING. That is the same end state as letting the swap wedge the container, minus the
+# wedged containerd and the nine hours. The grace matches the validator's
+# CONTAINER_STOP_GRACE_SECONDS -- killing GPU workloads fast wedges containerd/sysbox (DAH-2364),
+# which is the worst thing that could happen immediately before a daemon swap. Only pod_/filler_
+# are rentals; container_*/health_check_* are the validator's own throwaway probes and
+# executor-runner is the executor itself.
+if ! lium_rentals=$(docker ps -q \
+    --filter status=running --filter status=restarting \
+    --filter name=^pod_ --filter name=^filler_ 2>/dev/null); then
+    lium_say "could not list containers -- dockerd not answering, rentals may survive the sysbox swap"
+elif [ -n "$lium_rentals" ]; then
+    lium_say "stopping rental containers before the sysbox swap"
+    docker stop -t 30 $lium_rentals >/dev/null 2>&1 || \
+        lium_say "some rental containers did not stop cleanly"
+fi
+
 # dstack-nvidia-0.5.11 bakes upstream sysbox CE 0.6.7, which rejects --gpus
 # (docker device requests) and so fails the SN51 sysbox/GPU compatibility
 # check. Stop the baked daemons and force-install the Datura sysbox build
@@ -9,10 +44,78 @@ chmod +x /usr/bin/containerd-shim-runc-v2
 systemctl unmask sysbox-mgr sysbox-fs 2>/dev/null || true
 systemctl stop sysbox-mgr sysbox-fs 2>/dev/null || true
 systemctl disable sysbox-mgr sysbox-fs 2>/dev/null || true
+# The stop above is best-effort, so record whatever survived it: the gate below has no other way to
+# tell the daemon we are about to install from a baked 0.6.7 one that never died. Comparing the
+# unit's MainPID alone cannot -- the unit name is the same either way.
+lium_stale_mgr_pid=$(systemctl show -p MainPID --value sysbox-mgr 2>/dev/null)
+lium_stale_fs_pid=$(systemctl show -p MainPID --value sysbox-fs 2>/dev/null)
 # TODO: pin digest
+# Whenever this digest moves, re-check that the sed anchor below still matches the installer's
+# check_existing definition: sed exits 0 when it replaces nothing, so a renamed function would
+# silently leave the gate in place and the baked 0.6.7 daemons would survive.
 docker run --rm --privileged --pid=host --net=host -v /:/host dstacktee/dstack-sysbox-installer:1.0.0@sha256:2f5dbea99176f3ea0362b85346b31b1160bfb70c1d98d1c8d375d57782127dd1 bash -c "sed -i '/^check_existing() {/,/^}/c\\check_existing() { return 0; }' /usr/local/bin/install-sysbox-complete.sh && /usr/local/bin/install-sysbox-complete.sh"
+
+# DAH-2780: prove the daemons we just installed are actually serving before anything is allowed to
+# use them. Neither of the obvious signals is worth anything here: the units are Type=simple, so
+# `systemctl is-active` only says a process exists, and sysbox-fs sends its readiness notification
+# and logs "Ready" before it starts listening. A socket file left behind by a dead daemon also
+# stays on disk, so `[ -S ... ]` passes while connect() gives ECONNREFUSED -- that was the 26 August
+# shape exactly. /proc/net/unix is the one source that answers the real question: flags 00010000 is
+# SO_ACCEPTCON, i.e. a socket that has reached listen(), not merely bind().
+#
+# The socket inode is matched against the unit's MainPID as well, so a socket entry left over from
+# a dead daemon cannot answer for a live one. The MainPID is then checked against the pid that
+# survived the best-effort stop above: if that stop silently failed, the baked 0.6.7 daemon is
+# still listening on the same path *under the same unit*, so without that third comparison the
+# gate would go green on a runtime that rejects --gpus.
+lium_unit_is_serving() {  # <unit> <socket path> <pid that survived the stop>
+    local inode pid
+    inode=$(awk -v p="$2" '$4 == "00010000" && $8 == p { print $7; exit }' /proc/net/unix)
+    [ -n "$inode" ] || return 1
+    pid=$(systemctl show -p MainPID --value "$1" 2>/dev/null)
+    [ -n "$pid" ] && [ "$pid" != "0" ] && [ "$pid" != "$3" ] || return 1
+    ls -l "/proc/$pid/fd" 2>/dev/null | grep -q "socket:\[$inode\]"
+}
+
+lium_sysbox_is_serving() {
+    lium_unit_is_serving sysbox-mgr /run/sysbox/sysmgr.sock "$lium_stale_mgr_pid" &&
+        lium_unit_is_serving sysbox-fs /run/sysbox/sysfs.sock "$lium_stale_fs_pid"
+}
+
+lium_await_sysbox() {
+    local left=30
+    while [ "$left" -gt 0 ]; do
+        lium_sysbox_is_serving && return 0
+        sleep 1
+        left=$((left - 1))
+    done
+    return 1
+}
+
+# A boot that gets this far owns the verdict, so a marker from an earlier failure goes now.
+rm -f "$lium_not_ready_marker"
+if ! lium_await_sysbox; then
+    # --no-block is not optional: the daemon being restarted is the one that may be wedged in
+    # uninterruptible sleep, and a blocking `systemctl restart` on it never returns. There is no
+    # way to bound that from here, and a boot script that never finishes leaves a box whose only
+    # door -- the executor -- never opens. Restarting by hand is what fixed the machine in one
+    # second on 26 August.
+    lium_say "sysbox is not serving; restarting the daemons"
+    systemctl --no-block restart sysbox-mgr sysbox-fs 2>/dev/null || true
+    if ! lium_await_sysbox; then
+        # Keep booting on purpose. The executor is the only way anyone reaches this guest, so a
+        # node that comes up visibly broken is worth more than one that never comes up. The line
+        # below lands on the serial console, i.e. in the host's journal for the CVM unit.
+        date -u '+%Y-%m-%dT%H:%M:%SZ sysbox daemons never started serving' > "$lium_not_ready_marker" 2>/dev/null
+        lium_say "SYSBOX NOT READY -- rentals on this node will fail until sysbox is repaired"
+    fi
+fi
+
 systemctl restart docker
 # Warm the images the validator's sysbox/DinD probes run, so first-cycle
 # probes don't burn their timeout budget on multi-GB registry pulls.
 docker pull daturaai/dind:0.0.1 >/dev/null 2>&1 || true
 docker pull daturaai/compute-subnet-executor:latest >/dev/null 2>&1 || true
+
+unset -f lium_say lium_unit_is_serving lium_sysbox_is_serving lium_await_sysbox
+unset lium_not_ready_marker lium_rentals lium_stale_mgr_pid lium_stale_fs_pid


### PR DESCRIPTION
### Task Link

[DAH-2780 — A CVM guest restart leaves the rental container down for hours, and only the customer notices](https://app.notion.com/p/A-CVM-guest-restart-leaves-the-rental-container-down-for-hours-and-only-the-customer-notices-3c8b8bfdbde981fdb2a6f4b3962faf1b)

---

Part 3 of 3 for DAH-2780, and the expensive one. **This file is measured**, so every byte here changes `compose_hash` → RTMR3 → the guest's disk-encryption key: a provider taking this change must destroy and recreate the VM, and the renter's data on `hda.img` is gone. Read it line by line; merging it changes nothing on its own, and a mistake found later costs the fleet another recreate round.

Merge after #1264 (provider docs) and #1265 (validator).

## Why

On 26 August a provider restarted a CVM guest. Two things went wrong at once, both inside this script's blast radius:

1. dockerd, which systemd starts **before** `app-compose.service` (`Wants=docker.service` / `After=docker.service` in dstack's `basefiles/app-compose.service`), restored the customer's `pod_526856dd-b65d-407d-af89-7287321ac691` with its `unless-stopped` policy. Then this script stopped the sysbox daemons out from under it. The container kept handles on a runtime that no longer existed and died with exit 128.
2. sysbox came back only half-way, and nothing checked. The executor came up, reported the node healthy, and the rental stayed down for nine hours until the customer complained. $695.036512022889 in penalties, the whole miner fleet demoted to SPOT at 39.60133910497886% penalty coverage against a 20% threshold.

## What changes

**Stop rentals before the swap.** Only `pod_*` and `filler_*` are rentals (`services/const.py:238-239`, `docker_service.py:692-695`); `container_{hotkey}_*` and `health_check_*` are the validator's own throwaway probes and `executor-runner` is the executor. Stop grace is `-t 30`, matching the validator's `CONTAINER_STOP_GRACE_SECONDS` — killing GPU workloads fast wedges containerd/sysbox (DAH-2364), which is the last thing anyone wants immediately before a daemon swap. A container stopped here is not brought back by the `systemctl restart docker` below; the validator recreates it.

**Gate on the daemons actually serving.** None of the obvious signals is worth anything here, which is the whole lesson of the incident:
- the units are `Type=simple`, so `systemctl is-active` proves only that a process exists;
- sysbox-fs calls `SdNotify(Ready)` and logs `Ready` *before* `ipcService.Init()` starts listening;
- a socket file left behind by a dead daemon stays on disk, so `[ -S ... ]` passes while `connect()` gives ECONNREFUSED — that is the 26 August shape exactly.

`/proc/net/unix` answers the real question: flags `00010000` is `SO_ACCEPTCON`, a socket that has reached `listen()`, not merely `bind()`. The socket inode is also matched against the unit's `MainPID`, because the stop of the baked 0.6.7 daemons above is best-effort (`|| true`) — if it silently failed, the old GPU-incapable daemon would still be listening on the same path and a path-only gate would go green on it.

**On failure: restart with `--no-block`, then fail loudly and keep booting.** `--no-block` is not decoration: the daemon being restarted is the one that may be wedged in uninterruptible sleep, a blocking `systemctl restart` on it never returns, there is no `timeout` in this guest to bound it, and a boot script that never finishes leaves a box whose only door — the executor — never opens. Restarting by hand is what fixed the machine in one second on 26 August. If the second poll also fails, the script writes `/dstack/sysbox-not-ready` and prints a loud line, then lets the boot continue: a node that comes up visibly broken is worth more than one that never comes up. A healthy boot clears the marker, so the first reader ever added does not report a failure fixed weeks ago.

The loud line is readable. The guest writes with `StandardOutput=journal+console`, the console is the serial port, and `dstack.py:711-716` hands QEMU `-chardev stdio,id=ser0 -serial chardev:ser0` with QEMU in the foreground of `lium-cvm.sh run` — so it lands in the host journal for the CVM unit that #1264 asks providers to create. Surfacing the marker through executor specs would be a DAH-2514-class three-repo change and is deliberately not in this wave.

**Sourced, not executed.** `basefiles/app-compose.sh` runs this file as `source <(jq -r '.pre_launch_script' app-compose.json)` under bash. So `exit` here would kill the boot before the compose ever starts, and any `set -e` would change how the rest of `app-compose.sh` behaves. This script does neither, and unsets the names it defines. There is no deadline to fit inside: `app-compose.service` is `Type=oneshot` with no `TimeoutStartSec`, and systemd disables the start timeout by default for oneshot units; the host does not supervise boot progress either (`dstack.py` uses vsock only for the shutdown RPC).

One comment added on the existing `sed` stub: it exits 0 when it replaces nothing, so any future installer-digest bump must re-verify the anchor or the baked daemons would silently survive.

## Verification

We own no TDX hardware and there is no staging CVM, so the gate was staged off-guest with the real code and fixture `/proc` trees: `untracked/scripts/dah2780_gate_harness.sh`. 22 checks over 10 scenarios — healthy boot; the 26 August shape (socket file present, nobody listening) recovering after the restart; never-ready writing the marker and continuing; a stale marker cleared by a healthy boot; only sysbox-fs serving; a foreign daemon holding the socket; both sockets bound but not listening; dockerd not answering; the script sourced twice in a row; and a `systemctl stop` of the baked 0.6.7 daemons that silently failed, leaving them listening under the same unit name. Every scenario also asserts the parent shell reaches the line after the `source` and that no shell options or `lium_*` names leak into it.

The checks were then mutation-tested, because a test that certifies the wrong behaviour is worse than none — the earlier draft of this change used the `container_` prefix and its test used the same wrong name, so it would have gone green. Nine mutations, all caught (`untracked/scripts/dah2780_gate_mutations.sh`): revision-1's `container_` selector; dropping the `SO_ACCEPTCON` flag check; dropping `--no-block`; dropping the `MainPID` owner check; trusting a daemon that survived the stop; polling only sysbox-fs; not clearing a stale marker; `exit` instead of continuing the boot; and `docker stop` without the 30 s grace.

What this does **not** prove: that the recreated guest attests, and that the script behaves identically inside a measured TDX guest. Only a canary on a free machine proves those.

`compose_hash` moves, as expected — computed against a placeholder runner digest, since `lium-cvm.sh:436-457` substitutes `EXECUTOR_RUNNER_IMAGE_DIGEST` into the measured compose before it is measured, so the value is only defined per (tree × runner digest):

```
runner digest : sha256:0000…0000  (placeholder)
old           : df7893451cd832b03eeffd9b890dd2d9272216d6e55d0448e3cd08a57d8fe1cf
new           : 9be75cb21373848af315ec1d1bcc9911ef5b4e3abcb30fdfd8e15de52c5ae93e
```

Re-render with the released digest at release time to get the value to whitelist (`untracked/scripts/dah2780_compose_hash.py`). `ENABLE_ATTESTATION_WHITELIST` is `"false"` in production, so old and new hashes coexist and machines can be recreated one at a time.

## Rollout

Dormant on merge. It reaches a machine only when a provider manually runs `git checkout <tag>` + `lium-cvm.sh new`, which destroys that guest's data disk — so this goes out one machine at a time, starting with a free one, and #1264 should be in providers' hands first.

PR #1151 touches this same file (sysbox 0.7.0) and is deliberately **not** in this wave: upstream 0.7.0 does not carry the sysbox-fs FUSE deadlock fix (nestybox/sysbox-fs PR#121), and nothing records whether that installer image was built with the patch. Shipping it later costs a second recreate round; that is the accepted price.
