### PR TITLE
DAH-2472 - [P3] cover customer pod beside two filler bundles in the tenant check

### DIFF
--- a/neurons/validators/tests/test_rented_machine_check.py
+++ b/neurons/validators/tests/test_rented_machine_check.py
@@ -848,6 +848,47 @@ async def test_tenant_enforcement_allows_mapped_filler_with_customer_rental(cont
     assert score_calculator.called_with["rented"] is True
 
 
+@pytest.mark.asyncio
+async def test_tenant_enforcement_allows_every_filler_bundle_beside_customer_pod(context_factory):
+    # DAH-2472: a partially rented GPU-split node keeps one filler per free VRAM bundle. Every
+    # bundle's GPU process must count as in-tenant, not only the first filler's.
+    executor_uuid = "executor-123"
+    pod_container = "tenant-123"
+    fillers = ["filler_bundle_a", "filler_bundle_b"]
+    rented_data = build_rented_data(
+        executor_uuid,
+        {"containers": [{"name": pod_container, "pod_id": "pod-1"}], "owner_flag": False},
+    )
+    rented_data.all_filler_containers_by_executor[executor_uuid] = fillers
+    score_calculator = DummyScoreCalculator(actual_score=1.0, job_score=1.0)
+    services = build_services(
+        score_calculator=score_calculator,
+        container_cleanup=MockContainerCleanup(),
+    )
+    state = build_state(
+        gpu_processes=[
+            {"container_name": pod_container, "pid": 1001},
+            {"container_name": fillers[0], "pid": 1002},
+            {"container_name": fillers[1], "pid": 1003},
+        ],
+        gpu_details=[{"gpu_utilization": 95, "memory_utilization": 80}],
+        rented_data=rented_data,
+    )
+    ctx = context_factory(
+        services=services,
+        state=state,
+        ssh=DummySSHClient(pod_running=True, ssh_keys=["ssh-rsa AAA..."]),
+        collateral_deposited=True,
+        contract_version="v1.0.0",
+    )
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is True, result.event
+    assert result.event.reason_code == Msg.ALREADY_RENTED.reason
+    assert result.updates["rented"] is True
+
+
 def build_recovery_context(
     context_factory,
     ssh: DummySSHClient,


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-2472](https://app.notion.com/p/Do-not-penalize-GPU-split-nodes-with-rented-GPUs-and-fillers-3a5b8bfdbde98184a435c7282e6fbb9f) · reviewer: @jam6099 @pixel29913

**TL;DR** — The ticket reproduces `GPU_USAGE_OUTSIDE_TENANT` on a partially rented GPU-split node with 2+ filler bundles (`expected_containers = ['tenant-123', 'filler_bundle_a']`, bundle_b dropped). One test, `test_tenant_enforcement_allows_every_filler_bundle_beside_customer_pod`: customer pod + two fillers in `all_filler_containers_by_executor`, a GPU process in each of the three containers, utilisation above the 5 % limit, `owner_flag=False`. Touches validator/executor (`neurons/validators/tests/test_rented_machine_check.py`) — read that file first.

**What changed**
- One test, `test_tenant_enforcement_allows_every_filler_bundle_beside_customer_pod`: customer pod + two fillers in `all_filler_containers_by_executor`, a GPU process in each of the three containers.

**How to verify**
- `pdm run pytest tests/test_rented_machine_check.py` → → 37 passed

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1940 passed · Result: PASS efc57162 · Gate: not run

**Docs:** none changed in this PR — tests only.

<details><summary>Details</summary>

[DAH-2472](https://app.notion.com/p/Do-not-penalize-GPU-split-nodes-with-rented-GPUs-and-fillers-3a5b8bfdbde98184a435c7282e6fbb9f) — Do not penalize GPU-split nodes with rented GPUs and fillers.

## Origin
The ticket reproduces `GPU_USAGE_OUTSIDE_TENANT` on a partially rented GPU-split node with 2+ filler bundles (`expected_containers = ['tenant-123', 'filler_bundle_a']`, bundle_b dropped). The code half of its plan already landed in DAH-2467 (#1153, merged 2026-08-26): `TenantEnforcementCheck.run` reads `rented_data.get_filler_containers(...)` and extends `container_names` with every filler. The test half — "a `test_rented_machine_check` case: customer pod + 2 filler bundles produces a passing check" — did not; `test_rented_machine_check.py` only covers a single filler.

## Change
One test, `test_tenant_enforcement_allows_every_filler_bundle_beside_customer_pod`: customer pod + two fillers in `all_filler_containers_by_executor`, a GPU process in each of the three containers, utilisation above the 5 % limit, `owner_flag=False`. Expects `passed=True` / `ALREADY_RENTED`. No production code changes.

## Verification
- `pdm run pytest tests/test_rented_machine_check.py` → 37 passed.
- The test guards the fix: with `rented_machine.py` temporarily reverted to the single-filler list (`[get_filler_container(...)]`) it fails with `GPU_USAGE_OUTSIDE_TENANT`, the ticket's exact symptom.

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `efc57162` merged onto `main` `07ec64cd` (clean merge), then: pytest: validators (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1940 passed, 15 skipped, 149 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes
Closes the ticket's remaining plan item; the staging/Loki verification steps in the ticket stay with the team.

Docs: none changed in this PR — tests only.

</details>
