### PR TITLE
DAH-3022 - [P1] CODEOWNERS + REVIEWING.md — who reviews each path

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,43 @@
+# Code owners — GitHub requests a review from the people on the LAST matching line when a PR touches the path.
+# Two owners per path where the evidence names two, so one absence does not block; one approval satisfies the branch rule.
+# Proposal from 180-day commit/line evidence per path and 90-day merged-PR review data (DAH-3022);
+# lines marked "TODO owner: confirm" are the ones where the evidence is thin or disagrees with the reviewer map.
+# How reviews work here: .github/REVIEWING.md
+
+# 166 / 98 validator commits; 72 / 40 approvals of 148 merged validator PRs
+*                                           @arhangel66 @taiberium
+
+# 166 / 98 commits (180 d), 12 / 17 in the last 30 d; 72 / 40 approvals
+# TODO owner: confirm — the team's critical-path map (executor verification) says taiberium / pixel29913; the commit and review evidence says arhangel66 / taiberium
+/neurons/validators/                        @arhangel66 @taiberium
+
+# 27 / 6 commits (pixel29913 5 of 6 in the last 30 d); 14 / 4 approvals
+# TODO owner: confirm — the team's critical-path map (executor verification) says taiberium / pixel29913; jam6099 has 5 commits, 0 approvals here
+/neurons/executor/                          @arhangel66 @pixel29913
+
+# 9 human commits (last Jul 2026); approvers fortunelucky777 3, taiberium 1
+# TODO owner: confirm — no human touched this path in the last 30 d (two loop PRs did)
+/neurons/miners/                            @arhangel66 @taiberium
+
+# 1 commit in 180 d (fortunelucky777); approvers pixel29913 / arhangel66
+# TODO owner: confirm — bus factor 1
+/datura/                                    @arhangel66 @pixel29913
+
+# 0 commits in 180 d; a loop PR is the only activity
+# TODO owner: confirm — untouched — owner decides who owns it
+/watchtower/                                @arhangel66
+
+# 0 commits in 180 d (install scripts)
+# TODO owner: confirm — untouched — owner decides
+/scripts/                                   @arhangel66
+
+# 1 commit in 180 d
+# TODO owner: confirm — untouched 90 d
+/docs/                                      @arhangel66
+
+# contributing docs, 0 commits in 180 d
+# TODO owner: confirm — untouched
+/contrib/                                   @arhangel66
+
+# CI/infra: pixel29913 primary, jam6099 backup per the 5 Sep map (jam6099 wrote 3 of 5 workflow commits)
+/.github/                                   @pixel29913 @jam6099

