### PR TITLE
DAH-2957 - [P1] central miner refreshes the portal snapshot after 30 s

### DIFF
--- a/neurons/miners/src/clients/miner_portal_api.py
+++ b/neurons/miners/src/clients/miner_portal_api.py
@@ -11,7 +11,11 @@ from protocol.miner_request import AuthenticateRequest
 
 logger = logging.getLogger(__name__)
 
-SNAPSHOT_TTL_SECONDS = 300
+# Short on purpose: rental key-submits refresh the snapshot between waves, and a node
+# registered after such a refresh is invisible to a wave that starts inside the TTL --
+# it then waits a whole extra 15-min cycle (DAH-2957). The wave itself still collapses
+# into one bulk request through the single-flight lock below.
+SNAPSHOT_TTL_SECONDS = 30
 FAILED_REFRESH_RETRY_SECONDS = 30
 BULK_FETCH_TIMEOUT_SECONDS = 15
 

--- a/neurons/miners/tests/test_miner_portal_api.py
+++ b/neurons/miners/tests/test_miner_portal_api.py
@@ -90,6 +90,25 @@ async def test_expired_snapshot_is_fully_replaced(monkeypatch):
     assert bulk.await_count == 2
 
 
+async def test_wave_sees_node_added_after_a_recent_rental_refresh(monkeypatch):
+    # DAH-2957, prod 4 Sep: a rental refreshed the snapshot at T, the provider added a
+    # node at T+38s, the validator wave came at T+101s and was served the T snapshot.
+    clock = Mock(monotonic=lambda: 1000.0)
+    monkeypatch.setattr("clients.miner_portal_api.time", clock)
+    bulk = AsyncMock(return_value=SNAPSHOT)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
+    await MinerPortalAPI.fetch_executors("hotkey-a", "aaaa-1")  # rental key-submit at T
+
+    added = {"id": "aaaa-new", "validator_hotkey": "v1"}
+    bulk.return_value = {**SNAPSHOT, "hotkey-a": SNAPSHOT["hotkey-a"] + [added]}
+    clock.monotonic = lambda: 1101.0  # wave start, T+101s
+
+    executors_a = await MinerPortalAPI.fetch_executors("hotkey-a", None)
+
+    assert added in executors_a
+    assert bulk.await_count == 2
+
+
 async def test_stale_snapshot_served_when_refresh_fails(monkeypatch):
     bulk = AsyncMock(return_value=SNAPSHOT)
     monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-2957](https://app.notion.com/p/New-nodes-miss-their-first-validator-cycle-the-central-miner-s-5-min-portal-snapshot-is-served-as-f-3d3b8bfdbde981cb9267e1cd046c6f46) · reviewer: @jam6099 @pixel29913

**TL;DR** — A node registered in the portal shortly after a rental refreshed the central miner's executor snapshot is invisible to the validator wave that starts inside the snapshot's 5-minute TTL. `neurons/miners/src/clients/miner_portal_api.py`: `SNAPSHOT_TTL_SECONDS` 300 → 30, with a comment saying why. Touches validator/executor (`neurons/miners/src/clients/miner_portal_api.py`) — read that file first.

**What changed**
- Test `test_wave_sees_node_added_after_a_recent_rental_refresh` replays the prod timeline (rental refresh at T, node added.

**How to verify**
- `cd neurons/miners && pdm run pytest -q tests/test_miner_portal_api.py` → green

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · miners 27 passed · Result: PASS 1007b41c · Gate: not run

**Docs:** none changed in this PR — executor/validator internals; nothing a provider sees or sets changes.

<details><summary>Details</summary>

[DAH-2957](https://app.notion.com/p/New-nodes-miss-their-first-validator-cycle-the-central-miner-s-5-min-portal-snapshot-is-served-as-f-3d3b8bfdbde981cb9267e1cd046c6f46).

## Problem
A node registered in the portal shortly after a rental refreshed the central miner's executor snapshot is invisible to the validator wave that starts inside the snapshot's 5-minute TTL, and waits a whole extra 15-minute cycle. Prod Loki, 4 Sep: node `b3e4ca69` added 15:32:51 — snapshot refreshed 15:32:13 by a rental key-submit, wave at 15:33:54 served the 101-s-old snapshot, no pubkey went to the node, next wave 15:49:03 picked it up (+15 min). Same shape for `aeb904f6` (refresh 18:31:20, add 18:33:13, wave 18:34:21 skipped, 18:49:38 picked up).

Population (read-only prod DB, 175 nodes added through the portal in the last 30 days): node add → first AVAILABLE p50 21.4 min, p90 63.5 min; the 25–45 min band (26 nodes, 15 %) is exactly one missed cycle. Adds in the 5 min before a wave are 1/3 of all adds, and rental/unrent key-submits (~5 per cycle) refresh the snapshot often enough that the window is usually live.

## Change
`neurons/miners/src/clients/miner_portal_api.py`: `SNAPSHOT_TTL_SECONDS` 300 → 30, with a comment saying why. Nothing else moves: the single-flight lock still collapses the 189-miner wave into one bulk `GET /miners/executors`; stale-on-error and the failed-refresh backoff are unchanged. Cost: at most one extra bulk request per 30 s of rental traffic (≈ 5 per 15-min cycle instead of ≈ 3), against the thin JOIN endpoint DAH-2469 added for exactly this call. Residual miss window 30 s ≈ 0.5 % of adds instead of ≈ 15 %.

Test `test_wave_sees_node_added_after_a_recent_rental_refresh` replays the prod timeline (rental refresh at T, node added, wave at T+101 s) with a mocked monotonic clock; it fails on the old constant.

## How to test
```
cd neurons/miners && pdm run pytest -q tests/test_miner_portal_api.py
```
Run on a Lium pod: 14 passed (13 existing + 1 new); whole miners suite 27 passed. With the constant set back to 300 the new test fails at `assert added in executors_a`.

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `1007b41c` merged onto `main` `07ec64cd` (clean merge), then: pytest: miners (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Miners 27 passed, 21 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 3 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers
DAH-2469 chose 5 min to kill the per-hotkey fan-out; the fan-out protection is the single-flight lock, not the TTL, so shortening it does not reopen that incident. If you would rather keep 300 s for rentals and force a refresh only on the wave path, the same effect needs a `max_age` parameter threaded from `register_pubkey` (fleet-wide requests have `executor_id=None`); we chose the one-line version. Measurement report and the two other time-to-ready buckets (cycle boundary + slowest-miner wait, DAH-2958; VerifyX first-sample gate, DAH-2959) are on the Notion ticket.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-2957.

Docs: none changed in this PR — executor/validator internals; nothing a provider sees or sets changes.

</details>
