### PR TITLE
DAH-3011 - [P1] validator: a fast first pass for a never-validated executor

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -26,6 +26,13 @@ COMPUTE_APP_URI=wss://lium.io/api
 
 HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
 
+# First-pass fast path (DAH-3011): a never-validated executor gets a right-sized matmul (min(card VRAM, this MB)) and a
+# smaller VerifyX write (GB of RAM / disk) on its first pass; scored verifications are unchanged. Off by default.
+FIRST_PASS_FAST_PATH_ENABLED=false
+FIRST_PASS_MATMUL_VRAM_MB=8192
+FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB=16
+FIRST_PASS_VERIFYX_STORAGE_TEST_GB=1
+
 #############################
 # Local Dev                 #
 #############################

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -205,6 +205,21 @@ class Settings(BaseSettings):
         default=True,
     )
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
+    # DAH-3011: a never-validated executor's FIRST verification (the express lane's, DAH-2958 —
+    # published spec-only, never scored) proves "this GPU exists, is the model claimed, the host is
+    # reachable and rentable"; the VRAM-filling matmul and the 128 GB RAM proof exist to make a
+    # SCORED cycle expensive to fake, and the next scored cycle runs them anyway. Only a caller that
+    # passes `first_pass=True` to TaskService.create_task gets the fast path, and only with this
+    # flag on; the wave never does, so every scored verification is unchanged. Measured (Loki,
+    # 2–6 Sep, idle runs): matmul p50 26 s (74 s on the fresh dogfood node), VerifyX p50 78 s.
+    FIRST_PASS_FAST_PATH_ENABLED: bool = Field(env="FIRST_PASS_FAST_PATH_ENABLED", default=False)
+    # The matmul is sized from min(card VRAM, this) instead of the whole card: same challenge,
+    # seal and UUID check, 5–17x less data to generate and copy.
+    FIRST_PASS_MATMUL_VRAM_MB: int = Field(env="FIRST_PASS_MATMUL_VRAM_MB", default=8192)
+    # VerifyX challenge config for the first pass (defaults 128 GB / 5 GB in VerifyXSettings). The
+    # measurements are still taken and published; only the amount of RAM/disk written shrinks.
+    FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB: int = Field(env="FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB", default=16)
+    FIRST_PASS_VERIFYX_STORAGE_TEST_GB: int = Field(env="FIRST_PASS_VERIFYX_STORAGE_TEST_GB", default=1)
     # DAH-2667: measure a RoCE fabric with ib_write_bw between the free hosts of one segment, rather
     # than inferring it from the addresses alone. The backend reads a flag of the SAME name to decide
     # whether a fabric must be measured before it is sold, so the feature has one switch across both

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -425,7 +425,11 @@ class ValidationService:
         executor_info,
         default_extra: dict,
         machine_spec: dict,
+        vram_budget_mb: int | None = None,
     ) -> ValidationResult:
+        # vram_budget_mb (DAH-3011): size the matmul from min(card VRAM, budget) instead of the whole
+        # card. Same challenge, seal and UUID check — a wrong/absent GPU or a spoofed UUID still
+        # fails; only the "fill the card" capacity proof is deferred. None = today's full-card size.
         # DAH-2671 item 3: all-claimed-cards work-proof. Shadow (MATMUL_ALLCARDS_CHECK_ENABLED
         # without enforcement) logs timing + per-card outcome and NEVER changes the returned result;
         # enforcement fails a count lie (device-selection error / OOM / serialised aggregate
@@ -479,6 +483,8 @@ class ValidationService:
             # GpuVramPrecheck (before the rented short-circuit), so it is NOT
             # repeated here. gpu_capacity_mb is still needed to size the matmul.
             gpu_capacity_mb = self.get_gpu_memory(machine_spec)
+            if vram_budget_mb and gpu_capacity_mb:
+                gpu_capacity_mb = min(gpu_capacity_mb, vram_budget_mb)
 
             verifier_params = VerifierParams()
             verifier_params.generate()
@@ -501,6 +507,7 @@ class ValidationService:
                 **default_extra,
                 "dim_n": verifier_params.dim_n,
                 "dim_k": verifier_params.dim_k,
+                "sized_vram_mb": gpu_capacity_mb,
                 "seed": verifier_params.seed,
                 "uuid": verifier_params.uuid,
                 "cipher_text": verifier_params.cipher_text,

--- a/neurons/validators/src/services/task/checks/capability.py
+++ b/neurons/validators/src/services/task/checks/capability.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+from core.config import settings
+
 from ..messages import CapabilityMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
@@ -39,6 +41,11 @@ class CapabilityCheck:
 
         validation_service = ctx.services.validation
 
+        # DAH-3011: a first, unscored verification sizes the matmul from a VRAM budget instead of
+        # the whole card (same challenge/seal/UUID check). The keyword is only passed on that path
+        # so the scored call is byte-for-byte today's.
+        sizing = {"vram_budget_mb": settings.FIRST_PASS_MATMUL_VRAM_MB} if ctx.config.first_pass else {}
+
         result = None
         failure_reason = None
         try:
@@ -47,16 +54,20 @@ class CapabilityCheck:
                 executor_info=ctx.executor,
                 default_extra=ctx.default_extra,
                 machine_spec=specs,
