### PR TITLE
DAH-2959 - [P1] validator re-measures a cold VerifyX sample once (flag, off)

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -25,6 +25,9 @@ REDIS_PASSWORD=
 COMPUTE_APP_URI=wss://lium.io/api
 
 HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
+# Cold-sample retry (DAH-2959): re-measure a never-validated node's cold VerifyX download sample once before failing it.
+# Gate, threshold and known-host EMA are unchanged. Off by default.
+VERIFYX_COLD_SAMPLE_RETRY_ENABLED=false
 
 # First-pass fast path (DAH-3011): a never-validated executor gets a right-sized matmul (min(card VRAM, this MB)) and a
 # smaller VerifyX write (GB of RAM / disk) on its first pass; scored verifications are unchanged. Off by default.

--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -26,6 +26,13 @@ COMPUTE_APP_URI=wss://lium.io/api
 
 HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
 
+# First-pass fast path (DAH-3011): a never-validated executor gets a right-sized matmul (min(card VRAM, this MB)) and a
+# smaller VerifyX write (GB of RAM / disk) on its first pass; scored verifications are unchanged. Off by default.
+FIRST_PASS_FAST_PATH_ENABLED=false
+FIRST_PASS_MATMUL_VRAM_MB=8192
+FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB=16
+FIRST_PASS_VERIFYX_STORAGE_TEST_GB=1
+
 #############################
 # Local Dev                 #
 #############################

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -196,6 +196,12 @@ class Settings(BaseSettings):
 
     ENABLE_NO_COLLATERAL: bool = True
     ENABLE_VERIFYX: bool = True
+    # DAH-2959: a never-measured executor whose first VerifyX download sample is below the 100 Mbps
+    # EMA gate gets one more sample inside the same task, and the better one seeds the EMA. 11 of
+    # 80 fresh nodes (2–5 Sep) lost 1–3 cycles to a cold first sample (32–88 Mbps on one
+    # single-stream CDN object) and passed the next cycle at 205–760 Mbps. The gate, the threshold
+    # and known hosts (any prior EMA) are unchanged.
+    VERIFYX_COLD_SAMPLE_RETRY_ENABLED: bool = Field(env="VERIFYX_COLD_SAMPLE_RETRY_ENABLED", default=False)
     ENABLE_INSPECTOR: bool = True
     # DAH-2794: feed the obfuscated scrape to the executor's own interpreter over stdin
     # instead of freezing it into a ~13 MB onefile and uploading that every cycle.

--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
 from core.config import settings
+from core.utils import _m, get_extra_info
 
 from ..messages import VerifyXMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 from .network_ema import compute_ema
+
+logger = logging.getLogger(__name__)
 
 MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS = 100.0
 
@@ -82,13 +86,48 @@ class VerifyXCheck:
             **sizing,
         )
 
-        # Extract errors with clear priority: data.errors > result.error
-        errors = self._extract_errors(result)
-
         prev_ema = (
             ctx.state.rented_data.network_ema.get(ctx.executor.uuid)
             if ctx.state.rented_data else None
         )
+
+        cold_sample_retry: dict[str, Any] | None = None
+        if _is_cold_sample_below_gate(ctx, result, prev_ema):
+            # DAH-2959: a node's first sample decides its first cycle on its own (the EMA bootstraps
+            # from it). 11 of 80 fresh nodes (2–5 Sep) measured 32–88 Mbps on that one sample — one
+            # single-stream 260–500 MB CDN object, cold (the scrape's own speedtest read 0.7–1.7 Gbps
+            # on two of the traced hosts, 104 Mbps on the third whose link the executor's on-boot
+            # template pre-pull was sharing) — and passed the next cycle at 205–760 Mbps. One more
+            # sample inside the same task costs at most one VerifyX run; the failure costs the
+            # provider a whole cycle. Known hosts (any prior EMA) are not retried, and the gate is
+            # unchanged: one of the two samples must clear it.
+            retry = await verifyx_service.validate_verifyx_and_process_job(
+                shell=ctx.services.shell,
+                executor_info=ctx.executor,
+                default_extra=ctx.default_extra,
+                machine_spec=specs,
+            )
+            first_speed = _download_speed(result)
+            retry_speed = _download_speed(retry)
+            use_retry = retry.data is not None and bool(retry.data.get("success")) and (
+                retry_speed or 0.0
+            ) > (first_speed or 0.0)
+            cold_sample_retry = {
+                "first_download_speed_mbps": first_speed,
+                "retry_download_speed_mbps": retry_speed,
+                "used": "retry" if use_retry else "first",
+            }
+            logger.info(
+                _m(
+                    "VerifyX cold first sample below the gate, re-measured once",
+                    extra=get_extra_info({**ctx.default_extra, **cold_sample_retry}),
+                )
+            )
+            if use_retry:
+                result = retry
+
+        # Extract errors with clear priority: data.errors > result.error
+        errors = self._extract_errors(result)
 
         if result.data and result.data.get("success"):
             base_specs = ctx.state.specs
