### PR TITLE
DAH-2859: preflight the CVM host gates in lium-cvm.sh check and guard stop against zombie VMs

### DIFF
--- a/neurons/executor/dstacktee/docs/host-setup.md
+++ b/neurons/executor/dstacktee/docs/host-setup.md
@@ -12,7 +12,48 @@ Provider guide for taking a TDX host from bare metal to an attested Lium CVM exe
 
 - **CPU**: Intel Xeon with TDX **and** SGX — Sapphire Rapids (XCC/MCC SKUs only), Emerald Rapids, or Granite Rapids. SGX is not optional: the sealing-key provider runs in an SGX enclave.
 - **GPU**: NVIDIA Confidential-Computing capable — Hopper (H100/H200) or Blackwell (B200/B300). Hopper: CC mode for a single GPU per CVM, Protected PCIe (GPUs **and** NVSwitches, `CVM_GPUS=all` — a listed set leaves the NVSwitches on the host) for a whole 8× HGX board. Blackwell: CC mode only. Commands and checks: [Enable GPU Confidential Computing mode](https://docs.lium.io/providers/nodes/cvm#4-enable-gpu-confidential-computing-mode). Bring-up scripts written against the older single-GPU guidance, such as `cvm-host-phase2.sh`, set Protected PCIe back to off — keep Protected PCIe nodes out of them and re-query the mode after any run.
-- **BIOS**: latest vendor BIOS; enable TDX, SGX, VT-x/VT-d. After boot, `/dev/sgx_enclave` and `/dev/sgx_provision` must exist.
+- **BIOS**: latest vendor BIOS; enable TDX, SGX, VT-x/VT-d, and **SGX Auto MP Registration** (§4). After boot, `/dev/sgx_enclave` and `/dev/sgx_provision` must exist.
+
+### TDX module — Intel's minimum TCB
+
+A TDX module below Intel's published minimum is refused by **every** attester (our key provider, our validator, Phala's own KMS): DCAP verification of the quote answers `No matching TCB level found`. For Granite Rapids (FMSPC `00A06D080000`) the minimum is **TDX module 2.0.08, build 882, minor SVN 5**; current is 2.0.18 (build 1013).
+
+| tag | build | date | minor SVN |
+|---|---|---|---|
+| 2.0.02 | 786 | 2024-08-14 | 3 — below the minimum |
+| 2.0.08 | 882 | 2025-04-02 | 5 — Intel minimum |
+| 2.0.18 | 1013 | 2026-02-11 | 9 — latest |
+
+Sapphire and Emerald Rapids run the 1.5 series, whose build numbers are not comparable with the table; `lium-cvm.sh check` only reports those and the quote's `tee_tcb_svn` is the proof.
+
+Check on a 6.x kernel:
+
+```bash
+sudo dmesg | grep 'TDX module'   # ... build_date 20250402, build_num 882
+```
+
+Kernel 7.0 does not print that line and there is no `/sys/firmware/tdx`. There the proof is the quote: `tee_tcb_svn` starts `09 03 …` after updating to 2.0.18, and the key provider's DCAP verification stops saying `No matching TCB level found`. `sudo dmesg | grep virt/tdx` must still end in `module initialized`.
+
+**Updating without a vendor BIOS.** Intel publishes the signed module at [intel/confidential-computing.tdx.tdx-module](https://github.com/intel/confidential-computing.tdx.tdx-module/releases); NVIDIA's *Deployment Guide for Confidential Computing* gives this procedure verbatim (and names `TDX_MODULE_2.0.08` for Granite Rapids), the alternative being an OEM BIOS:
+
+```bash
+tar -xvzf intel_tdx_module.tar.gz
+sudo mkdir -p /boot/efi/EFI/TDX/
+sudo cp TDX-Module/intel_tdx_module.so /boot/efi/EFI/TDX/TDX-SEAM.so
+sudo cp TDX-Module/intel_tdx_module.so.sigstruct /boot/efi/EFI/TDX/TDX-SEAM.so.sigstruct
+sudo reboot
+```
+
+The BIOS's TDX loader picks the module up from the ESP at boot. Only Intel-signed modules load, so a wrong file is inert — the built-in module keeps loading and nothing is lost. Verified working on an AIVRES KR9288-X3 (AMI 03.04.01) on 2026-09-03; whether a given board keeps this Intel reference-BIOS hook is what the reboot tells you.
+
+### NUMA — possible vs online nodes
+
+```bash
+cat /sys/devices/system/node/possible   # e.g. 0-19
+cat /sys/devices/system/node/online     # e.g. 0-1
+```
+
+Firmware that advertises more *possible* than *online* nodes (seen on a Xeon 6767P: 20 possible, 2 online) breaks the pinned Gramine 1.5 key provider: it sizes its NUMA arrays from `possible`, reads `node<i>/distance` expecting that many numbers, and `load_enclave` dies with `EINVAL` before ever opening `/dev/sgx_enclave` (Gramine issue #1452, fixed in 1.6). Hardware-dependent, kernel- and OS-independent — reprovisioning the OS changes nothing. Until the image is re-pinned (DAH-2860), rebuild the key provider on `gramineproject/gramine:1.9-jammy` (§4).
 
 ## 2. Kernel and boot parameters
 
@@ -63,6 +104,15 @@ sudo make install
 
 This is a plain build — do **not** add the `DUMP_ACPI_TABLES` define (that variant is only for the verifier's oracle binary and cannot run VMs).
 
+**GCC 15 (Ubuntu 26.04):** the bundled `dtc` subproject does not inherit `--disable-werror` and the build stops at `subprojects/dtc/libfdt/fdt_overlay.c:461: error: … -Werror=discarded-qualifiers`. Keep the subproject out of the build instead of patching it — the x86_64 target does not need libfdt:
+
+```bash
+../configure --prefix=/opt/qemu-dstack --target-list=x86_64-softmmu \
+    --disable-werror --enable-kvm --enable-slirp --disable-fdt
+```
+
+Or `--enable-fdt=system` with `libfdt-dev` installed, to use the distro dtc. Verified against the pinned tree: `x86_64-softmmu.mak` declares no `TARGET_NEED_FDT`, and `configure` maps these flags to `-Dfdt=disabled` / `-Dfdt=system` (`meson.build` only builds `subprojects/dtc` for `-Dfdt=internal`). Not verified by an actual GCC 15 build — the host that hit this patched `fdt_overlay.c` by hand and got a working 9.2.1.
+
 Point the launcher at it via `/etc/dstack/client.conf`:
 
 ```ini
@@ -90,7 +140,19 @@ docker compose logs -f gramine-sealing-key-provider   # watch first start
 curl -k https://localhost:3443                        # endpoint reachable
 ```
 
-Two containers: `aesmd` (SGX architectural enclaves, host network) and `gramine-sealing-key-provider` (`127.0.0.1:3443`). DCAP collateral comes from the PCCS configured in [`key-provider/sgx_default_qcnl.conf`](../key-provider/sgx_default_qcnl.conf) — the default is Phala's public PCCS and works out of the box; point `pccs_url` at your own PCCS if you run one.
+Two containers: `aesmd` (SGX architectural enclaves, host network) and `gramine-sealing-key-provider` (`127.0.0.1:3443`).
+
+**Register the platform with Intel.** DCAP collateral comes from the PCCS configured in [`key-provider/sgx_default_qcnl.conf`](../key-provider/sgx_default_qcnl.conf), which defaults to Phala's public PCCS. That default is not enough on its own: no PCCS can serve PCK certificates for a platform that Intel does not know about, and the key provider then fails with AESM error 44 → `load_enclave … EPERM`. Multi-package platforms need registration. Two steps, once per host:
+
+1. Enable **SGX Auto MP Registration** in BIOS, or register manually against a PCCS you run with an Intel PCS API key:
+
+   ```bash
+   PCKIDRetrievalTool -url https://<your-pccs>:8081 -use_secure_cert false
+   ```
+
+2. Point `pccs_url` in `key-provider/sgx_default_qcnl.conf` at that PCCS. `aesmd` runs with `network_mode: host`, so a PCCS on the same box is `https://127.0.0.1:8081/sgx/certification/v4/`.
+
+**Gramine version.** The image is pinned to Gramine 1.5, which fails to load the enclave on hosts whose firmware over-declares NUMA nodes (§1). On such a host rebuild it on `gramineproject/gramine:1.9-jammy` (upstream `MoeMahhouk/gramine-sealing-key-provider` already carries the 1.9 base) and install `libsgx-dcap-default-qpl`. The validator does not pin the key provider's `mr_enclave`, so a rebuild changes no whitelist.
 
 ## 5. Per-executor deployment
 
@@ -127,7 +189,9 @@ Per release:
 ```bash
 sudo ./lium-cvm.sh stop my-executor
 git pull                                   # the release tag
-# update EXECUTOR_RUNNER_IMAGE_DIGEST in .env from the release notes
+# update EXECUTOR_RUNNER_IMAGE_DIGEST in .env — copy it from the release notes, never
+# from an older doc or chat message: the digest is measured, so a wrong one costs a
+# full redeploy (measurements change, the data disk is recreated)
 sudo rm -rf run/vms/my-executor            # see warning below
 sudo ./lium-cvm.sh new my-executor
 sudo ./lium-cvm.sh run my-executor
@@ -146,4 +210,9 @@ The host QEMU from §3 is **not** touched by executor releases; leave it alone u
 | Attestation fails on RTMR0 / quote not whitelisted, image and compose correct | host running distro QEMU instead of the dstack 9.2.1 build | §3 — install the fork and set `client.conf`; confirm with `--version` |
 | QEMU launch error mentioning `iommufd` / `VFIO_DEVICE_BIND_IOMMUFD` EINVAL | launcher predates the QEMU-version-gated VFIO backend | update to the current release — `dstack.py` now selects type1 automatically for QEMU < 10 |
 | Validation fails `CHECK_SYSBOX_COMPATIBILITY` inside the guest | compose not the released one (pre-launch sysbox force-install missing or altered) | redeploy with the unmodified released compose (§5) |
-| `lium-cvm.sh check` reports QEMU missing although §3 is done | `check` looks for `qemu-system-x86_64` on PATH; the launcher itself uses `client.conf` | add the §3 symlink, or ignore this one check line |
+| Key-provider log: `No matching TCB level found` while verifying the CVM's quote | TDX module below Intel's minimum (2.0 series on Granite Rapids: build < 882; the 1.5 series on Sapphire/Emerald Rapids has its own floor) | §1 — drop Intel's signed module into `/boot/efi/EFI/TDX/` and reboot, or get a vendor BIOS |
+| `gramine-sealing-key-provider` dies with `load_enclave … EINVAL` before touching `/dev/sgx_enclave` | firmware declares more possible than online NUMA nodes; Gramine 1.5 bug | §4 — rebuild the key provider on `gramine:1.9` (DAH-2860) |
+| AESM error 44 / `load_enclave … EPERM` | platform not registered with Intel, or a PCCS that has no PCK certs for it | §4 — SGX Auto MP Registration / `PCKIDRetrievalTool`, then point `pccs_url` at that PCCS |
+| Executor answers the validator with `401 Invalid validator signature` | `EXECUTOR_RUNNER_IMAGE_DIGEST` pins the July staging build `sha256:f85b948b6cb280423b17e34ea28c0f98139243ecea32cd42106f90d19dc619f1` (a dev validator hotkey is baked into it) | §5/§6 — redeploy with the runner digest from the release notes (`sha256:8c07d3a91f8900bd3f0e19025fb7a2c32f82577385550187b28c7769060d18b7` as of 2026-08-19) |
+| QEMU prints `TDX doesn't support requested feature: CPUID.07H_01H:EDX.avx10 [bit 19]` | `-cpu host` advertises AVX10, the TDX module masks it | harmless — CPUID bits are not measured into the RTMRs; the VM boots |
+| `lium-cvm.sh check` reports QEMU missing although §3 is done | no `[qemu] path` in a `client.conf` `check` can read (it reads `/etc/dstack`, `~/.config/dstack` and `.dstack` next to the script) | §3 — set `/etc/dstack/client.conf`, or add the symlink |

--- a/neurons/executor/dstacktee/lium-cvm.sh
+++ b/neurons/executor/dstacktee/lium-cvm.sh
@@ -60,6 +60,34 @@ container_running() {
     docker ps --format "table {{.Names}}" | grep -q "$1" 2>/dev/null
 }
 
+# Resolve the QEMU binary the launcher will actually use: dstack.py reads
+# [qemu] path from the client.conf chain (later files override earlier ones)
+# and only falls back to PATH when no config sets it.
+resolve_qemu_path() {
+    local resolved=""
+    local conf
+    for conf in /etc/dstack/client.conf "$HOME/.config/dstack/client.conf" "$THIS_DIR/.dstack/client.conf"; do
+        [ -f "$conf" ] || continue
+        local configured
+        configured=$(awk '/^[[:space:]]*\[/ { section = $0 }
+            section ~ /\[qemu\]/ && /^[[:space:]]*path[[:space:]]*=/ { sub(/^[^=]*=[[:space:]]*/, ""); print }' "$conf" | tail -n1)
+        [ -n "$configured" ] && resolved="$configured"
+    done
+    if [ -n "$resolved" ]; then
+        echo "$resolved"
+    else
+        command -v qemu-system-x86_64 2>/dev/null
+    fi
+}
+
+# List host processes still holding a VM directory: the dstack.py launcher and
+# the QEMU it runs as a child (both carry the VM directory on their command line).
+cvm_pids() {
+    local vm_dir="$1"
+    pgrep -f "dstack\.py run ${vm_dir}(/|[[:space:]]|\$)" 2>/dev/null || true
+    pgrep -f "qemu-system-x86_64.*${vm_dir}/" 2>/dev/null || true
+}
+
 # Function to download and extract OS image
 download_os_image() {
     local temp_file="/tmp/dstack-os-image-$$.tar.gz"
@@ -142,10 +170,29 @@ check_requirements() {
 
     # Check QEMU
     log_info "Checking QEMU installation..."
-    if command_exists qemu-system-x86_64; then
-        log_success "QEMU is installed: $(qemu-system-x86_64 --version | head -n1)"
+    local qemu_bin
+    qemu_bin=$(resolve_qemu_path || true)
+    if [ -n "$qemu_bin" ] && "$qemu_bin" --version >/dev/null 2>&1; then
+        local qemu_version
+        qemu_version=$("$qemu_bin" --version 2>/dev/null | sed -n 's/.*version \([0-9][0-9.]*\).*/\1/p' | head -n1)
+        case "$qemu_version" in
+        9.2.1)
+            log_success "QEMU is the dstack 9.2.1 build: $qemu_bin"
+            ;;
+        1[0-9].*)
+            log_error "QEMU $qemu_version at $qemu_bin is a distro build: the verifier's RTMR0 oracle is built from dstack QEMU 9.2.1, so attestation can never pass"
+            log_info "See docs/host-setup.md section 3 — build kvinwang/qemu-tdx branch dstack-qemu-9.2.1 and point [qemu] path in client.conf at it"
+            all_good=false
+            ;;
+        "")
+            log_warning "Could not parse the QEMU version of $qemu_bin; attestation requires the dstack 9.2.1 build (docs/host-setup.md section 3)"
+            ;;
+        *)
+            log_warning "QEMU $qemu_version at $qemu_bin is not the dstack 9.2.1 build attestation expects (docs/host-setup.md section 3)"
+            ;;
+        esac
     else
-        log_error "QEMU (qemu-system-x86_64) is not installed"
+        log_error "QEMU (qemu-system-x86_64) is not installed or not executable${qemu_bin:+ at $qemu_bin}"
         all_good=false
     fi
 
@@ -166,12 +213,49 @@ check_requirements() {
         log_warning "Intel TDX support not detected in CPU info"
     fi
 
+    # Check the TDX module TCB. The 882 floor (2.0.08, minor SVN 5) is Intel's minimum for
+    # the 2.0 series on Granite Rapids; the 1.5 series on Sapphire/Emerald Rapids numbers its
+    # builds differently, so it only gets reported. Too old = "No matching TCB level found".
+    log_info "Checking Intel TDX module build..."
+    local tdx_line tdx_major tdx_build
+    tdx_line=$(dmesg 2>/dev/null | grep -i 'virt/tdx' | grep -i 'build_num' | tail -n1)
+    tdx_major=$(printf '%s' "$tdx_line" | sed -n 's/.*major_version[^0-9]*\([0-9][0-9]*\).*/\1/p')
+    tdx_build=$(printf '%s' "$tdx_line" | sed -n 's/.*build_num[^0-9]*\([0-9][0-9]*\).*/\1/p')
+    if [ -z "$tdx_build" ]; then
+        log_warning "No TDX module build number in dmesg (kernel 7.0 prints none, and dmesg may need root); the proof is then the quote's tee_tcb_svn — see docs/host-setup.md section 1"
+    elif [ "$tdx_major" != "2" ]; then
+        log_info "TDX module ${tdx_major:-?}.x build $tdx_build (pre-Granite Rapids series); Intel's minimum is per platform — the quote's tee_tcb_svn is the proof, see docs/host-setup.md section 1"
+    elif [ "$tdx_build" -ge 882 ]; then
+        log_success "TDX module build $tdx_build meets Intel's minimum (882 = 2.0.08)"
+    else
+        log_error "TDX module build $tdx_build is below Intel's minimum 882 (2.0.08, minor SVN 5): DCAP verification fails with 'No matching TCB level found'"
+        log_info "See docs/host-setup.md section 1 — update the module via /boot/efi/EFI/TDX/ or a vendor BIOS"
+        all_good=false
+    fi
+
     # Check SGX devices
     log_info "Checking SGX devices..."
     if [ -e /dev/sgx_enclave ] && [ -e /dev/sgx_provision ]; then
         log_success "SGX devices are available"
     else
         log_warning "SGX devices (/dev/sgx_enclave, /dev/sgx_provision) not found"
+    fi
+
+    # Check NUMA topology. The possible set is always a superset of the online one,
+    # so any difference means the firmware over-declares nodes.
+    log_info "Checking NUMA node topology..."
+    if [ -r /sys/devices/system/node/possible ] && [ -r /sys/devices/system/node/online ]; then
+        local numa_possible numa_online
+        numa_possible=$(cat /sys/devices/system/node/possible)
+        numa_online=$(cat /sys/devices/system/node/online)
+        if [ "$numa_possible" = "$numa_online" ]; then
+            log_success "NUMA nodes possible=$numa_possible online=$numa_online"
+        else
+            log_warning "NUMA nodes possible=$numa_possible but online=$numa_online: Gramine 1.5 (the pinned key-provider image) fails load_enclave with EINVAL on such firmware"
+            log_info "See docs/host-setup.md section 4 — rebuild the key provider on gramine:1.9"
+        fi
+    else
+        log_warning "Cannot read /sys/devices/system/node/{possible,online}; skipping the NUMA check"
     fi
 
     # Check key-provider
@@ -188,6 +272,26 @@ check_requirements() {
     else
         log_error "Key-provider configuration not found at $KEY_PROVIDER_DIR"
         all_good=false
+    fi
+
+    # Check the PCCS the key provider takes DCAP collateral from
+    log_info "Checking PCCS reachability..."
+    local qcnl_conf="$KEY_PROVIDER_DIR/sgx_default_qcnl.conf"
+    if [ -f "$qcnl_conf" ]; then
+        local pccs_url
+        pccs_url=$(sed -n 's/.*"pccs_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$qcnl_conf" | head -n1)
+        if [ -z "$pccs_url" ]; then
+            log_warning "No pccs_url in $qcnl_conf"
+        elif ! command_exists curl; then
+            log_warning "curl is not installed; cannot check whether $pccs_url answers"
+        elif curl -k -s -o /dev/null --max-time 5 "$pccs_url"; then
+            log_success "PCCS answers: $pccs_url"
+        else
+            log_warning "PCCS $pccs_url does not answer; the key provider will fail DCAP collateral fetch"
+        fi
+        log_info "A reachable PCCS is not enough: the platform must be registered with Intel (multi-package platforms need it) — enable 'SGX Auto MP Registration' in BIOS or run PCKIDRetrievalTool against your PCCS, see docs/host-setup.md section 4"
+    else
+        log_warning "QCNL configuration not found at $qcnl_conf"
     fi
 
     # Check dstack-os-image
@@ -568,18 +672,39 @@ stop_cvm() {
 
     if [ ! -d "$VMS_DIR/$cvm_name" ]; then
         log_error "CVM '$cvm_name' not found at $VMS_DIR/$cvm_name"
+        # the directory was removed under a running VM: the processes are the only trace left
+        local orphan_pids
+        orphan_pids=$(cvm_pids "$VMS_DIR/$cvm_name" | sort -u | xargs)
+        if [ -n "$orphan_pids" ]; then
+            log_error "but a VM from that directory is still running (pids: $orphan_pids) and keeps holding its GPUs and ports; kill those pids"
+        fi
         return 1
     fi
 
     shift
-    python3 "$SCRIPTS_DIR/dstack.py" stop "$VMS_DIR/$cvm_name" "$@"
+    local stop_rc=0
+    python3 "$SCRIPTS_DIR/dstack.py" stop "$VMS_DIR/$cvm_name" "$@" || stop_rc=$?
 
-    if [ $? -eq 0 ]; then
-        log_success "CVM '$cvm_name' stopped"
-    else
+    if [ $stop_rc -ne 0 ]; then
         log_error "Failed to stop CVM '$cvm_name'"
         return 1
     fi
+
+    # dstack.py stop exits 0 when runtime.json is missing — after 'rm -rf run/vms/<name>'
+    # under a running VM it stops nothing, so only the process list proves the VM is gone.
+    local leftover_pids attempt
+    for attempt in 1 2 3 4 5; do
+        leftover_pids=$(cvm_pids "$VMS_DIR/$cvm_name" | sort -u | xargs)
+        [ -z "$leftover_pids" ] && break
+        sleep 1
+    done
+    if [ -n "$leftover_pids" ]; then
+        log_error "CVM '$cvm_name' is still running (pids: $leftover_pids) and keeps holding its GPUs and ports"
+        log_info "Retry with '$0 stop $cvm_name --force', or kill those pids once you know what they are"
+        return 1
+    fi
+
+    log_success "CVM '$cvm_name' stopped"
 }
 
 # List available GPUs


### PR DESCRIPTION
## Summary

`lium-cvm.sh check` passed on a host that could not possibly run an attested CVM, and `lium-cvm.sh stop` reported success while the VM kept running. This PR makes `check` a real preflight for the four gates a provider host hit in Aug/Sep 2026, makes `stop` prove the VM is gone, and writes the missing host requirements into `docs/host-setup.md`.

### Task Link

[CVM host preflight: `lium-cvm.sh check` misses every gate](https://app.notion.com/p/CVM-host-preflight-lium-cvm-sh-check-misses-every-gate-TEEmo-s-B200-hit-stop-leaves-zombie-VMs-ho-3d1b8bfdbde981329cedc87b61f14b03)

---

## Problem

Onboarding one B200 host cost several days and four CVM redeploys. Every blocker was checkable in seconds before the first launch, and `check` reported none of them:

1. **QEMU.** `check` only asked whether *some* `qemu-system-x86_64` is on PATH. The launcher takes its binary from `client.conf`, and only the dstack 9.2.1 build reproduces RTMR0 against the prod verifier's oracle — a host on distro QEMU 10.x can never pass attestation (`is_valid=false`, RTMR0 mismatch). That verdict is enforced unconditionally, independent of the compose whitelist.
2. **TDX module TCB.** Build 786 (2.0.02, minor SVN 3) is below Intel's minimum for Granite Rapids (2.0.08, build 882, minor SVN 5), so DCAP verification of the CVM's quote answers `No matching TCB level found` — for our key provider, our validator and Phala's KMS alike.
3. **NUMA.** Firmware advertising more possible than online nodes (Xeon 6767P: `0-19` vs `0-1`) kills the pinned Gramine 1.5 key provider with `load_enclave … EINVAL` (Gramine issue #1452, fixed in 1.6). Hardware-dependent; an OS reprovision changes nothing.
4. **PCCS / platform registration.** Phala's public PCCS cannot serve PCK certificates for a platform Intel does not know about → AESM error 44, `load_enclave … EPERM`. `docs/host-setup.md` claimed the default "works out of the box".

Separately, `dstack.py stop` returns success when there is no `runtime.json`. Doing `rm -rf run/vms/<name>` before `stop` (the upgrade sequence, in the wrong order) therefore stops nothing while `lium-cvm.sh` prints `[SUCCESS] CVM stopped` — the VM keeps holding all 8 GPUs and its ports, and the next `new`+`run` fails with resources busy. Seen on the provider host 2026-09-03 10:25–10:35 UTC.

## Solution

`check` resolves and verifies the same QEMU the launcher will use, reads the TDX module build out of `dmesg`, compares possible vs online NUMA nodes, and probes the configured PCCS — each with a pointer to the section of `docs/host-setup.md` that fixes it. `stop` no longer trusts the exit code: after `dstack.py stop` it looks for the launcher and QEMU processes that carry the VM directory on their command line and fails loudly if any survive. The docs gain the TDX module minimum with the vendor-independent update path, the NUMA note, platform registration, the GCC 15 build note, and six troubleshooting rows.

## Changes

- `lium-cvm.sh`: new `resolve_qemu_path` (reads `[qemu] path` from the `client.conf` chain, falls back to PATH) and `cvm_pids` helpers.
- `check_requirements`: QEMU 9.2.1 required (distro 10.x → `log_error`), TDX module build ≥ 882 required, NUMA possible vs online warning, PCCS reachability + platform-registration reminder. Existing checks untouched.
- `stop_cvm`: verifies no `dstack.py run` / QEMU process still holds the VM directory; returns 1 with the surviving pids instead of `log_success`.
- `docs/host-setup.md` §1: TDX module minimum table, how to check on 6.x vs 7.0 kernels, the EFI update path from Intel's signed package.
- `docs/host-setup.md` §1/§4: NUMA possible-vs-online note and the Gramine 1.9 workaround; §4 corrects the "Phala's PCCS works out of the box" claim and adds registration.
- `docs/host-setup.md` §3: GCC 15 / bundled `dtc` build failure and how to avoid the subproject; §6: the runner digest comment; 6 new troubleshooting rows.

## Deployment Steps

Nothing to deploy — a provider-side script and its docs. Providers get it with the next `git pull` of the release tag; no CVM redeploy, no measurement change.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None. Related follow-ups tracked separately: DAH-2860 (re-pin the key provider to Gramine 1.9), PR #1134 (QEMU 10 verifier).

## Risks

- `check` can now fail (`return 1`) on hosts it used to pass: distro QEMU ≥ 10 and TDX module build < 882 are hard errors. That is the intent — both make attestation impossible — but a provider who ignored `check` before will now see it red.
- QEMU is resolved from `client.conf` the way `dstack.py` does it, with one simplification: the config walk-up starts at the script directory instead of the launcher's cwd. A `.dstack/client.conf` placed above the repo would be seen by the launcher and not by `check`.
- The new checks are read-only (`dmesg`, `/sys`, `curl`, `pgrep`); none of them touch a running VM.
- The `stop` guard matches processes by the VM directory on their command line. If it ever produced a false positive, `stop` would report failure for a VM that is actually down; the boundary case (`my-executor` vs `my-executor-2`) is covered by the pattern and tested below.
- No change to `dstack.py`, the measured compose, or anything inside the attestation boundary.

## Test Cases

`shellcheck` is not installed on this machine, so it was not run; `bash -n` passes.

### Test Case 1 — syntax and a full `check` run

**Actions** `bash -n neurons/executor/dstacktee/lium-cvm.sh`, then `./lium-cvm.sh check` on macOS (no `/sys`, no readable `dmesg`, no `/dev/kvm`).

**Expected Output** No syntax errors; `check` runs to the end under `set -e` and every new check takes its "cannot determine" branch instead of crashing:

```
[WARNING] QEMU 9.0.2 at /usr/local/bin/qemu-system-x86_64 is not the dstack 9.2.1 build attestation expects (docs/host-setup.md section 3)
[WARNING] No TDX module build number in dmesg (kernel 7.0 prints none, and dmesg may need root); the proof is then the quote's tee_tcb_svn — see docs/host-setup.md section 1
[WARNING] Cannot read /sys/devices/system/node/{possible,online}; skipping the NUMA check
[WARNING] PCCS https://pccs.phala.network/sgx/certification/v4/ does not answer; the key provider will fail DCAP collateral fetch
[INFO] A reachable PCCS is not enough: the platform must be registered with Intel …
```

### Test Case 2 — QEMU resolution and verdicts (stub binaries)

**Actions** A stub `qemu-system-x86_64` printing `QEMU emulator version 10.2.1 (Debian 1:10.2.1+ds-1ubuntu1)` and another printing `9.2.1`, selected through `[qemu] path` in a `client.conf` that also contains an `[image]` section; then a run with no config and no QEMU on PATH.

**Expected Output**

```
[ERROR] QEMU 10.2.1 at /tmp/…/q10/qemu-system-x86_64 is a distro build: the verifier's RTMR0 oracle is built from dstack QEMU 9.2.1, so attestation can never pass
[INFO] See docs/host-setup.md section 3 — build kvinwang/qemu-tdx branch dstack-qemu-9.2.1 and point [qemu] path in client.conf at it
[SUCCESS] QEMU is the dstack 9.2.1 build: /tmp/…/q921/qemu-system-x86_64
[ERROR] QEMU (qemu-system-x86_64) is not installed or not executable
```

The `[qemu] path` value wins over the PATH binary, and the `path` key is read only inside the `[qemu]` section.

### Test Case 3 — TDX module build and NUMA parsing

**Actions** Feed the parser real `virt/tdx` dmesg lines (builds 786 / 882 / 1013, plus a kernel-7.0 line with no `build_num`) and the NUMA pairs `0-1|0-1` and `0-19|0-1`.

**Expected Output** `786 → ERROR (below Intel minimum)`, `882 → SUCCESS`, `1013 → SUCCESS`, no `build_num` → WARNING; `0-1/0-1 → SUCCESS`, `0-19/0-1 → WARNING (Gramine 1.5 EINVAL)`.

### Test Case 4 — PCCS probe

**Actions** Point `pccs_url` at an unreachable host, then at a reachable one.

**Expected Output** `[WARNING] PCCS … does not answer` / `[SUCCESS] PCCS answers: …`, followed in both cases by the registration reminder.

### Test Case 5 — `stop` against a zombie VM

**Actions** Five cases with a stubbed `dstack.py stop` that always exits 0 (the real no-`runtime.json` behaviour): (1) nothing running; (2) a `dstack.py run` of `my-executor-2` while stopping `my-executor`; (3) a live `dstack.py run …/vms/my-executor`; (4) only a leftover `qemu-system-x86_64 … -virtfs local,path=…/vms/my-executor/shared`; (5) `dstack.py stop` itself exiting non-zero.

**Expected Output**

```
### case 1: nothing running -> stop succeeds
[SUCCESS] CVM 'my-executor' stopped
  rc=0
### case 2: dstack.py run of ANOTHER vm (my-executor-2) must not trip my-executor
[SUCCESS] CVM 'my-executor' stopped
  rc=0
### case 3: zombie launcher for my-executor still alive -> stop must fail
[ERROR] CVM 'my-executor' is still running (pids: 27226) and keeps holding its GPUs and ports
  rc=1
### case 4: only a leftover QEMU holding the vm dir -> stop must fail
[ERROR] CVM 'my-executor' is still running (pids: 27245) and keeps holding its GPUs and ports
  rc=1
### case 5: dstack.py stop itself fails -> old behaviour kept
[ERROR] Failed to stop CVM 'my-executor'
  rc=1
```

### Not verified

- Nothing was run on a real TDX host: the TDX-module, NUMA and QEMU-9.2.1 success branches were exercised with stubs and real dmesg/sysfs strings, not on hardware.
- The GCC 15 workaround in §3 (`--disable-fdt` / `--enable-fdt=system`) is verified against the pinned QEMU tree (`configs/targets/x86_64-softmmu.mak` declares no `TARGET_NEED_FDT`; `scripts/meson-buildoptions.sh` maps the flags to `-Dfdt=disabled` / `-Dfdt=system`; `meson.build` builds `subprojects/dtc` only for `-Dfdt=internal`) but not by an actual build on GCC 15.

## Checklist

- [x] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described


## Review pass (Mikhail)
- The build-882 floor now applies only to the 2.0 module series (Granite Rapids); Sapphire/Emerald Rapids hosts on the 1.5 series are reported, not failed.
- `stop` also reports surviving VM processes when the VM directory is already gone (the exact `rm` then `stop` sequence that left the zombie on 2026-09-03), and re-checks for up to 5 s so the launcher's own exit after QEMU is not mistaken for a survivor.