+                **sizing,
             )
         except Exception as exc:
             failure_reason = str(exc)
 
         if result and result.success:
+            what: dict = {"metrics": result.metrics}
+            if sizing:
+                what["first_pass_vram_budget_mb"] = sizing["vram_budget_mb"]
             event = render_message(
                 Msg.VERIFY_OK,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={"metrics": result.metrics},
+                what=what,
             )
             # Carry FP32 TFLOPS metrics into pipeline state so ResultHandler can nest them
             # in the published specs. Only on success and only when present (fail-safe:

--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -4,6 +4,8 @@ from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
+from core.config import settings
+
 from ..messages import VerifyXMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 from .network_ema import compute_ema
@@ -66,11 +68,18 @@ class VerifyXCheck:
                 updates={"state": replace(ctx.state, specs=updated_specs)},
             )
 
+        # DAH-3011: a first, unscored verification writes less RAM/disk (the measurements are still
+        # taken and published). The keyword is only passed on that path so the scored call is
+        # byte-for-byte today's.
+        sizing = (
+            {"challenge_config_overrides": _first_pass_challenge_config()} if ctx.config.first_pass else {}
+        )
         result = await verifyx_service.validate_verifyx_and_process_job(
             shell=ctx.services.shell,
             executor_info=ctx.executor,
             default_extra=ctx.default_extra,
             machine_spec=specs,
+            **sizing,
         )
 
         # Extract errors with clear priority: data.errors > result.error
@@ -135,10 +144,31 @@ class VerifyXCheck:
             )
             if errors:
                 event.what_we_saw["errors"] = errors
+            if sizing:
+                event.what_we_saw["first_pass_challenge_config"] = sizing["challenge_config_overrides"]
 
             updated_state = replace(ctx.state, specs=updated_specs)
 
             ema_download = updated_specs["network"]["ema_verifyx_download_speed"]