@@ -146,6 +185,8 @@ class VerifyXCheck:
                 event.what_we_saw["errors"] = errors
             if sizing:
                 event.what_we_saw["first_pass_challenge_config"] = sizing["challenge_config_overrides"]
+            if cold_sample_retry:
+                event.what_we_saw["cold_sample_retry"] = cold_sample_retry
 
             updated_state = replace(ctx.state, specs=updated_specs)
 
@@ -179,6 +220,8 @@ class VerifyXCheck:
                         "min_download_speed_mbps": MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS,
                     },
                 )
+                if cold_sample_retry:
+                    slow_event.what_we_saw["cold_sample_retry"] = cold_sample_retry
                 return CheckResult(passed=False, event=slow_event, updates={"state": updated_state})
 
             return CheckResult(
@@ -221,6 +264,29 @@ def _first_pass_challenge_config() -> dict[str, int]:
         "memory_max_test_gb": settings.FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB,
         "storage_throughput_test_gb": settings.FIRST_PASS_VERIFYX_STORAGE_TEST_GB,
     }
+def _download_speed(result) -> float | None:
+    if not result.data:
+        return None
+    return (result.data.get("network") or {}).get("download_speed")
+
+
+def _is_cold_sample_below_gate(ctx: Context, result, prev_ema) -> bool:
+    """The one case DAH-2959 re-measures: a never-measured executor whose probe otherwise passed
+    but whose single download sample would fail the EMA gate on its own.
+
+    `rented_data` present is required — without the backend's answer every executor looks
+    never-measured, and a backend blip must not double VerifyX for the whole fleet.
+    """
+    if not settings.VERIFYX_COLD_SAMPLE_RETRY_ENABLED:
+        return False
+    if ctx.state.rented_data is None:
+        return False
+    if prev_ema is not None and prev_ema.ema_verifyx_download_speed is not None:
+        return False
+    if not result.data or not result.data.get("success"):
+        return False
+    speed = _download_speed(result)
+    return speed is None or speed < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS
 
 
 def _get_filler_only_container(ctx: Context) -> str | None:

--- a/neurons/validators/tests/test_verifyx_cold_sample_retry.py
+++ b/neurons/validators/tests/test_verifyx_cold_sample_retry.py
@@ -1,0 +1,190 @@
+"""DAH-2959: a never-measured executor's first VerifyX download sample decides its first cycle alone
+(the EMA bootstraps from it). With VERIFYX_COLD_SAMPLE_RETRY_ENABLED the check takes one more sample
+inside the same task and gates on the better one; flag off is today's single sample."""
+
+import pytest
+
+from core.config import settings
+from neurons.validators.src.services.task.checks.verifyx import VerifyXCheck
+from neurons.validators.src.services.task.messages import VerifyXMessages as Msg
+from protocol.vc_protocol.compute_requests import NetworkEMA, RentedExecutorsResponse
+
+from tests.helpers import build_context_config, build_services, build_state
+from tests.test_verifyx_check import MockVerifyXResponse
+
+EXECUTOR = "executor-123"  # tests.helpers.default_executor().uuid
+
+
+def _probe(download: float | None, *, success: bool = True, upload: float | None = 40.0) -> MockVerifyXResponse:
+    network = {} if download is None else {"download_speed": download, "upload_speed": upload}
+    return MockVerifyXResponse(
+        data={"success": success, "ram": {"total": 64}, "hard_disk": {"total": 1000}, "network": network}
+    )
+
+
+class _ProbeSequence:
+    """Returns the queued responses in order and counts the calls."""
+
+    def __init__(self, *responses: MockVerifyXResponse):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def validate_verifyx_and_process_job(self, *, shell, executor_info, default_extra, machine_spec):
+        self.calls += 1
+        return self._responses.pop(0)
+
+
+def _never_measured() -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(executors={}, banned_guids=[], network_ema={})
+
+
+def _known(download: float) -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(
+        executors={},
+        banned_guids=[],
+        network_ema={EXECUTOR: NetworkEMA(ema_verifyx_download_speed=download, ema_verifyx_upload_speed=50.0)},
+    )
+
+
+def _ctx(context_factory, service, rented_data):
+    return context_factory(
+        services=build_services(verifyx=service),
+        config=build_context_config(verifyx_enabled=True),
+        state=build_state(specs={"gpu": {"count": 1}}, rented_data=rented_data),
+    )
+
+
+@pytest.fixture
+def retry_on(monkeypatch):
+    monkeypatch.setattr(settings, "VERIFYX_COLD_SAMPLE_RETRY_ENABLED", True)
+
+
+@pytest.mark.asyncio
+async def test_flag_off_is_todays_single_cold_sample(monkeypatch, context_factory):
+    monkeypatch.setattr(settings, "VERIFYX_COLD_SAMPLE_RETRY_ENABLED", False)
+    service = _ProbeSequence(_probe(59.9), _probe(760.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 1
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(59.9)
+    assert "cold_sample_retry" not in result.event.what_we_saw
+
+
+@pytest.mark.asyncio
+async def test_cold_first_sample_is_re_measured_and_the_better_one_seeds_the_ema(retry_on, context_factory):
+    # b3e4ca69, 4 Sep: 59.9 Mbps on the first sample, ~760 Mbps once the link was free.
+    service = _ProbeSequence(_probe(59.9, upload=20.0), _probe(760.0, upload=110.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is True
+    assert result.event.reason_code == Msg.VERIFY_SUCCESS.reason
+    network = result.updates["state"].specs["network"]
+    assert network["verifyx_download_speed"] == pytest.approx(760.0)
+    assert network["ema_verifyx_download_speed"] == pytest.approx(760.0)
+    assert network["verifyx_upload_speed"] == pytest.approx(110.0)
+    assert result.event.what_we_saw["cold_sample_retry"] == {
+        "first_download_speed_mbps": 59.9,
+        "retry_download_speed_mbps": 760.0,
+        "used": "retry",
+    }
+
+
+@pytest.mark.asyncio
+async def test_two_slow_samples_still_fail_the_unchanged_gate(retry_on, context_factory):
+    service = _ProbeSequence(_probe(40.0), _probe(88.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+    # The better of the two is what the node is judged on and what seeds the EMA.
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(88.0)
+    assert result.event.what_we_saw["cold_sample_retry"]["used"] == "retry"
+
+
+@pytest.mark.asyncio
+async def test_failed_network_probe_on_first_sample_is_retried(retry_on, context_factory):
+    # download_speed None (probe timed out) would bootstrap the EMA to 0.0.
+    service = _ProbeSequence(_probe(None), _probe(300.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is True
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(300.0)
+    assert result.event.what_we_saw["cold_sample_retry"]["first_download_speed_mbps"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_worse_retry_keeps_the_first_sample(retry_on, context_factory):
+    service = _ProbeSequence(_probe(70.0), _probe(30.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is False
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(70.0)
+    assert result.event.what_we_saw["cold_sample_retry"]["used"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_a_retry_whose_probe_failed_outright_is_not_used(retry_on, context_factory):
+    service = _ProbeSequence(_probe(70.0), _probe(900.0, success=False))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is False
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(70.0)
+
+
+@pytest.mark.asyncio
+async def test_known_host_below_the_gate_is_not_retried(retry_on, context_factory):
+    # prev EMA 110 + sample 20 -> EMA 65: a real slow host, judged as today.
+    service = _ProbeSequence(_probe(20.0), _probe(900.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _known(110.0)))
+
+    assert service.calls == 1
+    assert result.passed is False
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(65.0)
+
+
+@pytest.mark.asyncio
+async def test_fast_first_sample_is_not_retried(retry_on, context_factory):
+    service = _ProbeSequence(_probe(500.0), _probe(1.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 1
+    assert result.passed is True
+    assert "cold_sample_retry" not in result.event.what_we_saw
+
+
+@pytest.mark.asyncio
+async def test_without_backend_data_nobody_looks_new_and_nothing_is_retried(retry_on, context_factory):
+    # rented_data None: every executor would look never-measured; a backend blip must not double VerifyX fleet-wide.
+    service = _ProbeSequence(_probe(59.9), _probe(760.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, None))
+
+    assert service.calls == 1
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_ram_or_disk_failure_on_the_first_sample_is_not_retried(retry_on, context_factory):
+    # The retry is for the network sample only; a probe that failed on RAM/disk is judged as today.
+    service = _ProbeSequence(_probe(59.9, success=False), _probe(760.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 1
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_FAILED.reason


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-2959](https://app.notion.com/p/First-VerifyX-sample-of-a-new-node-fails-the-100-Mbps-EMA-gate-on-a-cold-measurement-11-of-80-fres-3d3b8bfdbde9819e8732d6dc2620c3e7) · stacked on #1291 · reviewer: @jam6099 @pixel29913

**TL;DR** — A new node's first VerifyX network sample is often below the 100 Mbps EMA gate (`services/task/checks/verifyx.py`, `MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS`) and the node fails its first cycle. `VERIFYX_COLD_SAMPLE_RETRY_ENABLED` (default False — flag off is byte-for-byte today's single sample). Touches validator/executor (`neurons/validators/.env.template`) — read that file first.

**What changed**
- With the flag on, `VerifyXCheck` takes one more VerifyX sample inside the same task when, and only when, all of.
- the backend answered this cycle (`rented_data` present) and it has no EMA for this executor (never measured).
- the first probe otherwise passed (RAM + disk fine — a RAM/disk failure is judged as today).
- its download sample is below the gate (or the network probe failed, which would bootstrap the EMA to 0).
- The better of the two samples (by download speed.

**How to verify**
- `cd neurons/validators && pdm run pytest -q tests/test_verifyx_cold_sample_retry.py tests/test_verifyx_check.py` → green

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1977 passed · miners 27 passed · Result: PASS 60e2fd0d · Gate: not run

**Docs:** neurons/validators/.env.template (VERIFYX_COLD_SAMPLE_RETRY_ENABLED) (this PR) · public: none changed in this PR — validator flag off by default; gate, threshold and reason codes unchanged

<details><summary>Details</summary>

Merge after #1291 — this branch is stacked on it; GitHub retargets this PR to main when #1291 merges. Review/merge order per repo: https://github.com/Datura-ai/lium-loop/blob/main/improvements/CHANGES_FOR_REVIEW.md

[DAH-2959](https://app.notion.com/p/First-VerifyX-sample-of-a-new-node-fails-the-100-Mbps-EMA-gate-on-a-cold-measurement-11-of-80-fres-3d3b8bfdbde9819e8732d6dc2620c3e7). Origin: prod Loki, 2–5 Sep — 11 of 80 fresh nodes failed their first cycle on the VerifyX 100 Mbps EMA gate with a cold first sample and passed the next cycle (`RECOVERY/reports/provider_time_to_ready.md` §3.3; three nodes traced end to end below).

## Problem
A new node's first VerifyX network sample is often below the 100 Mbps EMA gate (`services/task/checks/verifyx.py`, `MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS`) and the node fails its first cycle. The EMA bootstraps from the first sample (`checks/network_ema.py`: `prev is None → EMA = current`), so one cold measurement decides the cycle, and the next cycle then needs ≥ 100 + (100 − first) Mbps to recover. Each failure is +15 min for the provider (one cycle), sometimes +30–45 min.

Prod Loki, 2–5 Sep (`VerifyX validation failed (network speed too slow)`): **11 of 80 fresh central-mode nodes (14 %)** failed ≥ 1 cycle on this gate before their first AVAILABLE, 3 of them 2–3 cycles; first-sample EMAs 32.2–88.4 Mbps; all passed the following cycle. Three traced end to end:

| node | first cycle | next cycle | what the same task's scrape speedtest read |
|---|---|---|---|
| `b3e4ca69` | VerifyX 59.9 Mbps, 164 s, fail (15:55) | ≈ 760 Mbps sample (EMA 59.9 → 410), pass (16:09) | 104 Mbps, then 368 Mbps — the link was busy; the recommended template image is present by 16:09 (executor on-boot pre-pull, `neurons/executor/src/services/cache_template_service.py`) |
| `aeb904f6` | 32.2 Mbps, 158 s, fail (18:55) | 205 Mbps, 87 s, pass (19:09) | 1708 Mbps both times — the link was free; the one 260–500 MB single-stream CDN object (`verifyx/src/challenge/network.rs`: `seed % 134` of `pkg_verify/verified_pkg_list.json`, huggingface.co / files.pythonhosted.org) came in cold |
| `0187e017` | 48.9 Mbps, 164 s, fail (23:56) | 501 Mbps, 105 s, pass (00:10) | 739 / 476 Mbps — same shape as `aeb904f6` |

So the cold sample is one slow single-connection object fetch (a CDN edge miss or a link shared with the node's own first image pull), not the host's bandwidth; a second sample in the same task (a different object — the seed is per challenge) reads the real link. Fleet-wide the same message fired 338× / 64 executors in 4 days, 179 of them on two hosts: those are real slow hosts, and this change does not touch them (they have an EMA).

## Change
`VERIFYX_COLD_SAMPLE_RETRY_ENABLED` (default **False** — flag off is byte-for-byte today's single sample).

With the flag on, `VerifyXCheck` takes one more VerifyX sample inside the same task when, and only when, all of:
- the backend answered this cycle (`rented_data` present) and it has **no EMA** for this executor (never measured) — without the backend's answer every executor looks new, and a backend blip must not double VerifyX fleet-wide;
- the first probe otherwise **passed** (RAM + disk fine — a RAM/disk failure is judged as today);
- its download sample is below the gate (or the network probe failed, which would bootstrap the EMA to 0).

The better of the two samples (by download speed; the retry only when its probe succeeded) is the one the existing code then processes — same EMA bootstrap, same `MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS` gate, same specs. The event's `what_we_saw.cold_sample_retry` records `{first_download_speed_mbps, retry_download_speed_mbps, used}`, and one INFO line `VerifyX cold first sample below the gate, re-measured once` carries the same fields for Loki. Nothing changes for an executor with any prior EMA, so no known host is measured twice and the gate's purpose (real slow hosts) is intact.

Cost: at most one extra VerifyX run (p50 78 s, p90 120 s measured) for the ~14 % of fresh nodes whose first sample is cold, once in their life; today that node loses 15–45 min. With the express lane (lium-io#1282) the retry runs inside the express verification, so the node is still published ≈ 4–5 min after `node add` instead of failing and waiting for the next cycle.

## How to test
```
cd neurons/validators && pdm run pytest -q tests/test_verifyx_cold_sample_retry.py tests/test_verifyx_check.py
```
10 new tests: flag off → one sample, fails as today, no `cold_sample_retry` key; cold first sample then a good one (the `b3e4ca69` numbers) → two calls, pass, EMA and raw speeds seeded from the retry, `used: retry`; two slow samples → still fail the unchanged gate, EMA seeded from the better; a failed network probe (None) on the first sample is retried; a worse retry keeps the first sample; a retry whose probe failed outright is not used; a known host below the gate → one call, fails as today (EMA decay unchanged); a fast first sample → one call; `rented_data` None → one call; RAM/disk failure on the first sample → one call, `VERIFYX_FAILED`. The 22 existing VerifyX check tests are unchanged and pass.

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `60e2fd0d` merged onto `main` `07ec64cd` (clean merge), then: pytest: validators, miners (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1977 passed, 15 skipped, 158 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); Miners 27 passed, 21 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers
- This is the ticket's option A (re-measure inside the task). Option B (provisional first sample) was not taken here because it would pass a scored cycle on an unproven link; it is the right shape for the unscored express-lane first pass and is proposed there separately (DAH-3011, `first_pass`).
- Root-cause follow-ups outside this PR, both for validator owners: (1) the VerifyX object is 263–501 MB on one connection (`verifyx/src/challenge/network.rs`), so at the 100 Mbps gate the download alone is ≥ 30 s and its cold-start penalty is large — a 100 MB object with a minimum-duration floor would measure the same thing in a quarter of the time (that is the VerifyX step's p50 78 s / p90 120 s); (2) the executor's on-boot template pre-pull runs during the node's first validation on the same link — `lium mine` could pre-pull before `node add`, or the executor could wait for its first verification. DAH-1571 (team, Dec 2025: "fix bandwidth check once and for all … run the test every 12 hours and keep the number") is the same complaint from the other side.
- Composes with lium-io#1282: the express lane runs this same check with the same inputs; no code dependency between the two PRs.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-2959.

Docs: neurons/validators/.env.template (VERIFYX_COLD_SAMPLE_RETRY_ENABLED) (this PR) · public: none changed in this PR — validator flag off by default; gate, threshold and reason codes unchanged

</details>
