### PR TITLE
DAH-3007 - [P2] validator verdicts link providers to the reason-code reference

### DIFF
--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -9,6 +9,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from .pipeline import Context
 
 
+# Where every failing verdict sends the provider when its template names no page of its
+# own: the docs table that lists each reason code with its cause and fix. The miner portal
+# renders `help_uri` as the "Learn more" link on the node's error panel.
+REASON_CODE_DOCS_URL = "https://docs.lium.io/providers/troubleshooting#6-validator-reason-codes"
+_HELP_URI_SEVERITIES = frozenset({"error", "warning"})
+
+
 @dataclass(frozen=True)
 class MessageTemplate:
     event: str
@@ -34,10 +41,14 @@ def render_message(
     extra: dict[str, Any] | None = None,
 ) -> Any:
     """Render a `MessageTemplate` into a structured message via `build_msg`."""
+    resolved_severity = severity or template.severity
+    resolved_help_uri = help_uri or template.help_uri
+    if resolved_help_uri is None and resolved_severity in _HELP_URI_SEVERITIES:
+        resolved_help_uri = REASON_CODE_DOCS_URL
     return build_msg(
         event=template.event,
         reason=template.reason,
-        severity=severity or template.severity,
+        severity=resolved_severity,
         category=category or template.category,
         impact=impact or template.impact,
         remediation=(remediation if remediation is not None else template.remediation) or "",
@@ -45,7 +56,7 @@ def render_message(
         check_id=check_id,
         pipeline_id=ctx.pipeline_id,
         ctx={**ctx.default_extra, **(extra or {})},
-        help_uri=help_uri or template.help_uri,
+        help_uri=resolved_help_uri,
     )
 
 

--- a/neurons/validators/tests/test_messages_help_uri.py
+++ b/neurons/validators/tests/test_messages_help_uri.py
@@ -1,0 +1,60 @@
+"""Every verdict that costs a provider score carries a help link.
+
+The miner portal renders `help_uri` as "Learn more" on the node's error panel; only the
+VerifyX templates set one, so the other ~50 error/warning codes shipped without a link.
+"""
+
+from services.task.messages import (
+    REASON_CODE_DOCS_URL,
+    VERIFYX_DEBUG_DOC_URL,
+    GpuUsageMessages,
+    PortCountMessages,
+    SysboxRequiredMessages,
+    VerifyXMessages,
+    render_message,
+)
+from tests.helpers import make_context
+
+
+def test_error_and_warning_templates_default_to_the_reason_code_docs():
+    ctx = make_context()
+
+    error = render_message(GpuUsageMessages.ORPHANED_CONTAINER, ctx=ctx, check_id="c")
+    warning = render_message(PortCountMessages.INSUFFICIENT_PORTS, ctx=ctx, check_id="c")
+
+    assert error.severity == "error"
+    assert error.help_uri == REASON_CODE_DOCS_URL
+    assert warning.severity == "warning"
+    assert warning.help_uri == REASON_CODE_DOCS_URL
+
+
+def test_template_and_call_site_links_win_over_the_default():
+    ctx = make_context()
+
+    own = render_message(VerifyXMessages.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW, ctx=ctx, check_id="c")
+    override = render_message(
+        GpuUsageMessages.ORPHANED_CONTAINER, ctx=ctx, check_id="c", help_uri="https://example.test/x"
+    )
+
+    assert own.help_uri == VERIFYX_DEBUG_DOC_URL
+    assert override.help_uri == "https://example.test/x"
+
+
+def test_info_verdicts_carry_no_link():
+    ctx = make_context()
+
+    ok = render_message(SysboxRequiredMessages.SYSBOX_OK, ctx=ctx, check_id="c")
+
+    assert ok.severity == "info"
+    assert ok.help_uri is None
+
+
+def test_severity_override_decides_the_default():
+    # A template rendered as "info" at the call site (the observe-mode pattern) gets no link.
+    ctx = make_context()
+
+    downgraded = render_message(
+        PortCountMessages.INSUFFICIENT_PORTS, ctx=ctx, check_id="c", severity="info"
+    )
+
+    assert downgraded.help_uri is None


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3007](https://app.notion.com/p/Validator-verdicts-ship-help_uri-None-on-82-of-failures-8-722-of-10-649-in-7-days-339-nodes-on-3d3b8bfdbde9817d8e96f1b7bc2736f7) · reviewer: @taiberium

**TL;DR** — 82 % of the failing verdicts in a 7-day read of the validator log shipped `help_uri: None`, so the miner portal's "Learn more" link was empty for every reason code but the six VerifyX ones. `render_message` now defaults `help_uri` to the reason-code table on docs.lium.io for `error` and `warning` verdicts when neither the template nor the call site sets one. No change to codes, severities, scoring or the log format.

**What changed**
- `messages.py`: `REASON_CODE_DOCS_URL` and the default in `render_message` — template links (VerifyX) and call-site overrides still win; `info` verdicts carry no link
- `test_messages_help_uri.py`: four tests — an error and a warning template get the default, template/call-site links win, `info` stays `None`, a call-site `severity="info"` override gets no link

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_messages_help_uri.py tests/test_verifyx_check.py tests/test_executor_image_check.py -q` → 39 passed
- `pdm run pytest tests/ -q` → green apart from main's two root-only tests (sysfs, sshd)

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1943 passed · Result: PASS 07ec64cd · Gate: PASS 7ff6063

**Ran it:** in the EC2 run above, the four new tests: `render_message(GpuUsageMessages.ORPHANED_CONTAINER, …)` → `help_uri` is the reason-code URL, `SYSBOX_OK` (info) → `None`, a VerifyX template → its own debug URL, a call-site `severity="info"` → `None` · not run: a live validator against a real chain

**Self-review:** clean at 7ff6063 (11 checks, 3 low)

**Parts:** backend ✓ validator `messages.py` (the portal pass-through is lium-platform#90, open, not this repo) · migration n/a — no schema · frontend n/a — the portal already renders `help_uri` · CLI/SDK n/a — validator-side only · docs ✓ lium-docs#217 carries the reason-code table (the anchor) · tests ✓ 4 in `test_messages_help_uri.py` · dashboards n/a — no new metric

**Docs:** lium-docs#217 (companion — the `## 6. Validator reason codes` table the link points at; lium-docs#176 was folded into it). Merge order: the link lands on the page top until #217 is live.

<details><summary>Details</summary>

[DAH-3007](https://app.notion.com/p/Validator-verdicts-ship-help_uri-None-on-82-of-failures-8-722-of-10-649-in-7-days-339-nodes-on-3d3b8bfdbde9817d8e96f1b7bc2736f7).

## Problem

Origin: 7-day read of the validator's `prod_executors` log (Timescale, 6 Sep 2026) during the provider-experience audit; #providers 1 Sep 2026 "executors show offline but Docker logs are normal".

`ValidationEvent.help_uri` exists so a verdict can point the provider at an explanation, and the miner portal renders it as the **Learn more** link on the node's error panel (`NodeLastErrorDisplay.tsx`; the backend pass-through is lium-platform#90, DAH-2995). Only the six VerifyX templates set it (`_verify_failed(...)` → `VERIFYX_DEBUG_DOC_URL`). Every other template in `services/task/messages.py` — about 70 error/warning codes, including the ones that zeroed the most nodes in the week to 6 Sep (`GPU_VERIFY_FAILED` 126 nodes, `SYSBOX_REQUIRED_MISSING` 94, `SCRAPE_FAILED` 72, `INSUFFICIENT_PORTS` 68, `UPLOAD_FAILED` 50, `GPU_USAGE_HIGH` 41, `ORPHANED_RENTAL_CONTAINER` 38) — ships `help_uri=None`. Measured: **8,722 of 10,649 failure verdicts (82 %, 339 nodes) carried no link**.

The docs now have a page keyed by reason code — `https://docs.lium.io/providers/troubleshooting#6-validator-reason-codes` (written in lium-docs#176, DAH-2994, which was folded into lium-docs#217; the `## 6. Validator reason codes` heading is on that branch, so the anchor resolves once #217 is live and lands on the page top until then) — so there is a target.

## Change

`neurons/validators/src/services/task/messages.py`

- `REASON_CODE_DOCS_URL` constant.
- `render_message`: when neither the call site nor the template supplies a `help_uri` and the *resolved* severity is `error` or `warning`, use `REASON_CODE_DOCS_URL`. Template links (VerifyX) and call-site overrides still win; `info` verdicts carry no link, as before. Shadow (observe-mode) call sites render their templates as `warning` (`severity=None if enforce else "warning"`), so those verdicts carry the link too — the provider can read the code before it starts to cost score.

`neurons/validators/tests/test_messages_help_uri.py` — four tests: default applied to an error and a warning template; template/call-site links win; info stays `None`; a severity override to `info` suppresses the default.

No change to reason codes, severities, impacts, remediations, scoring, or the log format; only the previously-`None` `help_uri` field is filled on `error` and `warning` verdicts (shadow warnings included).

## How to test

```
cd neurons/validators && pdm run pytest tests/test_messages_help_uri.py tests/test_verifyx_check.py tests/test_executor_image_check.py -q   # 39 passed
pdm run pytest tests/ -q   # a checkout without docker or a database: 1933 passed, the 3 failures + 9 errors (test_sshd_bootstrap_script.py / test_port_mapping_dao.py) identical on origin/main there; EC2 CI shape: 1952 passed, 2 root-only failures
```

Then, on the portal, any node whose last verdict is e.g. `INSUFFICIENT_PORTS` shows **Learn more** after "How to fix" once lium-platform#90 is deployed.

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — the earlier head merged onto `main` `07ec64cd` (clean merge), then: pytest: validators (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1943 passed, 15 skipped, 149 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers

- The link target is one page anchor rather than one per code: the docs table is keyed by code and searchable, and a per-code map would have to be kept in step with the docs in two repos. If per-code anchors are wanted later, `help_uri` on individual templates still overrides.
- Depends on nothing to merge, but is only visible after lium-platform#90 (portal pass-through) and lium-docs#217 (the anchor; #176 was folded into it) are live.

Docs: lium-docs#217 (companion; the anchor page — #176 was folded into it)

### Self-review

Verdict `clean` at `7ff6063` · 11 checks · by subagent-r34fresh2 · 2026-09-09 03:24Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | CLAIMS | `neurons/validators/src/services/task/messages.py:44` | The Parts line says 'backend n/a — the portal pass-through is lium-platform#90' although this diff IS validator backend code (messages.py, section 6 of the brief lists backend as 'in diff'); it reads as if no backend was touched, where the intent is 'lium-platform backend n/a'. | Write 'backend ✓ validator messages.py (this diff); lium-platform pass-through n/a here — lium-platform#90, open'. |
| low | STALE-BODY | `neurons/validators/tests/test_messages_help_uri.py:1` | The fold's 'How to test' still carries the earlier local run ('1933 passed; the 3 failures + 9 errors in test_sshd_bootstrap_script.py / test_port_mapping_dao.py ... need bash+docker / a database') while the top 'How to verify' and the Verified line describe a different environment ('green apart from main's two root-only tests', '1952 passed, 2 failed'); both can be true per environment, but a reader sees two different totals for the same command. | Either label the fold's line as the no-docker local environment or replace it with the EC2 numbers so the two sections agree. |
| low | TESTS | `neurons/validators/tests/test_messages_help_uri.py:52` | Known low carried over from round 1 (code not touched by agreement): the test comment still calls the `severity="info"` override 'the observe-mode pattern', which the body now correctly describes as rendering to `warning`. | Next time this file is touched, reword the comment to 'a call-site severity override to info'. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/src/services/task/checks/gpu_usage.py:141` Round-1 medium (observe-mode claim) resolved: the body's quote `severity=None if enforce else "warning"` is verbatim at six call sites (gpu_usage.py:141, cpu_truth.py:73, provider_side_load.py:523, rental_verification.py:381/582/599) whose templates (e.g. CPU_MISMATCH, LOAD_ABOVE_LIMIT) set no help_uri, so 'those verdicts carry the link too' and 'filled on error and warning verdicts (shadow warnings included)' are true of render_message at messages.py:44-47. · `neurons/validators/src/services/task/messages.py:15` Round-1 medium (merge order / closed companion) resolved: every lium-docs#176 mention now names lium-docs#217 as the folded companion, with the merge-order note that the link lands on the page top until #217 is live — consistent with the established facts (#176 closed, #217 open carrying `## 6. Validator reason codes`). · `neurons/validators/tests/test_messages_help_uri.py:19` Ran-it line matches the four tests: ORPHANED_CONTAINER → REASON_CODE_DOCS_URL (test 1, which also asserts INSUFFICIENT_PORTS/warning), SYSBOX_OK info → None (test 3), VerifyX template → VERIFYX_DEBUG_DOC_URL (test 2, which also asserts the call-site override), severity="info" override → None (test 4); nothing stated that the tests do not assert. · `neurons/validators/src/services/task/messages.py:1` 'about 70 error/warning codes' now matches the count (35 error + 36 warning templates, 70 without help_uri); 'six VerifyX templates' matches the six `_verify_failed(` uses; '39 passed' for the three files matches 29 functions + 10 parametrize expansions. · `neurons/validators/src/services/task/messages.py:1` Stale-sha low resolved: the fold's verification paragraph now says 'the earlier head'; the only sha cited there, `07ec64cd`, is on origin/main; the new Verified line is at 7ff6063 (the HEAD), whose 1952/2-failed run cannot be verified here and is not contradicted by anything in the repo. · `neurons/validators/src/services/task/messages.py:44` 'template links (VerifyX) and call-site overrides still win; info verdicts carry no link' — true of `help_uri or template.help_uri` followed by the `resolved_severity in {error, warning}` guard.

### Verified

Gate: PASS (7ff6063) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1287)

</details>