+            never_measured = prev_ema is None or prev_ema.ema_verifyx_download_speed is None
+            if ema_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS and ctx.config.first_pass and never_measured:
+                # DAH-3011: the first pass is never scored, and a fresh node's single cold sample fails
+                # this gate 14 % of the time (DAH-2959). Publish the raw sample, leave the EMA unseeded
+                # so the first SCORED cycle bootstraps from a warm sample and enforces the gate, and say
+                # so on the event. A known host, or any scored cycle, never takes this branch.
+                deferred_network = {
+                    key: value
+                    for key, value in updated_specs["network"].items()
+                    if key not in ("ema_verifyx_download_speed", "ema_verifyx_upload_speed")
+                }
+                updated_state = replace(
+                    ctx.state, specs={**updated_specs, "network": deferred_network}
+                )
+                event.what_we_saw["bandwidth_gate"] = "deferred_to_first_scored_cycle"
+                event.what_we_saw["first_sample_download_speed_mbps"] = download_speed
+                event.what_we_saw["min_download_speed_mbps"] = MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS
+                return CheckResult(passed=True, event=event, updates={"state": updated_state})
+
             if ema_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS:
                 slow_event = render_message(
                     Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW,
@@ -184,6 +214,13 @@ _FAILURE_TEMPLATE_BY_CLASS = {
     "EMPTY_RESPONSE": Msg.VERIFY_FAILED_EMPTY_RESPONSE,
     "CIPHER_REJECTED": Msg.VERIFY_FAILED_CIPHER_REJECTED,
 }
+
+
+def _first_pass_challenge_config() -> dict[str, int]:
+    return {
+        "memory_max_test_gb": settings.FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB,
+        "storage_throughput_test_gb": settings.FIRST_PASS_VERIFYX_STORAGE_TEST_GB,
+    }
 
 
 def _get_filler_only_container(ctx: Context) -> str | None:

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -89,6 +89,11 @@ class ContextConfig:
     # DAH-2794: obfuscated scrape source, piped to the executor's interpreter over stdin.
     # None => the legacy path, where the scrape is a binary uploaded by UploadFilesCheck.
     machine_scrape_source: Optional[str] = None
+    # DAH-3011: True only for a never-validated executor's first, unscored verification AND with
+    # FIRST_PASS_FAST_PATH_ENABLED on (resolved in PipelineFactory.build_context). The capability
+    # matmul and VerifyX right-size their probes and the bandwidth gate is deferred to the first
+    # scored cycle; every other check is the same.
+    first_pass: bool = False
 
 
 @dataclass(frozen=True)

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -143,6 +143,7 @@ class PipelineFactory:
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
         tdx_attestation_passed: bool = False,
         gpu_attestation_passed: bool | None = None,
+        first_pass: bool = False,
     ) -> Context:
         """Build the base validation context with all configuration.
 
@@ -156,6 +157,8 @@ class PipelineFactory:
             encrypted_files: Encrypted validation files
             tdx_attestation_passed: Whether TDX attestation passed
             gpu_attestation_passed: NVIDIA CC GPU attestation outcome (None = not performed)
+            first_pass: the executor's first, unscored verification (DAH-3011); takes effect
+                only with settings.FIRST_PASS_FAST_PATH_ENABLED
 
         Returns:
             Configured Context ready for pipeline execution
@@ -243,6 +246,7 @@ class PipelineFactory:
                 port_private_key=private_key,
                 port_public_key=public_key,
                 job_batch_id=miner_info.job_batch_id,
+                first_pass=first_pass and settings.FIRST_PASS_FAST_PATH_ENABLED,
             ),
             state=ContextState(
                 upload_local_dir=encrypted_files.tmp_directory,

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -69,8 +69,13 @@ class TaskService:
         default_docker_image_digests: dict[str, str],
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
         attestation_nonce: AttestationNonce | None = None,
+        first_pass: bool = False,
     ):
-        """New pipeline-based validation task implementation."""
+        """New pipeline-based validation task implementation.
+
+        `first_pass` (DAH-3011): the caller knows this is the executor's first, unscored verification
+        (the express lane, DAH-2958). The wave never sets it.
+        """
         attestation_digest = None
         tee_type = None
         attestation_passed = False
@@ -127,6 +132,7 @@ class TaskService:
                     executor_image_snapshot=executor_image_snapshot,
                     tdx_attestation_passed=attestation_passed,
                     gpu_attestation_passed=gpu_attestation_passed,
+                    first_pass=first_pass,
                 )
 
                 # Build and run validation pipeline

--- a/neurons/validators/src/services/verifyx_validation_service.py
+++ b/neurons/validators/src/services/verifyx_validation_service.py
@@ -152,7 +152,10 @@ class VerifyXValidationService:
         executor_info,
         default_extra: dict,
         machine_spec: dict,
+        challenge_config_overrides: dict | None = None,
     ):
+        # challenge_config_overrides (DAH-3011): keys of the challenge `config` block to replace for
+        # this run — a first, unscored verification writes less RAM/disk. None = today's config.
         try:
             # Verify checksum before proceeding with validation
             local_checksum = sha256_from_path(self.lib_name)
@@ -171,18 +174,21 @@ class VerifyXValidationService:
             seed = random.getrandbits(64)
             verifyx_validator = VerifyXValidator(self.lib_name, seed)
 
+            challenge_config = {
+                "memory_allocation_percentage": settings.verifyx.MEMORY_ALLOCATION_PERCENTAGE,
+                "memory_min_test_gb": settings.verifyx.MEMORY_MIN_TEST_GB,
+                "memory_max_test_gb": settings.verifyx.MEMORY_MAX_TEST_GB,
+                "storage_min_available_gb": settings.verifyx.STORAGE_MIN_AVAILABLE_GB,
+                "storage_throughput_test_gb": settings.verifyx.STORAGE_THROUGHPUT_TEST_GB,
+                "network_timeout_seconds": settings.verifyx.NETWORK_TIMEOUT_SECONDS,
+                "enable_xet_challenge": settings.verifyx.ENABLE_XET_CHALLENGE,
+            }
+            if challenge_config_overrides:
+                challenge_config.update(challenge_config_overrides)
             challenge_input = {
                 "seed": seed,
                 "machine_info": gpu_info,
-                "config": {
-                    "memory_allocation_percentage": settings.verifyx.MEMORY_ALLOCATION_PERCENTAGE,
-                    "memory_min_test_gb": settings.verifyx.MEMORY_MIN_TEST_GB,
-                    "memory_max_test_gb": settings.verifyx.MEMORY_MAX_TEST_GB,
-                    "storage_min_available_gb": settings.verifyx.STORAGE_MIN_AVAILABLE_GB,
-                    "storage_throughput_test_gb": settings.verifyx.STORAGE_THROUGHPUT_TEST_GB,
-                    "network_timeout_seconds": settings.verifyx.NETWORK_TIMEOUT_SECONDS,
-                    "enable_xet_challenge": settings.verifyx.ENABLE_XET_CHALLENGE,
-                },
+                "config": challenge_config,
             }
 
             cipher_text = verifyx_validator.generate_challenge(challenge_input)

--- a/neurons/validators/tests/test_first_pass_fast_path.py
+++ b/neurons/validators/tests/test_first_pass_fast_path.py
@@ -1,0 +1,362 @@
+"""DAH-3011: the fast first pass for a never-validated executor.
+
+Only a caller that passes `first_pass=True` (the express lane, DAH-2958 — spec-only, never scored)
+with FIRST_PASS_FAST_PATH_ENABLED on gets it: the capability matmul is sized from a VRAM budget,
+VerifyX writes less RAM/disk, and a cold bandwidth sample is published but not enforced. The wave
+never sets `first_pass`, so a scored verification is byte-for-byte today's.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import services.matrix_validation_service as mvs
+from core.config import settings
+from neurons.validators.src.services.task.checks.capability import CapabilityCheck
+from neurons.validators.src.services.task.checks.verifyx import VerifyXCheck
+from neurons.validators.src.services.task.messages import CapabilityMessages as CapMsg
+from neurons.validators.src.services.task.messages import VerifyXMessages as VxMsg
+from neurons.validators.src.services.task import pipeline_factory as pipeline_factory_module
+from neurons.validators.src.services.task.pipeline_factory import PipelineFactory
+from neurons.validators.src.services.verifyx_validation_service import VerifyXValidationService
+from protocol.vc_protocol.compute_requests import NetworkEMA, RentedExecutorsResponse
+
+from tests.helpers import build_context_config, build_services, build_state
+from tests.test_capability_check import DummyValidationService
+from tests.test_verifyx_check import MockVerifyXResponse
+
+EXECUTOR = "executor-123"
+
+
+@pytest.fixture
+def fast_path_on(monkeypatch):
+    monkeypatch.setattr(settings, "FIRST_PASS_FAST_PATH_ENABLED", True)
+
+
+# --- plumbing: the flag AND the caller's first_pass are both needed ---------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "flag,first_pass,expected",
+    [(False, False, False), (False, True, False), (True, False, False), (True, True, True)],
+)
+async def test_context_first_pass_needs_the_flag_and_the_caller(monkeypatch, flag, first_pass, expected):
+    monkeypatch.setattr(settings, "FIRST_PASS_FAST_PATH_ENABLED", flag)
+    # Context validates a live asyncssh connection; what is under test is the ContextConfig
+    # build_context assembles, so capture the kwargs instead of constructing the model.
+    monkeypatch.setattr(pipeline_factory_module, "Context", lambda **kw: SimpleNamespace(**kw))
+    redis = SimpleNamespace(
+        get_verified_job_info=AsyncMock(return_value={}),
+        is_elem_exists_in_set=AsyncMock(return_value=False),
+    )
+    factory = PipelineFactory.__new__(PipelineFactory)
+    factory.redis_service = redis
+    for name in (
+        "ssh_service",
+        "validation_service",
+        "verifyx_validation_service",
+        "inspector_validation_service",
+        "collateral_contract_service",
+        "executor_connectivity_service",
+        "backend_client",
+        "pod_recovery",
+        "container_cleanup",
+    ):
+        setattr(factory, name, MagicMock())
+    shell = SimpleNamespace(ssh_client=MagicMock())
+    executor = SimpleNamespace(
+        uuid=EXECUTOR, address="1.2.3.4", port=8000, ssh_username="root", ssh_port=22, root_dir="/root/app"
+    )
+    encrypted_files = SimpleNamespace(
+        encrypt_key="k", machine_scrape_file_name="scrape", machine_scrape_source=None,
+        all_keys={}, tmp_directory="/tmp/x",
+    )
+    miner_info = SimpleNamespace(
+        job_batch_id="b", miner_hotkey="m", miner_coldkey="c", miner_address="1.1.1.1", miner_port=1
+    )
+
+    ctx = await factory.build_context(
+        shell=shell,
+        miner_info=miner_info,
+        executor_info=executor,
+        keypair=None,
+        private_key="p",
+        public_key="q",
+        encrypted_files=encrypted_files,
+        rented_data=None,
+        default_docker_image_digests={},
+        first_pass=first_pass,
+    )
+
+    assert ctx.config.first_pass is expected
+
+
+def test_context_config_default_is_not_a_first_pass():
+    assert build_context_config().first_pass is False
+
+
+# --- capability matmul --------------------------------------------------------------------
+
+
+class _SizingAwareValidationService(DummyValidationService):
+    async def validate_gpu_model_and_process_job(self, *, ssh_client, executor_info, default_extra, machine_spec, **kw):
+        self.sizing_kwargs = kw
+        return await super().validate_gpu_model_and_process_job(
+            ssh_client=ssh_client, executor_info=executor_info, default_extra=default_extra, machine_spec=machine_spec
+        )
+
+
+@pytest.mark.asyncio
+async def test_scored_capability_call_passes_no_sizing(fast_path_on, context_factory):
+    service = _SizingAwareValidationService(success=True)
+    ctx = context_factory(
+        services=build_services(validation=service),
+        config=build_context_config(first_pass=False),
+        state=build_state(specs={"gpu": {"count": 1}}),
+    )
+
+    result = await CapabilityCheck().run(ctx)
+
+    assert result.passed is True
+    assert service.sizing_kwargs == {}
+    assert "first_pass_vram_budget_mb" not in result.event.what_we_saw
+
+
+@pytest.mark.asyncio
+async def test_first_pass_capability_call_sizes_the_matmul_from_the_budget(fast_path_on, context_factory):
+    service = _SizingAwareValidationService(success=True, metrics={"fp32_tflops": 1.0})
+    ctx = context_factory(
+        services=build_services(validation=service),
+        config=build_context_config(first_pass=True),
+        state=build_state(specs={"gpu": {"count": 1}}),
+    )
+
+    result = await CapabilityCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == CapMsg.VERIFY_OK.reason
+    assert service.sizing_kwargs == {"vram_budget_mb": settings.FIRST_PASS_MATMUL_VRAM_MB}
+    assert result.event.what_we_saw["first_pass_vram_budget_mb"] == 8192
+    # A failed matmul still fails the first pass: the check itself is not skipped.
+    failing = _SizingAwareValidationService(success=False)
+    ctx = context_factory(
+        services=build_services(validation=failing),
+        config=build_context_config(first_pass=True),
+        state=build_state(specs={"gpu": {"count": 1}}),
+    )
+    assert (await CapabilityCheck().run(ctx)).passed is False
+
+
+@pytest.fixture
+def matrix_service(monkeypatch):
+    wrapper = MagicMock(name="DMCompVerifyWrapper")
+    wrapper.DMCompVerify_new.return_value = "ptr"
+    wrapper.getCipherText.return_value = "deadbeef"
+    monkeypatch.setattr(mvs, "DMCompVerifyWrapper", lambda *_a, **_kw: wrapper)
+    return mvs.ValidationService(), wrapper
+
+
+def _h200_spec():
+    return {"gpu": {"count": 1, "details": [{"name": "NVIDIA H200", "uuid": "GPU-1", "capacity": 143771}]}}
+
+
+@pytest.mark.asyncio
+async def test_vram_budget_shrinks_dim_k_and_default_is_full_card(matrix_service):
+    svc, wrapper = matrix_service
+    ssh = SimpleNamespace(run=AsyncMock(return_value=SimpleNamespace(stdout="UUID: nope", stderr="")))
+    executor = SimpleNamespace(root_dir="/root/app", python_path="/usr/bin/python3")
+
+    async def sized_for(machine_spec, **kw) -> tuple[int, int]:
+        await svc.validate_gpu_model_and_process_job(
+            ssh_client=ssh, executor_info=executor, default_extra={}, machine_spec=machine_spec, **kw
+        )
+        _ptr, dim_n, dim_k = wrapper.setDimension.call_args_list[-1].args
+        return dim_n, dim_k
+
+    dim_n, full_dim_k = await sized_for(_h200_spec())
+    assert full_dim_k == int(svc.get_max_matrix_dimensions(143771, dim_n))
+    dim_n, budget_dim_k = await sized_for(_h200_spec(), vram_budget_mb=8192)
+    assert budget_dim_k == int(svc.get_max_matrix_dimensions(8192, dim_n))
+    # (143771 - 4096) MB vs (8192 - 2048) MB of matrices: 20x less to generate and copy.
+    assert full_dim_k > 15 * budget_dim_k
+    assert budget_dim_k > 100_000  # still a real matmul, not a no-op
+
+    # A card smaller than the budget is sized as today.
+    small = {"gpu": {"count": 1, "details": [{"name": "RTX 3070", "uuid": "GPU-2", "capacity": 8192}]}}
+    dim_n, small_dim_k = await sized_for(small, vram_budget_mb=16384)
+    assert small_dim_k == int(svc.get_max_matrix_dimensions(8192, dim_n))
+
+
+# --- VerifyX ------------------------------------------------------------------------------
+
+
+class _ConfigAwareVerifyX:
+    def __init__(self, response: MockVerifyXResponse):
+        self._response = response
+        self.kwargs: dict = {}
+
+    async def validate_verifyx_and_process_job(self, *, shell, executor_info, default_extra, machine_spec, **kw):
+        self.kwargs = kw
+        return self._response
+
+
+def _probe(download: float | None) -> MockVerifyXResponse:
+    network = {} if download is None else {"download_speed": download, "upload_speed": 30.0}
+    return MockVerifyXResponse(data={"success": True, "ram": {"total": 64}, "hard_disk": {"total": 900}, "network": network})
+
+
+def _ctx(context_factory, service, *, first_pass: bool, rented_data=None):
+    return context_factory(
+        services=build_services(verifyx=service),
+        config=build_context_config(verifyx_enabled=True, first_pass=first_pass),
+        state=build_state(specs={"gpu": {"count": 1}}, rented_data=rented_data),
+    )
+
+
+def _never_measured():
+    return RentedExecutorsResponse(executors={}, banned_guids=[], network_ema={})
+
+
+@pytest.mark.asyncio
+async def test_scored_verifyx_call_passes_no_overrides_and_keeps_the_gate(fast_path_on, context_factory):
+    service = _ConfigAwareVerifyX(_probe(59.9))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, first_pass=False, rented_data=_never_measured()))
+
+    assert service.kwargs == {}
+    assert result.passed is False
+    assert result.event.reason_code == VxMsg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+
+
+@pytest.mark.asyncio
+async def test_first_pass_verifyx_uses_the_smaller_challenge_config(fast_path_on, context_factory):
+    service = _ConfigAwareVerifyX(_probe(500.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, first_pass=True, rented_data=_never_measured()))
+
+    assert service.kwargs == {
+        "challenge_config_overrides": {"memory_max_test_gb": 16, "storage_throughput_test_gb": 1}
+    }
+    assert result.passed is True
+    assert result.event.what_we_saw["first_pass_challenge_config"] == {
+        "memory_max_test_gb": 16,
+        "storage_throughput_test_gb": 1,
+    }
+    # A warm sample seeds the EMA exactly as today.
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(500.0)
+
+
+@pytest.mark.asyncio
+async def test_first_pass_cold_sample_is_published_but_the_gate_is_deferred(fast_path_on, context_factory):
+    service = _ConfigAwareVerifyX(_probe(59.9))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, first_pass=True, rented_data=_never_measured()))
+
+    assert result.passed is True
+    assert result.event.reason_code == VxMsg.VERIFY_SUCCESS.reason
+    assert result.event.what_we_saw["bandwidth_gate"] == "deferred_to_first_scored_cycle"
+    assert result.event.what_we_saw["first_sample_download_speed_mbps"] == 59.9
+    network = result.updates["state"].specs["network"]
+    assert network["verifyx_download_speed"] == 59.9  # measured and published
+    assert "ema_verifyx_download_speed" not in network  # not seeded: the first scored cycle bootstraps
+    assert "ema_verifyx_upload_speed" not in network
+    assert result.updates["state"].specs["ram"] == {"total": 64}
+
+
+@pytest.mark.asyncio
+async def test_first_pass_failed_network_probe_is_deferred_too(fast_path_on, context_factory):
+    result = await VerifyXCheck().run(
+        _ctx(context_factory, _ConfigAwareVerifyX(_probe(None)), first_pass=True, rented_data=_never_measured())
+    )
+
+    assert result.passed is True
+    assert result.event.what_we_saw["bandwidth_gate"] == "deferred_to_first_scored_cycle"
+    assert result.event.what_we_saw["first_sample_download_speed_mbps"] is None
+
+
+@pytest.mark.asyncio
+async def test_first_pass_on_a_host_with_an_ema_keeps_the_gate(fast_path_on, context_factory):
+    known = RentedExecutorsResponse(
+        executors={}, banned_guids=[],
+        network_ema={EXECUTOR: NetworkEMA(ema_verifyx_download_speed=110.0, ema_verifyx_upload_speed=40.0)},
+    )
+
+    result = await VerifyXCheck().run(_ctx(context_factory, _ConfigAwareVerifyX(_probe(20.0)), first_pass=True, rented_data=known))
+
+    assert result.passed is False
+    assert result.event.reason_code == VxMsg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+
+
+@pytest.mark.asyncio
+async def test_first_pass_ram_or_disk_failure_still_fails(fast_path_on, context_factory):
+    failed = MockVerifyXResponse(data={"success": False, "errors": ["Insufficient memory: 6 GB allocated, 8 GB required"]})
+
+    result = await VerifyXCheck().run(_ctx(context_factory, _ConfigAwareVerifyX(failed), first_pass=True, rented_data=_never_measured()))
+
+    assert result.passed is False
+    assert result.event.reason_code == VxMsg.VERIFY_FAILED.reason
+
+
+@pytest.mark.asyncio
+async def test_flag_off_first_pass_is_todays_behaviour(monkeypatch, context_factory):
+    monkeypatch.setattr(settings, "FIRST_PASS_FAST_PATH_ENABLED", False)
+    # The flag is resolved in build_context, so ContextConfig.first_pass is False; here we assert
+    # the checks themselves also do nothing special when it is False.
+    verifyx = _ConfigAwareVerifyX(_probe(59.9))
+    result = await VerifyXCheck().run(_ctx(context_factory, verifyx, first_pass=False, rented_data=_never_measured()))
+    assert verifyx.kwargs == {}
+    assert result.passed is False
+
+    matmul = _SizingAwareValidationService(success=True)
+    ctx = context_factory(
+        services=build_services(validation=matmul),
+        config=build_context_config(first_pass=False),
+        state=build_state(specs={"gpu": {"count": 1}}),
+    )
+    await CapabilityCheck().run(ctx)
+    assert matmul.sizing_kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_verifyx_service_applies_overrides_to_the_challenge_config_only():
+    service = VerifyXValidationService()
+    seen: dict = {}
+
+    class _FakeValidator:
+        def __init__(self, lib_name, seed):
+            pass
+
+        def generate_challenge(self, challenge_input):
+            seen.update(challenge_input)
+            return "deadbeef"
+
+    with patch(
+        "neurons.validators.src.services.verifyx_validation_service.sha256_from_path", return_value="s"
+    ), patch(
+        "neurons.validators.src.services.verifyx_validation_service.VerifyXValidator", _FakeValidator
+    ):
+        shell = MagicMock()
+        shell.get_sha256_checksum_by_path = AsyncMock(return_value="s")
+        shell.get_checksums_over_scp = AsyncMock(return_value="md5:s")
+        shell.ssh_client = MagicMock()
+        shell.ssh_client.run = AsyncMock(return_value=SimpleNamespace(stdout="", stderr="", exit_status=0))
+        executor = SimpleNamespace(root_dir="/root/app", python_path="/usr/bin/python3")
+        spec = {"gpu": {"count": 1, "details": [{"uuid": "u", "name": "H100"}]}}
+
+        await service.validate_verifyx_and_process_job(shell=shell, executor_info=executor, default_extra={}, machine_spec=spec)
+        default_config = dict(seen["config"])
+        await service.validate_verifyx_and_process_job(
+            shell=shell, executor_info=executor, default_extra={}, machine_spec=spec,
+            challenge_config_overrides={"memory_max_test_gb": 16, "storage_throughput_test_gb": 1},
+        )
+        first_pass_config = dict(seen["config"])
+
+    assert default_config["memory_max_test_gb"] == settings.verifyx.MEMORY_MAX_TEST_GB
+    assert default_config["storage_throughput_test_gb"] == settings.verifyx.STORAGE_THROUGHPUT_TEST_GB
+    assert first_pass_config == {**default_config, "memory_max_test_gb": 16, "storage_throughput_test_gb": 1}
+    # Untouched: the RAM minimum the executor must still allocate, the disk minimum, the download.
+    assert first_pass_config["memory_min_test_gb"] == default_config["memory_min_test_gb"]
+    assert first_pass_config["storage_min_available_gb"] == default_config["storage_min_available_gb"]
+    assert first_pass_config["network_timeout_seconds"] == default_config["network_timeout_seconds"]


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3011](https://app.notion.com/p/Fast-first-pass-for-a-never-validated-executor-right-size-the-matmul-and-the-VerifyX-RAM-disk-probe-3d3b8bfdbde98150aed2da13af160eb5) · stacked on #1282 · reviewer: @jam6099 @pixel29913

**TL;DR** — The express lane (lium-io#1282, DAH-2958) verifies a never-validated executor between cycles and publishes it spec-only (no score, `scored_at=None`). `FIRST_PASS_FAST_PATH_ENABLED` (default False) plus a `first_pass: bool = False` argument threaded `TaskService.create_task` → `PipelineFactory.build_context` → `ContextConfig.first_pass`. Touches validator/executor (`neurons/validators/.env.template`) — read that file first.

**What changed**
- With both on, two checks change and only two.
- `CapabilityCheck` (matmul): `dim_k` is sized from `min(card VRAM, FIRST_PASS_MATMUL_VRAM_MB = 8192)` instead of the whole card.
- `VerifyXCheck` (RAM/disk/network probe): the challenge config uses `memory_max_test_gb = FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB` (16) and `storage_throughput_test_gb = FIRST_PASS_VERIFYX_STORAGE_TEST_GB` (1) instead of 128 /…
- What the fast first pass skips, explicitly: the VRAM-filling matmul (capacity proof — the matmul still runs.
- Expected first-pass pipeline for the fresh dogfood node (6 Sep, 1× A6000, measured 253 s): ≈ 150 s.

**How to verify**
- `cd neurons/validators && pdm run pytest -q tests/test_first_pass_fast_path.py tests/test_capability_check.py tests/test_verifyx_check.py tests/test_matrix_validation_service_precheck.py` → green

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1967 passed · miners 27 passed · Result: PASS 0a890c35 · Gate: not run

**Docs:** neurons/validators/.env.template (FIRST_PASS_*) (this PR) · public: none changed in this PR — validator flag off by default; scored verifications unchanged

<details><summary>Details</summary>

Merge after #1282 — this branch is stacked on it; GitHub retargets this PR to main when #1282 merges. Review/merge order per repo: https://github.com/Datura-ai/lium-loop/blob/main/improvements/CHANGES_FOR_REVIEW.md

[DAH-3011](https://app.notion.com/p/Fast-first-pass-for-a-never-validated-executor-right-size-the-matmul-and-the-VerifyX-RAM-disk-probe-3d3b8bfdbde98150aed2da13af160eb5). Origin: owner ask (6 Sep 21:54Z) to decrease time until a provider's GPUs are rentable; prod Loki per-step measurement 1–6 Sep (`provider-dogfood/VERIFICATION_PIPELINE.md`) — a non-filler idle node's pipeline is p50 256 s / p90 356 s, of which VerifyX p50 80 s and the matmul p50 26 s (74 s on the fresh dogfood node) prove capacity a spec-only first publish does not need.

## Problem
The express lane (lium-io#1282, DAH-2958) verifies a never-validated executor between cycles and publishes it spec-only (no score, `scored_at=None`), so a new node is listed ≈ 0.5 min + its own pipeline after `node add`. That pipeline is the full scored pipeline: p50 152 s / p90 208 s fleet-wide, 253 s for the fresh dogfood node (6 Sep). Measured per step on idle non-filler runs, 2–6 Sep (Loki `execution_time_ms`, 6-h windows): VerifyX p50 78 s / p90 120 s (RAM write/read of up to 128 GB, a 5 GB disk write/read, a 260–500 MB single-stream download, a 100 MB Cloudflare up/down); the capability matmul p50 26 s / p90 29 s (a `dim_n × dim_k` double matmul sized to fill the card's VRAM minus 2–4 GB); scrape 21 s; port connectivity 18 s; rental verification 24 s. For a first, unscored publish the pipeline proves far more than "this GPU exists, is the model claimed, and the host is reachable/rentable": the VRAM-filling matmul and the 128 GB RAM proof exist to make a scored cycle expensive to fake, and the next scored cycle runs them anyway.

The first pass also inherits the cold-bandwidth failure (DAH-2959): 14 % of fresh nodes fail their very first VerifyX sample and are published with score 0.

## Change
`FIRST_PASS_FAST_PATH_ENABLED` (default **False**) plus a `first_pass: bool = False` argument threaded `TaskService.create_task` → `PipelineFactory.build_context` → `ContextConfig.first_pass`. Nothing changes unless a caller passes `first_pass=True` **and** the flag is on; the wave never does, so every scored verification is byte-for-byte today's. The express lane (lium-io#1282) is the intended caller: one argument at its `request_job_to_miner(...)` → `create_task(...)` call once both PRs land.

With both on, two checks change and only two:
- `CapabilityCheck` (matmul): `dim_k` is sized from `min(card VRAM, FIRST_PASS_MATMUL_VRAM_MB = 8192)` instead of the whole card — the same challenge/response, seal and UUID check, so a wrong or absent GPU, a driver that cannot run CUDA, or a spoofed UUID still fails; only the "fill the card" part is deferred. Expected saving: the matmul's time is dominated by generating and copying `2 × dim_n × dim_k × 8` bytes (≈ 44 GB on a 48 GB card, ≈ 137 GB on an H200) — 8 GB is 5–17× less, so 26 s → ≈ 5–8 s on data-center cards, 74 s → ≈ 10 s on the dogfood A6000.
- `VerifyXCheck` (RAM/disk/network probe): the challenge config uses `memory_max_test_gb = FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB` (16) and `storage_throughput_test_gb = FIRST_PASS_VERIFYX_STORAGE_TEST_GB` (1) instead of 128 / 5 — the same binary, the same challenge/response, the same download; the RAM/disk *measurements* are still taken and published. The download sample still seeds the EMA, but a **first-pass** sample below the gate does not fail the pass: the node is published spec-only with its measured `verifyx_download_speed`, the EMA is left unseeded so the first scored cycle bootstraps from a warm sample, and the event says so (`bandwidth_gate: deferred_to_first_scored_cycle`). Expected saving: 78 s → ≈ 45 s (the download is unchanged; RAM/disk work shrinks 8–100×).
What the fast first pass skips, explicitly: the VRAM-filling matmul (capacity proof — the matmul still runs, sized from 8 GB), the 128 GB / 5 GB RAM-and-disk write proof (16 GB / 1 GB are written; RAM/disk totals are still measured and published), and the bandwidth *gate* for a never-measured node (measured, published as `verifyx_download_speed`, not enforced; EMA left unseeded so the first scored cycle bootstraps from a warm sample and enforces it). What it does not skip: SSH + key install, scrape, GPU count/model/VRAM/driver/NVML/fingerprint/banned/duplicate/collateral checks, sysbox, port connectivity + port count, executor image, GPU usage, TDX, capability matmul (right-sized), VerifyX (right-sized), rental verification (backend rents a container on the node), scoring. The next scored cycle — the one that pays — runs the full pipeline as today and overwrites the row.

Expected first-pass pipeline for the fresh dogfood node (6 Sep, 1× A6000, measured 253 s): ≈ 150 s — matmul 74 s → ≈ 10 s, VerifyX 86 s → ≈ 45 s, the 31-s Redis queue wait gone with DAH-3006 (an express verification between waves never queues anyway). With lium-io#1282's ≤ 30-s poll and 1–5-s key install, `node add` → published ≈ 3 min for that node instead of ≈ 4.5 min.

## How to test
```
cd neurons/validators && pdm run pytest -q tests/test_first_pass_fast_path.py tests/test_capability_check.py tests/test_verifyx_check.py tests/test_matrix_validation_service_precheck.py
```
14 new tests: `build_context` resolves `ContextConfig.first_pass` only when the flag AND the caller's `first_pass` are both on (4 combinations); `ContextConfig` default is False; the scored capability call passes no sizing keyword; the first-pass call sizes from `FIRST_PASS_MATMUL_VRAM_MB` and a failed matmul still fails; `ValidationService` `dim_k` follows `get_max_matrix_dimensions(min(card, budget))` — 20× less for an H200, unchanged for a card smaller than the budget; the scored VerifyX call passes no overrides and keeps the gate; the first pass sends `memory_max_test_gb=16, storage_throughput_test_gb=1` and a warm sample seeds the EMA as today; a cold sample passes with `bandwidth_gate: deferred_to_first_scored_cycle`, raw speed published, no EMA; a failed network probe is deferred too; a host with an EMA keeps the gate even on a first pass; RAM/disk failure still fails; flag off is today's behaviour; `VerifyXValidationService` applies the overrides to the challenge `config` only (min RAM, min disk, download timeout untouched). Existing capability / VerifyX / matrix tests unchanged (87).

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `0a890c35` merged onto `main` `07ec64cd` (clean merge), then: pytest: validators, miners (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1967 passed, 15 skipped, 157 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); Miners 27 passed, 21 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers
- Sizing knobs are settings so the owners can tune them on staging without a code redeploy; the 8 GB default means a card at or below 8 GB still runs a full-card matmul.
- The all-cards work-proof (`MATMUL_ALLCARDS_CHECK_ENABLED`, off in prod) is untouched: it is the count-lie detector and sizes from the registry, not from this budget.
- Not proposed: skipping VerifyX or the matmul entirely on the first pass — a GPU-less host would then be listed for up to 15 min.
- Wiring for lium-io#1282: `ExpressLane._verify` → `request_job_to_miner(...)` → `create_task(...)` gains `first_pass=True` (one argument through `MinerService`); left out of this PR to avoid a conflicting diff on `miner_service.py` while #1282 is in review. The `VerifyXCheck` here composes with DAH-2959 (lium-io#1288): with both on, a cold first-pass sample is re-measured once first and deferred only if the retry is cold too.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-3011.

Docs: neurons/validators/.env.template (FIRST_PASS_*) (this PR) · public: none changed in this PR — validator flag off by default; scored verifications unchanged

</details>
