### PR TITLE
[P1] feat: run the miners tests and ruff format on every PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# neurons/executor/dstacktee/key-provider carries a Cargo.lock with no Cargo.toml: the
+# manifest lives in the upstream repository the Dockerfile clones, the lock only pins its
+# dependencies. The dependency graph still indexes the lock, so every Dependabot security
+# job for it fails with "Cargo.toml not found" (4 of 4 runs). Skip that path; there is no
+# other Cargo project, so version updates stay off.
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 0
+    exclude-paths:
+      - neurons/executor/dstacktee/key-provider/**

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,22 +1,21 @@
 name: Tests
 
 on:
+  # no `paths:` filter any more: a required status check that never reports blocks the
+  # merge button, and the miners tree was outside the old filter (lium-io#1280 ran no test
+  # job at all). 4.7 min on a docs-only PR is cheaper than a required check that never comes.
   pull_request:
     branches: [main, dev]
-    paths:
-      - 'neurons/validators/**'
-      - 'neurons/executor/**'
-      - 'datura/**'
-      - '.github/workflows/test.yml'
   push:
     branches: [main]
-    paths:
-      - 'neurons/validators/**'
-      - 'neurons/executor/**'
-      - 'datura/**'
 
 permissions:
   contents: read
+
+# a second push to the same PR cancels the first run
+concurrency:
+  group: tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validators:
@@ -85,3 +84,64 @@ jobs:
 
       - name: Run tests
         run: mkdir -p tmp && pdm run pytest tests/ -v --tb=short
+
+  miners:
+    # neurons/miners/tests never ran in CI; the miner talks to the portal API and the
+    # validators, so a broken client ships to every provider on the next tag
+    name: Miners Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    defaults:
+      run:
+        working-directory: neurons/miners
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install pdm
+        uses: pdm-project/setup-pdm@v4
+        with:
+          cache: true
+          cache-dependency-path: neurons/miners/pdm.lock
+
+      - name: Install dependencies
+        run: pdm install
+
+      - name: Run tests
+        run: pdm run pytest tests/ -v --tb=short
+
+  lint:
+    # ruff format is the repo's pre-commit hook (.pre-commit-config.yaml, same version pin)
+    # and CI never ran it. `format --check` only, like lium-platform: `ruff check` has open
+    # findings and is the team's call to gate on.
+    name: ruff format (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [validators, executor, miners]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          version: "0.5.1"
+          args: format --check
+          src: neurons/${{ matrix.package }}
+
+  tests-ok:
+    # the one context to require in the ruleset; lium-io requires no status check today
+    name: tests-ok
+    needs: [validators, executor, miners, lint]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,11 +119,14 @@ jobs:
 
   lint:
     # ruff format is the repo's pre-commit hook (.pre-commit-config.yaml, same version pin)
-    # and CI never ran it. `format --check` only, like lium-platform: `ruff check` has open
-    # findings and is the team's call to gate on.
+    # and CI never ran it. REPORT-ONLY: on 6 Sep 2026 main had 207/301 validators, 30/51
+    # executor and 20/43 miners files unformatted, so gating would block every PR until one
+    # `ruff format` commit per package lands; drop continue-on-error and add `lint` to
+    # tests-ok after that. `ruff check` is left out: it has open findings too.
     name: ruff format (${{ matrix.package }})
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -137,9 +140,10 @@ jobs:
           src: neurons/${{ matrix.package }}
 
   tests-ok:
-    # the one context to require in the ruleset; lium-io requires no status check today
+    # the one context to require in the ruleset; lium-io requires no status check today.
+    # `lint` joins once the packages are formatted (see above).
     name: tests-ok
-    needs: [validators, executor, miners, lint]
+    needs: [validators, executor, miners]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,7 +126,6 @@ jobs:
     name: ruff format (${{ matrix.package }})
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -134,6 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/ruff-action@v3
+        continue-on-error: true
         with:
           version: "0.5.1"
           args: format --check


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3001](https://app.notion.com/p/CI-run-the-miners-tests-and-ruff-format-on-every-lium-io-PR-drop-the-path-filter-so-a-status-check-3d3b8bfdbde981408568d94f6fdfe26e) · reviewer: @jam6099 @pixel29913

**TL;DR** — CI audit of the Lium repos (6 Sep 2026, 300 `Tests` runs since 11 Aug). `.github/workflows/test.yml`: - `Miners Tests` job, same shape as the executor job (pdm, Python 3.11, `pytest tests/`), working directory `neurons/miners`. Touches CI/containers (`.github/workflows/test.yml`) — read that file first.

**What changed**
- `.github/workflows/test.yml`.
- **`Miners Tests`**: job, same shape as the executor job (pdm, Python 3.11, `pytest tests/`), working directory `neurons/miners`.
- **`ruff format (validators|executor|miners)`**: `ruff format --check` at the pre-commit pin `0.5.1`, report-only (`continue-on-error` on the step.
- `paths:` filters removed from `pull_request` and `push` so every PR reports.
- `concurrency` group per PR, `cancel-in-progress`.
- **`tests-ok`**: aggregate over the three test jobs.

**How to verify**
- `gh pr checks 1289 -R Datura-ai/lium-io` → all green
- re-run the loop's suites (Details → Verification) → validators 1939 passed, executor 128 passed, miners 26 passed

**Verified by the loop:** 7 Sep 2026 · Linux pod (py3.11) · validators 1939 passed · executor 128 passed · miners 26 passed · Result: PASS · Gate: not run

**Docs:** none changed in this PR — CI plumbing; contributors see no new check, label or step.

<details><summary>Details</summary>

[DAH-3001](https://app.notion.com/p/CI-run-the-miners-tests-and-ruff-format-on-every-lium-io-PR-drop-the-path-filter-so-a-status-check-3d3b8bfdbde981408568d94f6fdfe26e).

## Origin

CI audit of the Lium repos (6 Sep 2026, 300 `Tests` runs since 11 Aug). `test.yml` triggers only on `neurons/validators/**`, `neurons/executor/**`, `datura/**` and has no miners job: `neurons/miners/tests/` has never run in CI, and a PR under `neurons/miners` reports no test check at all (#1280 — `miner_portal_api.py` plus its test — shows only CodeQL). The path filter also makes a required status check impossible: a check that never reports blocks the merge button, which is why lium-io requires none today and a red `Tests` does not stop a merge. `ruff` (lint + format) is the repo's pre-commit hook (`.pre-commit-config.yaml`, v0.5.1) and CI never runs it. Two hygiene items from the same audit: the `Dependabot Updates` workflow fails 4 of 4 runs on `neurons/executor/dstacktee/key-provider/Cargo.lock` (a lock with no `Cargo.toml` — the manifest is in the upstream repo the Dockerfile clones), and two runs sat `queued` for 31 and 59 days (cancelled by hand, no code).

## Change

`.github/workflows/test.yml`:
- **`Miners Tests`** job, same shape as the executor job (pdm, Python 3.11, `pytest tests/`), working directory `neurons/miners`.
- **`ruff format (validators|executor|miners)`**: `ruff format --check` at the pre-commit pin `0.5.1`, **report-only** (`continue-on-error` on the step, not part of `tests-ok`): on `main` today it would reformat 207 of 301 validators files, 30 of 51 executor, 20 of 43 miners, so gating would block every PR until one `ruff format` commit per package lands. `ruff check` is left out for the same reason.
- `paths:` filters removed from `pull_request` and `push` so every PR reports; a docs-only PR now costs ≈ 4.7 GitHub-hosted minutes (≈ $0.04) instead of an unenforceable gate.
- `concurrency` group per PR, `cancel-in-progress`.
- **`tests-ok`** aggregate over the three test jobs — the one context to require in the ruleset (`lint` joins once the packages are formatted).

`.github/dependabot.yml` (new): a `cargo` block with version updates off (`open-pull-requests-limit: 0`) and `exclude-paths: neurons/executor/dstacktee/key-provider/**`, so Dependabot stops opening security jobs against a lock it cannot update (there is no other Cargo project in the repo).

Cost: ≈ +2 min per PR (≈ $0.015), about $4–5/month at the current volume.

## Verification

This PR's own run ([34064302160](https://github.com/Datura-ai/lium-io/actions/runs/34064302160)): `Miners Tests` ✓ 59s — **the miners suite passes on current `main`** · `Validators Tests` ✓ 3m12s · `Executor Tests` ✓ 1m33s · `ruff format (…)` ✓ with the reformat counts above as annotations · `tests-ok` ✓. Not staged: CI configuration only, no runtime behaviour.

**Verified by the loop on 7 Sep 2026:** PR head merged onto `main` (55be0e9e) on a Linux pod, the three CI suites (Python 3.11.11, pdm, sqlite, CI env vars): Validators 1939 passed, 15 skipped, 2 env artefacts, Executor 128 passed, Miners 26 passed. The only validator failures are two root-on-a-pod artefacts `main` has too (`test_scrape_infiniband::…unreadable_sysfs…` — chmod 000 does not stop root; `test_sshd_bootstrap_script::…adopt_path…` — the pod runs a live sshd), both pass as a non-root user / in CI. The new Miners job is real: `neurons/miners` `pdm install` + `pytest tests/` → 26 passed here and on this PR's own CI (tests-ok ✓).

## Notes for reviewers

- After merge, the ruleset for `main` should require the `tests-ok` context.
- If Dependabot still schedules a security job for the key-provider lock after this merges, the remaining option is to rename the file (`Cargo.lock.pinned`, `COPY Cargo.lock.pinned Cargo.lock` in `Dockerfile.key-provider`) so the dependency graph stops indexing it; not done here because it touches the executor build.

Docs: none changed in this PR — CI plumbing; contributors see no new check, label or step.

</details>
