### PR TITLE
DAH-2860: re-pin the sealing key provider to Gramine 1.9

### DIFF
--- a/neurons/executor/dstacktee/key-provider/Dockerfile.key-provider
+++ b/neurons/executor/dstacktee/key-provider/Dockerfile.key-provider
@@ -1,16 +1,22 @@
 # SPDX-FileCopyrightText: © 2024-2025 Phala Network <dstack@phala.network>
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM gramineproject/gramine:v1.5@sha256:615849089db84477f03cd13209c08eaf6b6a3a68b4df733e097db56781935589
+# Gramine < 1.6 sizes NUMA arrays from node/possible and expects that many distances per
+# node, so firmware with more possible than online nodes kills load_enclave with EINVAL
+# before /dev/sgx_enclave is opened (gramine#1452, fixed in v1.6).
+FROM gramineproject/gramine:1.9-jammy@sha256:84b3d222e0bd9ab941f0078a462af0dbc5518156b99b147c10a7b83722ac0c38
 
-# The base image's CA store is too old to trust download.01.org's current
-# Sectigo cert; upgrade ca-certificates from the Ubuntu repos first.
+# The base image's CA store can lag download.01.org's current Sectigo cert, which
+# breaks the Intel SGX apt repo it ships; upgrade ca-certificates before using it.
 RUN apt-get update 2>/dev/null || true
 RUN apt-get install -y --only-upgrade ca-certificates && update-ca-certificates
 
+# No apt version pins: the old ones existed only in focal, and jammy revisions move.
+# libsgx-dcap-default-qpl supplies the quote-provider library the DCAP stack dlopens.
 RUN apt-get update && apt-get install -y \
-    git=1:2.25.1-1ubuntu3.14 \
-    build-essential=12.8ubuntu1.1 \
+    git \
+    build-essential \
+    libsgx-dcap-default-qpl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --default-toolchain 1.85 -y
@@ -23,10 +29,11 @@ ENV DEV_MODE=0
 ENV GRAMINE=gramine-sgx
 ENV RUST_LOG=info
 
-# Clone and checkout the repository
+# Clone and checkout the repository. This commit carries the manifest cleanup the
+# 1.7+ syntax needs (no loader.entrypoint, no sgx.enable_stats), so no local patching.
 RUN git clone https://github.com/MoeMahhouk/gramine-sealing-key-provider && \
     cd gramine-sealing-key-provider && \
-    git checkout 327e8b52515ab671dcadb75014b7ca7e272d86bc
+    git checkout 180ff4691dce5aae7cd7d6c1344c3e1ec872f174
 
 WORKDIR /gramine-sealing-key-provider
 COPY Cargo.lock .


### PR DESCRIPTION
## Summary

### Task Link

