### PR TITLE
DAH-3012 - [P2] validator's final event carries per-step results and durations

### DIFF
--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -198,6 +198,32 @@ class LoggerSink:
         getattr(self.logger, level)(_m(event.event, extra=event.model_dump(mode="json")))
 
 
+# DAH-3012: steps shorter than this are left out of the final event's summary — they are the
+# ~25 sub-second bookkeeping checks; the 6–8 that carry the run's time are what a provider (and a
+# Loki query) needs to see, in ~300 bytes.
+STEP_SUMMARY_MIN_MS = 1000
+
+
+def summarize_steps(
+    steps: list[tuple[str, int]], elapsed_time_ms: int, failed_check_id: str | None = None
+) -> dict[str, Any]:
+    """What the run spent its time on, for the last event's `what_we_saw` (DAH-3012).
+
+    The last event is the one the backend stores as the executor's `log_text` and the portal shows
+    as `last_validation`, so this is how per-step durations reach the provider without a new
+    field anywhere downstream.
+    """
+    summary: dict[str, Any] = {
+        "steps": {
+            check_id: round(ms / 1000, 1) for check_id, ms in steps if ms >= STEP_SUMMARY_MIN_MS
+        },
+        "steps_total_s": round(elapsed_time_ms / 1000, 1),
+    }
+    if failed_check_id:
+        summary["steps_failed"] = failed_check_id
+    return summary
+
+
 class Pipeline:
     def __init__(self, checks: List[Check], sink: EventSink):
         self.checks = checks
@@ -207,8 +233,10 @@ class Pipeline:
         events: list[ValidationEvent] = []
         current_ctx = ctx
         pipeline_start_time = time.perf_counter()
+        steps: list[tuple[str, int]] = []
+        last_index = len(self.checks) - 1
 
-        for chk in self.checks:
+        for index, chk in enumerate(self.checks):
             check_start_time = time.perf_counter()
             res = await chk.run(current_ctx)
             check_end_time = time.perf_counter()
@@ -218,6 +246,15 @@ class Pipeline:
 
             res.event.context["execution_time_ms"] = execution_time_ms
             res.event.context["elapsed_time_ms"] = elapsed_time_ms
+            steps.append((chk.check_id, execution_time_ms))
+
+            failed = not res.passed and getattr(chk, "fatal", False)
+            if failed or res.halt or index == last_index:
+                res.event.what_we_saw.update(
+                    summarize_steps(
+                        steps, elapsed_time_ms, failed_check_id=chk.check_id if failed else None
+                    )
+                )
 
             await self.sink.emit(res.event)
             events.append(res.event)
@@ -225,7 +262,7 @@ class Pipeline:
             if res.updates:
                 current_ctx = current_ctx.model_copy(update=res.updates)
 
-            if not res.passed and getattr(chk, "fatal", False):
+            if failed:
                 return False, events, current_ctx
 
             if res.halt:

--- a/neurons/validators/tests/test_pipeline_steps_summary.py
+++ b/neurons/validators/tests/test_pipeline_steps_summary.py
@@ -1,0 +1,161 @@
+"""DAH-3012: the last pipeline event carries a per-step duration summary, so the provider-facing
+`last_validation` (backend `log_text` -> portal `what_we_saw`) and one Loki line show what a run
+spent its time on and where it stopped."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from neurons.validators.src.services.task import pipeline as pipeline_module
+from neurons.validators.src.services.task.models import ValidationEvent
+from neurons.validators.src.services.task.pipeline import (
+    STEP_SUMMARY_MIN_MS,
+    CheckResult,
+    Pipeline,
+    summarize_steps,
+)
+
+
+class _Clock:
+    """Replaces time.perf_counter so a check can take exactly the seconds it declares."""
+
+    def __init__(self):
+        self.now = 1000.0
+
+    def perf_counter(self) -> float:
+        return self.now
+
+
+class _TimedCheck:
+    def __init__(self, check_id: str, seconds: float, clock: _Clock, *, passed=True, fatal=True, halt=False):
+        self.check_id = check_id
+        self.fatal = fatal
+        self._seconds = seconds
+        self._clock = clock
+        self._passed = passed
+        self._halt = halt
+
+    async def run(self, ctx) -> CheckResult:
+        self._clock.now += self._seconds
+        event = ValidationEvent(
+            event=f"{self.check_id} ran",
+            reason_code="TEST",
+            severity="info" if self._passed else "error",
+            impact="",
+            check_id=self.check_id,
+            when=datetime.now(UTC),
+        )
+        return CheckResult(passed=self._passed, event=event, halt=self._halt)
+
+
+class _Sink:
+    def __init__(self):
+        self.emitted: list[ValidationEvent] = []
+
+    async def emit(self, event: ValidationEvent) -> None:
+        self.emitted.append(event)
+
+
+@pytest.fixture
+def clock(monkeypatch) -> _Clock:
+    clock = _Clock()
+    monkeypatch.setattr(pipeline_module.time, "perf_counter", clock.perf_counter)
+    return clock
+
+
+@pytest.mark.asyncio
+async def test_passing_run_lists_the_slow_steps_and_the_total_on_the_last_event(clock, context_factory):
+    checks = [
+        _TimedCheck("prep.start_gpu_monitor", 0.2, clock),
+        _TimedCheck("gpu.scrape.machine_spec", 21.04, clock),
+        _TimedCheck("gpu.validate.count", 0.0, clock),
+        _TimedCheck("gpu.validate.verifyx", 78.5, clock),
+        _TimedCheck("gpu.validate.capability", 26.2, clock),
+        _TimedCheck("pipeline.finalize", 0.0, clock),
+    ]
+    sink = _Sink()
+
+    ok, events, _ = await Pipeline(checks, sink).run(context_factory())
+
+    assert ok is True
+    last = events[-1].what_we_saw
+    assert last["steps"] == {
+        "gpu.scrape.machine_spec": 21.0,
+        "gpu.validate.verifyx": 78.5,
+        "gpu.validate.capability": 26.2,
+    }
+    assert last["steps_total_s"] == pytest.approx(125.9, abs=0.11)
+    assert "steps_failed" not in last
+    # Only the last event carries the summary; the others are as before.
+    assert all("steps" not in event.what_we_saw for event in events[:-1])
+    # The summary is on the event the sink saw, i.e. the Loki line, not added afterwards.
+    assert sink.emitted[-1] is events[-1]
+    assert "steps" in sink.emitted[-1].what_we_saw
+    # Per-event timing fields are unchanged.
+    assert events[3].context["execution_time_ms"] == 78500
+    assert events[3].context["elapsed_time_ms"] == pytest.approx(99740, abs=10)
+
+
+@pytest.mark.asyncio
+async def test_fatal_stop_names_the_failed_step_on_the_event_the_provider_sees(clock, context_factory):
+    checks = [
+        _TimedCheck("gpu.scrape.machine_spec", 8.0, clock),
+        _TimedCheck("executor.validate.duplicate", 31.0, clock),
+        _TimedCheck("gpu.validate.verifyx", 164.6, clock, passed=False),
+        _TimedCheck("gpu.validate.capability", 26.0, clock),  # never runs
+    ]
+
+    ok, events, _ = await Pipeline(checks, _Sink()).run(context_factory())
+
+    assert ok is False
+    assert len(events) == 3
+    last = events[-1].what_we_saw
+    assert last["steps_failed"] == "gpu.validate.verifyx"
+    assert last["steps"] == {
+        "gpu.scrape.machine_spec": 8.0,
+        "executor.validate.duplicate": 31.0,
+        "gpu.validate.verifyx": 164.6,
+    }
+    assert last["steps_total_s"] == pytest.approx(203.6, abs=0.11)
+
+
+@pytest.mark.asyncio
+async def test_non_fatal_failure_does_not_stop_and_is_not_named(clock, context_factory):
+    checks = [
+        _TimedCheck("host.validate.cpu_truth", 1.5, clock, passed=False, fatal=False),
+        _TimedCheck("pipeline.finalize", 0.0, clock),
+    ]
+
+    ok, events, _ = await Pipeline(checks, _Sink()).run(context_factory())
+
+    assert ok is True
+    assert "steps_failed" not in events[-1].what_we_saw
+    assert events[-1].what_we_saw["steps"] == {"host.validate.cpu_truth": 1.5}
+
+
+@pytest.mark.asyncio
+async def test_halt_is_a_final_event_too(clock, context_factory):
+    checks = [
+        _TimedCheck("gpu.scrape.machine_spec", 12.0, clock),
+        _TimedCheck("executor.validate.rented_state", 2.0, clock, halt=True),
+        _TimedCheck("gpu.validate.verifyx", 80.0, clock),  # never runs on a rented box
+    ]
+
+    ok, events, _ = await Pipeline(checks, _Sink()).run(context_factory())
+
+    assert ok is True
+    assert len(events) == 2
+    assert events[-1].what_we_saw["steps"] == {
+        "gpu.scrape.machine_spec": 12.0,
+        "executor.validate.rented_state": 2.0,
+    }
+    assert "steps_failed" not in events[-1].what_we_saw
+
+
+def test_summary_omits_sub_second_steps_and_rounds_to_a_tenth():
+    steps = [("a", STEP_SUMMARY_MIN_MS - 1), ("b", STEP_SUMMARY_MIN_MS), ("c", 73_090)]
+
+    summary = summarize_steps(steps, elapsed_time_ms=152_345)
+
+    assert summary == {"steps": {"b": 1.0, "c": 73.1}, "steps_total_s": 152.3}
+    assert summarize_steps(steps, 1, failed_check_id="c")["steps_failed"] == "c"


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3012](https://app.notion.com/p/Per-step-verification-results-and-durations-in-the-validator-s-final-event-what_we_saw-steps-so-li-3d3b8bfdbde98170b6c7d581bc27ceea) · reviewer: @jam6099 (approved by @jam6099)

**TL;DR** — The portal and `lium provider node status` read only the validator's last pipeline event, so a provider never sees which steps ran or where a 4-minute verification went. `Pipeline.run` now attaches a per-step summary (check id and seconds, the total, the fatal check it stopped on) to that final event's `what_we_saw`; rendering it has its own ticket. Not proven on a real chain.

**What changed**
- `Pipeline.run` collects `(check_id, execution_time_ms)` per step; the final event's `what_we_saw` gets `steps`, `steps_total_s` and, on a fatal stop, `steps_failed`
- `tests/test_pipeline_steps_summary.py`: slow steps and total, the fatal stop named, a non-fatal failure not named, halt, the ≥ 1 s filter
- Not in this PR: CLI and portal rendering as `bandwidth 42 s ✓ · GPU benchmark 26 s ✓ · rental check ✗`

**How to verify**
- `cd neurons/validators && pdm run pytest -q tests/test_pipeline_steps_summary.py tests/test_pipeline_default_scenarios.py` → green
- lium-platform's `_parse_log_text` passes `what_we_saw` through as a dict; no consumer asserts a fixed key set

**Verified by the loop:** validators suite at the earlier head (same patch, rebased to `cfd66f1`) on sandbox EC2: 1944 passed, 15 skipped, 2 root-only box failures also on `main`; e2e cycle/protocol/rental passed; CI green at `cfd66f1`

**Ran it:** `cd neurons/validators && pdm run pytest -q tests/test_pipeline_steps_summary.py` → green, and the #1312 subnet-loop e2e stack (full validator cycle) · sandbox EC2 (Linux), earlier head; not run on macOS — validators run on Linux hosts only

**Self-review:** clean at cfd66f1 (15 checks, 1 low)

**Parts:** backend n/a — reads `what_we_saw` as a dict already · migration n/a — no schema · frontend n/a — rendering has its own ticket · CLI/SDK n/a — same · docs n/a — see Docs · tests ✓ `test_pipeline_steps_summary.py` · dashboards n/a — no new metric

**Docs:** none needed because no docs page describes the `what_we_saw` JSON the portal shows under Technical Details, where the new `steps` keys appear as raw JSON; the rendered per-step view has its own ticket

<details><summary>Details</summary>

[DAH-3012](https://app.notion.com/p/Per-step-verification-results-and-durations-in-the-validator-s-final-event-what_we_saw-steps-so-li-3d3b8bfdbde98170b6c7d581bc27ceea). Origin: provider-dogfood finding #6 ("validator preflight runs 127 s with no progress output — what is it doing now?", `provider-dogfood/REPORT.md`) and the owner's ask (6 Sep) to show per-step verification results to providers; the per-step measurement for `provider-dogfood/VERIFICATION_PIPELINE.md` needed 224 Loki metric queries because the numbers are spread over 32 lines per run.

## Problem
A provider sees one line about their node's verification: the portal's `last_validation` (lium-platform `apps/portal/backend/src/services/executor_validation_log_service.py::_parse_log_text`) parses the validator's `log_text`, which is the **last** pipeline event only (`services/task/service.py`: `events[-1]`). Nothing says which steps ran, how long each took, or where a 4-minute verification spent its time; `lium provider node status`/the portal cannot show "bandwidth 42 s ✓, GPU benchmark 26 s ✓, rental check failed". On the validator side each step is already timed (`Pipeline.run` stamps `execution_time_ms` on every event) but the per-step numbers are spread over ~32 Loki lines per run — measuring the pipeline for the time-to-ready work (`provider-dogfood/VERIFICATION_PIPELINE.md`) took 224 metric queries over 6-h windows.

## Change
`Pipeline.run` collects `(check_id, execution_time_ms)` per step and attaches a compact summary to the **final** event's `what_we_saw` — the durations, the total, and the fatal check the run stopped on (a non-fatal failure such as `CpuTruthCheck` is listed by duration only; its own event carries the verdict):
```
"steps": {"gpu.scrape.machine_spec": 21.0, "executor.validate.duplicate": 73.1, "gpu.validate.verifyx": 78.5, ...},
"steps_failed": "gpu.validate.verifyx"      # only when the run stopped on a fatal check
"steps_total_s": 152.3
```
Only steps ≥ 1 s are listed (typically 6–8 of 32), so the addition is ≈ 300 bytes on an event that already carries ~1.5 KB, and `log_text` — the same JSON — reaches the backend's `prod_executors` row and the portal's `ValidationDetails.what_we_saw` with no backend change. No flag: additive keys in an existing dict, no behaviour change.

Follow-ups (tickets, not this PR): CLI — `lium provider node status` renders `what_we_saw.steps` as `bandwidth 42 s ✓ · GPU benchmark 26 s ✓ · rental check ✗ (reason)`; portal frontend — same on the node page. Live "running…" needs the validator to push interim events (not possible with publish-at-end; noted in the plan).

## How to test
```
cd neurons/validators && pdm run pytest -q tests/test_pipeline_steps_summary.py tests/test_pipeline_default_scenarios.py
```
Tests: a passing pipeline's final event lists every step ≥ 1 s with seconds to one decimal and the total; a fatal stop lists the failed step and the steps that ran; sub-second steps are omitted; the per-event `execution_time_ms`/`elapsed_time_ms` fields are unchanged.

## Verification


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-3012.


Docs: none changed in this PR — the new `steps` keys show up only as raw JSON under the portal's Technical Details on a failed validation; no docs page describes that JSON; the rendered per-step view is the follow-up ticket's.

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — the earlier head (same patch, rebased to `cfd66f1`) merged onto that day's `main` (clean merge), then: pytest: validators (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1944 passed, 15 skipped, 149 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

### Self-review

Verdict `clean` at `cfd66f1` · 15 checks · by subagent-r33rev3 · 2026-09-09 03:25Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | CODE-QUALITY | `neurons/validators/tests/test_pipeline_steps_summary.py:30` | `_TimedCheck.__init__` is 109 chars with untyped keyword args (`passed=True, fatal=True, halt=False`); `ruff format` at line-length 100 would rewrap it (lines 67 and 100 are 104/103 chars); the CI `ruff format` job is report-only (`continue-on-error: true`), so its green tick does not cover this. | Run `ruff format` on the file and type the three kwargs as `bool` (known nit; do not block). |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `PR body (TL;DR l.6, What changed l.9, Details Change l.33):6` Round-2 medium resolved: all three places now say `(check_id, execution_time_ms)` per step, `steps_total_s`, and `steps_failed` only on a fatal stop, with a non-fatal failure (`CpuTruthCheck`) listed by duration only — matches `pipeline.py:236,249-256` and `test_non_fatal_failure_does_not_stop_and_is_not_named`. · `PR body (What changed, tests bullet):10` Round-2 low resolved: the bullet now names what the five test functions cover (slow steps and total on the last event, fatal stop named, non-fatal failure not named, halt, ≥ 1 s filter and rounding); 'ordering' and 'dry-run' are gone. · `PR body (Docs line, fold l.23 and Details):23` Round-1 medium resolved and unchanged since: raw `steps` JSON under the portal's Technical Details on a failed validation, no docs page describes it, rendered view is the follow-up's. · `PR body (Verified by the loop, l.17 and Details):17` "the earlier head (same patch, rebased to `cfd66f1`)" — no unreachable sha; `cfd66f1` is HEAD; CI green at this head per `gh pr checks`. · `PR body (Change section):39` "`prod_executors` row" — the table is `config.TIMESCALE_DB_TABLE` (default `executors`); prod env name, not a finding. · `neurons/validators/src/services/task/pipeline.py:252` Head unchanged since round 1 (`cfd66f14`); round-1 code checks stand: final-event attach on fatal/halt/last in both pipelines, fresh per-event `what_we_saw` dicts on a non-frozen model, no `steps*` key collision, validator-only content bounded by 32 checks, `perf_counter` int ms, `_parse_log_text` passes nested dicts through, `test_pipeline_default_scenarios.py` unaffected.

### Verified

Gate: PASS (cfd66f1) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1290)

</details>
