### PR TITLE
DAH-3006 - [P1] validator stops serialising every Redis command behind one lock

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -21,6 +21,9 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_USERNAME=
 REDIS_PASSWORD=
+# DAH-3006: false = Redis commands run concurrently on the bounded pool instead of queueing
+# behind one process-wide lock (p50 73 s per executor in a 500-executor wave). true = legacy.
+REDIS_COMMAND_LOCK_ENABLED=true
 
 COMPUTE_APP_URI=wss://lium.io/api
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -111,6 +111,12 @@ class Settings(BaseSettings):
     REDIS_PORT: int = Field(env="REDIS_PORT", default=6379)
     REDIS_USERNAME: str | None = Field(env="REDIS_USERNAME", default=None)
     REDIS_PASSWORD: str | None = Field(env="REDIS_PASSWORD", default=None)
+    # DAH-3006: RedisService wraps every command in one process-wide asyncio.Lock. In a ~500-executor
+    # wave the lock's FIFO queue drains at ~0.4 s per command (each hold spans several starved
+    # event-loop iterations), so a 1-ms SISMEMBER waits p50 73 s (Loki, 6 Sep 12:03 wave) — ~45 %
+    # of the median idle pipeline. Off: commands go straight to the bounded BlockingConnectionPool
+    # (DAH-2475), which is what serialises them when it must. On = today's behaviour.
+    REDIS_COMMAND_LOCK_ENABLED: bool = Field(env="REDIS_COMMAND_LOCK_ENABLED", default=True)
     COMPUTE_APP_URI: str = Field(env="COMPUTE_APP_URI", default="wss://lium.io/api")
     COMPUTE_REST_API_URL: str | None = Field(
         env="COMPUTE_REST_API_URL", default="https://lium.io/api"

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -72,6 +72,21 @@ REDIS_HEALTH_CHECK_INTERVAL_SECONDS = 30
 logger = logging.getLogger(__name__)
 
 
+class _PassThroughLock:
+    """`RedisService.lock` with REDIS_COMMAND_LOCK_ENABLED off (DAH-3006): every `async with
+    self.lock:` site stays as it is, but nothing waits — each call is one atomic Redis command
+    and the pool bounds the concurrency."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def locked(self) -> bool:
+        return False
+
+
 class RedisService:
     def __init__(self):
         self.redis = aioredis.Redis(
@@ -99,7 +114,7 @@ class RedisService:
                 retry_on_error=[redis.exceptions.ConnectionError, redis.exceptions.TimeoutError],
             )
         )
-        self.lock = asyncio.Lock()
+        self.lock = asyncio.Lock() if settings.REDIS_COMMAND_LOCK_ENABLED else _PassThroughLock()
 
     @asynccontextmanager
     async def acquire_executor_lock(

--- a/neurons/validators/tests/test_redis_command_lock.py
+++ b/neurons/validators/tests/test_redis_command_lock.py
@@ -1,0 +1,94 @@
+"""DAH-3006: the process-wide Redis command lock.
+
+In a ~500-executor wave every pipeline queues on `RedisService.lock` for its one-command calls,
+and the FIFO queue drains at ~0.4 s per command: the duplicate check's single SISMEMBER measured
+p50 73 s (Loki, 6 Sep 12:03 wave). With REDIS_COMMAND_LOCK_ENABLED off the lock is a pass-through
+and the calls overlap on the connection pool.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from core.config import settings
+from services import redis_service as redis_service_module
+from services.redis_service import RedisService, _PassThroughLock
+
+CALLS = 20
+COMMAND_SECONDS = 0.05
+
+
+class _SlowFakeRedis:
+    """A Redis whose every command takes COMMAND_SECONDS, so serialisation is measurable."""
+
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    async def _cmd(self, *args):
+        self.calls.append(args)
+        await asyncio.sleep(COMMAND_SECONDS)
+        return True
+
+    sismember = sadd = hset = hget = _cmd
+
+
+def _service(monkeypatch, *, lock_enabled: bool) -> RedisService:
+    monkeypatch.setattr(settings, "REDIS_COMMAND_LOCK_ENABLED", lock_enabled)
+    # The constructor only builds pools from settings; nothing connects until a command runs.
+    service = RedisService()
+    service.redis = _SlowFakeRedis()
+    return service
+
+
+async def _timed(coro_factory, n: int = CALLS) -> tuple[float, list]:
+    started = time.perf_counter()
+    results = await asyncio.gather(*(coro_factory(i) for i in range(n)))
+    return time.perf_counter() - started, results
+
+
+@pytest.mark.asyncio
+async def test_default_keeps_the_lock_and_serialises_commands(monkeypatch):
+    service = _service(monkeypatch, lock_enabled=True)
+
+    assert isinstance(service.lock, asyncio.Lock)
+    elapsed, results = await _timed(lambda i: service.is_elem_exists_in_set("set", f"e{i}"))
+
+    # Today's behaviour: one command at a time, N x command time.
+    assert elapsed >= CALLS * COMMAND_SECONDS * 0.9
+    assert results == [True] * CALLS
+
+
+@pytest.mark.asyncio
+async def test_flag_off_lets_concurrent_reads_overlap(monkeypatch):
+    service = _service(monkeypatch, lock_enabled=False)
+
+    assert isinstance(service.lock, _PassThroughLock)
+    elapsed, results = await _timed(lambda i: service.is_elem_exists_in_set("set", f"e{i}"))
+
+    # All N calls in flight together: about one command time, not N.
+    assert elapsed < CALLS * COMMAND_SECONDS * 0.3
+    assert results == [True] * CALLS
+    assert len(service.redis.calls) == CALLS
+
+
+@pytest.mark.asyncio
+async def test_flag_off_writes_still_reach_the_client(monkeypatch):
+    service = _service(monkeypatch, lock_enabled=False)
+
+    await service.sadd("set", "elem")
+    await service.hset("hash", "field", "value")
+    await service.set_verified_job_info("miner", "executor", prev_info={}, success=True)
+
+    commands = [call[0] for call in service.redis.calls]
+    assert commands == ["set", "hash", redis_service_module.VERIFIED_JOB_COUNT_KEY]
+
+
+@pytest.mark.asyncio
+async def test_pass_through_lock_is_reusable_and_never_held():
+    lock = _PassThroughLock()
+
+    for _ in range(3):
+        async with lock:
+            assert lock.locked() is False
+    assert lock.locked() is False


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3006](https://app.notion.com/p/Validator-pipeline-one-process-wide-asyncio-Lock-serialises-every-Redis-command-across-500-concurr-3d3b8bfdbde98108a459f72b039cea86) · reviewer: @jam6099 (approved by @jam6099)

**TL;DR** — Nearly every `RedisService` method takes one process-wide `asyncio.Lock` per Redis command; with ~500 executor pipelines in one event loop the duplicate check (one `SISMEMBER`) waited p50 73 s. `REDIS_COMMAND_LOCK_ENABLED` (default `True`, today's behaviour) turns the lock into a pass-through when off; the client is a pooled `redis.asyncio`, no pipeline or MULTI depends on it. Not proven on a real chain.

**What changed**
- `core/config.py`: `REDIS_COMMAND_LOCK_ENABLED` (default `True` — today's behaviour)
- `services/redis_service.py`: with the flag off, `self.lock` is a pass-through async context manager (`_PassThroughLock`)
- `.env.template`: the new setting; `tests/test_redis_command_lock.py`: the real lock serialises, the pass-through overlaps

**How to verify**
- `cd neurons/validators && pdm run pytest -q tests/test_redis_command_lock.py` → green
- `git diff origin/main...bab2aae -- neurons/validators/src/services/redis_service.py`: with the flag on, the same lock at the same 19 sites

**Verified by the loop:** validators suite at the earlier head (same four files, byte-identical to `bab2aae`) on sandbox EC2: 1943 passed, 15 skipped, 2 root-only box failures also on `main`; e2e cycle/protocol/rental passed; CI green at `bab2aae`

**Ran it:** `cd neurons/validators && pdm run pytest -q tests/test_redis_command_lock.py` → green, and the #1312 subnet-loop e2e stack (full validator cycle, flag at its default) · sandbox EC2 (Linux), earlier head. The flag-off path ran only in the unit test; the prod measurement is the ticket's; not run on macOS — validators run on Linux hosts only

**Self-review:** clean at bab2aae (16 checks, 4 low)

**Parts:** backend n/a — validator only · migration n/a — no schema · frontend n/a — no UI · CLI/SDK n/a — no surface · docs ✓ `.env.template` (operator setting) · tests ✓ `test_redis_command_lock.py` · dashboards n/a — the Loki check-duration panel already exists

**Docs:** `neurons/validators/.env.template` — an operator setting for the validator, not a provider or renter surface

<details><summary>Details</summary>

[DAH-3006](https://app.notion.com/p/Validator-pipeline-one-process-wide-asyncio-Lock-serialises-every-Redis-command-across-500-concurr-3d3b8bfdbde98108a459f72b039cea86). Origin: prod Loki measurement of the validator pipeline per check (31 Aug–6 Sep; `provider-dogfood/VERIFICATION_PIPELINE.md`) for the owner's ask to shorten provider time-to-ready — `executor.validate.duplicate` (one SISMEMBER) p50 73 s in a 492-executor wave, p50 68.5 s over 7 days.

## Problem
Nearly every method of `RedisService` (`neurons/validators/src/services/redis_service.py`) wraps its single Redis command in the same `asyncio.Lock` (`self.lock`, `:102`; `publish` and the banned-guids helpers never took it). In a validation wave ~500 executor pipelines run concurrently in one event loop and hit that lock at the same points; the queue is FIFO and each holder needs several event-loop iterations to complete (send, await reply, release) while the loop is busy with the other coroutines' scrape JSON parsing and cipher generation, so the queue drains at roughly one command per 0.4 s.

Measured (prod Loki, `execution_time_ms` of the `executor.validate.duplicate` check — one `SISMEMBER`, `checks/duplicate_executor.py:22`):
- Wave `2026-09-06 12:03:00`, 492 idle executors: p50 **73.1 s**, p90 128.3 s, max 134.8 s. The durations grow linearly with the executor's position in the queue (emitted +17 s → waited 15 s; +82 s → 60 s; +156 s → 128 s); the queue drained over 218 s.
- Same check in the 37-executor batch at 12:18: p50 0.24 s, max 10.8 s. Same code, no queue.
- 7 days (31 Aug–6 Sep, 28 six-hour windows, 278 k idle executor runs): **p50 68.5 s / p90 115 s** (window p90 up to 141 s). The fleet-wide pipeline is p50 152 s (`elapsed_time_ms` at `pipeline.finalize`), so the lock queue is ~45 % of the median idle pipeline; for the non-filler idle nodes a fresh node belongs to (p50 259 s) it is 26 % — second only to VerifyX (80 s), ahead of the matmul (27 s) and the rental probe (21 s). Full table: `provider-dogfood/VERIFICATION_PIPELINE.md` §1.1.
- The same lock is taken before the pipeline (`build_context`: `get_verified_job_info` + `is_elem_exists_in_set`) and after it (`ResultHandler`: `hset` verified-job info), where `elapsed_time_ms` does not see it; those waits extend the wave and the "slowest miner" tail every new node waits for (DAH-2958).

The lock predates the bounded, blocking connection pool (DAH-2475). Each wrapped call is a single atomic Redis command; none of the wrapped methods does a read-modify-write inside the lock (`add_rented_pod`, `add_pending_pod` take it twice, once per command, so the lock never made them atomic either). redis-py's asyncio client is designed for concurrent commands over its pool; the lock only turns 64 pooled connections into 1.

## Change
- `core/config.py`: `REDIS_COMMAND_LOCK_ENABLED` (default **True** — today's behaviour, byte for byte).
- `services/redis_service.py`: with the flag off, `self.lock` is a pass-through async context manager (`_PassThroughLock`), so every `async with self.lock:` site is unchanged and commands go straight to the `BlockingConnectionPool` (64 connections, 10-s wait, retry — DAH-2475). Nothing else moves: no method signature, no key, no pubsub change.
- Expected effect with the flag off: the duplicate check returns in one round trip (≈ a loop iteration, 0.1–0.5 s under wave load) instead of p50 73 s; the idle pipeline p50 152 s → ≈ 80 s; the pre/post-pipeline Redis waits disappear from the wave tail. A 500-executor burst becomes ≤ 64 concurrent commands + a sub-second pool queue, well inside `REDIS_POOL_WAIT_TIMEOUT_SECONDS` = 10.

## How to test
```
cd neurons/validators && pdm run pytest -q tests/test_redis_command_lock.py
```
4 tests: default flag → `RedisService.lock` is a real `asyncio.Lock` and 20 concurrent `is_elem_exists_in_set` calls on a fake Redis whose `SISMEMBER` takes 50 ms serialise (≥ 1.0 s total); flag off → the same 20 calls overlap (< 0.3 s total) and every result is returned; the pass-through lock is reusable and never reports `locked()`; write paths (`sadd`, `hset`) still reach the client with the flag off.

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — the earlier head (the same four files, byte-identical to `bab2aae`) merged onto that day's `main` (clean merge), then: pytest: validators (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1943 passed, 15 skipped, 150 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers
- Default-on keeps prod identical until someone flips it; the flag is the rollback. If you would rather delete the lock outright, the diff is the same three lines minus the setting.
- `clear_by_pattern` (scan + delete) is the only multi-command method and does not need atomicity.
- Related: DAH-2958 (express lane) — a single express verification between waves never queues, so this fix is for the wave path and for the wave tail every node waits for; DAH-1295 (mock Redis in tests) — the new test uses a hand-rolled fake, no Redis needed.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-3006.

Docs: neurons/validators/.env.template

### Self-review

Verdict `clean` at `bab2aae` · 16 checks · by subagent-r33rev · 2026-09-09 03:08Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `PR body:0` | "Result: PASS dc9e6e25" and "branch head `dc9e6e25`" cite the pre-rebase head: `git merge-base --is-ancestor dc9e6e25 HEAD` is false (the branch is now the single commit bab2aae on 75298589); the four touched files are byte-identical between dc9e6e25 and HEAD (`git diff dc9e6e25 HEAD -- <4 files>` is empty), so the 1943-passed result still describes this code, but the sha is not reachable from the branch. | Re-render the Verification line with the current head (bab2aae) or say "same tree as bab2aae, verified at the pre-rebase head" without a hex literal. |
| low | PROSE-VS-CODE | `PR body:0` | "Every method of `RedisService` wraps its single Redis command in the same `asyncio.Lock`" overstates main: `publish`, `subscribe`, `acquire_executor_lock`, `set_banned_guids` and `get_banned_guids` (redis_service.py:145-161, 456-463) never take `self.lock`; the 19 `async with self.lock:` sites are the per-command wrappers (set/get/delete/sadd/.../hdel) and `clear_by_pattern`. The conclusion (the wave path is serialised) is unaffected. | "Every per-command wrapper of `RedisService` (set, get, sadd, sismember, hset, ... 19 sites) takes the same `asyncio.Lock`". |
| low | STALE-BODY | `PR body:0` | Above-the-fold bullet is truncated: "the duplicate check returns in one round trip (≈ a loop iteration." (the fold has the full sentence); the "Docs: neurons/validators/.env.template" line is printed twice (above the fold and at the end of Details). | Complete the bullet "(≈ a loop iteration, 0.1–0.5 s under wave load) instead of p50 73 s." and drop one of the two Docs lines. |
| low | CODE-QUALITY | `neurons/validators/tests/test_redis_command_lock.py:83` | `commands = [call[0] for call in service.redis.calls]` holds the first positional argument of each fake call, i.e. the Redis KEY ("set", "hash", VERIFIED_JOB_COUNT_KEY), not the command name; the assertion is right, the name is misleading. | Rename to `keys` (and the docstring/body sentence "write paths still reach the client" stays true). |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/src/services/redis_service.py:117` Flag on (default True): `self.lock = asyncio.Lock()`, same object type, and every `async with self.lock:` site (19, lines 167-259) is untouched — `git diff origin/main...HEAD` on the file is only the class and this one line, so behaviour is identical to main. · `neurons/validators/src/services/redis_service.py:75` `_PassThroughLock` is a correct async CM: `__aenter__` returns self, `__aexit__` returns False so exceptions propagate, no state so reentry/concurrent use is trivially fine; no caller in the validator tree does `redis_service.lock`/`.lock.locked()`/`acquire()` outside redis_service.py (grep of `neurons/validators`), tests that set `service.lock = asyncio.Lock()` still work. · `neurons/validators/src/services/redis_service.py:258` No wrapped method needs the serialisation: `self.redis` is `redis.asyncio.Redis` over a `BlockingConnectionPool` (64), one pooled connection per command, safe for concurrent commands; no `pipeline()`/MULTI/WATCH anywhere in `neurons/validators/src`; the read-modify-write helpers (`add_rented_pod`, `remove_rented_machine`, `add_pending_pod`, `remove_pending_pod`) take the lock once per command via hget/hset, so they were never atomic under it; `clear_by_pattern` (scan_iter + delete) needs no atomicity. · `neurons/validators/src/core/config.py:118` `REDIS_COMMAND_LOCK_ENABLED: bool = Field(env=..., default=True)` follows the file's existing pattern (pydantic-settings v2 reads the env var by field name); default True is the safe/legacy path; `.env.template` line `REDIS_COMMAND_LOCK_ENABLED=true` matches the field name and parses as bool. · `neurons/validators/tests/test_redis_command_lock.py:51` Tests test what they say: flag on asserts `isinstance(service.lock, asyncio.Lock)` and 20×50 ms calls take ≥ 0.9 s; flag off asserts `_PassThroughLock`, < 0.3 s (6× margin over one command), all 20 results and 20 fake calls; `monkeypatch.setattr(settings, ...)` works on a non-frozen pydantic v2 BaseSettings and `RedisService()` only builds pools (no connect) — same pattern as test_redis_pubsub_timeout.py. Flag-off tests fail on main (import of `_PassThroughLock` errors). · `PR body:0` Counts: 4 files, +119 −1 matches `git diff --numstat origin/main...HEAD` (3+6+16+94 / 1); `07ec64cd` is an ancestor of HEAD; branch merges clean onto origin/main (8 behind, `merge-tree` clean); Docs = `.env.template` is the operator-facing config file and validator operators are Datura ops, so no renter doc is missing; migration/frontend/CLI/dashboards parts do not apply to a validator-process flag. · `neurons/validators/src/services/redis_service.py:86` `locked()` has no production caller (only the test) but mirrors the `asyncio.Lock` surface so a future `.locked()` caller does not break with the flag off; harmless, not worth a round. · `neurons/validators/tests/test_redis_command_lock.py:47` Section 3b security properties (ownership, scope, mail, cache, regex, Sentry, TEST-NET) do not apply to an in-process asyncio lock toggle; no new external call, no new key, no user data.

### Verified

Gate: PASS (bab2aae) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1285)

</details>