[DAH-2860 — Key provider image pins Gramine 1.5: EINVAL on hosts with possible>online NUMA nodes, re-pin to 1.9](https://app.notion.com/p/Key-provider-image-pins-Gramine-1-5-EINVAL-on-hosts-with-possible-online-NUMA-nodes-re-pin-to-1-9--3d1b8bfdbde9817eaceee7778cf06434)

---

## Problem

`neurons/executor/dstacktee/key-provider/Dockerfile.key-provider` pinned
`gramineproject/gramine:v1.5@sha256:615849089db8…`. Gramine 1.5 sizes its NUMA arrays from
`/sys/devices/system/node/possible` (`pal/src/host/linux-common/topo_info.c`) and then reads
`node<i>/distance` expecting that many numbers. Firmware that declares more possible than online
nodes — the Xeon 6767P in TEEmo's B200 declares 20 possible / 2 online, the distance file has 2
numbers — makes `read_numbers_from_file` return `-EINVAL`, and `load_enclave` dies before
`/dev/sgx_enclave` is ever opened:

```
gramine-sgx gramine-sealing-key-provider
load_enclave() failed with error: Invalid argument (EINVAL)
make: *** [Makefile:66: run-provider] Error 234
```

This is Gramine issue #1452 ("NUMA info is initialized on `possible` instead of `online`"), opened
2023-07-11, four days after v1.5 shipped; fix PR #1545 merged 2023-09-13, first released in **v1.6**.
So the failure is kernel-independent (TEEmo reproduced it on 6.8, 6.17 and 7.0), OS-independent
(same on Jammy and Noble), and **hardware-dependent** — any host whose firmware advertises more
possible than online NUMA nodes cannot run our pinned image at all. The reprovision to Noble that we
recommended cost him hours and changed nothing.

TEEmo rebuilt on `gramine:1.9-jammy` on his host and the provider came up in PRODUCTION mode on
3443.

## Solution

Re-pin the image to Gramine 1.9 and move the pinned upstream commit forward to the one that already
carries the manifest cleanup 1.7+ requires, so we ship a re-pin rather than a local patch.

## Changes

Single file, `neurons/executor/dstacktee/key-provider/Dockerfile.key-provider`:

- Base image `gramineproject/gramine:v1.5@sha256:615849089db84477f03cd13209c08eaf6b6a3a68b4df733e097db56781935589`
  → `gramineproject/gramine:1.9-jammy@sha256:84b3d222e0bd9ab941f0078a462af0dbc5518156b99b147c10a7b83722ac0c38`.
  Digest resolved from the Docker Hub registry today and identical to the one upstream pins.
- Upstream `MoeMahhouk/gramine-sealing-key-provider` checkout `327e8b52515ab671dcadb75014b7ca7e272d86bc`
  → `180ff4691dce5aae7cd7d6c1344c3e1ec872f174` (still a commit pin, not a branch). That commit's
  manifest template already drops `loader.entrypoint`, `sgx.enable_stats`,
  `sys.insecure__allow_eventfd` and `file:{{ gramine.libos }}` from `sgx.trusted_files`, which is
  exactly the 1.7+ syntax fix — no local `sed` needed.
- Dropped the apt version pins `git=1:2.25.1-1ubuntu3.14` and `build-essential=12.8ubuntu1.1`; both
  versions exist only in focal and the image is now jammy.
- Added `libsgx-dcap-default-qpl`. The Gramine 1.9 image installs `libsgx-dcap-quote-verify` but not
  the default quote-provider library; TEEmo hit this after the enclave started loading.
- Comments updated: the base-image line now records why the version matters, the CA-certificates
  block says what it actually protects (the Intel SGX apt repo the base image ships — the build
  upgrades ca-certificates 20240203 → 20260601), and the clone block says why this commit.

Everything else is untouched: Rust 1.85, the vendored `Cargo.lock`, the `ENV` block, the build and
`gramine-sgx-sigstruct-view` steps, the entrypoint, `docker-compose.yaml`, `Dockerfile.aesmd`,
`sgx_default_qcnl.conf`.

### dcap-qvl: left at 0.3.11 on purpose

The vendored `Cargo.lock` pins `dcap-qvl` 0.3.11 while the crate is at 0.6.x. Not bumped here.
Upstream's `Cargo.toml` at the pinned commit declares `dcap-qvl = "0.3.10"`, i.e. `^0.3`, so 0.3.11
is already the top of the allowed range — a lockfile bump cannot reach 0.6. Getting there means
changing upstream's `Cargo.toml` and its `src/quote/handler.rs` call sites
(`get_collateral_from_pcs`, `verify`, `Quote::parse`), which is an upstream change, not a re-pin, and
one nobody can validate without SGX hardware. Worth a separate task; the collateral format does move.

## Deployment Steps

Not a GitHub Action — the key provider is built on the provider's host, outside the CVM:

```
cd neurons/executor/dstacktee/key-provider && docker compose up --build -d
docker compose logs -f gramine-sealing-key-provider
```

Read the risk below before doing this on a host that already serves CVMs.

## Review Request

- [x] Just code review
- [ ] QA - local test on reviewer side

## Other PRs

None.

## Risks

- **The MRENCLAVE changes, and the sealing key is derived from it.** `src/quote/handler.rs` does
  `derive_key(&sealing_key, &measurements)` where `sealing_key` is
  `/dev/attestation/keys/_sgx_mrenclave`. A different enclave measurement means a different derived
  key for every CVM the provider serves, so a CVM whose encrypted volume was unlocked by the old
  enclave will not be unlocked by the new one. Rebuilding this image on a host that already runs
  encrypted CVMs must be planned as a reprovision, not as a routine `docker compose up --build`.
  This is the risk to weigh before merging, not a build concern.
- **The validator does not pin the key-provider MRENCLAVE — verified.** `grep` over
  `neurons/validators/src` finds no `mr_enclave` / `mrenclave` / `key-provider` reference; PROD
  `TDX_WHITELIST` carries only compose and OS image hashes. So nothing on our side has to be
  re-whitelisted for the new measurement. This answers the question TEEmo asked on 2026-09-02 19:37.
- **Unknown: how the dstack verifier library treats the `key-provider` RTMR3 event.** Not checked in
  this PR and not checkable without a running CVM. If the verifier compares that event against a
  known measurement, the new MRENCLAVE will show up there. Flagging it as the one open unknown.
- **The upstream commit brings behaviour changes, not only the base image.** `327e8b5…180ff46`
  includes commit `ec55b53` "harden attestation flow": `/dev/attestation` access is now serialized
  behind a mutex, and `EACCES` on `/dev/attestation/*` makes the process `exit(1)` instead of logging
  a connection error — with compose `restart: always` that turns a permission fault into a container
  restart loop rather than a silently degraded provider. Intended upstream, but a real change of
  runtime behaviour.
- **`libsgx-dcap-default-qpl` config is not mounted into this container.** `docker-compose.yaml`
  mounts `sgx_default_qcnl.conf` into the `aesmd` container only. The provider container now carries
  the QPL with the package default `/etc/sgx_default_qcnl.conf`. Left alone deliberately — the
  quote verification path in this binary fetches collateral itself via `get_collateral_from_pcs`,
  and there is no evidence the container's QPL needs our PCCS URL. If the hardware test shows
  otherwise, the mount is a one-line follow-up.
- **Unrelated blocker on TEEmo's box, listed so it is not mistaken for this change.** After the
  enclave loads, his host fails DCAP with `No matching TCB level found`: TDX module SVN 3
  (build 786, Aug 2024) against Intel's published minimum SVN 5 for FMSPC `00A06D080000`. That needs
  a vendor BIOS with a current TDX module, not a software fix.

## Test Cases

### Test Case 1 — image builds and the enclave signs

**Actions**

`docker build --platform linux/amd64 -f Dockerfile.key-provider .` from
`neurons/executor/dstacktee/key-provider/` on a macOS arm64 laptop (linux/amd64 under emulation).

**Expected Output**

Build succeeds end to end (exit 0, ~8 min; the Rust release build is 5m35s under emulation). Every
step passes, including the two that could have broken on the new base: `apt-get install git
build-essential libsgx-dcap-default-qpl` resolves on jammy from the Intel SGX repo the base image
ships, and `make` generates the manifest from the pinned commit's template without a local patch.
The signing step then prints:

```
{
    "mr_signer": "ee929ebfcf0be01d999f312468a2530766053161370e8babff6cdac72958e874",
    "mr_enclave": "ebd52ce1a6d63586584b44d873d17837d634a0051f3783293f6a4cc7614af594",
    "isv_prod_id": 0,
    "isv_svn": 0,
    "debug_enclave": false
}
```

`mr_signer` is meaningless here — `gramine-sgx-gen-private-key` makes a fresh signing key on every
build, so each host that runs `docker compose up --build` gets its own. `mr_enclave` is the
measurement of the binary plus the manifest; it differs from TEEmo's `17af0c1e…` because his build
patched the manifest locally instead of taking the upstream commit.

### Test Case 2 — hardware run (NOT DONE — why this PR is a draft)

**Actions**

`docker compose up --build -d` on an SGX+TDX host, then watch
`docker compose logs -f gramine-sealing-key-provider`.

**Expected Output**

`load_enclave` succeeds instead of returning EINVAL, the provider listens on 3443 in PRODUCTION
mode, and a CVM can fetch its key. **This has not been run.** No SGX hardware is reachable from the
build machine — `/dev/sgx_enclave` does not exist on a Mac and the enclave cannot be loaded under
emulation. The test is planned for the B300 host on 2026-09-05. **Do not merge before it passes.**

## Checklist

- [x] Proper labels added (`ready-review`, `require-qa`, `breaking-changes` if applicable)
- [x] PR description is clear and complete
- [x] Risks are documented
- [x] Tests are described
