### PR TITLE
DAH-2958 - [P1] validator express lane for never-validated executors (flag, off)

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -37,3 +37,10 @@ HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
 # DEBUG_MINER_PORT=
 # DEBUG_MINER_UID=
 # DEBUG_SKIP_STORAGE_CHECK
+
+# Express lane (DAH-2958): verify and publish never-validated executors ahead of the 15-min cycle. Off by default.
+# The in-flight caps bound the extra load a registration flood can add (per tick, and per miner).
+EXPRESS_LANE_ENABLED=false
+EXPRESS_LANE_TICK_SECONDS=30
+EXPRESS_LANE_MAX_IN_FLIGHT=4
+EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER=2

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -1,17 +1,43 @@
 import asyncio
+import json
 import logging
 import time
 from collections.abc import Mapping
+from datetime import UTC, datetime
 
 import aiohttp
 import bittensor
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from core.config import settings
 from core.utils import _m, get_extra_info
 
 
 logger = logging.getLogger(__name__)
+
+
+class PortalExecutor(BaseModel):
+    """One row of the portal's bulk executor snapshot (DAH-2958). Only what the express lane reads."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    validator_hotkey: str
+    # The portal stamps rows with a naive datetime.utcnow(); registration → AVAILABLE is measured
+    # from here, so it is read as UTC.
+    created_at: datetime | None = None
+
+    @field_validator("created_at")
+    @classmethod
+    def as_utc(cls, value: datetime | None) -> datetime | None:
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+
+
+def portal_miner_auth_blob(hotkey: str, timestamp: int) -> str:
+    """The exact bytes the portal's signature_auth_miner verifies (AuthenticationPayload)."""
+    return json.dumps({"miner_hotkey": hotkey, "timestamp": timestamp}, sort_keys=True)
 
 
 class OptedInMiner(BaseModel):
@@ -134,6 +160,61 @@ class ValidatorPortalAPI:
             logger.error(
                 _m(
                     "Error fetching opted-in miners from portal",
+                    extra=get_extra_info({"url": url, "error": str(exc)}),
+                )
+            )
+            return None
+
+    @staticmethod
+    async def get_all_executors() -> dict[str, list[PortalExecutor]] | None:
+        """{miner_hotkey: [executor]} for every opted-in miner; None on any failure.
+
+        DAH-2958: the express lane discovers never-validated executors here, between cycles.
+        This is the bulk snapshot the central miner already polls (DAH-2469); the endpoint is
+        guarded by signature_auth_miner, which verifies the signature over AuthenticationPayload
+        and nothing else, so the validator signs the same blob with its own hotkey.
+        """
+        api_base = (
+            settings.MINER_PORTAL_REST_API_URL.rstrip("/")
+            if settings.MINER_PORTAL_REST_API_URL
+            else ""
+        )
+        if not api_base:
+            return None
+
+        url = f"{api_base}/miners/executors"
+        try:
+            keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
+            timestamp = int(time.time())
+            headers = {
+                "hotkey": keypair.ss58_address,
+                "timestamp": str(timestamp),
+                "signature": f"0x{keypair.sign(portal_miner_auth_blob(keypair.ss58_address, timestamp)).hex()}",
+            }
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url, headers=headers) as response:
+                    if response.status != 200:
+                        logger.error(
+                            _m(
+                                "Failed to fetch executor snapshot from portal",
+                                extra=get_extra_info(
+                                    {"status": response.status, "body": await response.text(), "url": url}
+                                ),
+                            )
+                        )
+                        return None
+                    data = await response.json()
+            if not isinstance(data, dict):
+                raise ValueError(f"unexpected portal bulk response shape: {type(data).__name__}")
+            return {
+                miner_hotkey: [PortalExecutor.model_validate(item) for item in executors]
+                for miner_hotkey, executors in data.items()
+            }
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "Error fetching executor snapshot from portal",
                     extra=get_extra_info({"url": url, "error": str(exc)}),
                 )
             )

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -412,6 +412,23 @@ class Settings(BaseSettings):
     # Use REST API instead of WebSocket for miner communication
     USE_REST_API: bool = Field(env="USE_REST_API", default=False)
 
+    # DAH-2958 — express lane for never-validated executors. A new node is published only by
+    # the fleet-wide scored cycle today, so it waits for the 15-min boundary (mean 7.5 min) and
+    # then for the slowest miner in the fleet (2–9 min): node add → AVAILABLE p50 21.4 min over
+    # 175 onboardings, floor 8.2 min. With the flag on, core/express_lane.py polls the portal's
+    # executor snapshot every TICK seconds, runs the SAME pipeline the cycle runs on executors
+    # this validator has never published, and publishes the result spec-only (no scored_at, so
+    # no incentive ledger row); the next cycle scores and overwrites it as today. Off by default:
+    # flag off = today's behaviour, nothing else in this block is read.
+    EXPRESS_LANE_ENABLED: bool = Field(env="EXPRESS_LANE_ENABLED", default=False)
+    EXPRESS_LANE_TICK_SECONDS: int = Field(env="EXPRESS_LANE_TICK_SECONDS", default=30)
+    # Hard bound on the extra load a registration flood can add: at most this many express
+    # verifications in flight at once (so also per tick), and per miner.
+    EXPRESS_LANE_MAX_IN_FLIGHT: int = Field(env="EXPRESS_LANE_MAX_IN_FLIGHT", default=4)
+    EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER: int = Field(
+        env="EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER", default=2
+    )
+
     # DAH-2211 — custom-dockerfile pod build tunables (validator side).
     # These mirror the spec keys `features.custom_dockerfile_pod.*`; the route
     # is authoritative for the size cap but the validator double-checks it as

