### PR TITLE
DAH-2862: recognise TDX guests reporting the cpu as raw family/model

### DIFF
--- a/neurons/validators/src/services/task/checks/tdx_host.py
+++ b/neurons/validators/src/services/task/checks/tdx_host.py
@@ -33,9 +33,9 @@ _TDX_CAPABLE_PATTERNS: list[re.Pattern] = [
 ]
 
 # In a TDX guest lscpu has no marketing name and prints the raw CPUID as "family/model" in hex
-# ("06/cf" on the H200 CVMs, "06/ad" on the B200). Only TDX-capable family 6 models pass; ids from
-# the kernel's arch/x86/include/asm/intel-family.h (SPR 0x8F, EMR 0xCF, GNR 0xAD, GNR-D 0xAE).
-_TDX_CAPABLE_RAW_CPUID = re.compile(r"^\s*0*6/(?:8f|cf|ad|ae)\s*$", re.IGNORECASE)
+# ("06/cf" on the H200 CVMs, "06/ad" on the B200). One model id per generation the name patterns
+# above accept, from arch/x86/include/asm/intel-family.h: SPR 8f, EMR cf, GNR ad, GNR-D ae, SRF af.
+_TDX_CAPABLE_RAW_CPUID = re.compile(r"^\s*0*6/(?:8f|cf|ad|ae|af)\s*$", re.IGNORECASE)
 
 
 class TdxHostCheck:
@@ -56,7 +56,7 @@ class TdxHostCheck:
 
     @staticmethod
     def is_tdx_capable(cpu_model: str) -> bool:
-        """Return True if the CPU model name matches a known TDX-capable Intel processor."""
+        """Return True if the model name or raw CPUID belongs to a TDX-capable Intel processor."""
         if _TDX_CAPABLE_RAW_CPUID.match(cpu_model):
             return True
         return any(p.search(cpu_model) for p in _TDX_CAPABLE_PATTERNS)

--- a/neurons/validators/src/services/task/checks/tdx_host.py
+++ b/neurons/validators/src/services/task/checks/tdx_host.py
@@ -32,6 +32,11 @@ _TDX_CAPABLE_PATTERNS: list[re.Pattern] = [
     re.compile(r"Xeon" + _SEP + r"W[579]-[23][4-9]\d{2}", re.IGNORECASE),
 ]
 
