### PR TITLE
DAH-1515 - [P2] Executor README: set a node up with lium mine

### DIFF
--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -1,8 +1,35 @@
 # Executor
 
-**[Executor Documentation](https://docs.lium.io/bittensor-subnet/executor)**
+**[Node Quickstart on docs.lium.io](https://docs.lium.io/providers/nodes/quickstart)**
 
-## Setup project
+## Quick setup with `lium mine` (recommended)
+
+Install [Sysbox](https://docs.lium.io/providers/nodes/sysbox) first — validators reject a node without the `sysbox-runc` runtime. The installer below also sets up the NVIDIA Container Toolkit:
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash
+```
+
+Then run the node in one command, with your miner hotkey:
+
+```shell
+curl -fsSL https://lium.io/mine.sh | bash -s -- -k <your_miner_hotkey_ss58>
+```
+
+The script installs the [`lium`](https://github.com/Datura-ai/lium) CLI and runs `lium mine`, which:
+
+1. clones this repository into `./compute-subnet` (or pulls the branch if the directory already exists),
+2. runs `scripts/install_executor_on_ubuntu.sh` (Docker, NVIDIA Container Toolkit and GPU checks),
+3. renders `neurons/executor/.env` from `.env.template` with the hotkey and the ports — you are prompted for the service port (`8080`), the node SSH port (`2200`), an optional public SSH port and an optional renting port range; pass `--auto` to accept the defaults without prompts,
+4. starts the executor with `docker compose up -d` and waits for the container to report `healthy`,
+5. runs the validator's own check against the node (`daturaai/lium-validator:latest`).
+
+At the end it prints the node's endpoint, GPU type and count, and a `provider.lium.io/nodes?action=add&…` link that pre-fills the **Add Node** form in the [Provider Portal](https://provider.lium.io) with those values. Other options: `-d/--dir` (checkout directory, default `compute-subnet`) and `-b/--branch` (default `main`); `lium mine --help` lists them.
+
+## Manual setup
+
+Use this path if you want to set every value yourself instead of running `lium mine`.
+
 ### Requirements
 * Ubuntu machine
 * install [docker](https://docs.docker.com/engine/install/ubuntu/)
@@ -11,14 +38,14 @@
 ### Step 1: Clone project
 
 ```
-git clone https://github.com/Datura-ai/compute-subnet.git
+git clone https://github.com/Datura-ai/lium-io.git
 ```
 
 ### Step 2: Install Required Tools
 
 Run following command to install required tools: 
 ```shell
-cd compute-subnet && chmod +x scripts/install_executor_on_ubuntu.sh && scripts/install_executor_on_ubuntu.sh
+cd lium-io && chmod +x scripts/install_executor_on_ubuntu.sh && scripts/install_executor_on_ubuntu.sh
 ```
 
 if you don't have sudo on your machine, run

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -4,6 +4,15 @@
 
 ## Quick setup with `lium mine` (recommended)
 
+Before the first command, the machine needs:
+
+- **Ubuntu 22.04 on x86_64**, kernel 5.19 or newer (6.x recommended; `hostnamectl` shows both), and root or passwordless `sudo`;
+- **the NVIDIA driver loaded** — `nvidia-smi` lists the GPUs;
+- **Docker Engine installed and running** — `docker ps` works. The Sysbox installer below refuses to run without it (`lium mine` runs the Docker install script too, but only after this step, and it is a no-op on a machine that already has Docker);
+- **a public IP** with the service port (`8080`) and the node SSH port (`2200`) reachable, and the SS58 hotkey of a provider registered on subnet 51.
+
+RAM, disk (including the 1.5× VRAM rule for the idle incentive) and the recommended XFS storage setup are in the [Node Quickstart requirements](https://docs.lium.io/providers/nodes/quickstart#requirements).
+
 Install [Sysbox](https://docs.lium.io/providers/nodes/sysbox) first — validators reject a node without the `sysbox-runc` runtime. The installer below also sets up the NVIDIA Container Toolkit:
 
 ```shell

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://lium.io/mine.sh | bash -s -- -k <your_miner_hotkey_ss58>
 The script installs the [`lium`](https://github.com/Datura-ai/lium) CLI and runs `lium mine`, which:
 
 1. clones this repository into `./compute-subnet` (or pulls the branch if the directory already exists),
-2. runs `scripts/install_executor_on_ubuntu.sh` (Docker, NVIDIA Container Toolkit and GPU checks),
+2. runs `scripts/install_executor_on_ubuntu.sh` (Docker Engine and the compose plugin), then checks prerequisites — `nvidia-smi`, `nvidia-container-cli`, `docker info`,
 3. renders `neurons/executor/.env` from `.env.template` with the hotkey and the ports — you are prompted for the service port (`8080`), the node SSH port (`2200`), an optional public SSH port and an optional renting port range; pass `--auto` to accept the defaults without prompts,
 4. starts the executor with `docker compose up -d` and waits for the container to report `healthy`,
 5. runs the validator's own check against the node (`daturaai/lium-validator:latest`).


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-1515](https://app.notion.com/p/Subnet-Update-executor-neuron-README-md-to-use-the-new-lium-mine-CLI-to-add-an-executor-28eb8bfdbde9800ea61beab45a3eac52) · reviewer: @arhangel66

**TL;DR** — `neurons/executor/README.md` still documents only the hand-rolled setup — clone, run the install script, copy `.env.template`, fill the keys in, `docker compose up -d` — and never mentions `lium mine`. Executor README: set a node up with lium mine. Touches validator/executor (`neurons/executor/README.md`) — read that file first.

**What changed**
- `neurons/executor/README.md` only.
- Header link → `https://docs.lium.io/providers/nodes/quickstart` (the redirect's target).
- New first section Quick setup with `lium mine` (recommended).
- The old section is kept as Manual setup with one sentence on when to use it.

**How to verify**
- `gh pr checks 1277 -R Datura-ai/lium-io` → all green
- re-run the loop's suites (Details → Verification) → validators 1940 passed, executor 128 passed, miners 26 passed

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · executor 128 passed · Result: PASS 0c25220f · Gate: not run

**Docs:** this PR is the docs change.

<details><summary>Details</summary>

[DAH-1515](https://app.notion.com/p/Subnet-Update-executor-neuron-README-md-to-use-the-new-lium-mine-CLI-to-add-an-executor-28eb8bfdbde9800ea61beab45a3eac52).

## Problem

`neurons/executor/README.md` still documents only the hand-rolled setup — clone, run the install script, copy `.env.template`, fill the keys in, `docker compose up -d` — and never mentions `lium mine`, which is the path docs.lium.io gives providers (Node Quickstart → Step 2: `curl -fsSL https://lium.io/mine.sh | bash -s -- -k <hotkey>`). A provider who lands on the repo instead of the docs does everything by hand and misses the validator self-check the CLI runs for them.

Two stale details on top: the header links `docs.lium.io/bittensor-subnet/executor`, which is a redirect to `/providers/nodes/quickstart`, and the clone command names `Datura-ai/compute-subnet.git`, the repository's old name (GitHub redirects it; the next step's `cd compute-subnet` then points at a directory the current clone does not create).

## Change

`neurons/executor/README.md` only:

- Header link → `https://docs.lium.io/providers/nodes/quickstart` (the redirect's target).
- New first section **Quick setup with `lium mine` (recommended)**: install Sysbox first with `nvidia_docker_sysbox_setup.sh` (the CLI's install script does not install it, and validators reject a node without `sysbox-runc`), then the one-line `mine.sh` command. The five steps listed are what `lium/cli/commands/mine.py` does on `Datura-ai/lium@main`: `_clone_or_update_repo` (clone into `./compute-subnet`, or `git pull` the branch when it exists), `_install_executor_tools` (`scripts/install_executor_on_ubuntu.sh`), `_setup_executor_env` (renders `.env` from `.env.template`; `_gather_inputs` prompts for service port 8080, SSH port 2200, optional public SSH port and renting port range, `--auto` takes the defaults), `_start_executor` (`docker compose up -d`, waits for `healthy`), `_validate_executor` (`daturaai/lium-validator:latest`). The closing paragraph describes the summary the command prints (endpoint, GPU count×type, and the `provider.lium.io/nodes?action=add&…` link that pre-fills Add Node) and names the `-d/--dir` and `-b/--branch` options.
- The old section is kept as **Manual setup** with one sentence on when to use it; its clone URL becomes `Datura-ai/lium-io.git` and the following `cd` becomes `cd lium-io`. The environment-variable reference and the GPU/Docker/Sysbox sections below it are unchanged.

## How to test

Read the page on the branch. Every command in the new section is copied from the docs Node Quickstart and from `mine.py`; `lium mine --help` on lium 0.0.33 shows the `-k/-d/-b/-a/-v` options named. `https://docs.lium.io/providers/nodes/quickstart` answers 200; the old header link answers 308 to it.

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `0c25220f` merged onto `main` `07ec64cd` (clean merge), then: pytest: executor (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Executor 128 passed, 18 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 4 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers

- The ticket has no body; the title asks for the README to use `lium mine`. Nothing in the executor code or compose files changes.
- Kept the manual path rather than deleting it: `.env.template` keys (`RENTING_PORT_RANGE`, `RENTING_PORT_MAPPINGS`, `SSH_PUBLIC_PORT`) are documented nowhere else, and `lium mine` writes the same file, so the reference still serves both paths.
- `lium mine` clones into `./compute-subnet` by default while a manual clone of `lium-io.git` lands in `./lium-io`; the README states each where it applies.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-1515.

Docs: this PR is the docs change.

</details>