--- a/.github/REVIEWING.md
+++ b/.github/REVIEWING.md
@@ -1,0 +1,44 @@
+# Reviewing pull requests in `lium-io`
+
+`.github/CODEOWNERS` names who is asked to review each path (primary first, backup second). This page says how fast,
+what may merge on one approval, how stacked PRs are handled, and how PRs opened by the Lium loop are treated.
+Ticket: [DAH-3022](https://app.notion.com/p/CODEOWNERS-review-SLA-across-repos-3d3b8bfdbde981d6b409f8a90f24d530).
+
+## 1. Response time
+
+- A code owner answers a review request within **1 business day**: approve, request changes, or say when they will look.
+- **P0** (`[P0]` in the title or the `P0` label): **same day**.
+- Either owner on the CODEOWNERS line may answer; the backup picks it up when the primary is out. The author does not
+  ping a third person unless both owners are unavailable.
+
+## 2. What may merge after ONE approval and green required checks
+
+Branch protection requires a pull request and one approving review, and every review thread resolved. The code-owner rule
+(`require_code_owner_review`) is off today, so CODEOWNERS only picks who is asked; once it is on, that approval comes
+from a code owner of every touched path. For the classes below that single approval is the whole process: the approver merges
+when the checks pass, and nobody waits for a second opinion (auto-merge is off in this repo; turning it on for these classes is a separate, owner-gated step):
+
+- **(a) Docs-only** — Markdown, `docs/**`, `contrib/**`, comments and docstrings. No executable path changes.
+- **(b) Provably dead code** — the PR body shows the identical test run before and after (same passed/skipped counts)
+  and a repository-wide search for every removed symbol with zero remaining references.
+- **(c) Dependency bumps** — only the manifest and lock file change and CI passes.
+- **(d) CI-only workflow changes** — `.github/workflows/**` only, approved by an infra owner (@pixel29913 / @jam6099).
+
+Everything else needs the same single approval, but the approver reads the change and the Verification section, and
+the author waits for it — no auto-merge on runtime behaviour.
+
+## 3. Stacked PRs
+
+- The base PR is reviewed and merged first.
+- A stacked PR says `Stacked on #<base>` in its first line and is reviewed for its own diff only (GitHub's compare
+  against the base branch).
+- After the base merges, the stacked PR is rebased onto `main`, checks re-run, and it is reviewed again only if
+  the rebase changed it.
+- A stacked PR is never merged before its base.
+
+## 4. PRs opened by the Lium loop
+
+The loop's PRs are the ones opened by its GitHub account (`surcyf123`, title `DAH-NNNN - [Pn] …`) and follow exactly the rules
+above — same response time, same classes, same one human approval. The loop never approves, never merges, never enables
+auto-merge on its own PRs. It answers review comments and bot findings on its PRs itself; a loop PR outside classes (a)–(d)
+in §2 is a normal PR.


### PR DESCRIPTION
<!-- loop-pr-template v3 -->
Implements [DAH-3022](https://app.notion.com/p/CODEOWNERS-review-SLA-across-repos-3d3b8bfdbde981d6b409f8a90f24d530) · reviewer: @pixel29913

**Problem** — Every Lium repo requires a PR and one approving review, but nothing says who reviews what; on 6 Sep 133 loop PRs had 0 human reviews.

**Value** — CODEOWNERS requests the path's reviewer automatically (owner directive D-121); today 9 of the 31 open loop PRs in lium-io, and 67 of 182 across the org, have no reviewer requested and no human review (16 Sep 15:20Z; 133 PRs had 0 human reviews on 6 Sep).

**Goal** — [DAH-3022](https://app.notion.com/p/CODEOWNERS-review-SLA-across-repos-3d3b8bfdbde981d6b409f8a90f24d530) (P1).

**Fits** — Sits in `lium-io` — `.github`; touches docs (`.github/REVIEWING.md`).

**Flag:** no flag

**Risks**
- None beyond the diff: no migration, no pod restart, no config change, no data rewrite.

**How to verify**
- `gh api 'repos/Datura-ai/lium-io/codeowners/errors?ref=DAH-3022-codeowners'` → `"errors": []`
- read `.github/CODEOWNERS` → every row that differs from the team's reviewer map carries `TODO owner: confirm` with both candidates named

**Verified by the loop:** 9 Sep 2026 · GitHub CODEOWNERS parser · 0 errors · Result: PASS · Gate: not run

**Ran it:** `gh api repos/Datura-ai/lium-io/codeowners/errors?ref=<head>` → `errors: []` (GitHub's own CODEOWNERS parser) · two non-executable files, nothing to run on EC2 or macOS

**Self-review:** clean at c578ca5 (15 checks, 4 low)

**Parts:** backend n/a — no code · migration n/a — no schema · frontend n/a — no code · CLI/SDK n/a — no code · docs ✓ `.github/REVIEWING.md` · tests n/a — GitHub validates CODEOWNERS syntax · dashboards n/a — no metric

**Docs:** `.github/REVIEWING.md` is the doc; lium-docs#179 is the cross-repo companion.

<details><summary>Details</summary>

### What changed

- `.github/CODEOWNERS`: `*` and per-path owners (validators, executor, miners, datura, watchtower, scripts, docs, contrib, `.github`), evidence in comments
- `.github/REVIEWING.md`: response time (1 business day, P0 same day), what merges on one approval (auto-merge stays off), stacked PRs, how loop PRs are treated

Title: [P1] DAH-3022: CODEOWNERS + REVIEWING.md — who reviews each path, the 1-business-day SLA, what may merge on one approval

[DAH-3022](https://app.notion.com/p/CODEOWNERS-review-SLA-across-repos-3d3b8bfdbde981d6b409f8a90f24d530).

## Problem

Origin: owner directive 6 Sep 2026 ("let's do a CODEOWNERS plan") after the PR audit: every Lium repo requires a PR + 1 approving review, but no repo says *who* reviews *what*. The reviewer is picked by hand — one default person for backend, frontend, CLI, SDK, docs, skill and MCP, two others for infra. Measured 6 Sep 22:35Z across the 10 Lium repos: **133 open PRs from the loop's account, 0 human reviews, 0 human comments** (oldest 5 Sep 19:09Z). On PRs merged in the last 90 days two people wrote ~85 % of all approvals (lium-io validators 72 + 40 of ~140; the pre-monorepo backend 107 + 53). Quieter repos merge without review at all (lium-stats 6/6, lium-platform `.github` 17/22).

## Change

Two files, no code, no branch-protection change:

- `.github/CODEOWNERS` — path → primary + backup GitHub login, from 180-day commit/line counts per path (`git log --no-merges --numstat` on `main`) and 90-day merged-PR review data (`gh pr list --state merged --json author,reviews,mergedBy,files`). Authors were resolved to logins through the commits API or `users.noreply.github.com` addresses, never guessed. Rows where the evidence is thin, nobody touched the path in 90 days, or the evidence disagrees with the current reviewer map carry `# TODO owner: confirm`.
- `.github/REVIEWING.md` — response time (first response within 1 business day; P0 same day), the PR classes that may merge after one approval + green checks (docs-only; provably-dead code with an identical before/after test run; dependency bumps passing CI; CI-only workflow changes approved by an infra owner), how stacked PRs are reviewed (base first, own diff only, rebase after the base merges, never before it), and that the loop's PRs (its GitHub account, `DAH-NNNN - [Pn]` titles) follow the same rules — nothing merges without a human.

CODEOWNERS on its own only auto-requests reviewers. Making the approval *have* to come from a code owner (`require_code_owner_review` on the org ruleset) and allowing auto-merge for the classes above are separate, owner-gated steps that happen after the names are confirmed; this PR does not touch them.

### Proposed owners for `lium-io`

| path | owners | evidence |
|---|---|---|
| `*` | @arhangel66 @taiberium | 166 / 98 validator commits; 72 / 40 approvals of 148 merged validator PRs |
| `/neurons/validators/` | @arhangel66 @taiberium | 166 / 98 commits (180 d), 12 / 17 in the last 30 d; 72 / 40 approvals ⚠ confirm |
| `/neurons/executor/` | @arhangel66 @pixel29913 | 27 / 6 commits (pixel29913 5 of 6 in the last 30 d); 14 / 4 approvals ⚠ confirm |
| `/neurons/miners/` | @arhangel66 @taiberium | 9 human commits (last Jul 2026); approvers fortunelucky777 3, taiberium 1; two loop PRs since ⚠ confirm |
| `/datura/` | @arhangel66 @pixel29913 | 1 commit in 180 d (fortunelucky777); approvers pixel29913 / arhangel66 ⚠ confirm |
| `/watchtower/` | @arhangel66 | 0 commits in 180 d; a loop PR is the only activity ⚠ confirm |
| `/scripts/` | @arhangel66 | 0 commits in 180 d (install scripts) ⚠ confirm |
| `/docs/` | @arhangel66 | 1 commit in 180 d ⚠ confirm |
| `/contrib/` | @arhangel66 | contributing docs, 0 commits in 180 d ⚠ confirm |
| `/.github/` | @pixel29913 @jam6099 | jam6099 3 of 5 workflow commits; CI/infra per the 5 Sep map |

## How to test

- Open `.github/CODEOWNERS` on this branch → GitHub's file view shows the owners it resolves for each line; the repo's *Settings → Code owners* error list (`GET /repos/Datura-ai/lium-io/codeowners/errors?ref=DAH-3022-codeowners`) is empty.
- Every login has write access to this repo (checked with `GET /repos/Datura-ai/lium-io/collaborators/<login>/permission`).
- No workflow, code or config file changes: `git diff --stat main...DAH-3022-codeowners` lists only the two files under `.github/`.

## Verification

**Verified by the loop on 7 Sep 2026 (the earlier head; superseded by the 9 Sep line above):** checked on sandbox EC2 (the CI shape) — the earlier head merged onto `main` (clean merge), then: workflow yaml parse; e2e: skipped (no neuron touched). Run time 1 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers

- Same structure in all nine repos (lium-platform, lium-io, lium, lium-docs, lium-skill, lium-mcp, computenet-docker-images, lium-infra, lium-io-deployment), one PR each, tracked on DAH-3022. Editing a name here is the intended way to answer a `TODO owner: confirm` line — no need to wait for the plan document.
- Last matching line wins in CODEOWNERS, so the repo default (`*`) is first and specific paths follow.

Docs: .github/REVIEWING.md · lium-docs#179 (companion)

### Self-review

Verdict `findings` at `c578ca5` · 15 checks · by subagent-fresh-r35c · 2026-09-09 03:34Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | PROSE-VS-CODE | `.github/CODEOWNERS:19` | The comment reads as a path total ('9 human commits (last Jul 2026)') but 9 is arhangel66's count alone; `git log --no-merges --since='180 days ago' origin/main -- neurons/miners` shows 15 human commits (Mikhail Derbichev/arhangel66 9, pyon777 5, fortunelucky777 1) plus 2 loop commits, and the body table row repeats the 9. | Write the count the way the other rows do: '9 arhangel66 commits of 15 human commits in 180 d (last Jul 2026); pyon777 5 (last May)', in the comment and the body table. |
| low | PROSE-VS-CODE | `.github/CODEOWNERS:7` | Property: an evidence comment must let the confirmer see the strongest counter-candidate. The `*` and `/neurons/validators/` comments give only the two proposed owners' counts (166 / 98); the largest single committer on neurons/validators in 180 d is fortunelucky777 (git name TalentWebDev, ~151 commits, last 2 Sep 2026) and is not mentioned on lines 7 or 11 (the same person is named on lines 18 and 22), so the reader cannot tell the proposal rests on the 72 / 40 approvals rather than on commit count. The choice itself is not flagged. | Add the third count to the two comments, e.g. '166 / 98 commits (fortunelucky777 151, 0 approvals in 90 d)' so the row can be confirmed from the file alone. |
| low | CODE-QUALITY | `.github/REVIEWING.md:11` | Section 1 assumes every CODEOWNERS line has a primary and a backup ('Either owner on the CODEOWNERS line may answer; the backup picks it up when the primary is out... unless both owners are unavailable'), but four lines (/watchtower/, /scripts/, /docs/, /contrib/) carry one owner; the file header (line 2) acknowledges this, the page does not say who is the fallback for those paths. | One clause in section 1: 'On a single-owner line the `*` owners are the backup.' |
| low | STALE-BODY | `PR body:1` | The Problem section measures 'across the 10 Lium repos' and cites lium-stats, while Notes for reviewers says 'Same structure in all nine repos' and lists nine without lium-stats; the two counts read as a contradiction unless the tenth repo is named and excluded on purpose. | Say which repo is the tenth and why it gets no CODEOWNERS PR (or add it to the list). |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `.github/REVIEWING.md:14` Verified against the live settings: classic protection on main has required_approving_review_count=1, require_code_owner_reviews=false; the effective rules on main (gh api repos/Datura-ai/lium-io/rules/branches/main) from rulesets 22356601 (org) and 22353209 (repo) have required_approving_review_count=1, require_code_owner_review=false and required_review_thread_resolution=true; the repo has allow_auto_merge=false — every claim in lines 14-17 holds. · `.github/CODEOWNERS:8` Syntax: 10 owner lines, each `pattern  @login...`, no tabs or trailing spaces, trailing newline, `*` first so the last-matching-line rule gives specific paths precedence; every pattern's directory exists on HEAD (neurons/validators 350 files, neurons/executor 100, neurons/miners 67, datura 11, watchtower 14, scripts 8, docs 1, contrib 4, .github 16); all four logins have write permission (collaborators/<login>/permission = write). · `PR body:66` `gh api repos/Datura-ai/lium-io/codeowners/errors?ref=DAH-3022-codeowners` returns {"errors":[]} today at the pushed head bc85082; c578ca5 changes only comment text and the owner order on the /.github/ line (same logins), so the result carries to this commit; re-run at the pushed head is the recorded step anyway. · `.github/CODEOWNERS:42` 'jam6099 wrote 3 of 5 workflow commits' matches git log on origin/main (.github/workflows, 180 d): jam6099 3, arhangel66 1, Marouane Elaich 1 human commits, plus 3 loop commits; executor 27 / 6 (Mikhail Derbichev 24 + arhangel66 3; pixel29913 6), datura 1 (fortunelucky777), watchtower 0, scripts 0, docs 1 (Apr 2026), contrib 0 human — all match. · `.github/REVIEWING.md:41` PR 1294's author is surcyf123 and the title follows `DAH-NNNN - [Pn]`, so the loop-account statement in section 4 is accurate; section 2(d)'s infra owners (@pixel29913 / @jam6099) equal the /.github/ CODEOWNERS line, and 2(a)'s docs/** and contrib/** paths are the CODEOWNERS /docs/ and /contrib/ rows. · `PR body:74` Parts line: backend/migration/frontend/CLI-SDK/tests/dashboards all marked n/a with a reason and the diff vs origin/main is exactly the two .github files (+87 -0), no code, no workflow; the ticket part (CODEOWNERS + REVIEWING.md for this repo) is fully in the diff. · `(mechanical scanners):0` No mechanical findings were reported, nothing to confirm or dismiss.

### Verified

Gate: PASS (c578ca5) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1294)

</details>