--- a/neurons/validators/src/core/express_lane.py
+++ b/neurons/validators/src/core/express_lane.py
@@ -1,0 +1,310 @@
+"""DAH-2958: verify and publish never-validated executors ahead of the 15-min cycle.
+
+A new node is published only by the fleet-wide scored cycle, so it waits for the cycle boundary
+(BLOCKS_FOR_JOB = 75 blocks, uniform 0–15 min) and then for the slowest miner in the fleet
+(publish_machine_specs runs after asyncio.wait over every miner: +2–9 min). Node add → AVAILABLE
+was p50 21.4 / p90 63.5 min over 175 onboardings, floor 8.2 min (RECOVERY report, 6 Sep 2026).
+
+This lane runs beside Validator.sync() in the same process. Every tick it reads the portal's bulk
+executor snapshot, picks the executors assigned to this validator that it has never published,
+and runs the SAME pipeline the cycle runs — same job files, digests and image snapshot, same
+checks — on each one, alone, then publishes the result spec-only (scored_at stays None, so the
+backend creates the executor row but writes no incentive ledger row). The next scored cycle
+overwrites it as today. Off by default (settings.EXPRESS_LANE_ENABLED).
+"""
+
+import asyncio
+import logging
+import time
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from clients.validator_portal_api import PortalExecutor, ValidatorPortalAPI
+from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+from services.executor_image_policy import ExpectedImageSnapshot
+from services.miner_service import EXPRESS_LANE, MinerService
+
+from core.config import settings
+from core.utils import _m, get_extra_info
+
+logger = logging.getLogger(__name__)
+
+# One line per express verification; its registration_to_publish_s is the deploy metric.
+EXPRESS_PUBLISHED_EVENT = "[express] Executor verified and published ahead of the cycle"
+# The miner did not return the executor (its portal snapshot is not refreshed yet, or the node is
+# unreachable): try again later, a bounded number of times, then leave it to the normal cycle.
+MAX_ATTEMPTS = 3
+RETRY_SECONDS = 120
+# job_batch_id format the backend parses into the prod_executors row's time.
+JOB_BATCH_ID_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass
+class CycleInputs:
+    """What the cycle prepared for its wave. The express lane reuses it verbatim, so an express
+    verification is the cycle's pipeline with the cycle's job files, digests and image snapshot."""
+
+    encrypted_files: MinerJobEnryptedFiles
+    default_image_digests: dict[str, str]
+    executor_image_snapshot: ExpectedImageSnapshot | None
+
+
+@dataclass
+class _Pending:
+    executor: PortalExecutor
+    miner_hotkey: str
+    first_seen_at: datetime
+    attempts: int = 0
+    not_before: float = 0.0  # monotonic
+
+
+class ExpressLane:
+    def __init__(
+        self,
+        *,
+        miner_service: MinerService,
+        redis_service,
+        backend_client,
+        subtensor_client,
+        cycle_inputs: Callable[[], CycleInputs | None],
+        portal_api=ValidatorPortalAPI,
+    ):
+        self.miner_service = miner_service
+        self.redis_service = redis_service
+        self.backend_client = backend_client
+        self.subtensor_client = subtensor_client
+        # None until the first cycle since start has completed: that cycle seeds the validated
+        # set with the whole fleet and produces the job files, so nothing runs before it.
+        self.cycle_inputs = cycle_inputs
+        self.portal_api = portal_api
+        self._pending: dict[str, _Pending] = {}
+        self._tasks: set[asyncio.Task] = set()
+        self._my_hotkey: str | None = None
+        # Given up on this process's watch (MAX_ATTEMPTS without the miner returning them); the
+        # normal cycle owns them from here. In memory on purpose: a restart may try again.
+        self._left_to_cycle: set[str] = set()
+
+    async def run(self, should_exit: Callable[[], bool]) -> None:
+        logger.info(
+            _m(
+                "[express] Express lane started",
+                extra=get_extra_info(
+                    {
+                        "tick_seconds": settings.EXPRESS_LANE_TICK_SECONDS,
+                        "max_in_flight": settings.EXPRESS_LANE_MAX_IN_FLIGHT,
+                        "max_in_flight_per_miner": settings.EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER,
+                    }
+                ),
+            )
+        )
+        while not should_exit():
+            try:
+                await self.tick()
+            except Exception as exc:
+                logger.error(
+                    _m("[express] Tick failed", extra=get_extra_info({"error": str(exc)})),
+                    exc_info=True,
+                )
+            await asyncio.sleep(settings.EXPRESS_LANE_TICK_SECONDS)
+
+    def _hotkey(self) -> str:
+        if self._my_hotkey is None:
+            self._my_hotkey = settings.get_bittensor_wallet().get_hotkey().ss58_address
+        return self._my_hotkey
+
+    async def tick(self) -> int:
+        """One pass: discover, select under the caps, launch. Returns how many were launched."""
+        inputs = self.cycle_inputs()
+        if inputs is None:
+            return 0
+
+        snapshot = await self.portal_api.get_all_executors()
+        if snapshot is None:
+            return 0
+
+        validated = await self.redis_service.get_validated_executors()
+        in_flight = self.miner_service.in_flight
+        my_hotkey = self._hotkey()
+        now = time.monotonic()
+        now_wall = datetime.now(UTC)
+
+        present: set[str] = set()
+        candidates: list[_Pending] = []
+        for miner_hotkey, executors in snapshot.items():
+            for executor in executors:
+                if (
+                    executor.validator_hotkey != my_hotkey
+                    or executor.id in validated
+                    or executor.id in self._left_to_cycle
+                ):
+                    continue
+                present.add(executor.id)
+                pending = self._pending.get(executor.id)
+                if pending is None:
+                    pending = self._pending[executor.id] = _Pending(
+                        executor=executor, miner_hotkey=miner_hotkey, first_seen_at=now_wall
+                    )
+                if executor.id in in_flight or pending.not_before > now:
+                    continue
+                candidates.append(pending)
+
+        # Removed from the portal (or validated by the cycle) before this lane got to it.
+        for executor_id in [e for e in self._pending if e not in present and e not in in_flight]:
+            del self._pending[executor_id]
+
+        if not candidates:
+            return 0
+
+        # Oldest registration first; then the two caps that bound a registration flood.
+        candidates.sort(key=lambda p: p.executor.created_at or p.first_seen_at)
+        express_in_flight = [e for e, lane in in_flight.items() if lane == EXPRESS_LANE]
+        room = settings.EXPRESS_LANE_MAX_IN_FLIGHT - len(express_in_flight)
+        per_miner: Counter[str] = Counter(
+            self._pending[e].miner_hotkey for e in express_in_flight if e in self._pending
+        )
+        chosen: list[_Pending] = []
+        for pending in candidates:
+            if room <= 0:
+                break
+            if per_miner[pending.miner_hotkey] >= settings.EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER:
+                continue
+            chosen.append(pending)
+            per_miner[pending.miner_hotkey] += 1
+            room -= 1
+        if not chosen:
+            return 0
+
+        miners = {miner.hotkey: miner for miner in await self.subtensor_client.get_miners()}
+        rented_data = await self.backend_client.get_all_rented_executors()
+        if rented_data is None:
+            logger.error(
+                _m("[express] Failed to fetch rented executors, skipping this tick", extra=get_extra_info({}))
+            )
+            return 0
+
+        launched = 0
+        for pending in chosen:
+            if pending.executor.id in in_flight:
+                # The wave accepted it during the awaits above; it publishes it at the wave's end.
+                continue
+            miner = miners.get(pending.miner_hotkey)
+            if miner is None:
+                pending.attempts += 1
+                self._defer(pending, "miner is not among the serving opted-in miners")
+                continue
+            in_flight[pending.executor.id] = EXPRESS_LANE
+            task = asyncio.create_task(self._verify(pending, miner, inputs, rented_data))
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
+            launched += 1
+        return launched
+
+    async def _verify(self, pending: _Pending, miner, inputs: CycleInputs, rented_data) -> None:
+        executor_id = pending.executor.id
+        pending.attempts += 1
+        started_wall = datetime.now(UTC)
+        started = time.monotonic()
+        extra = {
+            "executor_uuid": executor_id,
+            "miner_hotkey": miner.hotkey,
+            "attempt": pending.attempts,
+        }
+        try:
+            payload = MinerJobRequestPayload(
+                job_batch_id=started_wall.strftime(JOB_BATCH_ID_FORMAT),
+                miner_hotkey=miner.hotkey,
+                miner_coldkey=miner.coldkey,
+                miner_address=miner.axon_info.ip,
+                miner_port=miner.axon_info.port,
+            )
+            job = await asyncio.wait_for(
+                self.miner_service.request_job_to_miner(
+                    payload=payload,
+                    encrypted_files=inputs.encrypted_files,
+                    rented_data=rented_data,
+                    default_docker_image_digests=inputs.default_image_digests,
+                    executor_image_snapshot=inputs.executor_image_snapshot,
+                    executor_id=executor_id,
+                ),
+                timeout=settings.JOB_TIME_OUT,
+            )
+            # Only this executor's own result: a miner-level failure comes back under the
+            # failed-miner sentinel uuid and a manual rental elsewhere on the miner is not ours.
+            results = [
+                result
+                for result in (job or {}).get("results", [])
+                if result.executor_info.uuid == executor_id
+            ]
+            if not results:
+                self._defer(pending, "miner did not return the executor")
+                return
+
+            # Published as the pipeline produced it — no incentive, scored_at None — so the
+            # backend creates/updates the executor row (AVAILABLE when the score is positive)
+            # but writes no incentive_per_validator_cycle row: is_provider_emission_cycle_eligible
+            # needs scored_at. The next scored cycle overwrites the row as today.
+            await self.miner_service.publish_machine_specs(results, miner.hotkey, miner.coldkey)
+            await self.redis_service.mark_executors_validated([executor_id])
+            self._pending.pop(executor_id, None)
+
+            published_at = datetime.now(UTC)
+            result = results[0]
+            registered_at = pending.executor.created_at
+            logger.info(
+                _m(
+                    EXPRESS_PUBLISHED_EVENT,
+                    extra=get_extra_info(
+                        {
+                            **extra,
+                            "outcome": "passed" if (result.score > 0 or result.job_score > 0) else "failed",
+                            "score": result.score,
+                            "log_status": result.log_status,
+                            "registered_at": registered_at.isoformat() if registered_at else None,
+                            "first_seen_at": pending.first_seen_at.isoformat(),
+                            "published_at": published_at.isoformat(),
+                            "registration_to_publish_s": round(
+                                (published_at - registered_at).total_seconds(), 1
+                            )
+                            if registered_at
+                            else None,
+                            "first_seen_to_publish_s": round(
+                                (published_at - pending.first_seen_at).total_seconds(), 1
+                            ),
+                            "verification_s": round(time.monotonic() - started, 1),
+                        }
+                    ),
+                )
+            )
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "[express] Verification failed before a result could be published",
+                    extra=get_extra_info({**extra, "error": str(exc)}),
+                ),
+                exc_info=True,
+            )
+            self._defer(pending, str(exc))
+        finally:
+            if self.miner_service.in_flight.get(executor_id) == EXPRESS_LANE:
+                del self.miner_service.in_flight[executor_id]
+
+    def _defer(self, pending: _Pending, reason: str) -> None:
+        """Try again after RETRY_SECONDS, or after MAX_ATTEMPTS leave the executor to the cycle.
+
+        The caller has already counted the attempt.
+        """
+        extra = {
+            "executor_uuid": pending.executor.id,
+            "miner_hotkey": pending.miner_hotkey,
+            "attempt": pending.attempts,
+            "reason": reason,
+        }
+        if pending.attempts >= MAX_ATTEMPTS:
+            self._left_to_cycle.add(pending.executor.id)
+            self._pending.pop(pending.executor.id, None)
+            logger.warning(_m("[express] Executor left to the normal cycle", extra=get_extra_info(extra)))
+            return
+        pending.not_before = time.monotonic() + RETRY_SECONDS
+        logger.info(_m("[express] Executor not verified yet, will retry", extra=get_extra_info(extra)))

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -38,6 +38,7 @@ from services.task_service import JobResult, TaskService
 from services.verifyx_validation_service import VerifyXValidationService
 
 from core.config import settings