+# In a TDX guest lscpu has no marketing name and prints the raw CPUID as "family/model" in hex
+# ("06/cf" on the H200 CVMs, "06/ad" on the B200). Only TDX-capable family 6 models pass; ids from
+# the kernel's arch/x86/include/asm/intel-family.h (SPR 0x8F, EMR 0xCF, GNR 0xAD, GNR-D 0xAE).
+_TDX_CAPABLE_RAW_CPUID = re.compile(r"^\s*0*6/(?:8f|cf|ad|ae)\s*$", re.IGNORECASE)
+
 
 class TdxHostCheck:
     """Determine whether the executor's CPU silicon supports Intel TDX.
@@ -52,6 +57,8 @@ class TdxHostCheck:
     @staticmethod
     def is_tdx_capable(cpu_model: str) -> bool:
         """Return True if the CPU model name matches a known TDX-capable Intel processor."""
+        if _TDX_CAPABLE_RAW_CPUID.match(cpu_model):
+            return True
         return any(p.search(cpu_model) for p in _TDX_CAPABLE_PATTERNS)
 
     async def run(self, ctx: Context) -> CheckResult:

--- a/neurons/validators/tests/test_tdx_host_check.py
+++ b/neurons/validators/tests/test_tdx_host_check.py
@@ -26,6 +26,13 @@ from tests.helpers import build_context_config, build_services, build_state
         ("Intel(R) Xeon(R) 6766E", True),
         # TDX-capable: case-insensitive match
         ("INTEL(R) XEON(R) PLATINUM 8592+", True),
+        # TDX-capable: inside a CVM lscpu reports the raw "family/model" CPUID instead of a name
+        ("06/cf", True),  # Emerald Rapids, TEEmo H200 CVMs
+        ("06/ad", True),  # Granite Rapids, B200 CVM at 146.88.195.16
+        ("06/8f", True),  # Sapphire Rapids
+        ("06/AE", True),  # Granite Rapids D, uppercase hex
+        # Not TDX-capable: raw CPUID of a family 6 model without TDX (Alder Lake client)
+        ("06/97", False),
         # Not TDX-capable: 3rd Gen Xeon Scalable (Ice Lake)
         ("Intel(R) Xeon(R) Platinum 8380", False),
         ("Intel(R) Xeon(R) Gold 6330", False),

--- a/neurons/validators/tests/test_tdx_host_check.py
+++ b/neurons/validators/tests/test_tdx_host_check.py
@@ -27,12 +27,15 @@ from tests.helpers import build_context_config, build_services, build_state
         # TDX-capable: case-insensitive match
         ("INTEL(R) XEON(R) PLATINUM 8592+", True),
         # TDX-capable: inside a CVM lscpu reports the raw "family/model" CPUID instead of a name
-        ("06/cf", True),  # Emerald Rapids, TEEmo H200 CVMs
-        ("06/ad", True),  # Granite Rapids, B200 CVM at 146.88.195.16
+        ("06/cf", True),  # Emerald Rapids, the H200 CVMs
+        ("06/ad", True),  # Granite Rapids, the B200 CVM
         ("06/8f", True),  # Sapphire Rapids
+        ("06/af", True),  # Sierra Forest
         ("06/AE", True),  # Granite Rapids D, uppercase hex
         # Not TDX-capable: raw CPUID of a family 6 model without TDX (Alder Lake client)
         ("06/97", False),
+        # Not TDX-capable: a TDX model id under a different family
+        ("0f/cf", False),
         # Not TDX-capable: 3rd Gen Xeon Scalable (Ice Lake)
         ("Intel(R) Xeon(R) Platinum 8380", False),
         ("Intel(R) Xeon(R) Gold 6330", False),


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2862](https://app.notion.com/p/host-detect-tdx-does-not-recognise-CVM-guests-whose-cpu-model-is-raw-family-model-06-cf-06-ad-3d1b8bfdbde98190922af2e1065f8e71)

---

## Problem

The `host.detect.tdx` check matches the CPU by its marketing name (`Intel(R) Xeon(R) Platinum 8592+`
and friends). Inside a TDX guest the host CPU name is not passed through, so `lscpu` in the machine
scrape falls back to the raw CPUID and `specs["cpu"]["model"]` becomes a hex `family/model` string —
`06/cf` on every TEEmo H200 CVM (Emerald Rapids) and `06/ad` on the B200 CVM at 146.88.195.16
(Granite Rapids).

Result: every real CVM logs "Intel TDX CPU capability not detected" and records
`tdx_host_supported=False`. Prod validator log, 2026-09-03 13:17:25 UTC, node 146.88.195.16. The
check is non-fatal, so nothing is scored down, but the recorded boolean is wrong for exactly the
machines the check exists for.

## Solution

Keep the marketing-name regexes and additionally accept the raw CPUID form for family 6 with the
TDX-capable model ids only. Model ids follow the Linux kernel header
`arch/x86/include/asm/intel-family.h`: `SAPPHIRERAPIDS_X 0x8F`, `EMERALDRAPIDS_X 0xCF`,
`GRANITERAPIDS_X 0xAD`, `GRANITERAPIDS_D 0xAE`. Arbitrary family 6 models are still rejected.

## Changes

- `neurons/validators/src/services/task/checks/tdx_host.py`: new `_TDX_CAPABLE_RAW_CPUID` pattern,
  checked first in `TdxHostCheck.is_tdx_capable`.
- `neurons/validators/tests/test_tdx_host_check.py`: cases for `06/cf`, `06/ad`, `06/8f`, `06/AE`
  (detected) and `06/97` (Alder Lake client — not detected).

## Deployment Steps

Use GitHub Action.

## Review Request

- [x] Just code review

## Other PRs

None.

## Risks

- Low. The check is non-fatal (`fatal = False`, always `passed=True`); the only effect is the value
  of `tdx_host_supported` written into specs and the log line that goes with it.
- The raw form is matched against the whole string (anchored), so it cannot fire on a substring of a
  marketing name. Existing marketing-name behaviour is untouched.
- If a non-TDX host ever reported exactly `06/8f|cf|ad|ae`, it would be marked supported — but that
  string only appears when the CPU name cannot be resolved, which on our fleet means a CVM guest on
  that very silicon.

## Test Cases

### Test Case 1

**Actions**

`pdm run pytest tests/test_tdx_host_check.py -q` in `neurons/validators`.

**Expected Output**

`30 passed` — including the new raw-CPUID cases.

### Test Case 2

**Actions**

`pdm run pytest tests/ -q` in `neurons/validators`.

**Expected Output**

`3 failed, 1934 passed, 15 skipped, 9 errors` — the 3 failures are the pre-existing
`tests/test_sshd_bootstrap_script.py` ones on clean main, the 9 errors are `test_port_mapping_dao.py`
setup failing on a missing local `greenlet`/DB. Neither touches this check.

## Checklist

- [x] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
