### PR TITLE
DAH-2861: whitelist the latest CVM runner compose hash, drop the July staging build

### DIFF
--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -330,15 +330,15 @@ TDX_WHITELIST = {
     # (`hash in TDX_WHITELIST["COMPOSE_HASH"][env]`) keep working on the dict keys.
     "COMPOSE_HASH": {
         "PROD": {
-            # DAH-2338 — executor-v1.108 measured compose: executor-runner pinned to
-            # daturaai/compute-subnet-executor-runner:latest @
-            # sha256:f85b948b6cb280423b17e34ea28c0f98139243ecea32cd42106f90d19dc619f1
-            # (executor @ sha256:94b5e734…, pushed 2026-07-07), init/pre-launch as
-            # of 077f42c1 (G1 GPU attestation guest env whitelist). Replaces v2
-            # 0995e41b… (executor-v1.107 runner b58211e7…) — CVMs on the old digest
-            # must redeploy with EXECUTOR_RUNNER_IMAGE_DIGEST=sha256:f85b948b… .
-            # Assumes default `lium-cvm.sh new` flags (no --enable-logs/--enable-sysinfo).
-            "ab4d14336f0762c0d8ec7631a69148246661de84ceead7a215f8a33b74fd43e6": 3,
+            # DAH-2861 — measured compose of the latest runner, daturaai/compute-subnet-executor-runner
+            # @ sha256:8c07d3a91f8900bd3f0e19025fb7a2c32f82577385550187b28c7769060d18b7 (pushed
+            # 2026-08-19, executor @ sha256:8dbf5395…, a prod build with no config_override.py).
+            # Seen in the event log of the 146.88.195.16 CVM on 2026-09-03. Assumes default
+            # `lium-cvm.sh new` flags (no --enable-logs/--enable-sysinfo).
+            "8224d58801af6333561f116e2d566b179b399f1d1d700f0e8a5ab9326ae901d9": 4,
+            # Version 3 (ab4d1433…, July runner sha256:f85b948b…) is gone and its number burned:
+            # that runner bakes the STAGING validator hotkey via config_override.py and answers every
+            # prod validator with 401. Removed, not demoted: TDX_MINIMUM_COMPOSE_VERSION defaults to 0.
         },
         "STAGE": {
             "72c9c91a1b72cb016e1ed2ac85cdb1414502165dc3eb3723642f30a5ef0fcb11": 1,

--- a/neurons/validators/src/services/const.py
+++ b/neurons/validators/src/services/const.py
@@ -333,8 +333,11 @@ TDX_WHITELIST = {
             # DAH-2861 — measured compose of the latest runner, daturaai/compute-subnet-executor-runner
             # @ sha256:8c07d3a91f8900bd3f0e19025fb7a2c32f82577385550187b28c7769060d18b7 (pushed
             # 2026-08-19, executor @ sha256:8dbf5395…, a prod build with no config_override.py).
-            # Seen in the event log of the 146.88.195.16 CVM on 2026-09-03. Assumes default
-            # `lium-cvm.sh new` flags (no --enable-logs/--enable-sysinfo).
+            # Seen in the event log of the 146.88.195.16 CVM on 2026-09-03. Covers app/
+            # docker-compose.yml, init_script.sh and pre_launch_script.sh at 880cb585 plus default
+            # `lium-cvm.sh new` flags (no --enable-logs/--enable-sysinfo). Editing any of those
+            # three files moves the hash: DAH-2780 rewrites pre_launch_script.sh and needs its own
+            # version-5 entry here.
             "8224d58801af6333561f116e2d566b179b399f1d1d700f0e8a5ab9326ae901d9": 4,
             # Version 3 (ab4d1433…, July runner sha256:f85b948b…) is gone and its number burned:
             # that runner bakes the STAGING validator hotkey via config_override.py and answers every

--- a/neurons/validators/tests/test_attestation_gaps_g1_g4.py
+++ b/neurons/validators/tests/test_attestation_gaps_g1_g4.py
@@ -11,6 +11,8 @@ Covers, per the remediation-plan test matrix (§6):
   (TDX-pass + GPU-fail is never "passed").
 - Minimal-G5: the CVM ratchet fail-closed on an omitted quote and the score gate.
 - G2: monotonic compose version floor in the whitelist check.
+- DAH-2861: the PROD compose whitelist contents — the latest runner is accepted,
+  the July staging-hotkey build is gone.
 """
 
 import base64
@@ -596,3 +598,47 @@ async def test_g2_compose_version_floor(service, monkeypatch):
 
     # Act / Assert — unknown OS image always rejected
     assert await service._check_whitelist("new-hash", "bad-os-image", executor) is False
+
+
+# ---------------------------------------------------------------------------
+# DAH-2861 — the PROD compose whitelist itself
+# ---------------------------------------------------------------------------
+
+# executor-v1.123 runner sha256:8c07d3a9… (2026-08-19), the prod build.
+LATEST_RUNNER_COMPOSE_HASH = "8224d58801af6333561f116e2d566b179b399f1d1d700f0e8a5ab9326ae901d9"
+# executor-v1.108 runner sha256:f85b948b… (2026-07-07), which bakes the staging validator hotkey.
+JULY_STAGING_RUNNER_COMPOSE_HASH = "ab4d14336f0762c0d8ec7631a69148246661de84ceead7a215f8a33b74fd43e6"
+
+
+async def test_prod_whitelist_accepts_latest_runner_compose(service, monkeypatch):
+    # Arrange
+    from services import const
+
+    monkeypatch.setattr(settings, "DEPLOY_ENV", "PROD")
+    os_image = next(iter(const.TDX_WHITELIST["OS_IMAGE_HASH"]))
+    executor = _make_executor()
+
+    # Act / Assert — default floor
+    monkeypatch.setattr(settings, "TDX_MINIMUM_COMPOSE_VERSION", 0)
+    assert await service._check_whitelist(LATEST_RUNNER_COMPOSE_HASH, os_image, executor) is True
+
+    # Act / Assert — floor raised to this release: still at/above it
+    monkeypatch.setattr(settings, "TDX_MINIMUM_COMPOSE_VERSION", 4)
+    assert await service._check_whitelist(LATEST_RUNNER_COMPOSE_HASH, os_image, executor) is True
+
+
+async def test_prod_whitelist_rejects_july_staging_runner_compose(service, monkeypatch):
+    # Arrange — the July runner is gone from the dict, so rejection cannot depend on the floor
+    from services import const
+
+    monkeypatch.setattr(settings, "DEPLOY_ENV", "PROD")
+    monkeypatch.setattr(settings, "TDX_MINIMUM_COMPOSE_VERSION", 0)
+    os_image = next(iter(const.TDX_WHITELIST["OS_IMAGE_HASH"]))
+    executor = _make_executor()
+
+    # Act / Assert
+    assert JULY_STAGING_RUNNER_COMPOSE_HASH not in const.TDX_WHITELIST["COMPOSE_HASH"]["PROD"]
+    assert (
+        await service._check_whitelist(JULY_STAGING_RUNNER_COMPOSE_HASH, os_image, executor)
+        is False
+    )


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2861](https://app.notion.com/p/TDX-compose-whitelist-the-only-PROD-hash-points-at-a-staging-runner-build-add-the-latest-runner-ha-3d1b8bfdbde981daba4ec1ff28df1f94)

---

## Problem

`TDX_WHITELIST["COMPOSE_HASH"]["PROD"]` held exactly one hash,
`ab4d14336f0762c0d8ec7631a69148246661de84ceead7a215f8a33b74fd43e6` (version 3). Its measured
compose pins runner `sha256:f85b948b6cb280423b17e34ea28c0f98139243ecea32cd42106f90d19dc619f1`
(built 2026-07-07), which in turn pins executor
`sha256:94b5e734ffc636e45ea4ef872d5cb5da26951f39cdd971d7d8a8de3ff5f20ae5`. That executor image
ships `src/core/config_override.py` with
`_VALIDATOR_HOTKEY_SS58 = "5DHgdomxxHSQf7neJWcagvGhTMKpqvKWwuprEaFF8C653qty"` — the **staging**
validator hotkey, baked in by `executor_cd_dev.yml`. Verified from the Docker Hub registry on
2026-09-03.

Consequences:

- Every CVM pinned to that runner answers the prod validator's `/upload_ssh_key` with
  `401 Invalid validator signature` — observed on `146.88.195.16` on 2026-09-03. The node never
  scores.
- The only whitelisted PROD compose belongs to an image that can never talk to the prod validator,
  while the CVMs that actually work today run the latest runner
  `sha256:8c07d3a91f8900bd3f0e19025fb7a2c32f82577385550187b28c7769060d18b7` (2026-08-19, executor
  `sha256:8dbf5395…`, no override), whose compose hash
  `8224d58801af6333561f116e2d566b179b399f1d1d700f0e8a5ab9326ae901d9` was in no whitelist.
- The code comment above the dict told providers to redeploy with
  `EXECUTOR_RUNNER_IMAGE_DIGEST=sha256:f85b948b…`, i.e. it actively pointed at the broken build.

Nothing breaks today only because `ENABLE_ATTESTATION_WHITELIST` defaults to `False` and is off in
prod. The moment anyone flips it, the whitelist rejects every working CVM and accepts only a build
that cannot pass. This PR is inert until that flip — which is exactly why it has to be right first.

## Solution

Add the latest runner's compose hash as version 4 and remove the July hash outright, so the July
build is rejected regardless of any runtime setting. Rewrite the comment block to say what the July
runner actually is.

### Mechanism chosen for version 3: removal, not a floor demotion

`_check_whitelist` rejects a compose hash two ways: it is not a dict key at all, or its version is
below `settings.TDX_MINIMUM_COMPOSE_VERSION`. The floor is an env setting with **default 0**
(`core/config.py`), set outside this repo. Leaving `ab4d1433…: 3` in place and "relying on the
floor" would therefore be inert unless someone also sets `TDX_MINIMUM_COMPOSE_VERSION=4` in the
prod Pulumi config — the whitelist flip and the floor bump would have to land together or the bad
hash stays valid. Removing the key rejects it unconditionally.

The version counter stays append-only: 3 is burned, never reused, and the comment says so. This
also follows the precedent already in this dict — `OS_IMAGE_HASH` removed the legacy 0.5.5 hashes
the same way, with a comment explaining what to redeploy.

## Changes

- `neurons/validators/src/services/const.py`: PROD compose whitelist now holds
  `8224d588…` → version 4 (latest runner `sha256:8c07d3a9…`, 2026-08-19, prod build with no
  `config_override.py`); `ab4d1433…` (version 3) removed with a comment recording why the number is
  burned and why removal was chosen over a floor demotion.
- `neurons/validators/tests/test_attestation_gaps_g1_g4.py`: two tests over the real PROD dict —
  version 4 accepted at the default floor and at floor 4, the July hash absent from the dict and
  rejected.

## Deployment Steps

Use GitHub Action.

No config change required. `ENABLE_ATTESTATION_WHITELIST` stays off; this PR only makes the
whitelist correct for whenever it is turned on.

## Review Request

- [x] Just code review

## Other PRs

None.

## Risks

- **TEEmo's H200 nodes are still unwhitelisted.** They run runner
  `sha256:bedc508500c47fc491a53c75557146fa409386a9578009dc84dde04cca8fed00` (built 2026-08-03,
  executor `19654a7d83ecf4b11330dac5083efe71a93dbfa0f3ad814beae065ebdef0939e`, no override — so it
  is a healthy prod build). Its compose hash has not been computed or verified anywhere, so it is
  deliberately not added here. Flipping `ENABLE_ATTESTATION_WHITELIST` on would drop those nodes.
  Either compute and whitelist that hash first, or have them redeploy on the latest runner.
- **Any CVM still pinned to the July runner loses its only whitelisted hash.** In practice it loses
  nothing: those nodes already fail with the 401 and cannot score. Enforcement is off, so this
  changes nothing until the flag flips.
- **Whitelist enforcement remains a two-part switch.** Turning `ENABLE_ATTESTATION_WHITELIST` on
  without auditing every live CVM runner digest will drop nodes. The compose whitelist is not the
  only gate: the verifier's own `is_valid` (RTMR0 against its QEMU oracle) is always enforced and is
  unaffected by this PR.
- Version 4 is not the floor. `TDX_MINIMUM_COMPOSE_VERSION` stays at its default 0, so the change
  does not by itself retire anything else.

## Test Cases

### Test Case 1 — the latest runner's compose is accepted in PROD

**Actions**

`pdm run pytest tests/test_attestation_gaps_g1_g4.py::test_prod_whitelist_accepts_latest_runner_compose`
— `DEPLOY_ENV=PROD`, `_check_whitelist("8224d588…", <whitelisted OS image>)` at floor 0 and floor 4.

**Expected Output**

`True` in both cases: version 4 is at/above both floors.

### Test Case 2 — the July staging build is rejected in PROD

**Actions**

`pdm run pytest tests/test_attestation_gaps_g1_g4.py::test_prod_whitelist_rejects_july_staging_runner_compose`
— `DEPLOY_ENV=PROD`, floor at its default 0 (so rejection cannot come from the floor),
`_check_whitelist("ab4d1433…", <whitelisted OS image>)`.

**Expected Output**

The hash is not a key of `TDX_WHITELIST["COMPOSE_HASH"]["PROD"]`, and `_check_whitelist` returns
`False`.

### Test Case 3 — the existing floor logic still passes

**Actions**

`cd neurons/validators && pdm run pytest tests/ -q`

**Expected Output**

`3 failed, 1931 passed, 15 skipped, 9 errors`. All failures and errors are pre-existing and
unrelated: 3 in `tests/test_sshd_bootstrap_script.py` (fail on clean `main` too) and 9 errors in
`tests/test_port_mapping_dao.py` (`No module named 'greenlet'` — a local venv gap, not a code
failure). The attestation area is fully green: `tests/test_attestation_gaps_g1_g4.py` and
`tests/test_attestation_service.py` → 36 passed, including `test_g2_compose_version_floor`.

`pdm run ruff check` on both touched files: clean.

## Checklist

- [x] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