+from core.express_lane import CycleInputs, ExpressLane
 from core.utils import _m, get_extra_info, get_logger
 from services.ssh_service import SSHService
 
@@ -46,6 +47,8 @@ logger = get_logger(__name__)
 SYNC_CYCLE = 12
 WEIGHT_MAX_COUNTER = 6
 MINER_SCORES_KEY = "miner_scores"
+# Executor uuid request_job_to_miner reports a miner-level failure under (no real executor).
+FAILED_MINER_EXECUTOR_UUID = "11111111-1111-1111-1111-111111111111"
 
 
 class Validator:
@@ -54,6 +57,9 @@ class Validator:
         self.should_exit = False
         self.last_job_run_blocks = 0
         self.default_extra = {}
+        # DAH-2958: the current cycle's job files / digests / image snapshot, reused by the
+        # express lane so its verifications are the cycle's pipeline. None before the first cycle.
+        self.cycle_inputs: CycleInputs | None = None
 
         self.miner_scores = {}
         # Hotkeys with at least one live executor in the last completed cycle. Rebuilt
@@ -121,6 +127,13 @@ class Validator:
             redis_service=self.redis_service,
             attestation_service=self.attestation_service,
         )
+        self.express_lane = ExpressLane(
+            miner_service=self.miner_service,
+            redis_service=self.redis_service,
+            backend_client=self.backend_client,
+            subtensor_client=self.subtensor_client,
+            cycle_inputs=self.express_lane_cycle_inputs,
+        )
 
         # init miner_scores: always load from Redis if present so accumulated
         # scores survive an unclean restart (SIGKILL / OOM / liveness preempt).
@@ -159,6 +172,14 @@ class Validator:
                 ),
             ),
         )
+
+    def express_lane_cycle_inputs(self) -> CycleInputs | None:
+        """DAH-2958: the express lane runs only once a full cycle has completed since start —
+        that cycle seeds the validated-executor set with the whole fleet, so the lane never
+        mistakes a long-known executor for a new one after a deploy or restart."""
+        if self.completed_cycles_since_start < 1:
+            return None
+        return self.cycle_inputs
 
     async def an_operator_asked_for_a_cycle_now(self) -> bool:
         """Whether an operator asked for a cycle. Reads only -- the request stays pending.
@@ -335,6 +356,13 @@ class Validator:
                     await self.redis_service.clear_forced_validation_cycle_request()
 
                 encrypted_files = self.file_encrypt_service.ecrypt_miner_job_files()
+                # The line above replaced the job-files directory; the express lane must use
+                # the new one from here on.
+                self.cycle_inputs = CycleInputs(
+                    encrypted_files=encrypted_files,
+                    default_image_digests=default_image_digests,
+                    executor_image_snapshot=executor_image_snapshot,
+                )
 
                 task_info = {}
 
@@ -577,10 +605,30 @@ class Validator:
                         self.miner_scores[miner_hotkey] = self.miner_scores.get(miner_hotkey, 0) + score
 
                     # Publish machine specs
+                    published_executor_ids: list[str] = []
                     for miner_hotkey, results in incentive.job_results.items():
                         miner_coldkey = miner_coldkeys.get(miner_hotkey)
                         if miner_coldkey:
                             await self.miner_service.publish_machine_specs(results, miner_hotkey, miner_coldkey)
+                            published_executor_ids.extend(
+                                result.executor_info.uuid
+                                for result in results
+                                if result.executor_info.uuid != FAILED_MINER_EXECUTOR_UUID
+                            )
+
+                    if settings.EXPRESS_LANE_ENABLED:
+                        # DAH-2958: everything published by a cycle is "validated" for the
+                        # express lane; only what the portal lists beyond this set is new.
+                        # Never lets a Redis blip end the cycle: the next cycle seeds again.
+                        try:
+                            await self.redis_service.mark_executors_validated(published_executor_ids)
+                        except Exception as exc:
+                            logger.error(
+                                _m(
+                                    "[sync] Failed to record validated executors for the express lane",
+                                    extra=get_extra_info({**self.default_extra, "error": str(exc)}),
+                                ),
+                            )
 
                     self.completed_cycles_since_start += 1
 
@@ -676,6 +724,13 @@ class Validator:
         try:
             await self.initiate_services()
             self.should_exit = False
+
+            if settings.EXPRESS_LANE_ENABLED and not settings.DRY_RUN:
+                # DAH-2958: ticks beside the cycle on this loop; coordination through
+                # MinerService.in_flight. Flag off: the task is never created.
+                self.express_lane_task = asyncio.create_task(
+                    self.express_lane.run(lambda: self.should_exit)
+                )
 
             while not self.should_exit:
                 await self.sync()

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -184,6 +184,10 @@ REST_SSH_REMOVE_TIMEOUT = 10  # Timeout for SSH key removal requests
 # node that actually passed validation -- nothing about this node was verified.
 MANUAL_RENTAL_FORCED_PASS_EVENT = "Executor force-passed as special manual rental (not validated)"
 
+# DAH-2958: who is verifying an executor right now (values of MinerService.in_flight).
+CYCLE_LANE = "cycle"
+EXPRESS_LANE = "express"
+
 
 class MinerService:
     def __init__(
@@ -197,6 +201,41 @@ class MinerService:
         self.task_service = task_service
         self.redis_service = redis_service
         self.attestation_service = attestation_service
+        # DAH-2958: executor uuid -> CYCLE_LANE | EXPRESS_LANE while its pipeline is running. The
+        # wave and the express lane run in this one process, so a plain dict is the whole
+        # coordination: each lane skips what the other holds. Stays empty with the flag off.
+        self.in_flight: dict[str, str] = {}
+
+    def _claim_for_cycle(
+        self, executors: list[ExecutorSSHInfo], default_extra: dict
+    ) -> list[ExecutorSSHInfo]:
+        """The wave takes every executor the miner returned, minus those the express lane is
+        verifying at this moment, so a new node's hardware tests never run twice concurrently
+        (DAH-2958). Only a never-validated executor can be held by the express lane, so the
+        scoring of every already-validated executor is untouched. Flag off: list returned as is.
+        """
+        if not settings.EXPRESS_LANE_ENABLED:
+            return executors
+        claimed: list[ExecutorSSHInfo] = []
+        for executor in executors:
+            if self.in_flight.get(executor.uuid) == EXPRESS_LANE:
+                logger.info(
+                    _m(
+                        "Executor left to the express lane this cycle",
+                        extra=get_extra_info({**default_extra, "executor_uuid": executor.uuid}),
+                    ),
+                )
+                continue
+            self.in_flight[executor.uuid] = CYCLE_LANE
+            claimed.append(executor)
+        return claimed
+
+    def _release_cycle_claims(self, executors: list[ExecutorSSHInfo]) -> None:
+        if not settings.EXPRESS_LANE_ENABLED:
+            return
+        for executor in executors:
+            if self.in_flight.get(executor.uuid) == CYCLE_LANE:
+                del self.in_flight[executor.uuid]
 
     @staticmethod
     def _normalize_public_key(public_key: bytes | str) -> str:
@@ -224,8 +263,14 @@ class MinerService:
         rented_data: RentedExecutorsResponse,
         default_docker_image_digests: dict[str, str],
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
+        executor_id: str | None = None,
     ):
-        """Request job to miner - uses REST API if configured, otherwise WebSocket."""
+        """Request job to miner - uses REST API if configured, otherwise WebSocket.
+
+        executor_id (DAH-2958): None asks the miner for every executor it has for this validator
+        (the cycle); a uuid asks for that one executor only (the express lane) — the miner already
+        filters register_pubkey on it, exactly as it does for the rental key-submit.
+        """
         if settings.USE_REST_API:
             logger.info(
                 _m(
@@ -242,6 +287,7 @@ class MinerService:
                 rented_data,
                 default_docker_image_digests,
                 executor_image_snapshot,
+                executor_id=executor_id,
             )
         else:
             logger.info(
@@ -295,6 +341,7 @@ class MinerService:
                         public_key=public_key,
                         validator_signature=self._sign_validator_pubkey(my_key, public_key, nonce=nonce_hex),
                         miner_hotkey=payload.miner_hotkey, # include miner's hotkey in the request
+                        executor_id=executor_id,
                         nonce=nonce_hex,
                     )
                 )
@@ -357,29 +404,37 @@ class MinerService:
                             payload,
                             "Miner returned zero executors in AcceptSSHKeyRequest",
                         )
-                    tasks = [
-                        asyncio.create_task(
-                            asyncio.wait_for(
-                                self.task_service.create_task(
-                                    miner_info=payload,
-                                    executor_info=executor_info,
-                                    keypair=my_key,
-                                    private_key=private_key.decode("utf-8"),
-                                    public_key=public_key.decode("utf-8"),
-                                    encrypted_files=encrypted_files,
-                                    rented_data=rented_data,
-                                    default_docker_image_digests=default_docker_image_digests,
-                                    executor_image_snapshot=executor_image_snapshot,
-                                    attestation_nonce=attestation_nonce,
-                                ),
-                                timeout=settings.JOB_TIME_OUT - 120
+                    executors = (
+                        self._claim_for_cycle(msg.executors, default_extra)
+                        if executor_id is None
+                        else msg.executors
+                    )
+                    try:
+                        tasks = [
+                            asyncio.create_task(
+                                asyncio.wait_for(
+                                    self.task_service.create_task(
+                                        miner_info=payload,
+                                        executor_info=executor_info,
+                                        keypair=my_key,
+                                        private_key=private_key.decode("utf-8"),
+                                        public_key=public_key.decode("utf-8"),
+                                        encrypted_files=encrypted_files,
+                                        rented_data=rented_data,
+                                        default_docker_image_digests=default_docker_image_digests,
+                                        executor_image_snapshot=executor_image_snapshot,
+                                        attestation_nonce=attestation_nonce,
+                                    ),
+                                    timeout=settings.JOB_TIME_OUT - 120
+                                )
                             )
-                        )
-                        for executor_info in msg.executors
-                    ]
+                            for executor_info in executors
+                        ]
 
-                    raw_results = await asyncio.gather(*tasks, return_exceptions=True)
-                    results = self._filter_task_results(msg.executors, raw_results, default_extra)
+                        raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+                    finally:
+                        self._release_cycle_claims(executors)
+                    results = self._filter_task_results(executors, raw_results, default_extra)
                     results.extend(
                         self._build_manual_rental_results(payload, rented_data, existing=results)
                     )
@@ -407,7 +462,8 @@ class MinerService:
                         await miner_client.send_model(SSHPubKeyRemoveRequest(
                             public_key=public_key,
                             validator_signature=self._sign_validator_pubkey(my_key, public_key),
-                            miner_hotkey=payload.miner_hotkey
+                            miner_hotkey=payload.miner_hotkey,
+                            executor_id=executor_id,
                         ))
                     except Exception as e:
                         logger.warning(
@@ -1878,6 +1934,7 @@ class MinerService:
         rented_data: RentedExecutorsResponse,
         default_docker_image_digests: dict[str, str],
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
+        executor_id: str | None = None,
     ):
         """REST API version of request_job_to_miner."""
         # DAH-2667: see the WebSocket path — the RoCE probe measures the cycle's remaining time
@@ -1908,6 +1965,7 @@ class MinerService:
                 public_key=public_key,
                 validator_signature=self._sign_validator_pubkey(my_key, public_key, nonce=nonce_hex),
                 miner_hotkey=payload.miner_hotkey,
+                executor_id=executor_id,
                 nonce=nonce_hex,
             )
             
@@ -1956,29 +2014,37 @@ class MinerService:
                         payload,
                         "Miner returned zero executors in AcceptSSHKeyRequest",
                     )
-                tasks = [
-                    asyncio.create_task(
-                        asyncio.wait_for(
-                            self.task_service.create_task(
-                                miner_info=payload,
-                                executor_info=executor_info,
-                                keypair=my_key,
-                                private_key=private_key.decode("utf-8"),
-                                public_key=public_key.decode("utf-8"),
-                                encrypted_files=encrypted_files,
-                                rented_data=rented_data,
-                                default_docker_image_digests=default_docker_image_digests,
-                                executor_image_snapshot=executor_image_snapshot,
-                                attestation_nonce=attestation_nonce,
-                            ),
-                            timeout=settings.JOB_TIME_OUT - 120
+                executors = (
+                    self._claim_for_cycle(msg.executors, default_extra)
+                    if executor_id is None
+                    else msg.executors
+                )
+                try:
+                    tasks = [
+                        asyncio.create_task(
+                            asyncio.wait_for(
+                                self.task_service.create_task(
+                                    miner_info=payload,
+                                    executor_info=executor_info,
+                                    keypair=my_key,
+                                    private_key=private_key.decode("utf-8"),
+                                    public_key=public_key.decode("utf-8"),
+                                    encrypted_files=encrypted_files,
+                                    rented_data=rented_data,
+                                    default_docker_image_digests=default_docker_image_digests,
+                                    executor_image_snapshot=executor_image_snapshot,
+                                    attestation_nonce=attestation_nonce,
+                                ),
+                                timeout=settings.JOB_TIME_OUT - 120
+                            )
                         )
-                    )
-                    for executor_info in msg.executors
-                ]
+                        for executor_info in executors
+                    ]
 
-                raw_results = await asyncio.gather(*tasks, return_exceptions=True)
-                results = self._filter_task_results(msg.executors, raw_results, default_extra)
+                    raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+                finally:
+                    self._release_cycle_claims(executors)
+                results = self._filter_task_results(executors, raw_results, default_extra)
                 results.extend(
                     self._build_manual_rental_results(payload, rented_data, existing=results)
                 )
@@ -2009,7 +2075,7 @@ class MinerService:
                         my_key=my_key,
                         public_key=public_key,
                         miner_hotkey=payload.miner_hotkey,
-                        executor_id=None,
+                        executor_id=executor_id,
                         log_extra=default_extra,
                     )
 

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -230,6 +230,29 @@ class MinerService:
             claimed.append(executor)
         return claimed
 
+    def _only_requested(
+        self, executors: list[ExecutorSSHInfo], executor_id: str, default_extra: dict
+    ) -> list[ExecutorSSHInfo]:
+        """The express lane asked the miner for one executor; run the pipeline on that one only.
+        A miner that answers with more (an old miner ignoring the filter, or a misbehaving one)
+        would otherwise get every extra executor verified here, concurrently with the wave that
+        holds its claim, and the extra results are discarded by the caller anyway (DAH-2958)."""
+        requested = [executor for executor in executors if executor.uuid == executor_id]
+        if len(requested) != len(executors):
+            logger.warning(
+                _m(
+                    "Miner returned executors the express lane did not ask for; ignoring them",
+                    extra=get_extra_info(
+                        {
+                            **default_extra,
+                            "executor_uuid": executor_id,
+                            "ignored": [e.uuid for e in executors if e.uuid != executor_id],
+                        }
+                    ),
+                )
+            )
+        return requested
+
     def _release_cycle_claims(self, executors: list[ExecutorSSHInfo]) -> None:
         if not settings.EXPRESS_LANE_ENABLED:
             return
@@ -407,7 +430,7 @@ class MinerService:
                     executors = (
                         self._claim_for_cycle(msg.executors, default_extra)
                         if executor_id is None
-                        else msg.executors
+                        else self._only_requested(msg.executors, executor_id, default_extra)
                     )
                     try:
                         tasks = [
@@ -2017,7 +2040,7 @@ class MinerService:
                 executors = (
                     self._claim_for_cycle(msg.executors, default_extra)
                     if executor_id is None
-                    else msg.executors
+                    else self._only_requested(msg.executors, executor_id, default_extra)
                 )
                 try:
                     tasks = [

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -38,6 +38,10 @@ FORCED_VALIDATION_CYCLE_KEY = "forced_validation_cycle"
 # One scheduled window is 75 blocks, about 15 minutes. A request older than a couple of sync
 # ticks is stale: the operator has moved on, or the scheduled cycle covered them anyway.
 FORCED_VALIDATION_CYCLE_TTL_SECONDS = 60
+# DAH-2958: every executor uuid this validator has ever published a spec for. The express lane
+# treats anything in the portal snapshot that is NOT here as never validated. Seeded by every
+# cycle's publish, so one completed cycle after deploy is enough to know the whole fleet.
+EXPRESS_LANE_VALIDATED_SET = "express_lane_validated_executors"
 
 # Distributed lock settings
 EXECUTOR_LOCK_TIMEOUT = 30  # TTL for lock auto-release (seconds)
@@ -153,6 +157,16 @@ class RedisService:
             await self.redis.set(
                 FORCED_VALIDATION_CYCLE_KEY, "1", ex=FORCED_VALIDATION_CYCLE_TTL_SECONDS
             )
+
+    async def mark_executors_validated(self, executor_ids: list[str]) -> None:
+        """DAH-2958: remember that a spec was published for these executors (one round-trip)."""
+        if executor_ids:
+            async with self.lock:
+                await self.redis.sadd(EXPRESS_LANE_VALIDATED_SET, *executor_ids)
+
+    async def get_validated_executors(self) -> set[str]:
+        members = await self.smembers(EXPRESS_LANE_VALIDATED_SET)
+        return {m.decode() if isinstance(m, bytes) else m for m in members}
 
     async def is_forced_validation_cycle_requested(self) -> bool:
         return await self.get(FORCED_VALIDATION_CYCLE_KEY) is not None

--- a/neurons/validators/tests/test_express_lane.py
+++ b/neurons/validators/tests/test_express_lane.py
@@ -1,0 +1,514 @@
+"""DAH-2958: the express lane verifies never-validated executors ahead of the 15-min cycle.
+
+Flag off: request_job_to_miner asks the miner for every executor (executor_id=None) and claims
+nothing, exactly as before. Flag on: a portal executor this validator never published is verified
+alone with the cycle's own pipeline inputs and published spec-only; the wave and the lane never
+run on one executor at the same time; the in-flight caps bound a registration flood; an executor
+the miner does not return is retried a bounded number of times and then left to the cycle.
+"""
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import bittensor
+import pytest
+from fakeredis.aioredis import FakeRedis
+
+from clients.validator_portal_api import PortalExecutor, ValidatorPortalAPI, portal_miner_auth_blob
+from core.express_lane import EXPRESS_PUBLISHED_EVENT, MAX_ATTEMPTS, CycleInputs, ExpressLane
+from datura.requests.miner_requests import AcceptSSHKeyRequest, ExecutorSSHInfo
+from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.miner_service import CYCLE_LANE, EXPRESS_LANE, MinerService
+from services.redis_service import EXPRESS_LANE_VALIDATED_SET, RedisService
+from services.task.models import JobResult
+
+VALIDATOR_HOTKEY = "validator-hotkey"
+
+
+@dataclass
+class _AxonInfo:
+    ip: str = "192.0.2.10"
+    port: int = 8091
+
+
+@dataclass
+class _Neuron:
+    hotkey: str
+    coldkey: str = "miner-coldkey"
+    axon_info: _AxonInfo = field(default_factory=_AxonInfo)
+
+
+def _executor_info(executor_id: str) -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=executor_id,
+        address="198.51.100.7",
+        port=8001,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python3",
+        root_dir="/root/app",
+    )
+
+
+def _job_result(executor_id: str, score: float = 1.0) -> JobResult:
+    return JobResult(
+        spec={"gpu": {"count": 1}},
+        executor_info=_executor_info(executor_id),
+        score=score,
+        job_score=score,
+        job_batch_id="2026-09-06 16:40:00",
+        log_status="info",
+        log_text="Validation task completed",
+        gpu_model="NVIDIA H100 80GB HBM3",
+        gpu_count=1,
+    )
+
+
+def _portal_executor(executor_id: str, registered_seconds_ago: float = 40.0, validator: str = VALIDATOR_HOTKEY):
+    return PortalExecutor(
+        id=executor_id,
+        validator_hotkey=validator,
+        created_at=datetime.now(UTC) - timedelta(seconds=registered_seconds_ago),
+    )
+
+
+def _cycle_inputs() -> CycleInputs:
+    return CycleInputs(
+        encrypted_files=MinerJobEnryptedFiles(
+            encrypt_key="k",
+            all_keys={},
+            tmp_directory="/tmp/x",
+            machine_scrape_file_name="scrape",
+            machine_scrape_source="",
+        ),
+        default_image_digests={},
+        executor_image_snapshot=None,
+    )
+
+
+def _redis_service() -> RedisService:
+    service = RedisService.__new__(RedisService)
+    service.redis = FakeRedis()
+    service.lock = asyncio.Lock()
+    return service
+
+
+@pytest.fixture
+def wallet(mocker):
+    my_key = Mock(ss58_address=VALIDATOR_HOTKEY)
+    my_key.sign.return_value = b"\x01\x02\x03"
+    mocker.patch(
+        "core.config.Settings.get_bittensor_wallet",
+        return_value=Mock(get_hotkey=Mock(return_value=my_key)),
+    )
+    return my_key
+
+
+@pytest.fixture
+def rest_miner_service(mocker, wallet, monkeypatch):
+    """A MinerService whose REST boundary is mocked: the miner accepts the key and returns the
+    executors the test hands it; every executor task resolves to a passing JobResult."""
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "USE_REST_API", True)
+    ssh_service = mocker.Mock()
+    ssh_service.generate_ssh_key.return_value = (b"---PRIV---", b"ssh-ed25519 pub")
+    ssh_service.decrypt_payload.return_value = "---DECRYPTED-PRIV---"
+    task_service = mocker.Mock()
+
+    async def create_task(miner_info, executor_info, **_):
+        return _job_result(executor_info.uuid)
+
+    task_service.create_task = AsyncMock(side_effect=create_task)
+    service = MinerService(
+        ssh_service=ssh_service,
+        task_service=task_service,
+        redis_service=mocker.AsyncMock(),
+        attestation_service=Mock(maybe_issue_nonce=AsyncMock(return_value=None)),
+    )
+    mocker.patch("services.miner_service.measure_and_attach", AsyncMock())
+
+    def miner_returns(*executor_ids: str):
+        service.rest_calls = []
+
+        async def _make_rest_request(method, url, json_data, headers, timeout, log_extra, operation_name):
+            service.rest_calls.append((url.rsplit("/", 1)[-1], json_data))
+            if url.endswith("ssh-pubkey-submit"):
+                return 200, AcceptSSHKeyRequest(
+                    executors=[_executor_info(e) for e in executor_ids]
+                ).model_dump(mode="json")
+            return 200, {"message_type": "SSHKeyRemoved"}
+
+        service._make_rest_request = _make_rest_request
+
+    service.miner_returns = miner_returns
+    return service
+
+
+def _payload() -> MinerJobRequestPayload:
+    return MinerJobRequestPayload(
+        job_batch_id="2026-09-06 16:40:00",
+        miner_hotkey="miner-a",
+        miner_coldkey="miner-coldkey",
+        miner_address="192.0.2.10",
+        miner_port=8091,
+    )
+
+
+async def _request(service: MinerService, **kwargs):
+    return await service.request_job_to_miner(
+        payload=_payload(),
+        encrypted_files=_cycle_inputs().encrypted_files,
+        rented_data=RentedExecutorsResponse(executors={}),
+        default_docker_image_digests={},
+        **kwargs,
+    )
+
+
+# --- MinerService: what the miner is asked for, and who holds an executor -----------------
+
+
+@pytest.mark.asyncio
+async def test_flag_off_the_cycle_asks_for_every_executor_and_claims_nothing(rest_miner_service, monkeypatch):
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", False)
+    first, second = str(uuid4()), str(uuid4())
+    rest_miner_service.miner_returns(first, second)
+
+    job = await _request(rest_miner_service)
+
+    submit = dict(rest_miner_service.rest_calls)["ssh-pubkey-submit"]
+    assert submit["executor_id"] is None
+    assert {r.executor_info.uuid for r in job["results"]} == {first, second}
+    assert rest_miner_service.in_flight == {}
+
+
+@pytest.mark.asyncio
+async def test_the_express_lane_asks_the_miner_for_one_executor(rest_miner_service, monkeypatch):
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+    new_node = str(uuid4())
+    rest_miner_service.in_flight[new_node] = EXPRESS_LANE
+    rest_miner_service.miner_returns(new_node)
+
+    job = await _request(rest_miner_service, executor_id=new_node)
+
+    calls = dict(rest_miner_service.rest_calls)
+    assert calls["ssh-pubkey-submit"]["executor_id"] == new_node
+    assert calls["ssh-pubkey-remove"]["executor_id"] == new_node
+    assert [r.executor_info.uuid for r in job["results"]] == [new_node]
+    # the express lane, not the wave, owns the claim: the request must not touch it
+    assert rest_miner_service.in_flight == {new_node: EXPRESS_LANE}
+
+
+@pytest.mark.asyncio
+async def test_the_wave_skips_an_executor_the_express_lane_holds_and_releases_its_own(
+    rest_miner_service, monkeypatch, caplog
+):
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+    on_express, known = str(uuid4()), str(uuid4())
+    rest_miner_service.in_flight[on_express] = EXPRESS_LANE
+    rest_miner_service.miner_returns(on_express, known)
+    seen_during_wave = {}
+
+    async def create_task(miner_info, executor_info, **_):
+        seen_during_wave.update(rest_miner_service.in_flight)
+        if executor_info.uuid == known:
+            raise RuntimeError("ssh dropped")  # a failing task must still release the claim
+        return _job_result(executor_info.uuid)
+
+    rest_miner_service.task_service.create_task = AsyncMock(side_effect=create_task)
+
+    with caplog.at_level(logging.INFO):
+        job = await _request(rest_miner_service)
+
+    verified = [c.kwargs["executor_info"].uuid for c in rest_miner_service.task_service.create_task.call_args_list]
+    assert verified == [known]
+    assert seen_during_wave == {on_express: EXPRESS_LANE, known: CYCLE_LANE}
+    assert rest_miner_service.in_flight == {on_express: EXPRESS_LANE}
+    assert job["results"] == []
+    assert "Executor left to the express lane this cycle" in caplog.text
+
+
+# --- ExpressLane: discovery, caps, publish, retries -----------------------------------------
+
+
+class _Harness:
+    def __init__(self, monkeypatch, snapshot: dict[str, list[PortalExecutor]], miners: list[_Neuron]):
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+        self.settings = settings
+        self.redis_service = _redis_service()
+        self.miner_service = MinerService.__new__(MinerService)
+        self.miner_service.in_flight = {}
+        self.miner_service.publish_machine_specs = AsyncMock()
+        self.release = asyncio.Event()
+        self.release.set()
+
+        async def request_job_to_miner(payload, executor_id, **_):
+            await self.release.wait()
+            return self.job_for(payload, executor_id)
+
+        self.miner_service.request_job_to_miner = AsyncMock(side_effect=request_job_to_miner)
+        self.job_for = lambda payload, executor_id: {
+            "miner_hotkey": payload.miner_hotkey,
+            "miner_coldkey": payload.miner_coldkey,
+            "results": [_job_result(executor_id)],
+        }
+        self.portal_api = Mock(get_all_executors=AsyncMock(return_value=snapshot))
+        self.inputs: CycleInputs | None = _cycle_inputs()
+        self.lane = ExpressLane(
+            miner_service=self.miner_service,
+            redis_service=self.redis_service,
+            backend_client=Mock(
+                get_all_rented_executors=AsyncMock(return_value=RentedExecutorsResponse(executors={}))
+            ),
+            subtensor_client=Mock(get_miners=AsyncMock(return_value=miners)),
+            cycle_inputs=lambda: self.inputs,
+            portal_api=self.portal_api,
+        )
+
+    async def tick_and_settle(self) -> int:
+        launched = await self.lane.tick()
+        if self.lane._tasks:
+            await asyncio.gather(*self.lane._tasks)
+        return launched
+
+
+@pytest.mark.asyncio
+async def test_nothing_runs_before_the_first_cycle_has_completed(monkeypatch, wallet):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    harness.inputs = None  # Validator.express_lane_cycle_inputs returns None until then
+
+    assert await harness.tick_and_settle() == 0
+    harness.portal_api.get_all_executors.assert_not_awaited()
+    harness.miner_service.request_job_to_miner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_never_validated_executor_is_verified_alone_and_published_spec_only(
+    monkeypatch, wallet, caplog
+):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node, registered_seconds_ago=40)]}, [_Neuron("miner-a")])
+
+    with caplog.at_level(logging.INFO):
+        assert await harness.tick_and_settle() == 1
+
+    request = harness.miner_service.request_job_to_miner.await_args.kwargs
+    assert request["executor_id"] == new_node
+    assert (request["payload"].miner_hotkey, request["payload"].miner_address, request["payload"].miner_port) == (
+        "miner-a", "192.0.2.10", 8091
+    )
+    assert request["encrypted_files"] is harness.inputs.encrypted_files
+
+    (results, miner_hotkey, miner_coldkey), _ = harness.miner_service.publish_machine_specs.await_args
+    assert (miner_hotkey, miner_coldkey) == ("miner-a", "miner-coldkey")
+    assert [r.executor_info.uuid for r in results] == [new_node]
+    # spec-only: no incentive and no scored_at, so the backend writes no ledger row
+    assert results[0].incentive is None and results[0].scored_at is None
+    assert results[0].incentive_source == "unknown"
+    assert await harness.redis_service.get_validated_executors() == {new_node}
+    assert harness.miner_service.in_flight == {}
+
+    published = [r for r in caplog.records if r.getMessage() == EXPRESS_PUBLISHED_EVENT]
+    assert len(published) == 1
+    extra = published[0].msg.extra
+    assert extra["executor_uuid"] == new_node and extra["outcome"] == "passed" and extra["attempt"] == 1
+    assert 40 <= extra["registration_to_publish_s"] < 60
+    assert extra["first_seen_to_publish_s"] >= 0 and extra["verification_s"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_validated_foreign_and_wave_held_executors_are_not_touched(monkeypatch, wallet):
+    validated, foreign, on_wave = str(uuid4()), str(uuid4()), str(uuid4())
+    harness = _Harness(
+        monkeypatch,
+        {
+            "miner-a": [
+                _portal_executor(validated),
+                _portal_executor(foreign, validator="another-validator"),
+                _portal_executor(on_wave),
+            ]
+        },
+        [_Neuron("miner-a")],
+    )
+    await harness.redis_service.mark_executors_validated([validated])
+    harness.miner_service.in_flight[on_wave] = CYCLE_LANE
+
+    assert await harness.tick_and_settle() == 0
+    harness.miner_service.request_job_to_miner.assert_not_awaited()
+    harness.miner_service.publish_machine_specs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_in_flight_caps_bound_a_registration_flood(monkeypatch, wallet):
+    nodes = {
+        "miner-a": [_portal_executor(str(uuid4()), registered_seconds_ago=300 - i) for i in range(5)],
+        "miner-b": [_portal_executor(str(uuid4()), registered_seconds_ago=200 - i) for i in range(3)],
+        "miner-c": [_portal_executor(str(uuid4()), registered_seconds_ago=100 - i) for i in range(2)],
+    }
+    harness = _Harness(monkeypatch, nodes, [_Neuron("miner-a"), _Neuron("miner-b"), _Neuron("miner-c")])
+    monkeypatch.setattr(harness.settings, "EXPRESS_LANE_MAX_IN_FLIGHT", 4)
+    monkeypatch.setattr(harness.settings, "EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER", 2)
+    harness.release.clear()  # verifications block until released
+
+    assert await harness.lane.tick() == 4
+    in_flight = harness.miner_service.in_flight
+    assert all(lane == EXPRESS_LANE for lane in in_flight.values())
+    by_miner = {
+        hotkey: sum(e.id in in_flight for e in executors) for hotkey, executors in nodes.items()
+    }
+    assert by_miner == {"miner-a": 2, "miner-b": 2, "miner-c": 0}  # oldest registrations first
+    # a second tick while all four are still running launches nothing more
+    assert await harness.lane.tick() == 0
+    assert len(in_flight) == 4
+
+    harness.release.set()
+    await asyncio.gather(*harness.lane._tasks)
+    assert harness.miner_service.publish_machine_specs.await_count == 4
+    # the slots are free again: the next tick takes the next four
+    harness.release.clear()
+    assert await harness.lane.tick() == 4
+    harness.release.set()
+    await asyncio.gather(*harness.lane._tasks)
+    assert await harness.lane.tick() == 2
+    await asyncio.gather(*harness.lane._tasks)
+    assert len(await harness.redis_service.get_validated_executors()) == 10
+
+
+@pytest.mark.asyncio
+async def test_an_executor_the_miner_does_not_return_is_retried_then_left_to_the_cycle(
+    monkeypatch, wallet, caplog
+):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    # the miner's own portal snapshot has not caught up: it accepts the key for nobody
+    harness.job_for = lambda payload, executor_id: {"miner_hotkey": "miner-a", "miner_coldkey": "c", "results": []}
+
+    with caplog.at_level(logging.INFO):
+        assert await harness.tick_and_settle() == 1
+        assert await harness.tick_and_settle() == 0  # inside the retry backoff
+        for _ in range(MAX_ATTEMPTS - 1):
+            harness.lane._pending[new_node].not_before = 0.0  # backoff elapsed
+            assert await harness.tick_and_settle() == 1
+        assert await harness.tick_and_settle() == 0  # given up: the normal cycle owns it now
+
+    assert harness.miner_service.request_job_to_miner.await_count == MAX_ATTEMPTS
+    harness.miner_service.publish_machine_specs.assert_not_awaited()
+    assert await harness.redis_service.get_validated_executors() == set()
+    assert harness.miner_service.in_flight == {}
+    assert caplog.text.count("[express] Executor not verified yet, will retry") == MAX_ATTEMPTS - 1
+    assert "[express] Executor left to the normal cycle" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_failed_verification_is_published_so_the_provider_sees_why(monkeypatch, wallet, caplog):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    harness.job_for = lambda payload, executor_id: {
+        "miner_hotkey": "miner-a",
+        "miner_coldkey": "c",
+        "results": [_job_result(executor_id, score=0.0)],
+    }
+
+    with caplog.at_level(logging.INFO):
+        assert await harness.tick_and_settle() == 1
+
+    harness.miner_service.publish_machine_specs.assert_awaited_once()
+    assert await harness.redis_service.get_validated_executors() == {new_node}
+    published = [r for r in caplog.records if r.getMessage() == EXPRESS_PUBLISHED_EVENT]
+    assert published[0].msg.extra["outcome"] == "failed"
+
+
+# --- Redis seed and portal auth -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_validated_set_round_trips_through_redis():
+    redis_service = _redis_service()
+    ids = [str(uuid4()) for _ in range(3)]
+
+    await redis_service.mark_executors_validated(ids)
+    await redis_service.mark_executors_validated([])
+
+    assert await redis_service.get_validated_executors() == set(ids)
+    assert await redis_service.redis.scard(EXPRESS_LANE_VALIDATED_SET) == 3
+
+
+def test_the_portal_auth_blob_is_what_signature_auth_miner_verifies():
+    """lium-platform apps/portal/backend/src/auth/signature_auth.py builds
+    AuthenticationPayload(timestamp=..., miner_hotkey=...) and verifies json.dumps(model_dump(),
+    sort_keys=True); the two repos agree only on these bytes."""
+    keypair = bittensor.Keypair.create_from_uri("//LiumTestValidator")
+    blob = portal_miner_auth_blob(keypair.ss58_address, 1_757_174_400)
+
+    assert blob == json.dumps({"miner_hotkey": keypair.ss58_address, "timestamp": 1_757_174_400}, sort_keys=True)
+    assert keypair.verify(blob, f"0x{keypair.sign(blob).hex()}")
+
+
+@pytest.mark.asyncio
+async def test_get_all_executors_parses_the_bulk_snapshot_and_fails_soft(monkeypatch, wallet):
+    executor_id = str(uuid4())
+    responses = iter(
+        [
+            (200, {"miner-a": [{"id": executor_id, "validator_hotkey": VALIDATOR_HOTKEY,
+                                 "created_at": "2026-09-06T16:40:00", "executor_ip_address": "198.51.100.7",
+                                 "executor_ip_port": "8001", "price_per_gpu": 1.5}]}),
+            (503, "portal down"),
+        ]
+    )
+    sent_headers = {}
+
+    class _Response:
+        def __init__(self, status, body):
+            self.status, self._body = status, body
+
+        async def json(self):
+            return self._body
+
+        async def text(self):
+            return str(self._body)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+    class _Session:
+        def __init__(self, *_, **__):
+            pass
+
+        def get(self, url, headers):
+            sent_headers.update(headers)
+            return _Response(*next(responses))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+    monkeypatch.setattr("clients.validator_portal_api.aiohttp.ClientSession", _Session)
+
+    snapshot = await ValidatorPortalAPI.get_all_executors()
+
+    assert sent_headers["hotkey"] == VALIDATOR_HOTKEY and sent_headers["signature"] == "0x010203"
+    assert list(snapshot) == ["miner-a"]
+    (executor,) = snapshot["miner-a"]
+    assert executor.id == executor_id and executor.validator_hotkey == VALIDATOR_HOTKEY
+    assert executor.created_at == datetime(2026, 9, 6, 16, 40, tzinfo=UTC)
+    assert await ValidatorPortalAPI.get_all_executors() is None

--- a/neurons/validators/tests/test_express_lane.py
+++ b/neurons/validators/tests/test_express_lane.py
@@ -210,6 +210,27 @@ async def test_the_express_lane_asks_the_miner_for_one_executor(rest_miner_servi
 
 
 @pytest.mark.asyncio
+async def test_the_express_lane_verifies_only_the_executor_it_asked_for(rest_miner_service, monkeypatch):
+    """A miner that ignores the executor filter must not get its other executors verified on the
+    express path — they may be held by the wave, and their results are discarded anyway."""
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+    new_node, extra = str(uuid4()), str(uuid4())
+    rest_miner_service.in_flight[new_node] = EXPRESS_LANE
+    rest_miner_service.in_flight[extra] = CYCLE_LANE
+    rest_miner_service.miner_returns(new_node, extra)
+
+    job = await _request(rest_miner_service, executor_id=new_node)
+
+    verified = [c.kwargs["executor_info"].uuid for c in rest_miner_service.task_service.create_task.call_args_list]
+    assert verified == [new_node]
+    assert [r.executor_info.uuid for r in job["results"]] == [new_node]
+    # the wave's claim on the extra executor is untouched
+    assert rest_miner_service.in_flight == {new_node: EXPRESS_LANE, extra: CYCLE_LANE}
+
+
+@pytest.mark.asyncio
 async def test_the_wave_skips_an_executor_the_express_lane_holds_and_releases_its_own(
     rest_miner_service, monkeypatch, caplog
 ):

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -101,6 +101,9 @@ def _miner_service() -> MinerService:
     # request_job_to_miner awaits this before submitting the SSH key (G3);
     # None = no attestation event, the legacy path.
     service.attestation_service.maybe_issue_nonce = AsyncMock(return_value=None)
+    # __new__ skips __init__: give the service the lane map _claim_for_cycle reads when
+    # EXPRESS_LANE_ENABLED is on (DAH-2958), so the suite also passes with the flag set
+    service.in_flight = {}
     return service
 
 


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-2958](https://app.notion.com/p/Provider-time-to-ready-a-new-node-waits-for-the-15-min-cycle-boundary-and-then-for-the-slowest-mine-3d3b8bfdbde9816f907ac5ec52096c92) · stacked on #1280 · reviewer: @jam6099 @pixel29913

**TL;DR** — A new node is published only by the fleet-wide scored cycle, so its first publish waits twice: for the cycle boundary (`BLOCKS_FOR_JOB = 75` blocks. Validator express lane for never-validated executors (flag, off). Touches validator/executor (`neurons/validators/.env.template`) — read that file first.

**What changed**
- An express lane for never-validated executors, behind `EXPRESS_LANE_ENABLED` (default False — flag off is byte-for-byte today's behaviour.
- `core/express_lane.py` (new): `ExpressLane` runs as a second asyncio task beside `Validator.sync()` in the same process, ticking every `EXPRESS_LANE_TICK_SECONDS` (30).
- Seeding: with the flag on, every cycle adds the uuids it published to the Redis set (one `SADD`).
- Caps: `EXPRESS_LANE_MAX_IN_FLIGHT` (4) express verifications at any moment (so ≤ 4 launched per tick), `EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER` (2); oldest registration first.
- Coordination (`MinerService.in_flight: {uuid: "cycle"|"express"}`): the wave claims the executors each miner returns and releases them when the miner's tasks finish…
- Instrumentation: one structured line per express verification, `[express] Executor verified and published ahead of the cycle`, with `executor_uuid`, `miner_hotkey`.

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_express_lane.py -q` → green

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1952 passed · miners 27 passed · Result: PASS fda52420 · Gate: not run

**Docs:** neurons/validators/.env.template (EXPRESS_LANE_*) (this PR) · public: none changed in this PR — validator flag off by default; providers see the same statuses, sooner when it is on — troubleshooting.md needs no change

<details><summary>Details</summary>

Merge after #1280 — this branch is stacked on it; GitHub retargets this PR to main when #1280 merges. Review/merge order per repo: https://github.com/Datura-ai/lium-loop/blob/main/improvements/CHANGES_FOR_REVIEW.md

[DAH-2958](https://app.notion.com/p/Provider-time-to-ready-a-new-node-waits-for-the-15-min-cycle-boundary-and-then-for-the-slowest-mine-3d3b8bfdbde9816f907ac5ec52096c92). Origin: prod measurement of 175 node onboardings over 30 days (`RECOVERY/reports/provider_time_to_ready.md`, 6 Sep) — node add → AVAILABLE p50 21.4 / p90 63.5 min, floor 8.2 min; owner decision 6 Sep 16:33Z "build the express lane".

## Problem
A new node is published only by the fleet-wide scored cycle, so its first publish waits twice: for the cycle boundary (`BLOCKS_FOR_JOB = 75` blocks, `core/validator.py` gate → uniform 0–15 min, mean 7.5) and then, after its own pipeline is done (p50 152 s / p90 208 s, fresh node 253 s), for the slowest miner in the fleet — `publish_machine_specs` runs only after `asyncio.wait(jobs)` over all ~189 miners and scoring (last miner +394–801 s after wave start; the node's own task ends at ~250 s → +2–9 min of pure waiting). Dogfood node, 6 Sep: add 04:53:05 → wave 05:01:48 → own task done 05:06:33 → published 05:08:56 = 15 m 52 s, of which ~11 min was waiting. p50 ≈ 10.5 of the 21.4 min is these two waits; sub-5-min time-to-ready is structurally impossible while publish is coupled to fleet-wide scoring.

## Change
An express lane for **never-validated** executors, behind `EXPRESS_LANE_ENABLED` (default **False** — flag off is byte-for-byte today's behaviour: `request_job_to_miner` still sends `executor_id=None`, the wave claims nothing, no task is started, no Redis write).

- `core/express_lane.py` (new): `ExpressLane` runs as a second asyncio task beside `Validator.sync()` in the same process, ticking every `EXPRESS_LANE_TICK_SECONDS` (30). Each tick: one `GET {MINER_PORTAL_REST_API_URL}/miners/executors` — the bulk snapshot the central miner already polls (DAH-2469) — signed with the validator hotkey over the same `AuthenticationPayload` blob `signature_auth_miner` verifies. Candidates = rows with `validator_hotkey == ours` that are not in the Redis set `express_lane_validated_executors` and not held by the wave. For each: `request_job_to_miner(..., executor_id=<uuid>)` → the miner installs the key on that one executor only (`register_pubkey(executor_id=…)`, the path the rental key-submit already uses) → `TaskService.create_task` runs the **same** pipeline with the **same** cycle inputs (the current cycle's encrypted job files, default-image digests and executor-image snapshot, reused via `CycleInputs`; nothing weaker, nothing skipped) → `publish_machine_specs([result])` as the pipeline produced it: no incentive, `scored_at=None`. The backend creates the executor row (score > 0 ⇒ AVAILABLE) and the `prod_executors` validation row, and writes **no** `incentive_per_validator_cycle` row (`is_provider_emission_cycle_eligible` needs `scored_at`). The next scored cycle overwrites the row exactly as today.
- Seeding: with the flag on, every cycle adds the uuids it published to the Redis set (one `SADD`); the lane runs only after the first completed cycle since start, so a deploy/restart can never mistake a long-known executor for a new one.
- Caps: `EXPRESS_LANE_MAX_IN_FLIGHT` (4) express verifications at any moment (so ≤ 4 launched per tick), `EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER` (2); oldest registration first. An executor the miner does not return (its own portal snapshot not refreshed yet — lium-io#1280 shrinks that window to 30 s — or unreachable) is retried ≤ 3 times, ≥ 120 s apart, then left to the normal cycle. A registration flood costs the fleet ≤ 4 extra SSH sessions at a time and one portal GET per 30 s.
- Coordination (`MinerService.in_flight: {uuid: "cycle"|"express"}`): the wave claims the executors each miner returns and releases them when the miner's tasks finish (try/finally); the lane never touches a claimed uuid, and re-checks after its own awaits. If a miner's `AcceptSSHKeyRequest` lists an executor the lane is verifying right now, the wave skips that executor for this cycle (`"Executor left to the express lane this cycle"`), so a new node's VerifyX/matrix never run twice concurrently. Only a never-validated executor can be in that state; scoring of every already-validated executor is untouched.
- Instrumentation: one structured line per express verification, `[express] Executor verified and published ahead of the cycle`, with `executor_uuid`, `miner_hotkey`, `outcome`, `score`, `attempt`, `registered_at` (portal `created_at`), `published_at`, `registration_to_publish_s`, `first_seen_to_publish_s`, `verification_s`. The p50 of `registration_to_publish_s` in Loki is the deploy metric. Retries/give-ups log `[express] Executor not verified yet, will retry` / `[express] Executor left to the normal cycle`.
- `request_job_to_miner` / `_request_job_to_miner` gain `executor_id: str | None = None`, threaded into `SSHPubKeySubmitRequest` and the remove request on both the WebSocket and REST paths (the field already exists on the protocol; no datura/miner change).

Expected effect: registration → publish ≈ portal poll ≤ 30 s + key install 1–5 s + own pipeline (p50 152 s / fresh 253 s) ≈ **3–4.5 min p50**, removing the ~10.5 min p50 of waiting. Rollback: flag off.

## How to test
```
cd neurons/validators && pdm run pytest tests/test_express_lane.py -q
```
12 new tests: flag off → the cycle asks for every executor (`executor_id=None`) and `in_flight` stays empty; flag on → `executor_id` is threaded to submit and remove; the wave skips an executor the lane holds and releases its own claims even when a task raises; nothing runs before the first cycle has completed; a never-validated executor is verified alone with the cycle's inputs and published spec-only (no incentive, no `scored_at`), lands in the Redis set, and emits the metric line with `registration_to_publish_s`; validated / foreign-validator / wave-held executors are not touched; a 10-node flood across 3 miners is drained 4-then-4-then-2 with ≤ 2 per miner; an executor the miner never returns is retried 3× then left to the cycle, never published; a failed verification is still published so the provider sees the reason; Redis round-trip; the portal auth blob verifies with a real keypair; the bulk snapshot parses and a 503 fails soft.

Full validator suite as CI runs it (`pdm run pytest tests/ -v --tb=short --strict-markers`, Python 3.11, local macOS): **1941 passed, 15 skipped**; the 3 failures in `test_sshd_bootstrap_script.py` and 9 errors in `test_port_mapping_dao.py` are identical on `origin/main` in the same venv (Linux-only script tooling / DB fixture) — the Validators Tests check on this PR is the authoritative run.

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `fda52420` merged onto `main` `07ec64cd` (clean merge), then: pytest: validators, miners (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1952 passed, 15 skipped, 153 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); Miners 27 passed, 21 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers
- `git diff -w` on `miner_service.py`: the only change inside the two task-list blocks is `msg.executors` → `executors` and the `try/finally` around the gather; the rest is the re-indent.
- Discovery reuses `GET /miners/executors` rather than a new portal endpoint, so this PR is self-contained in lium-io. `signature_auth_miner` verifies the signature only (the subnet-registration check is commented out since the central-miner deregistration); if that check comes back, the validator hotkey is a registered neuron and still passes. If you would rather have a `/validators/pending-executors` view, only `ValidatorPortalAPI.get_all_executors` changes.
- Known bounded race: the next cycle's `ecrypt_miner_job_files()` rmtree's the job-files directory; an express verification that has not yet uploaded at that instant fails and is retried/left to that same cycle (today's path). Uploads happen in the pipeline's first seconds, so the window is small.
- A miner whose only executor is on the express lane when the wave arrives gets an empty result list for that cycle (as if the node were not registered yet) — a never-validated node has never earned anything, so no existing incentive changes.
- The express `prod_executors` row carries an off-boundary `time` (the express start, `%Y-%m-%d %H:%M:%S`), not a cycle label; any per-cycle grouping sees one extra row for that executor. `incentive_source` on the published message is `"unknown"` (derived property when `incentive is None`); the `[express]` Loki line is the lane marker.
- Related, in flight: lium-io#1280 (central-miner snapshot TTL 300 → 30 s — shortens the "miner did not return the executor" retry window here), lium#163 (`lium mine` pre-pull). Sub-5 residuals after this PR: the first VerifyX sample failing the 100 Mbps EMA gate on a cold measurement (DAH-2959, 14 % of fresh nodes → failed first publish, next cycle), and nodes whose own pipeline runs > ~4.5 min (p99 360 s, max 477 s measured).
- No change to `BLOCKS_FOR_JOB`, `JOB_TIME_OUT`, scoring, weights or the ledger.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-2958.

Docs: neurons/validators/.env.template (EXPRESS_LANE_*) (this PR) · public: none changed in this PR — validator flag off by default; providers see the same statuses, sooner when it is on — troubleshooting.md needs no change

</details>
