### PR TITLE
DAH-3035 - [P1] validator: a kernel-fault probe after the GPU matmul

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -23,6 +23,10 @@ REDIS_USERNAME=
 REDIS_PASSWORD=
 
 COMPUTE_APP_URI=wss://lium.io/api
+# GPU fault probe (DAH-3035): indexed access, atomics and pointer-chase kernels after the matmul. CHECK runs it and logs
+# the verdict; ENFORCEMENT lets a fault zero the score. Both off by default (shadow mode first).
+GPU_FAULT_PROBE_CHECK_ENABLED=false
+GPU_FAULT_PROBE_ENFORCEMENT_ENABLED=false
 
 HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -270,6 +270,13 @@ class Settings(BaseSettings):
     FOREIGN_GPU_WORKLOAD_ENFORCEMENT_ENABLED: bool = Field(
         env="FOREIGN_GPU_WORKLOAD_ENFORCEMENT_ENABLED", default=False
     )
+    # DAH-3035 — a ~6 s kernel-fault probe after the matmul: indexed/scattered access, atomics, a pointer
+    # chase and a pinned-memory copy round-trip over a ~2 GB working set, plus NVML ECC/row-remap deltas.
+    # A card that faults under indexed access (Blender "Illegal address in CUDA queue", 6 Sep) passes the
+    # sequential matmul. CHECK runs it and logs the verdict; ENFORCEMENT lets a fault zero the score. Both
+    # default off: the probe is new GPU work on every idle node per cycle, so it starts as an opt-in shadow.
+    GPU_FAULT_PROBE_CHECK_ENABLED: bool = Field(env="GPU_FAULT_PROBE_CHECK_ENABLED", default=False)
+    GPU_FAULT_PROBE_ENFORCEMENT_ENABLED: bool = Field(env="GPU_FAULT_PROBE_ENFORCEMENT_ENABLED", default=False)
     SKIP_COLLATERAL_PENALTY: bool = Field(env="SKIP_COLLATERAL_PENALTY", default=True)
     DRY_RUN: bool = Field(env="DRY_RUN", default=False, description="Run validation without publishing scores/weights")
     CONTAINER_CLEANUP_DRY_RUN: bool = Field(env="CONTAINER_CLEANUP_DRY_RUN", default=False, description="Dry run mode for stale container cleanup")

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -271,7 +271,8 @@ class Settings(BaseSettings):
         env="FOREIGN_GPU_WORKLOAD_ENFORCEMENT_ENABLED", default=False
     )
     # DAH-3035 — a ~6 s kernel-fault probe after the matmul: indexed/scattered access, atomics, a pointer
-    # chase and a pinned-memory copy round-trip over a ~2 GB working set, plus NVML ECC/row-remap deltas.
+    # chase and a pinned-memory copy round-trip over a ~2 GB working set, plus NVML before/after: a rise in
+    # uncorrected ECC or remapped rows, a pending or failed remap, or a required recovery action is a fault.
     # A card that faults under indexed access (Blender "Illegal address in CUDA queue", 6 Sep) passes the
     # sequential matmul. CHECK runs it and logs the verdict; ENFORCEMENT lets a fault zero the score. Both
     # default off: the probe is new GPU work on every idle node per cycle, so it starts as an opt-in shadow.

--- a/neurons/validators/src/miner_jobs/gpu_fault_probe.py
+++ b/neurons/validators/src/miner_jobs/gpu_fault_probe.py
@@ -1,0 +1,793 @@
+"""GPU kernel-fault probe, run on the executor by GpuFaultProbeCheck (`python -I -`, this file on stdin).
+
+Standard library only. The CUDA driver API is reached through ctypes (`libcuda.so.1` is in every
+container the NVIDIA runtime prepares), the kernels are PTX the driver JIT-compiles, NVML is read
+through nvidia-ml-py when it is importable. One forked worker per GPU runs, for a few seconds, the
+access patterns a cuBLAS matmul never exercises: a random permutation built on the device, a gather
+through it, a scatter back (plain stores and atomics), a dependent pointer chase, and a pinned-memory
+async H2D/D2H round-trip. Every result is verified on the device (mismatch counters) and a sample of
+the chase on the host. A fault is any non-zero CUDA return code once the context exists
+(CUDA_ERROR_ILLEGAL_ADDRESS is what Blender prints as "Illegal address in CUDA queue"), a data
+mismatch, a worker that crashes or hangs, or an uncorrected-ECC / remapped-row / recovery-action
+change in NVML across the run. A probe that cannot start (no libcuda, cuInit, PTX JIT) is an error,
+not a fault: the validator does not penalise what it could not measure.
+
+Prints one line `GPU_FAULT_PROBE_JSON: {...}`. Exit 0 ok, 1 fault, 2 could not run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import multiprocessing
+import os
+import subprocess
+import sys
+import time
+
+MB = 1024 * 1024
+JSON_MARKER = "GPU_FAULT_PROBE_JSON:"
+BLOCK = 256
+CHASE_STEPS = 32
+CHASE_SAMPLES = 64
+MIN_LOG2_N = 20  # 1 Mi elements = 4 MB per buffer
+MAX_LOG2_N = 28  # 256 Mi elements = 1 GB per buffer
+BUFFERS = 4  # in, idx, out, aux
+VRAM_RESERVE_MB = (
+    1024  # left free on the card: the runtime's own context and whatever else idles there
+)
+WORKER_GRACE_SECONDS = 30  # on top of --seconds: JIT, allocations, copies, host verification
+
+# fmix32-style mixer whose every step is a bijection on [0, 2**k): (x + seed) mod 2**k, odd multiplier
+# mod 2**k, xorshift within k bits. Mirrored in PTX by k_perm; the host replays it to check the chase.
+PERM_MUL = (0x9E3779B1, 0x85EBCA6B, 0xC2B2AE35)
+PERM_SHIFT = (15, 13, 16)
+
+PTX = r"""
+.version 6.0
+.target sm_50
+.address_size 64
+
+// idx[i] = perm(i): the permutation every other kernel gathers and scatters through
+.visible .entry k_perm(.param .u64 p_idx, .param .u32 p_n, .param .u32 p_seed, .param .u32 p_mask)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<16>;
+    .reg .b64 %rd<8>;
+    ld.param.u64 %rd1, [p_idx];
+    ld.param.u32 %r1, [p_n];
+    ld.param.u32 %r2, [p_seed];
+    ld.param.u32 %r3, [p_mask];
+    mov.u32 %r4, %ctaid.x;
+    mov.u32 %r5, %ntid.x;
+    mov.u32 %r6, %tid.x;
+    mad.lo.s32 %r7, %r4, %r5, %r6;
+    setp.ge.u32 %p1, %r7, %r1;
+    @%p1 bra L_end;
+    add.u32 %r8, %r7, %r2;
+    and.b32 %r8, %r8, %r3;
+    mov.u32 %r10, 0x9E3779B1;
+    mul.lo.u32 %r8, %r8, %r10;
+    and.b32 %r8, %r8, %r3;
+    shr.u32 %r9, %r8, 15;
+    xor.b32 %r8, %r8, %r9;
+    mov.u32 %r10, 0x85EBCA6B;
+    mul.lo.u32 %r8, %r8, %r10;
+    and.b32 %r8, %r8, %r3;
+    shr.u32 %r9, %r8, 13;
+    xor.b32 %r8, %r8, %r9;
+    mov.u32 %r10, 0xC2B2AE35;
+    mul.lo.u32 %r8, %r8, %r10;
+    and.b32 %r8, %r8, %r3;
+    shr.u32 %r9, %r8, 16;
+    xor.b32 %r8, %r8, %r9;
+    cvta.to.global.u64 %rd2, %rd1;
+    mul.wide.u32 %rd3, %r7, 4;
+    add.s64 %rd4, %rd2, %rd3;
+    st.global.u32 [%rd4], %r8;
+L_end:
+    ret;
+}
+
+// out[i] = i
+.visible .entry k_iota(.param .u64 p_out, .param .u32 p_n)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<8>;
+    ld.param.u64 %rd1, [p_out];
+    ld.param.u32 %r1, [p_n];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.u32 %p1, %r5, %r1;
+    @%p1 bra L_end;
+    cvta.to.global.u64 %rd2, %rd1;
+    mul.wide.u32 %rd3, %r5, 4;
+    add.s64 %rd4, %rd2, %rd3;
+    st.global.u32 [%rd4], %r5;
+L_end:
+    ret;
+}
+
+// out[i] = in[idx[i]]  (random reads)
+.visible .entry k_gather(.param .u64 p_out, .param .u64 p_in, .param .u64 p_idx, .param .u32 p_n)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<12>;
+    ld.param.u64 %rd1, [p_out];
+    ld.param.u64 %rd2, [p_in];
+    ld.param.u64 %rd3, [p_idx];
+    ld.param.u32 %r1, [p_n];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.u32 %p1, %r5, %r1;
+    @%p1 bra L_end;
+    cvta.to.global.u64 %rd4, %rd1;
+    cvta.to.global.u64 %rd5, %rd2;
+    cvta.to.global.u64 %rd6, %rd3;
+    mul.wide.u32 %rd7, %r5, 4;
+    add.s64 %rd8, %rd6, %rd7;
+    ld.global.u32 %r6, [%rd8];
+    mul.wide.u32 %rd9, %r6, 4;
+    add.s64 %rd10, %rd5, %rd9;
+    ld.global.u32 %r7, [%rd10];
+    add.s64 %rd11, %rd4, %rd7;
+    st.global.u32 [%rd11], %r7;
+L_end:
+    ret;
+}
+
+// out[idx[i]] = i  (random writes; out becomes the inverse permutation)
+.visible .entry k_scatter(.param .u64 p_out, .param .u64 p_idx, .param .u32 p_n)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<12>;
+    ld.param.u64 %rd1, [p_out];
+    ld.param.u64 %rd3, [p_idx];
+    ld.param.u32 %r1, [p_n];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.u32 %p1, %r5, %r1;
+    @%p1 bra L_end;
+    cvta.to.global.u64 %rd4, %rd1;
+    cvta.to.global.u64 %rd6, %rd3;
+    mul.wide.u32 %rd7, %r5, 4;
+    add.s64 %rd8, %rd6, %rd7;
+    ld.global.u32 %r6, [%rd8];
+    mul.wide.u32 %rd9, %r6, 4;
+    add.s64 %rd10, %rd4, %rd9;
+    st.global.u32 [%rd10], %r5;
+L_end:
+    ret;
+}
+
+// cnt[idx[i]] += 1  (random atomics; every slot ends at exactly 1)
+.visible .entry k_scatter_add(.param .u64 p_cnt, .param .u64 p_idx, .param .u32 p_n)
+{
+    .reg .pred %p<2>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<12>;
+    ld.param.u64 %rd1, [p_cnt];
+    ld.param.u64 %rd3, [p_idx];
+    ld.param.u32 %r1, [p_n];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.u32 %p1, %r5, %r1;
+    @%p1 bra L_end;
+    cvta.to.global.u64 %rd4, %rd1;
+    cvta.to.global.u64 %rd6, %rd3;
+    mul.wide.u32 %rd7, %r5, 4;
+    add.s64 %rd8, %rd6, %rd7;
+    ld.global.u32 %r6, [%rd8];
+    mul.wide.u32 %rd9, %r6, 4;
+    add.s64 %rd10, %rd4, %rd9;
+    red.global.add.u32 [%rd10], 1;
+L_end:
+    ret;
+}
+
+// j = i; steps times: j = idx[j]; out[i] = j  (dependent random reads)
+.visible .entry k_chase(.param .u64 p_out, .param .u64 p_idx, .param .u32 p_n, .param .u32 p_steps)
+{
+    .reg .pred %p<3>;
+    .reg .b32 %r<12>;
+    .reg .b64 %rd<12>;
+    ld.param.u64 %rd1, [p_out];
+    ld.param.u64 %rd3, [p_idx];
+    ld.param.u32 %r1, [p_n];
+    ld.param.u32 %r10, [p_steps];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.u32 %p1, %r5, %r1;
+    @%p1 bra L_end;
+    cvta.to.global.u64 %rd4, %rd1;
+    cvta.to.global.u64 %rd6, %rd3;
+    mov.u32 %r8, %r5;
+    mov.u32 %r9, 0;
+    setp.ge.u32 %p2, %r9, %r10;
+    @%p2 bra L_store;
+L_loop:
+    mul.wide.u32 %rd7, %r8, 4;
+    add.s64 %rd8, %rd6, %rd7;
+    ld.global.u32 %r8, [%rd8];
+    add.u32 %r9, %r9, 1;
+    setp.lt.u32 %p2, %r9, %r10;
+    @%p2 bra L_loop;
+L_store:
+    mul.wide.u32 %rd9, %r5, 4;
+    add.s64 %rd10, %rd4, %rd9;
+    st.global.u32 [%rd10], %r8;
+L_end:
+    ret;
+}
+
+// ctr += (a[i] != b[i])
+.visible .entry k_count_neq(.param .u64 p_a, .param .u64 p_b, .param .u32 p_n, .param .u64 p_ctr)
+{
+    .reg .pred %p<3>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<12>;
+    ld.param.u64 %rd1, [p_a];
+    ld.param.u64 %rd2, [p_b];
+    ld.param.u32 %r1, [p_n];
+    ld.param.u64 %rd3, [p_ctr];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.u32 %p1, %r5, %r1;
+    @%p1 bra L_end;
+    cvta.to.global.u64 %rd4, %rd1;
+    cvta.to.global.u64 %rd5, %rd2;
+    mul.wide.u32 %rd7, %r5, 4;
+    add.s64 %rd8, %rd4, %rd7;
+    ld.global.u32 %r6, [%rd8];
+    add.s64 %rd9, %rd5, %rd7;
+    ld.global.u32 %r7, [%rd9];
+    setp.eq.u32 %p2, %r6, %r7;
+    @%p2 bra L_end;
+    cvta.to.global.u64 %rd10, %rd3;
+    red.global.add.u32 [%rd10], 1;
+L_end:
+    ret;
+}
+
+// ctr += (a[i] != v)
+.visible .entry k_count_neq_const(.param .u64 p_a, .param .u32 p_n, .param .u32 p_v, .param .u64 p_ctr)
+{
+    .reg .pred %p<3>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<12>;
+    ld.param.u64 %rd1, [p_a];
+    ld.param.u32 %r1, [p_n];
+    ld.param.u32 %r7, [p_v];
+    ld.param.u64 %rd3, [p_ctr];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.u32 %p1, %r5, %r1;
+    @%p1 bra L_end;
+    cvta.to.global.u64 %rd4, %rd1;
+    mul.wide.u32 %rd7, %r5, 4;
+    add.s64 %rd8, %rd4, %rd7;
+    ld.global.u32 %r6, [%rd8];
+    setp.eq.u32 %p2, %r6, %r7;
+    @%p2 bra L_end;
+    cvta.to.global.u64 %rd10, %rd3;
+    red.global.add.u32 [%rd10], 1;
+L_end:
+    ret;
+}
+
+// ctr += (inv[idx[i]] != i)
+.visible .entry k_check_inverse(.param .u64 p_inv, .param .u64 p_idx, .param .u32 p_n, .param .u64 p_ctr)
+{
+    .reg .pred %p<3>;
+    .reg .b32 %r<8>;
+    .reg .b64 %rd<12>;
+    ld.param.u64 %rd1, [p_inv];
+    ld.param.u64 %rd2, [p_idx];
+    ld.param.u32 %r1, [p_n];
+    ld.param.u64 %rd3, [p_ctr];
+    mov.u32 %r2, %ctaid.x;
+    mov.u32 %r3, %ntid.x;
+    mov.u32 %r4, %tid.x;
+    mad.lo.s32 %r5, %r2, %r3, %r4;
+    setp.ge.u32 %p1, %r5, %r1;
+    @%p1 bra L_end;
+    cvta.to.global.u64 %rd4, %rd1;
+    cvta.to.global.u64 %rd5, %rd2;
+    mul.wide.u32 %rd7, %r5, 4;
+    add.s64 %rd8, %rd5, %rd7;
+    ld.global.u32 %r6, [%rd8];
+    mul.wide.u32 %rd9, %r6, 4;
+    add.s64 %rd10, %rd4, %rd9;
+    ld.global.u32 %r7, [%rd10];
+    setp.eq.u32 %p2, %r7, %r5;
+    @%p2 bra L_end;
+    cvta.to.global.u64 %rd11, %rd3;
+    red.global.add.u32 [%rd11], 1;
+L_end:
+    ret;
+}
+"""
+
+KERNELS = (
+    "k_perm",
+    "k_iota",
+    "k_gather",
+    "k_scatter",
+    "k_scatter_add",
+    "k_chase",
+    "k_count_neq",
+    "k_count_neq_const",
+    "k_check_inverse",
+)
+
+
+def perm(i: int, seed: int, mask: int) -> int:
+    x = (i + seed) & mask
+    for mul, shift in zip(PERM_MUL, PERM_SHIFT):
+        x = (x * mul) & mask
+        x ^= x >> shift
+    return x
+
+
+class ProbeError(Exception):
+    """The probe could not start on this device (library, cuInit, JIT): reported as an error, not a fault."""
+
+
+class CudaFault(Exception):
+    """A CUDA call failed once the context existed, or a result did not verify: the device is faulty."""
+
+
+class Cuda:
+    """The slice of the driver API the probe uses, through ctypes."""
+
+    def __init__(self) -> None:
+        self.lib = None
+        for name in ("libcuda.so.1", "libcuda.so"):
+            try:
+                self.lib = ctypes.CDLL(name)
+                break
+            except OSError:
+                continue
+        if self.lib is None:
+            raise ProbeError("libcuda.so.1 not found")
+        self.lib.cuGetErrorName.argtypes = [ctypes.c_int, ctypes.POINTER(ctypes.c_char_p)]
+        self.lib.cuGetErrorName.restype = ctypes.c_int
+
+    def error_name(self, code: int) -> str:
+        name = ctypes.c_char_p()
+        if self.lib.cuGetErrorName(code, ctypes.byref(name)) == 0 and name.value:
+            return name.value.decode()
+        return f"CUDA_ERROR_{code}"
+
+    def call(self, fn: str, *args, fault: bool = True) -> None:
+        code = getattr(self.lib, fn)(*args)
+        if code != 0:
+            message = f"{fn} -> {self.error_name(code)} ({code})"
+            raise CudaFault(message) if fault else ProbeError(message)
+
+
+class DevPtr(int):
+    """A CUdeviceptr; distinguishes 64-bit pointer arguments from 32-bit scalars in _launch."""
+
+
+def _launch(cuda: Cuda, func, stream, n: int, *args) -> None:
+    # kernel arguments travel as an array of pointers to their ctypes values, which must outlive the call
+    values = [ctypes.c_uint64(a) if isinstance(a, DevPtr) else ctypes.c_uint32(a) for a in args]
+    params = (ctypes.c_void_p * len(values))(*[ctypes.addressof(v) for v in values])
+    grid = (n + BLOCK - 1) // BLOCK
+    cuda.call("cuLaunchKernel", func, grid, 1, 1, BLOCK, 1, 1, 0, stream, params, None)
+
+
+def _read_counter(cuda: Cuda, d_ctr: int, h_ctr, stream) -> int:
+    cuda.call("cuMemcpyDtoHAsync_v2", h_ctr, ctypes.c_uint64(d_ctr), ctypes.c_size_t(4), stream)
+    cuda.call("cuStreamSynchronize", stream)
+    return ctypes.c_uint32.from_address(h_ctr.value).value
+
+
+def probe_device(index: int, seconds: float, vram_mb: int) -> dict:
+    report: dict = {"index": index}
+    cuda = Cuda()
+    lib = cuda.lib
+    lib.cuLaunchKernel.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_uint,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    lib.cuMemcpyHtoDAsync_v2.argtypes = [
+        ctypes.c_uint64,
+        ctypes.c_void_p,
+        ctypes.c_size_t,
+        ctypes.c_void_p,
+    ]
+    lib.cuMemcpyDtoHAsync_v2.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint64,
+        ctypes.c_size_t,
+        ctypes.c_void_p,
+    ]
+    lib.cuMemsetD32Async.argtypes = [
+        ctypes.c_uint64,
+        ctypes.c_uint,
+        ctypes.c_size_t,
+        ctypes.c_void_p,
+    ]
+    lib.cuMemAlloc_v2.argtypes = [ctypes.POINTER(ctypes.c_uint64), ctypes.c_size_t]
+    lib.cuMemFree_v2.argtypes = [ctypes.c_uint64]
+    lib.cuMemAllocHost_v2.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_size_t]
+    lib.cuMemFreeHost.argtypes = [ctypes.c_void_p]
+    lib.cuMemGetInfo_v2.argtypes = [
+        ctypes.POINTER(ctypes.c_size_t),
+        ctypes.POINTER(ctypes.c_size_t),
+    ]
+    lib.cuCtxCreate_v2.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_uint, ctypes.c_int]
+    lib.cuCtxDestroy_v2.argtypes = [ctypes.c_void_p]
+    lib.cuStreamCreate.argtypes = [ctypes.POINTER(ctypes.c_void_p), ctypes.c_uint]
+    lib.cuStreamSynchronize.argtypes = [ctypes.c_void_p]
+    lib.cuModuleLoadDataEx.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_void_p,
+        ctypes.c_uint,
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    lib.cuModuleGetFunction.argtypes = [
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_void_p,
+        ctypes.c_char_p,
+    ]
+    lib.cuDeviceGetName.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
+
+    cuda.call("cuInit", 0, fault=False)
+    device = ctypes.c_int()
+    cuda.call("cuDeviceGet", ctypes.byref(device), index, fault=False)
+    name = ctypes.create_string_buffer(256)
+    lib.cuDeviceGetName(name, 256, device)
+    report["name"] = name.value.decode(errors="replace")
+
+    context = ctypes.c_void_p()
+    cuda.call("cuCtxCreate_v2", ctypes.byref(context), 0, device)
+    free, total = ctypes.c_size_t(), ctypes.c_size_t()
+    cuda.call("cuMemGetInfo_v2", ctypes.byref(free), ctypes.byref(total))
+    report["vram_free_mb"] = free.value // MB
+
+    budget = min(vram_mb * MB, max(free.value - VRAM_RESERVE_MB * MB, 0))
+    log2_n = MIN_LOG2_N
+    while log2_n < MAX_LOG2_N and BUFFERS * 4 * (1 << (log2_n + 1)) <= budget:
+        log2_n += 1
+    n = 1 << log2_n
+    mask = n - 1
+    report["elements"] = n
+    report["working_set_mb"] = BUFFERS * 4 * n // MB
+
+    t_jit = time.perf_counter()
+    module = ctypes.c_void_p()
+    error_log = ctypes.create_string_buffer(8192)
+    options = (ctypes.c_int * 2)(
+        5, 6
+    )  # CU_JIT_ERROR_LOG_BUFFER, CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES
+    option_values = (ctypes.c_void_p * 2)(ctypes.addressof(error_log), 8192)
+    code = lib.cuModuleLoadDataEx(ctypes.byref(module), PTX.encode(), 2, options, option_values)
+    if code != 0:
+        raise ProbeError(
+            f"PTX JIT failed: {cuda.error_name(code)}: {error_log.value.decode(errors='replace')}"
+        )
+    funcs = {}
+    for kernel in KERNELS:
+        func = ctypes.c_void_p()
+        cuda.call("cuModuleGetFunction", ctypes.byref(func), module, kernel.encode(), fault=False)
+        funcs[kernel] = func
+    report["jit_ms"] = int((time.perf_counter() - t_jit) * 1000)
+
+    stream = ctypes.c_void_p()
+    cuda.call("cuStreamCreate", ctypes.byref(stream), 1)  # CU_STREAM_NON_BLOCKING
+    device_buffers = []
+    for _ in range(BUFFERS):
+        ptr = ctypes.c_uint64()
+        cuda.call("cuMemAlloc_v2", ctypes.byref(ptr), n * 4)
+        device_buffers.append(DevPtr(ptr.value))
+    d_in, d_idx, d_out, d_aux = device_buffers
+    d_ctr = ctypes.c_uint64()
+    cuda.call("cuMemAlloc_v2", ctypes.byref(d_ctr), 16)
+    d_ctr = DevPtr(d_ctr.value)
+    h_ctr = ctypes.c_void_p()
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_ctr), 16)
+    copy_bytes = min(32 * MB, n * 4)
+    h_src, h_dst = ctypes.c_void_p(), ctypes.c_void_p()
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_src), copy_bytes)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_dst), copy_bytes)
+    pattern = os.urandom(copy_bytes)
+    ctypes.memmove(h_src, pattern, copy_bytes)
+    h_sample = ctypes.c_void_p()
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_sample), CHASE_SAMPLES * 4)
+    report["copy_mb"] = copy_bytes // MB
+
+    def launch(kernel: str, *args) -> None:
+        _launch(cuda, funcs[kernel], stream, n, *args)
+
+    def counter_check(what: str, kernel: str, *args) -> None:
+        cuda.call("cuMemsetD32Async", d_ctr, 0, 4, stream)
+        launch(kernel, *args)
+        mismatches = _read_counter(cuda, d_ctr, h_ctr, stream)
+        if mismatches:
+            raise CudaFault(f"{what}: {mismatches} of {n} elements wrong")
+
+    launch("k_iota", d_in, n)
+    rounds = 0
+    t_work = time.perf_counter()
+    while rounds < 2 or (time.perf_counter() - t_work < seconds and rounds < 64):
+        seed = (rounds * 0x9E37 + 12345) & mask
+        launch("k_perm", d_idx, n, seed, mask)
+        launch("k_gather", d_out, d_in, d_idx, n)
+        counter_check("gather", "k_count_neq", d_out, d_idx, n, d_ctr)
+        cuda.call("cuMemsetD32Async", d_aux, 0, n, stream)
+        launch("k_scatter_add", d_aux, d_idx, n)
+        counter_check("scatter_add", "k_count_neq_const", d_aux, n, 1, d_ctr)
+        launch("k_scatter", d_aux, d_idx, n)
+        counter_check("scatter", "k_check_inverse", d_aux, d_idx, n, d_ctr)
+        launch("k_chase", d_out, d_idx, n, CHASE_STEPS)
+        # pinned-memory round trip through the copy engines, both directions, verified on the host
+        cuda.call("cuMemcpyHtoDAsync_v2", d_aux, h_src, copy_bytes, stream)
+        cuda.call("cuMemcpyDtoHAsync_v2", h_dst, d_aux, copy_bytes, stream)
+        # a host sample of the chase: 64 dependent-load chains replayed in Python
+        starts = [(perm(k, seed ^ 0x5BD1, mask)) for k in range(CHASE_SAMPLES)]
+        for k, start in enumerate(starts):
+            cuda.call(
+                "cuMemcpyDtoHAsync_v2",
+                ctypes.c_void_p(h_sample.value + 4 * k),
+                ctypes.c_uint64(d_out + 4 * start),
+                ctypes.c_size_t(4),
+                stream,
+            )
+        cuda.call("cuStreamSynchronize", stream)
+        cuda.call("cuCtxSynchronize")
+        if ctypes.string_at(h_dst, copy_bytes) != pattern:
+            raise CudaFault("async memcpy round trip: data differs")
+        sample = (ctypes.c_uint32 * CHASE_SAMPLES).from_address(h_sample.value)
+        for k, start in enumerate(starts):
+            j = start
+            for _ in range(CHASE_STEPS):
+                j = perm(j, seed, mask)
+            if sample[k] != j:
+                raise CudaFault(f"chase: start {start} reached {sample[k]}, expected {j}")
+        rounds += 1
+    report["rounds"] = rounds
+    report["work_s"] = round(time.perf_counter() - t_work, 2)
+
+    for ptr in device_buffers + [d_ctr]:
+        cuda.call("cuMemFree_v2", ptr)
+    for ptr in (h_ctr, h_src, h_dst, h_sample):
+        cuda.call("cuMemFreeHost", ptr)
+    cuda.call("cuCtxSynchronize")
+    cuda.call("cuCtxDestroy_v2", context)
+    return report
+
+
+def _worker(index: int, seconds: float, vram_mb: int, conn) -> None:
+    started = time.perf_counter()
+    try:
+        report = probe_device(index, seconds, vram_mb)
+        report["status"] = "ok"
+    except CudaFault as exc:
+        report = {"index": index, "status": "fault", "error": str(exc)}
+    except ProbeError as exc:
+        report = {"index": index, "status": "error", "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001 - the parent must always get a verdict
+        report = {"index": index, "status": "error", "error": f"{type(exc).__name__}: {exc}"}
+    report["elapsed_s"] = round(time.perf_counter() - started, 2)
+    conn.send(report)
+    conn.close()
+
+
+def _count_worker(conn) -> None:
+    try:
+        cuda = Cuda()
+        cuda.call("cuInit", 0, fault=False)
+        count = ctypes.c_int()
+        cuda.call("cuDeviceGetCount", ctypes.byref(count), fault=False)
+        conn.send({"count": count.value})
+    except Exception as exc:  # noqa: BLE001
+        conn.send({"error": str(exc)})
+    conn.close()
+
+
+def _device_count(mp) -> int:
+    # in its own fork: a process that has called cuInit cannot fork CUDA-capable children
+    parent_conn, child_conn = mp.Pipe(duplex=False)
+    process = mp.Process(target=_count_worker, args=(child_conn,))
+    process.start()
+    child_conn.close()
+    reply = (
+        parent_conn.recv()
+        if parent_conn.poll(WORKER_GRACE_SECONDS)
+        else {"error": "device enumeration hung"}
+    )
+    process.join(5)
+    if "error" in reply:
+        raise ProbeError(reply["error"])
+    return reply["count"]
+
+
+def nvml_snapshot() -> dict:
+    """Per-GPU counters that move when hardware faults: uncorrected ECC, remapped rows, recovery action."""
+    try:
+        import pynvml
+    except ImportError:
+        return {"available": False}
+    try:
+        pynvml.nvmlInit()
+    except Exception as exc:  # noqa: BLE001
+        return {"available": False, "error": str(exc)}
+    gpus = []
+    try:
+        for i in range(pynvml.nvmlDeviceGetCount()):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(i)
+            gpu: dict = {"index": i}
+            for key, read in (
+                ("uuid", lambda h: pynvml.nvmlDeviceGetUUID(h)),
+                (
+                    "ecc_uncorrected",
+                    lambda h: pynvml.nvmlDeviceGetTotalEccErrors(
+                        h, pynvml.NVML_MEMORY_ERROR_TYPE_UNCORRECTED, pynvml.NVML_VOLATILE_ECC
+                    ),
+                ),
+                ("remapped_rows", lambda h: list(pynvml.nvmlDeviceGetRemappedRows(h))),
+                ("recovery_action", lambda h: pynvml.nvmlDeviceGetGpuRecoveryAction(h)),
+            ):
+                try:
+                    value = read(handle)
+                    gpu[key] = value.decode() if isinstance(value, bytes) else value
+                except Exception:  # noqa: BLE001 - NotSupported on consumer cards, missing on old bindings
+                    gpu[key] = None
+            gpus.append(gpu)
+    finally:
+        pynvml.nvmlShutdown()
+    return {"available": True, "gpus": gpus}
+
+
+def nvml_faults(before: dict, after: dict) -> list[str]:
+    faults = []
+    for b, a in zip(before.get("gpus", []), after.get("gpus", [])):
+        if a.get("ecc_uncorrected") is not None and b.get("ecc_uncorrected") is not None:
+            if a["ecc_uncorrected"] > b["ecc_uncorrected"]:
+                faults.append(
+                    f"gpu {a['index']}: uncorrected ECC errors {b['ecc_uncorrected']} -> {a['ecc_uncorrected']}"
+                )
+        rows = a.get("remapped_rows")
+        if rows and len(rows) >= 4 and (rows[2] or rows[3]):
+            faults.append(f"gpu {a['index']}: remapped rows pending={rows[2]} failure={rows[3]}")
+        if a.get("recovery_action"):
+            faults.append(f"gpu {a['index']}: NVML recovery action {a['recovery_action']} required")
+    return faults
+
+
+def xid_lines() -> dict:
+    """The kernel log's NVRM Xid lines when the container may read it; most cannot, and that is fine."""
+    try:
+        out = subprocess.run(["dmesg"], capture_output=True, text=True, timeout=5)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"available": False, "error": str(exc)}
+    if out.returncode != 0:
+        return {"available": False, "error": (out.stderr or "").strip()[:200]}
+    lines = [line.strip() for line in out.stdout.splitlines() if "NVRM: Xid" in line]
+    return {"available": True, "count": len(lines), "last": lines[-5:]}
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--seconds", type=float, default=4.0, help="kernel work per GPU (default 4)"
+    )
+    parser.add_argument(
+        "--vram-mb", type=int, default=2048, help="working set cap per GPU (default 2048)"
+    )
+    parser.add_argument(
+        "--device", type=int, action="append", help="probe only this index (repeatable)"
+    )
+    args = parser.parse_args(argv)
+
+    started = time.perf_counter()
+    result: dict = {"status": "ok", "devices": [], "faults": []}
+    # every CUDA call happens in a forked worker (one per GPU, plus one to count them): a crash or hang
+    # in the driver takes the worker, not the verdict, and the parent never initialises CUDA itself
+    mp = multiprocessing.get_context("fork")
+    try:
+        indices = args.device if args.device else list(range(_device_count(mp)))
+        if not indices:
+            raise ProbeError("no CUDA devices")
+    except ProbeError as exc:
+        result.update(
+            status="error", error=str(exc), elapsed_s=round(time.perf_counter() - started, 2)
+        )
+        print(JSON_MARKER, json.dumps(result, sort_keys=True))
+        return 2
+
+    result["nvml_before"] = nvml_snapshot()
+    xid_before = xid_lines()
+
+    workers = []
+    for index in indices:
+        parent_conn, child_conn = mp.Pipe(duplex=False)
+        process = mp.Process(target=_worker, args=(index, args.seconds, args.vram_mb, child_conn))
+        process.start()
+        child_conn.close()
+        workers.append((index, process, parent_conn))
+
+    deadline = time.perf_counter() + args.seconds + WORKER_GRACE_SECONDS
+    for index, process, conn in workers:
+        report = None
+        while time.perf_counter() < deadline:
+            if conn.poll(0.2):
+                try:
+                    report = conn.recv()
+                except EOFError:
+                    pass
+                break
+            if not process.is_alive():
+                break
+        process.join(timeout=max(0.0, deadline - time.perf_counter()))
+        if process.is_alive():
+            process.kill()
+            process.join(5)
+            report = {
+                "index": index,
+                "status": "fault",
+                "error": f"hung: no result after {int(args.seconds + WORKER_GRACE_SECONDS)}s",
+            }
+        elif report is None:
+            code = process.exitcode
+            report = {
+                "index": index,
+                "status": "fault",
+                "error": f"worker died with exit code {code}",
+            }
+        result["devices"].append(report)
+
+    result["nvml_after"] = nvml_snapshot()
+    result["xid"] = xid_lines()
+    if xid_before.get("available") and result["xid"].get("available"):
+        new_xids = result["xid"]["count"] - xid_before["count"]
+        if new_xids > 0:
+            result["faults"].append(f"{new_xids} new NVRM Xid line(s): {result['xid']['last']}")
+    result["faults"].extend(nvml_faults(result["nvml_before"], result["nvml_after"]))
+    for report in result["devices"]:
+        if report["status"] == "fault":
+            result["faults"].append(f"gpu {report['index']}: {report['error']}")
+    errors = [r for r in result["devices"] if r["status"] == "error"]
+    if result["faults"]:
+        result["status"] = "fault"
+    elif errors:
+        result["status"] = "error"
+        result["error"] = "; ".join(f"gpu {r['index']}: {r['error']}" for r in errors)
+    result["elapsed_s"] = round(time.perf_counter() - started, 2)
+    print(JSON_MARKER, json.dumps(result, sort_keys=True))
+    return {"ok": 0, "fault": 1, "error": 2}[result["status"]]
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/neurons/validators/src/miner_jobs/gpu_fault_probe.py
+++ b/neurons/validators/src/miner_jobs/gpu_fault_probe.py
@@ -6,7 +6,7 @@ through nvidia-ml-py when it is importable. One forked worker per GPU runs, for 
 access patterns a cuBLAS matmul never exercises: a random permutation built on the device, a gather
 through it, a scatter back (plain stores and atomics), a dependent pointer chase, and a pinned-memory
 async H2D/D2H round-trip. Every result is verified on the device (mismatch counters) and a sample of
-the chase on the host. A fault is any non-zero CUDA return code once the context exists
+the chase on the host. A fault is any non-zero CUDA return code once the kernels run
 (CUDA_ERROR_ILLEGAL_ADDRESS is what Blender prints as "Illegal address in CUDA queue"), a data
 mismatch, a worker that crashes or hangs once its kernels run, or an uncorrected-ECC / remapped-row /
 recovery-action change in NVML across the run. A probe that cannot start (no libcuda, cuInit, PTX JIT,
@@ -24,6 +24,7 @@ import json
 import multiprocessing
 import multiprocessing.connection
 import os
+import re
 import subprocess
 import sys
 import time
@@ -43,6 +44,12 @@ WORKER_GRACE_SECONDS = 30  # on top of --seconds: JIT, allocations, copies, host
 WORKER_GRACE_PER_GPU_SECONDS = (
     5  # more of it per extra worker: they fork, JIT and allocate at the same time
 )
+NVML_GRACE_SECONDS = 10  # an NVML snapshot runs in its own fork: nvmlInit hangs on a wedged card
+WORKER_REAP_SECONDS = 5  # one shared wait for killed workers to be reaped, whatever their number
+DMESG_TIMEOUT_SECONDS = 5
+# Xid types an application raises on a healthy card (graphics exception, MMU fault, channel reset, preemptive
+# cleanup): a rented pod's own bug, not the hardware. The probe's own kernels report those through CUresult.
+SOFTWARE_XIDS = {13, 31, 43, 45}
 
 # fmix32-style mixer whose every step is a bijection on [0, 2**k): (x + seed) mod 2**k, odd multiplier
 # mod 2**k, xorshift within k bits. Mirrored in PTX by k_perm; the host replays it to check the chase.
@@ -474,6 +481,10 @@ def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dic
     name = ctypes.create_string_buffer(256)
     lib.cuDeviceGetName(name, 256, device)
     report["name"] = name.value.decode(errors="replace")
+    bus_id = ctypes.create_string_buffer(64)
+    lib.cuDeviceGetPCIBusId.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
+    if lib.cuDeviceGetPCIBusId(bus_id, 64, device) == 0:
+        report["pci_bus_id"] = bus_id.value.decode(errors="replace")
 
     # setup: everything up to the first kernel launch is "could the probe start", not "is the card faulty" —
     # a context the driver refuses, a busy or full card, a memlock cap on pinned memory all raise ProbeError
@@ -603,7 +614,17 @@ def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dic
     return report
 
 
+def _quiet_child() -> None:
+    # a forked worker inherits the SSH session's stdout/stderr; one the driver holds unreaped would keep the
+    # channel open after the parent has printed its verdict. Children talk to the parent over their pipe only.
+    devnull = os.open(os.devnull, os.O_WRONLY)
+    os.dup2(devnull, 1)
+    os.dup2(devnull, 2)
+    os.close(devnull)
+
+
 def _worker(index: int, seconds: float, vram_mb: int, conn) -> None:
+    _quiet_child()
     started = time.perf_counter()
 
     def on_phase(phase: str) -> None:
@@ -625,6 +646,7 @@ def _worker(index: int, seconds: float, vram_mb: int, conn) -> None:
 
 
 def _count_worker(conn) -> None:
+    _quiet_child()
     try:
         cuda = Cuda()
         cuda.call("cuInit", 0, fault=False)
@@ -675,6 +697,7 @@ def nvml_snapshot() -> dict:
             gpu: dict = {"index": i}
             for key, read in (
                 ("uuid", lambda h: pynvml.nvmlDeviceGetUUID(h)),
+                ("pci_bus_id", lambda h: pynvml.nvmlDeviceGetPciInfo(h).busId),
                 (
                     "ecc_uncorrected",
                     lambda h: pynvml.nvmlDeviceGetTotalEccErrors(
@@ -693,6 +716,34 @@ def nvml_snapshot() -> dict:
     finally:
         pynvml.nvmlShutdown()
     return {"available": True, "gpus": gpus}
+
+
+def _nvml_worker(conn) -> None:
+    _quiet_child()
+    try:
+        conn.send(nvml_snapshot())
+    except Exception as exc:  # noqa: BLE001
+        conn.send({"available": False, "error": f"{type(exc).__name__}: {exc}"})
+    conn.close()
+
+
+def nvml_snapshot_forked(mp) -> dict:
+    # in its own fork with a deadline: nvmlInit and the per-GPU reads block on a card that has wedged the
+    # driver, and this parent must always print its verdict
+    parent_conn, child_conn = mp.Pipe(duplex=False)
+    process = mp.Process(target=_nvml_worker, args=(child_conn,))
+    process.start()
+    child_conn.close()
+    snapshot = (
+        parent_conn.recv()
+        if parent_conn.poll(NVML_GRACE_SECONDS)
+        else {"available": False, "error": f"NVML snapshot hung for {NVML_GRACE_SECONDS}s"}
+    )
+    process.join(1)
+    if process.is_alive():
+        process.kill()
+        process.join(5)
+    return snapshot
 
 
 def nvml_faults(before: dict, after: dict) -> list[str]:
@@ -735,13 +786,49 @@ def nvml_faults(before: dict, after: dict) -> list[str]:
 def xid_lines() -> dict:
     """The kernel log's NVRM Xid lines when the container may read it; most cannot, and that is fine."""
     try:
-        out = subprocess.run(["dmesg"], capture_output=True, text=True, timeout=5)
+        out = subprocess.run(
+            ["dmesg"], capture_output=True, text=True, timeout=DMESG_TIMEOUT_SECONDS
+        )
     except (OSError, subprocess.TimeoutExpired) as exc:
         return {"available": False, "error": str(exc)}
     if out.returncode != 0:
         return {"available": False, "error": (out.stderr or "").strip()[:200]}
     lines = [line.strip() for line in out.stdout.splitlines() if "NVRM: Xid" in line]
-    return {"available": True, "count": len(lines), "last": lines[-5:]}
+    return {"available": True, "count": len(lines), "last": lines[-5:], "lines": lines}
+
+
+def pci_key(bus_id) -> str | None:
+    """`0000:81:00.0`, `00000000:81:00.0` and dmesg's `PCI:0000:81:00` all become `0000:81:00`."""
+    if not isinstance(bus_id, str):
+        return None
+    parts = bus_id.strip().lower().split(".")[0].split(":")
+    if len(parts) == 2:
+        parts = ["0000", *parts]
+    if len(parts) != 3:
+        return None
+    return f"{parts[0][-4:].rjust(4, '0')}:{parts[1]}:{parts[2]}"
+
+
+def xid_faults(before: dict, after: dict, bus_ids: set) -> tuple[list[str], list[str]]:
+    """New Xid lines split into this executor's hardware faults and evidence about other cards.
+
+    dmesg is host-wide: a rented pod's illegal address on another card, or a sibling executor's fault, must
+    not be scored against this one. A new line counts as a fault only when its PCI id is one of the probed
+    devices and its Xid type is not an application error (SOFTWARE_XIDS); everything else is kept as evidence.
+    """
+    if not (before.get("available") and after.get("available")):
+        return [], []
+    new_lines = (after.get("lines") or [])[len(before.get("lines") or []) :]
+    faults, other = [], []
+    for line in new_lines:
+        pci = re.search(r"Xid \(PCI:([0-9a-fA-F:.]+)\)", line)
+        code = re.search(r"Xid \([^)]*\): (\d+)", line)
+        xid = int(code.group(1)) if code else None
+        if pci and pci_key(pci.group(1)) in bus_ids and xid not in SOFTWARE_XIDS:
+            faults.append(f"new NVRM Xid on a probed GPU: {line[:200]}")
+        else:
+            other.append(line[:200])
+    return faults, other
 
 
 def drain_workers(workers: list, deadline: float, budget_s: float) -> list[dict]:
@@ -795,8 +882,11 @@ def drain_workers(workers: list, deadline: float, budget_s: float) -> list[dict]
     for index in list(pending):
         pending[index]["process"].kill()
         no_verdict(index, lambda phase: f"hung in {phase}: no result after {int(budget_s)}s")
+    # one reap grace for all of them, not 5 s each: a killed worker the driver still holds must not push
+    # the verdict past the validator's SSH cap on an 8-GPU host
+    reap_by = time.perf_counter() + WORKER_REAP_SECONDS
     for _, process, _ in workers:
-        process.join(5)
+        process.join(max(0.0, reap_by - time.perf_counter()))
     return [reports[index] for index, _, _ in workers]
 
 
@@ -834,7 +924,7 @@ def main(argv: list[str]) -> int:
         print(JSON_MARKER, json.dumps(result, sort_keys=True))
         return 2
 
-    result["nvml_before"] = nvml_snapshot()
+    result["nvml_before"] = nvml_snapshot_forked(mp)
     xid_before = xid_lines()
 
     workers = []
@@ -851,12 +941,19 @@ def main(argv: list[str]) -> int:
     budget = args.seconds + grace
     result["devices"] = drain_workers(workers, time.perf_counter() + budget, budget)
 
-    result["nvml_after"] = nvml_snapshot()
-    result["xid"] = xid_lines()
-    if xid_before.get("available") and result["xid"].get("available"):
-        new_xids = result["xid"]["count"] - xid_before["count"]
-        if new_xids > 0:
-            result["faults"].append(f"{new_xids} new NVRM Xid line(s): {result['xid']['last']}")
+    result["nvml_after"] = nvml_snapshot_forked(mp)
+    xid_after = xid_lines()
+    # the cards this run speaks for: the workers' own PCI ids, plus NVML's when every device was probed
+    bus_ids = {pci_key(r.get("pci_bus_id")) for r in result["devices"]} - {None}
+    if not args.device:
+        bus_ids |= {
+            pci_key(g.get("pci_bus_id")) for g in result["nvml_before"].get("gpus") or []
+        } - {None}
+    xid_new, xid_other = xid_faults(xid_before, xid_after, bus_ids)
+    result["faults"].extend(xid_new)
+    result["xid"] = {k: v for k, v in xid_after.items() if k != "lines"}
+    if xid_other:
+        result["xid"]["other_new"] = xid_other[-5:]
     result["faults"].extend(nvml_faults(result["nvml_before"], result["nvml_after"]))
     for report in result["devices"]:
         if report["status"] == "fault":
@@ -873,4 +970,10 @@ def main(argv: list[str]) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1:]))
+    code = main(sys.argv[1:])
+    # the verdict is printed into a pipe (block-buffered) and multiprocessing joins live children at exit
+    # without a timeout: flush, then leave without the exit handlers so a child the driver still holds
+    # cannot keep the verdict from the validator
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(code)

--- a/neurons/validators/src/miner_jobs/gpu_fault_probe.py
+++ b/neurons/validators/src/miner_jobs/gpu_fault_probe.py
@@ -414,10 +414,9 @@ def _read_counter(cuda: Cuda, d_ctr: int, h_ctr, stream) -> int:
     return ctypes.c_uint32.from_address(h_ctr.value).value
 
 
-def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dict:
-    report: dict = {"index": index}
-    cuda = Cuda()
-    lib = cuda.lib
+def _declare_driver_signatures(lib) -> None:
+    # ctypes defaults every argument to a C int: 64-bit device pointers and size_t lengths must be declared
+    # or they are truncated on the way into the driver
     lib.cuLaunchKernel.argtypes = [
         ctypes.c_void_p,
         ctypes.c_uint,
@@ -474,6 +473,14 @@ def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dic
         ctypes.c_char_p,
     ]
     lib.cuDeviceGetName.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
+    lib.cuDeviceGetPCIBusId.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
+
+
+def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dict:
+    report: dict = {"index": index}
+    cuda = Cuda()
+    lib = cuda.lib
+    _declare_driver_signatures(lib)
 
     cuda.call("cuInit", 0, fault=False)
     device = ctypes.c_int()
@@ -482,7 +489,6 @@ def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dic
     lib.cuDeviceGetName(name, 256, device)
     report["name"] = name.value.decode(errors="replace")
     bus_id = ctypes.create_string_buffer(64)
-    lib.cuDeviceGetPCIBusId.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
     if lib.cuDeviceGetPCIBusId(bus_id, 64, device) == 0:
         report["pci_bus_id"] = bus_id.value.decode(errors="replace")
 
@@ -664,11 +670,14 @@ def _device_count(mp) -> int:
     process = mp.Process(target=_count_worker, args=(child_conn,))
     process.start()
     child_conn.close()
-    reply = (
-        parent_conn.recv()
-        if parent_conn.poll(WORKER_GRACE_SECONDS)
-        else {"error": "device enumeration hung"}
-    )
+    try:
+        reply = (
+            parent_conn.recv()
+            if parent_conn.poll(WORKER_GRACE_SECONDS)
+            else {"error": "device enumeration hung"}
+        )
+    except EOFError:  # the pipe closed without a reply: the enumeration child died
+        reply = {"error": f"device enumeration worker died with exit code {_exit_code(process)}"}
     process.join(5)
     if process.is_alive():
         # multiprocessing joins live children at interpreter exit without a timeout: a hung enumeration
@@ -734,11 +743,14 @@ def nvml_snapshot_forked(mp) -> dict:
     process = mp.Process(target=_nvml_worker, args=(child_conn,))
     process.start()
     child_conn.close()
-    snapshot = (
-        parent_conn.recv()
-        if parent_conn.poll(NVML_GRACE_SECONDS)
-        else {"available": False, "error": f"NVML snapshot hung for {NVML_GRACE_SECONDS}s"}
-    )
+    try:
+        snapshot = (
+            parent_conn.recv()
+            if parent_conn.poll(NVML_GRACE_SECONDS)
+            else {"available": False, "error": f"NVML snapshot hung for {NVML_GRACE_SECONDS}s"}
+        )
+    except EOFError:  # the pipe closed without a snapshot: the NVML child died (a driver call that aborted)
+        snapshot = {"available": False, "error": f"NVML snapshot worker died with exit code {_exit_code(process)}"}
     process.join(1)
     if process.is_alive():
         process.kill()
@@ -748,7 +760,24 @@ def nvml_snapshot_forked(mp) -> dict:
 
 def nvml_faults(before: dict, after: dict) -> list[str]:
     faults = []
-    for b, a in zip(before.get("gpus", []), after.get("gpus", [])):
+    before_gpus, after_gpus = before.get("gpus", []), after.get("gpus", [])
+    # the UUID names the card; when any read of it failed (an old binding, one card) both snapshots fall
+    # back to the position, so the two sides are always keyed the same way
+    by_uuid = all(gpu.get("uuid") for gpu in before_gpus + after_gpus)
+
+    def key(gpu: dict):
+        return gpu["uuid"] if by_uuid else gpu.get("index")
+
+    after_by_key = {key(a): a for a in after_gpus}
+    for b in before_gpus:
+        a = after_by_key.get(key(b))
+        if a is None:
+            # matched by UUID, not by position: a card that fell off the bus mid-run must not be read
+            # as the card that took its index
+            faults.append(
+                f"gpu {b['index']} ({b.get('uuid') or b.get('pci_bus_id')}): missing from the NVML snapshot after the run"
+            )
+            continue
         if a.get("ecc_uncorrected") is not None and b.get("ecc_uncorrected") is not None:
             if a["ecc_uncorrected"] > b["ecc_uncorrected"]:
                 faults.append(
@@ -857,7 +886,7 @@ def drain_workers(workers: list, deadline: float, budget_s: float) -> list[dict]
         code = _exit_code(pending[index]["process"])
         no_verdict(index, lambda phase: f"worker died in {phase} with exit code {code}")
 
-    def sweep(timeout: float) -> None:
+    def poll_worker_pipes(timeout: float) -> None:
         by_conn = {worker["conn"]: index for index, worker in pending.items()}
         for conn in multiprocessing.connection.wait(list(by_conn), timeout=timeout):
             index = by_conn[conn]
@@ -876,9 +905,9 @@ def drain_workers(workers: list, deadline: float, budget_s: float) -> list[dict]
                 died(index)
 
     while pending and time.perf_counter() < deadline:
-        sweep(0.2)
+        poll_worker_pipes(0.2)
     if pending:
-        sweep(0)  # a message that landed as the deadline passed
+        poll_worker_pipes(0)  # a message that landed as the deadline passed
     for index in list(pending):
         pending[index]["process"].kill()
         no_verdict(index, lambda phase: f"hung in {phase}: no result after {int(budget_s)}s")

--- a/neurons/validators/src/miner_jobs/gpu_fault_probe.py
+++ b/neurons/validators/src/miner_jobs/gpu_fault_probe.py
@@ -22,6 +22,7 @@ import argparse
 import ctypes
 import json
 import multiprocessing
+import multiprocessing.connection
 import os
 import subprocess
 import sys
@@ -715,9 +716,16 @@ def nvml_faults(before: dict, after: dict) -> list[str]:
                     f"gpu {a['index']}: remapped rows corrected {rows_before[0]} -> {rows[0]}, "
                     f"uncorrected {rows_before[1]} -> {rows[1]}"
                 )
-            if rows[2] or rows[3]:
+            # isPending stays set until the GPU is reset, so a card already pending a remap before the run
+            # must not fault on every cycle: only a flag that came up during the run counts
+            if (
+                rows_before
+                and len(rows_before) >= 4
+                and ((rows[2] and not rows_before[2]) or (rows[3] and not rows_before[3]))
+            ):
                 faults.append(
-                    f"gpu {a['index']}: remapped rows pending={rows[2]} failure={rows[3]}"
+                    f"gpu {a['index']}: remapped rows pending={rows_before[2]} -> {rows[2]}, "
+                    f"failure={rows_before[3]} -> {rows[3]}"
                 )
         if a.get("recovery_action"):
             faults.append(f"gpu {a['index']}: NVML recovery action {a['recovery_action']} required")
@@ -734,6 +742,67 @@ def xid_lines() -> dict:
         return {"available": False, "error": (out.stderr or "").strip()[:200]}
     lines = [line.strip() for line in out.stdout.splitlines() if "NVRM: Xid" in line]
     return {"available": True, "count": len(lines), "last": lines[-5:]}
+
+
+def drain_workers(workers: list, deadline: float, budget_s: float) -> list[dict]:
+    """One report per worker, every pipe polled together until the deadline.
+
+    Every worker gets the whole budget: a card that hangs does not eat the time of the ones after it, and a
+    report a worker has already sent (a fault on GPU 3 while GPU 0 hangs) is read, not discarded. A worker
+    still in setup at the deadline did not get to measure anything: the host, the driver or the container's
+    limits kept it from starting, which is an error; once its kernels run, a hang or a crash is the card's.
+    """
+    pending = {
+        index: {"process": process, "conn": conn, "phase": "setup"}
+        for index, process, conn in workers
+    }
+    reports: dict[int, dict] = {}
+
+    def no_verdict(index: int, describe) -> None:
+        worker = pending.pop(index)
+        reports[index] = {
+            "index": index,
+            "status": "fault" if worker["phase"] == "kernels" else "error",
+            "error": describe(worker["phase"]),
+        }
+
+    def died(index: int) -> None:
+        code = _exit_code(pending[index]["process"])
+        no_verdict(index, lambda phase: f"worker died in {phase} with exit code {code}")
+
+    def sweep(timeout: float) -> None:
+        by_conn = {worker["conn"]: index for index, worker in pending.items()}
+        for conn in multiprocessing.connection.wait(list(by_conn), timeout=timeout):
+            index = by_conn[conn]
+            try:
+                message = conn.recv()
+            except EOFError:  # the pipe closed without a report: the worker is gone
+                died(index)
+                continue
+            if "phase" in message:
+                pending[index]["phase"] = message["phase"]
+            else:
+                reports[index] = message
+                del pending[index]
+        for index, worker in list(pending.items()):
+            if not worker["process"].is_alive() and not worker["conn"].poll(0):
+                died(index)
+
+    while pending and time.perf_counter() < deadline:
+        sweep(0.2)
+    if pending:
+        sweep(0)  # a message that landed as the deadline passed
+    for index in list(pending):
+        pending[index]["process"].kill()
+        no_verdict(index, lambda phase: f"hung in {phase}: no result after {int(budget_s)}s")
+    for _, process, _ in workers:
+        process.join(5)
+    return [reports[index] for index, _, _ in workers]
+
+
+def _exit_code(process):
+    process.join(1)
+    return process.exitcode
 
 
 def main(argv: list[str]) -> int:
@@ -776,45 +845,11 @@ def main(argv: list[str]) -> int:
         child_conn.close()
         workers.append((index, process, parent_conn))
 
-    # one deadline for the concurrent workers, with grace that grows with their number: eight interpreters
-    # forking, JIT-compiling and allocating at once on a loaded host take longer than one
+    # one wall-clock budget for the concurrent workers, with grace that grows with their number: eight
+    # interpreters forking, JIT-compiling and allocating at once on a loaded host take longer than one
     grace = WORKER_GRACE_SECONDS + WORKER_GRACE_PER_GPU_SECONDS * (len(workers) - 1)
-    deadline = time.perf_counter() + args.seconds + grace
-    for index, process, conn in workers:
-        report = None
-        phase = "setup"
-        while time.perf_counter() < deadline:
-            if conn.poll(0.2):
-                try:
-                    message = conn.recv()
-                except EOFError:
-                    break
-                if "phase" in message:
-                    phase = message["phase"]
-                    continue
-                report = message
-                break
-            if not process.is_alive():
-                break
-        process.join(timeout=max(0.0, deadline - time.perf_counter()))
-        # a worker still in setup did not get to measure anything: the host, the driver or the container's
-        # limits kept it from starting, which is an error; once its kernels run, a hang or a crash is the card's
-        if process.is_alive():
-            process.kill()
-            process.join(5)
-            report = {
-                "index": index,
-                "status": "fault" if phase == "kernels" else "error",
-                "error": f"hung in {phase}: no result after {int(args.seconds + grace)}s",
-            }
-        elif report is None:
-            code = process.exitcode
-            report = {
-                "index": index,
-                "status": "fault" if phase == "kernels" else "error",
-                "error": f"worker died in {phase} with exit code {code}",
-            }
-        result["devices"].append(report)
+    budget = args.seconds + grace
+    result["devices"] = drain_workers(workers, time.perf_counter() + budget, budget)
 
     result["nvml_after"] = nvml_snapshot()
     result["xid"] = xid_lines()

--- a/neurons/validators/src/miner_jobs/gpu_fault_probe.py
+++ b/neurons/validators/src/miner_jobs/gpu_fault_probe.py
@@ -28,6 +28,7 @@ import re
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 
 MB = 1024 * 1024
 JSON_MARKER = "GPU_FAULT_PROBE_JSON:"
@@ -45,7 +46,9 @@ WORKER_GRACE_PER_GPU_SECONDS = (
     5  # more of it per extra worker: they fork, JIT and allocate at the same time
 )
 NVML_GRACE_SECONDS = 10  # an NVML snapshot runs in its own fork: nvmlInit hangs on a wedged card
-WORKER_REAP_SECONDS = 5  # one shared wait for killed workers to be reaped, whatever their number
+WORKER_REAP_AFTER_KILL_SECONDS = (
+    5  # one shared wait, after the kill, for the workers to be reaped, whatever their number
+)
 DMESG_TIMEOUT_SECONDS = 5
 # Xid types an application raises on a healthy card (graphics exception, MMU fault, channel reset, preemptive
 # cleanup): a rented pod's own bug, not the hardware. The probe's own kernels report those through CUresult.
@@ -389,11 +392,11 @@ class Cuda:
             return name.value.decode()
         return f"CUDA_ERROR_{code}"
 
-    def call(self, fn: str, *args, fault: bool = True) -> None:
+    def call(self, fn: str, *args, raise_as_fault: bool = True) -> None:
         code = getattr(self.lib, fn)(*args)
         if code != 0:
             message = f"{fn} -> {self.error_name(code)} ({code})"
-            raise CudaFault(message) if fault else ProbeError(message)
+            raise CudaFault(message) if raise_as_fault else ProbeError(message)
 
 
 class DevPtr(int):
@@ -476,15 +479,40 @@ def _declare_driver_signatures(lib) -> None:
     lib.cuDeviceGetPCIBusId.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
 
 
-def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dict:
+@dataclass
+class ProbeSetup:
+    """What the allocation phase hands the kernel phase: the context, the JIT'd kernels, the stream and
+    the device and pinned host buffers, sized to the card. Built by ``_setup_device``, freed at the end
+    of ``probe_device``."""
+
+    report: dict
+    cuda: Cuda
+    context: ctypes.c_void_p
+    n: int
+    mask: int
+    funcs: dict
+    stream: ctypes.c_void_p
+    device_buffers: list
+    d_ctr: DevPtr
+    h_ctr: ctypes.c_void_p
+    copy_bytes: int
+    h_src: ctypes.c_void_p
+    h_dst: ctypes.c_void_p
+    pattern: bytes
+    h_sample: ctypes.c_void_p
+
+
+def _setup_device(index: int, vram_mb: int) -> ProbeSetup:
+    """The allocation phase: everything up to the first kernel launch is "could the probe start", not "is
+    the card faulty" — every CUDA call here is ``raise_as_fault=False`` (a ProbeError), never a CudaFault."""
     report: dict = {"index": index}
     cuda = Cuda()
     lib = cuda.lib
     _declare_driver_signatures(lib)
 
-    cuda.call("cuInit", 0, fault=False)
+    cuda.call("cuInit", 0, raise_as_fault=False)
     device = ctypes.c_int()
-    cuda.call("cuDeviceGet", ctypes.byref(device), index, fault=False)
+    cuda.call("cuDeviceGet", ctypes.byref(device), index, raise_as_fault=False)
     name = ctypes.create_string_buffer(256)
     lib.cuDeviceGetName(name, 256, device)
     report["name"] = name.value.decode(errors="replace")
@@ -495,9 +523,9 @@ def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dic
     # setup: everything up to the first kernel launch is "could the probe start", not "is the card faulty" —
     # a context the driver refuses, a busy or full card, a memlock cap on pinned memory all raise ProbeError
     context = ctypes.c_void_p()
-    cuda.call("cuCtxCreate_v2", ctypes.byref(context), 0, device, fault=False)
+    cuda.call("cuCtxCreate_v2", ctypes.byref(context), 0, device, raise_as_fault=False)
     free, total = ctypes.c_size_t(), ctypes.c_size_t()
-    cuda.call("cuMemGetInfo_v2", ctypes.byref(free), ctypes.byref(total), fault=False)
+    cuda.call("cuMemGetInfo_v2", ctypes.byref(free), ctypes.byref(total), raise_as_fault=False)
     report["vram_free_mb"] = free.value // MB
 
     budget = min(vram_mb * MB, max(free.value - VRAM_RESERVE_MB * MB, 0))
@@ -530,32 +558,67 @@ def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dic
     funcs = {}
     for kernel in KERNELS:
         func = ctypes.c_void_p()
-        cuda.call("cuModuleGetFunction", ctypes.byref(func), module, kernel.encode(), fault=False)
+        cuda.call(
+            "cuModuleGetFunction", ctypes.byref(func), module, kernel.encode(), raise_as_fault=False
+        )
         funcs[kernel] = func
     report["jit_ms"] = int((time.perf_counter() - t_jit) * 1000)
 
     stream = ctypes.c_void_p()
-    cuda.call("cuStreamCreate", ctypes.byref(stream), 1, fault=False)  # CU_STREAM_NON_BLOCKING
+    cuda.call(
+        "cuStreamCreate", ctypes.byref(stream), 1, raise_as_fault=False
+    )  # CU_STREAM_NON_BLOCKING
     device_buffers = []
     for _ in range(BUFFERS):
         ptr = ctypes.c_uint64()
-        cuda.call("cuMemAlloc_v2", ctypes.byref(ptr), n * 4, fault=False)
+        cuda.call("cuMemAlloc_v2", ctypes.byref(ptr), n * 4, raise_as_fault=False)
         device_buffers.append(DevPtr(ptr.value))
-    d_in, d_idx, d_out, d_aux = device_buffers
     d_ctr = ctypes.c_uint64()
-    cuda.call("cuMemAlloc_v2", ctypes.byref(d_ctr), 16, fault=False)
+    cuda.call("cuMemAlloc_v2", ctypes.byref(d_ctr), 16, raise_as_fault=False)
     d_ctr = DevPtr(d_ctr.value)
     h_ctr = ctypes.c_void_p()
-    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_ctr), 16, fault=False)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_ctr), 16, raise_as_fault=False)
     copy_bytes = min(32 * MB, n * 4)
     h_src, h_dst = ctypes.c_void_p(), ctypes.c_void_p()
-    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_src), copy_bytes, fault=False)
-    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_dst), copy_bytes, fault=False)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_src), copy_bytes, raise_as_fault=False)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_dst), copy_bytes, raise_as_fault=False)
     pattern = os.urandom(copy_bytes)
     ctypes.memmove(h_src, pattern, copy_bytes)
     h_sample = ctypes.c_void_p()
-    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_sample), CHASE_SAMPLES * 4, fault=False)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_sample), CHASE_SAMPLES * 4, raise_as_fault=False)
     report["copy_mb"] = copy_bytes // MB
+    return ProbeSetup(
+        report=report,
+        cuda=cuda,
+        context=context,
+        n=n,
+        mask=mask,
+        funcs=funcs,
+        stream=stream,
+        device_buffers=device_buffers,
+        d_ctr=d_ctr,
+        h_ctr=h_ctr,
+        copy_bytes=copy_bytes,
+        h_src=h_src,
+        h_dst=h_dst,
+        pattern=pattern,
+        h_sample=h_sample,
+    )
+
+
+def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dict:
+    setup = _setup_device(index, vram_mb)
+    report, cuda, context = setup.report, setup.cuda, setup.context
+    n, mask, funcs, stream = setup.n, setup.mask, setup.funcs, setup.stream
+    device_buffers, d_ctr, h_ctr = setup.device_buffers, setup.d_ctr, setup.h_ctr
+    copy_bytes, h_src, h_dst, pattern, h_sample = (
+        setup.copy_bytes,
+        setup.h_src,
+        setup.h_dst,
+        setup.pattern,
+        setup.h_sample,
+    )
+    d_in, d_idx, d_out, d_aux = device_buffers
     if on_phase is not None:
         on_phase("kernels")  # from here on a hang or a crash is the card's
 
@@ -655,9 +718,9 @@ def _count_worker(conn) -> None:
     _quiet_child()
     try:
         cuda = Cuda()
-        cuda.call("cuInit", 0, fault=False)
+        cuda.call("cuInit", 0, raise_as_fault=False)
         count = ctypes.c_int()
-        cuda.call("cuDeviceGetCount", ctypes.byref(count), fault=False)
+        cuda.call("cuDeviceGetCount", ctypes.byref(count), raise_as_fault=False)
         conn.send({"count": count.value})
     except Exception as exc:  # noqa: BLE001
         conn.send({"error": str(exc)})
@@ -749,8 +812,13 @@ def nvml_snapshot_forked(mp) -> dict:
             if parent_conn.poll(NVML_GRACE_SECONDS)
             else {"available": False, "error": f"NVML snapshot hung for {NVML_GRACE_SECONDS}s"}
         )
-    except EOFError:  # the pipe closed without a snapshot: the NVML child died (a driver call that aborted)
-        snapshot = {"available": False, "error": f"NVML snapshot worker died with exit code {_exit_code(process)}"}
+    except (
+        EOFError
+    ):  # the pipe closed without a snapshot: the NVML child died (a driver call that aborted)
+        snapshot = {
+            "available": False,
+            "error": f"NVML snapshot worker died with exit code {_exit_code(process)}",
+        }
     process.join(1)
     if process.is_alive():
         process.kill()
@@ -853,7 +921,13 @@ def xid_faults(before: dict, after: dict, bus_ids: set) -> tuple[list[str], list
         pci = re.search(r"Xid \(PCI:([0-9a-fA-F:.]+)\)", line)
         code = re.search(r"Xid \([^)]*\): (\d+)", line)
         xid = int(code.group(1)) if code else None
-        if pci and pci_key(pci.group(1)) in bus_ids and xid not in SOFTWARE_XIDS:
+        # a line whose Xid number the regex misses is kept as "other", not scored as hardware (review)
+        if (
+            pci
+            and pci_key(pci.group(1)) in bus_ids
+            and xid is not None
+            and xid not in SOFTWARE_XIDS
+        ):
             faults.append(f"new NVRM Xid on a probed GPU: {line[:200]}")
         else:
             other.append(line[:200])
@@ -913,7 +987,7 @@ def drain_workers(workers: list, deadline: float, budget_s: float) -> list[dict]
         no_verdict(index, lambda phase: f"hung in {phase}: no result after {int(budget_s)}s")
     # one reap grace for all of them, not 5 s each: a killed worker the driver still holds must not push
     # the verdict past the validator's SSH cap on an 8-GPU host
-    reap_by = time.perf_counter() + WORKER_REAP_SECONDS
+    reap_by = time.perf_counter() + WORKER_REAP_AFTER_KILL_SECONDS
     for _, process, _ in workers:
         process.join(max(0.0, reap_by - time.perf_counter()))
     return [reports[index] for index, _, _ in workers]

--- a/neurons/validators/src/miner_jobs/gpu_fault_probe.py
+++ b/neurons/validators/src/miner_jobs/gpu_fault_probe.py
@@ -8,9 +8,10 @@ through it, a scatter back (plain stores and atomics), a dependent pointer chase
 async H2D/D2H round-trip. Every result is verified on the device (mismatch counters) and a sample of
 the chase on the host. A fault is any non-zero CUDA return code once the context exists
 (CUDA_ERROR_ILLEGAL_ADDRESS is what Blender prints as "Illegal address in CUDA queue"), a data
-mismatch, a worker that crashes or hangs, or an uncorrected-ECC / remapped-row / recovery-action
-change in NVML across the run. A probe that cannot start (no libcuda, cuInit, PTX JIT) is an error,
-not a fault: the validator does not penalise what it could not measure.
+mismatch, a worker that crashes or hangs once its kernels run, or an uncorrected-ECC / remapped-row /
+recovery-action change in NVML across the run. A probe that cannot start (no libcuda, cuInit, PTX JIT,
+context creation, an allocation the card or the container's limits refuse, a worker that never gets past
+setup) is an error, not a fault: the validator does not penalise what it could not measure.
 
 Prints one line `GPU_FAULT_PROBE_JSON: {...}`. Exit 0 ok, 1 fault, 2 could not run.
 """
@@ -38,6 +39,9 @@ VRAM_RESERVE_MB = (
     1024  # left free on the card: the runtime's own context and whatever else idles there
 )
 WORKER_GRACE_SECONDS = 30  # on top of --seconds: JIT, allocations, copies, host verification
+WORKER_GRACE_PER_GPU_SECONDS = (
+    5  # more of it per extra worker: they fork, JIT and allocate at the same time
+)
 
 # fmix32-style mixer whose every step is a bijection on [0, 2**k): (x + seed) mod 2**k, odd multiplier
 # mod 2**k, xorshift within k bits. Mirrored in PTX by k_perm; the host replays it to check the chase.
@@ -402,7 +406,7 @@ def _read_counter(cuda: Cuda, d_ctr: int, h_ctr, stream) -> int:
     return ctypes.c_uint32.from_address(h_ctr.value).value
 
 
-def probe_device(index: int, seconds: float, vram_mb: int) -> dict:
+def probe_device(index: int, seconds: float, vram_mb: int, on_phase=None) -> dict:
     report: dict = {"index": index}
     cuda = Cuda()
     lib = cuda.lib
@@ -470,13 +474,21 @@ def probe_device(index: int, seconds: float, vram_mb: int) -> dict:
     lib.cuDeviceGetName(name, 256, device)
     report["name"] = name.value.decode(errors="replace")
 
+    # setup: everything up to the first kernel launch is "could the probe start", not "is the card faulty" —
+    # a context the driver refuses, a busy or full card, a memlock cap on pinned memory all raise ProbeError
     context = ctypes.c_void_p()
-    cuda.call("cuCtxCreate_v2", ctypes.byref(context), 0, device)
+    cuda.call("cuCtxCreate_v2", ctypes.byref(context), 0, device, fault=False)
     free, total = ctypes.c_size_t(), ctypes.c_size_t()
-    cuda.call("cuMemGetInfo_v2", ctypes.byref(free), ctypes.byref(total))
+    cuda.call("cuMemGetInfo_v2", ctypes.byref(free), ctypes.byref(total), fault=False)
     report["vram_free_mb"] = free.value // MB
 
     budget = min(vram_mb * MB, max(free.value - VRAM_RESERVE_MB * MB, 0))
+    smallest = BUFFERS * 4 * (1 << MIN_LOG2_N)
+    if budget < smallest:
+        raise ProbeError(
+            f"not enough free VRAM: {free.value // MB} MB free, {VRAM_RESERVE_MB} MB reserved, "
+            f"the smallest working set is {smallest // MB} MB"
+        )
     log2_n = MIN_LOG2_N
     while log2_n < MAX_LOG2_N and BUFFERS * 4 * (1 << (log2_n + 1)) <= budget:
         log2_n += 1
@@ -505,27 +517,29 @@ def probe_device(index: int, seconds: float, vram_mb: int) -> dict:
     report["jit_ms"] = int((time.perf_counter() - t_jit) * 1000)
 
     stream = ctypes.c_void_p()
-    cuda.call("cuStreamCreate", ctypes.byref(stream), 1)  # CU_STREAM_NON_BLOCKING
+    cuda.call("cuStreamCreate", ctypes.byref(stream), 1, fault=False)  # CU_STREAM_NON_BLOCKING
     device_buffers = []
     for _ in range(BUFFERS):
         ptr = ctypes.c_uint64()
-        cuda.call("cuMemAlloc_v2", ctypes.byref(ptr), n * 4)
+        cuda.call("cuMemAlloc_v2", ctypes.byref(ptr), n * 4, fault=False)
         device_buffers.append(DevPtr(ptr.value))
     d_in, d_idx, d_out, d_aux = device_buffers
     d_ctr = ctypes.c_uint64()
-    cuda.call("cuMemAlloc_v2", ctypes.byref(d_ctr), 16)
+    cuda.call("cuMemAlloc_v2", ctypes.byref(d_ctr), 16, fault=False)
     d_ctr = DevPtr(d_ctr.value)
     h_ctr = ctypes.c_void_p()
-    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_ctr), 16)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_ctr), 16, fault=False)
     copy_bytes = min(32 * MB, n * 4)
     h_src, h_dst = ctypes.c_void_p(), ctypes.c_void_p()
-    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_src), copy_bytes)
-    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_dst), copy_bytes)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_src), copy_bytes, fault=False)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_dst), copy_bytes, fault=False)
     pattern = os.urandom(copy_bytes)
     ctypes.memmove(h_src, pattern, copy_bytes)
     h_sample = ctypes.c_void_p()
-    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_sample), CHASE_SAMPLES * 4)
+    cuda.call("cuMemAllocHost_v2", ctypes.byref(h_sample), CHASE_SAMPLES * 4, fault=False)
     report["copy_mb"] = copy_bytes // MB
+    if on_phase is not None:
+        on_phase("kernels")  # from here on a hang or a crash is the card's
 
     def launch(kernel: str, *args) -> None:
         _launch(cuda, funcs[kernel], stream, n, *args)
@@ -590,8 +604,13 @@ def probe_device(index: int, seconds: float, vram_mb: int) -> dict:
 
 def _worker(index: int, seconds: float, vram_mb: int, conn) -> None:
     started = time.perf_counter()
+
+    def on_phase(phase: str) -> None:
+        # the parent classifies a worker that never answers by the phase it reached: setup -> error, kernels -> fault
+        conn.send({"phase": phase})
+
     try:
-        report = probe_device(index, seconds, vram_mb)
+        report = probe_device(index, seconds, vram_mb, on_phase)
         report["status"] = "ok"
     except CudaFault as exc:
         report = {"index": index, "status": "fault", "error": str(exc)}
@@ -628,6 +647,11 @@ def _device_count(mp) -> int:
         else {"error": "device enumeration hung"}
     )
     process.join(5)
+    if process.is_alive():
+        # multiprocessing joins live children at interpreter exit without a timeout: a hung enumeration
+        # would keep this process alive past the check's deadline and turn "could not count" into a fault
+        process.kill()
+        process.join(5)
     if "error" in reply:
         raise ProbeError(reply["error"])
     return reply["count"]
@@ -678,9 +702,23 @@ def nvml_faults(before: dict, after: dict) -> list[str]:
                 faults.append(
                     f"gpu {a['index']}: uncorrected ECC errors {b['ecc_uncorrected']} -> {a['ecc_uncorrected']}"
                 )
-        rows = a.get("remapped_rows")
-        if rows and len(rows) >= 4 and (rows[2] or rows[3]):
-            faults.append(f"gpu {a['index']}: remapped rows pending={rows[2]} failure={rows[3]}")
+        rows, rows_before = a.get("remapped_rows"), b.get("remapped_rows")
+        if rows and len(rows) >= 4:
+            # (corrected, uncorrected, isPending, failureOccurred): a row remapped during the run is a fault
+            # whether or not the remap is still pending or has failed
+            if (
+                rows_before
+                and len(rows_before) >= 2
+                and (rows[0] > rows_before[0] or rows[1] > rows_before[1])
+            ):
+                faults.append(
+                    f"gpu {a['index']}: remapped rows corrected {rows_before[0]} -> {rows[0]}, "
+                    f"uncorrected {rows_before[1]} -> {rows[1]}"
+                )
+            if rows[2] or rows[3]:
+                faults.append(
+                    f"gpu {a['index']}: remapped rows pending={rows[2]} failure={rows[3]}"
+                )
         if a.get("recovery_action"):
             faults.append(f"gpu {a['index']}: NVML recovery action {a['recovery_action']} required")
     return faults
@@ -738,33 +776,43 @@ def main(argv: list[str]) -> int:
         child_conn.close()
         workers.append((index, process, parent_conn))
 
-    deadline = time.perf_counter() + args.seconds + WORKER_GRACE_SECONDS
+    # one deadline for the concurrent workers, with grace that grows with their number: eight interpreters
+    # forking, JIT-compiling and allocating at once on a loaded host take longer than one
+    grace = WORKER_GRACE_SECONDS + WORKER_GRACE_PER_GPU_SECONDS * (len(workers) - 1)
+    deadline = time.perf_counter() + args.seconds + grace
     for index, process, conn in workers:
         report = None
+        phase = "setup"
         while time.perf_counter() < deadline:
             if conn.poll(0.2):
                 try:
-                    report = conn.recv()
+                    message = conn.recv()
                 except EOFError:
-                    pass
+                    break
+                if "phase" in message:
+                    phase = message["phase"]
+                    continue
+                report = message
                 break
             if not process.is_alive():
                 break
         process.join(timeout=max(0.0, deadline - time.perf_counter()))
+        # a worker still in setup did not get to measure anything: the host, the driver or the container's
+        # limits kept it from starting, which is an error; once its kernels run, a hang or a crash is the card's
         if process.is_alive():
             process.kill()
             process.join(5)
             report = {
                 "index": index,
-                "status": "fault",
-                "error": f"hung: no result after {int(args.seconds + WORKER_GRACE_SECONDS)}s",
+                "status": "fault" if phase == "kernels" else "error",
+                "error": f"hung in {phase}: no result after {int(args.seconds + grace)}s",
             }
         elif report is None:
             code = process.exitcode
             report = {
                 "index": index,
-                "status": "fault",
-                "error": f"worker died with exit code {code}",
+                "status": "fault" if phase == "kernels" else "error",
+                "error": f"worker died in {phase} with exit code {code}",
             }
         result["devices"].append(report)
 

--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -9,6 +9,7 @@ from .duplicate_executor import DuplicateExecutorCheck
 from .executor_image import ExecutorImageCheck
 from .finalize import FinalizeCheck
 from .gpu_count import GpuCountCheck
+from .gpu_fault_probe import GpuFaultProbeCheck
 from .gpu_fingerprint import GpuFingerprintCheck
 from .gpu_model_valid import GpuModelValidCheck
 from .gpu_power_limit import GpuPowerLimitCheck
@@ -43,6 +44,7 @@ __all__ = [
     "ExecutorImageCheck",
     "FinalizeCheck",
     "GpuCountCheck",
+    "GpuFaultProbeCheck",
     "GpuFingerprintCheck",
     "GpuModelValidCheck",
     "GpuPowerLimitCheck",

--- a/neurons/validators/src/services/task/checks/gpu_fault_probe.py
+++ b/neurons/validators/src/services/task/checks/gpu_fault_probe.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+
+from core.config import settings
+
+from ..messages import GpuFaultProbeMessages as Msg
+from ..messages import render_message
+from ..pipeline import CheckResult, Context
+from .capability import _get_filler_only_container
+
+# The probe runs on the executor's own interpreter, standard library only, and ships over stdin the way
+# the scrape source does (DAH-2794): nothing to upload, nothing the miner has to update.
+PROBE_SOURCE_PATH = Path(__file__).resolve().parents[3] / "miner_jobs" / "gpu_fault_probe.py"
+PROBE_SOURCE = PROBE_SOURCE_PATH.read_text()
+PROBE_JSON_MARKER = "GPU_FAULT_PROBE_JSON:"
+# Measured on a healthy 1x RTX 4090 (driver 580): 5.3 s in-script, 6.6 s over SSH, 7 rounds on a 2 GB
+# working set. The probe's own per-GPU deadline is --seconds + 30 s; this cap only catches an interpreter
+# that never printed — a wedged card that hangs the driver is a fault, not a slow host.
+PROBE_TIMEOUT_SECONDS = 90
+PROBE_SECONDS = 4
+OUTPUT_TAIL_CHARS = 800
+
+
+class GpuFaultProbeCheck:
+    """Run the kernel-fault probe on the executor's GPUs after the matmul has passed (DAH-3035).
+
+    A cuBLAS matmul reads and writes memory sequentially and verifies one number; a card whose memory
+    subsystem faults under indexed access renders nothing (Blender: "Illegal address in CUDA queue" on
+    both OptiX and CUDA, 6 Sep) yet passes it and stays listed. The probe (miner_jobs/gpu_fault_probe.py)
+    gathers, scatters, atomics and pointer-chases through a random permutation of a ~2 GB working set,
+    round-trips pinned memory through the copy engines, verifies every result on the device, and reads
+    uncorrected ECC / remapped rows / recovery action from NVML before and after.
+
+    Shadow-first like every score-zeroing gate: GPU_FAULT_PROBE_CHECK_ENABLED runs it and emits the verdict,
+    GPU_FAULT_PROBE_ENFORCEMENT_ENABLED lets a fault fail the (fatal) check. A probe that could not run
+    (no libcuda, cuInit, JIT) passes with GPU_FAULT_PROBE_UNKNOWN: inability to measure is not a fault.
+    """
+
+    check_id = "gpu.validate.fault_probe"
+    fatal = True
+
+    async def run(self, ctx: Context) -> CheckResult:
+        if not settings.GPU_FAULT_PROBE_CHECK_ENABLED:
+            return CheckResult(
+                passed=True, event=render_message(Msg.DISABLED, ctx=ctx, check_id=self.check_id)
+            )
+
+        filler_container = _get_filler_only_container(ctx)
+        if filler_container:
+            event = render_message(
+                Msg.FILLER_SKIPPED,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={"filler_container": filler_container},
+            )
+            return CheckResult(passed=True, event=event)
+
+        command = f"{shlex.quote(ctx.executor.python_path)} -I - --seconds {PROBE_SECONDS}"
+        run = await ctx.runner.run(
+            command, timeout=PROBE_TIMEOUT_SECONDS, retryable=False, stdin_text=PROBE_SOURCE
+        )
+        report = _parse_report(run.stdout)
+        what = {
+            "executor_uuid": ctx.executor.uuid,
+            "duration_ms": run.duration_ms,
+            "exit_code": run.exit_code,
+        }
+
+        if run.error_type == "timeout":
+            return self._fault(
+                ctx, what, error=f"probe did not finish in {PROBE_TIMEOUT_SECONDS}s", report=None
+            )
+        if report is None:
+            # the interpreter never printed a verdict: an SSH error, a python that could not run stdlib
+            # code, or a crash in the parent process. Not something the GPU is blamed for.
+            what.update(
+                error=run.error_message or "no probe report in output",
+                stdout_tail=run.stdout[-OUTPUT_TAIL_CHARS:],
+                stderr_tail=run.stderr[-OUTPUT_TAIL_CHARS:],
+            )
+            return CheckResult(
+                passed=True,
+                event=render_message(Msg.UNKNOWN, ctx=ctx, check_id=self.check_id, what=what),
+            )
+
+        what["probe"] = _summary(report)
+        status = report.get("status")
+        if status == "ok":
+            return CheckResult(
+                passed=True,
+                event=render_message(Msg.PROBE_OK, ctx=ctx, check_id=self.check_id, what=what),
+            )
+        if status == "fault":
+            return self._fault(
+                ctx, what, error="; ".join(report.get("faults") or []) or "fault", report=report
+            )
+        what["error"] = report.get("error") or f"probe status {status!r}"
+        return CheckResult(
+            passed=True,
+            event=render_message(Msg.UNKNOWN, ctx=ctx, check_id=self.check_id, what=what),
+        )
+
+    def _fault(self, ctx: Context, what: dict, *, error: str, report: dict | None) -> CheckResult:
+        enforce = settings.GPU_FAULT_PROBE_ENFORCEMENT_ENABLED
+        what["error"] = error
+        if report is not None:
+            what["xid"] = report.get("xid")
+        event = render_message(
+            Msg.PROBE_FAILED,
+            ctx=ctx,
+            check_id=self.check_id,
+            severity=None if enforce else "warning",
+            impact=None if enforce else "Shadow observation only: score was NOT changed",
+            what=what,
+        )
+        return CheckResult(passed=not enforce, event=event)
+
+
+def _parse_report(stdout: str) -> dict | None:
+    # the last marker line wins; the probe prints exactly one, but stdout is executor-controlled
+    for line in reversed(stdout.splitlines()):
+        if line.startswith(PROBE_JSON_MARKER):
+            try:
+                parsed = json.loads(line[len(PROBE_JSON_MARKER) :])
+            except (ValueError, TypeError):
+                return None
+            return parsed if isinstance(parsed, dict) else None
+    return None
+
+
+def _summary(report: dict) -> dict:
+    # what the operator needs from the report without the per-round noise: verdict, timing, devices, NVML deltas
+    devices = []
+    for device in report.get("devices") or []:
+        if not isinstance(device, dict):
+            continue
+        devices.append(
+            {
+                key: device.get(key)
+                for key in (
+                    "index",
+                    "name",
+                    "status",
+                    "error",
+                    "rounds",
+                    "work_s",
+                    "elapsed_s",
+                    "working_set_mb",
+                    "jit_ms",
+                )
+                if key in device
+            }
+        )
+    return {
+        "status": report.get("status"),
+        "elapsed_s": report.get("elapsed_s"),
+        "devices": devices,
+        "faults": report.get("faults"),
+        "nvml_after": report.get("nvml_after"),
+    }

--- a/neurons/validators/src/services/task/checks/gpu_fault_probe.py
+++ b/neurons/validators/src/services/task/checks/gpu_fault_probe.py
@@ -21,10 +21,13 @@ PROBE_JSON_MARKER = "GPU_FAULT_PROBE_JSON:"
 # working set. A hung card is caught INSIDE the probe: the workers share one wall-clock budget (--seconds
 # + 30 s + 5 s per extra GPU) and are drained together, so every card gets the whole budget and a verdict —
 # a hang in setup is an error (scored UNKNOWN), a hang in the kernels is a fault. This cap sits above the
-# largest budget (8 GPUs: 4 + 65 s) and only catches an interpreter that never printed or an SSH channel that stalled;
+# largest budget (8 GPUs: 4 + 65 s) plus the parent's bounded tail after the drain (one reap grace, two NVML
+# snapshots in a fork with their own deadline, two dmesg reads: 47 s when everything hangs at once) —
+# test_the_ssh_cap_sits_above_the_probes_own_largest_deadline adds it up — and only catches
+# an interpreter that never printed or an SSH channel that stalled;
 # the runner sets error_type "timeout" for any asyncio.TimeoutError around ssh.run, so that path cannot
 # tell a transport stall from a hung host and is scored UNKNOWN, like the other no-report outcomes.
-PROBE_TIMEOUT_SECONDS = 120
+PROBE_TIMEOUT_SECONDS = 150
 PROBE_SECONDS = 4
 OUTPUT_TAIL_CHARS = 800
 # the report is executor-controlled: bound what is copied into the event
@@ -113,10 +116,14 @@ class GpuFaultProbeCheck:
                 event=render_message(Msg.PROBE_OK, ctx=ctx, check_id=self.check_id, what=what),
             )
         if status == "fault":
-            return self._fault(
-                ctx, what, error="; ".join(report.get("faults") or []) or "fault", report=report
+            faults = _cap(report.get("faults"))
+            error = (
+                "; ".join(str(fault) for fault in faults if fault is not None)
+                if isinstance(faults, list)
+                else ""
             )
-        what["error"] = report.get("error") or f"probe status {status!r}"
+            return self._fault(ctx, what, error=error or "fault", report=report)
+        what["error"] = _cap(report.get("error")) or f"probe status {_cap(status)!r}"
         return CheckResult(
             passed=True,
             event=render_message(Msg.UNKNOWN, ctx=ctx, check_id=self.check_id, what=what),
@@ -152,16 +159,35 @@ def _parse_report(stdout: str) -> dict[str, Any] | None:
     return None
 
 
+def _cap(value: Any) -> Any:
+    """Bound anything copied out of the executor-written report: strings cut, lists cut and capped
+    element-wise, numbers and None kept, dicts and everything else dropped."""
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        return value[:MAX_FAULT_CHARS]
+    if isinstance(value, list):
+        return [
+            _cap(item) if isinstance(item, (str, bool, int, float)) or item is None else None
+            for item in value[:MAX_FAULT_LINES]
+        ]
+    return None
+
+
+def _capped_list(value: Any, limit: int) -> list[Any]:
+    return value[:limit] if isinstance(value, list) else []
+
+
 def _summary(report: dict[str, Any]) -> dict[str, Any]:
     # what the operator needs from the report without the per-round noise: verdict, timing, devices, NVML
-    # deltas — every list and string bounded, since the executor wrote the report
+    # deltas — every scalar and list bounded by _cap, since the executor wrote the report
     devices = []
-    for device in (report.get("devices") or [])[:MAX_NVML_GPUS]:
+    for device in _capped_list(report.get("devices"), MAX_NVML_GPUS):
         if not isinstance(device, dict):
             continue
         devices.append(
             {
-                key: device.get(key)
+                key: _cap(device.get(key))
                 for key in (
                     "index",
                     "name",
@@ -176,16 +202,11 @@ def _summary(report: dict[str, Any]) -> dict[str, Any]:
                 if key in device
             }
         )
-    faults = report.get("faults")
     return {
-        "status": report.get("status"),
-        "elapsed_s": report.get("elapsed_s"),
+        "status": _cap(report.get("status")),
+        "elapsed_s": _cap(report.get("elapsed_s")),
         "devices": devices,
-        "faults": (
-            [str(fault)[:MAX_FAULT_CHARS] for fault in faults[:MAX_FAULT_LINES]]
-            if isinstance(faults, list)
-            else faults
-        ),
+        "faults": _cap(report.get("faults")),
         "nvml_after": _capped_nvml(report.get("nvml_after")),
     }
 
@@ -194,16 +215,15 @@ def _capped_nvml(snapshot: Any) -> dict[str, Any] | None:
     if not isinstance(snapshot, dict):
         return None
     gpus = []
-    for gpu in (snapshot.get("gpus") or [])[:MAX_NVML_GPUS]:
+    for gpu in _capped_list(snapshot.get("gpus"), MAX_NVML_GPUS):
         if isinstance(gpu, dict):
             gpus.append(
                 {
-                    key: (
-                        str(gpu[key])[:MAX_FAULT_CHARS] if isinstance(gpu[key], str) else gpu[key]
-                    )
+                    key: _cap(gpu[key])
                     for key in (
                         "index",
                         "uuid",
+                        "pci_bus_id",
                         "ecc_uncorrected",
                         "remapped_rows",
                         "recovery_action",
@@ -225,6 +245,11 @@ def _capped_xid(xid: Any) -> dict[str, Any] | None:
         capped["count"] = xid["count"]
     if isinstance(xid.get("last"), list):
         capped["last"] = [str(line)[:MAX_XID_CHARS] for line in xid["last"][-MAX_XID_LINES:]]
+    if isinstance(xid.get("other_new"), list):
+        # new Xid lines on other cards (or of application types): evidence, not this executor's fault
+        capped["other_new"] = [
+            str(line)[:MAX_XID_CHARS] for line in xid["other_new"][-MAX_XID_LINES:]
+        ]
     if xid.get("error") is not None:
         capped["error"] = str(xid["error"])[:MAX_FAULT_CHARS]
     return capped

--- a/neurons/validators/src/services/task/checks/gpu_fault_probe.py
+++ b/neurons/validators/src/services/task/checks/gpu_fault_probe.py
@@ -18,9 +18,10 @@ PROBE_SOURCE_PATH = Path(__file__).resolve().parents[3] / "miner_jobs" / "gpu_fa
 PROBE_SOURCE = PROBE_SOURCE_PATH.read_text()
 PROBE_JSON_MARKER = "GPU_FAULT_PROBE_JSON:"
 # Measured on a healthy 1x RTX 4090 (driver 580): 5.3 s in-script, 6.6 s over SSH, 7 rounds on a 2 GB
-# working set. A hung card is caught INSIDE the probe: every worker has its own deadline (--seconds + 30 s
-# + 5 s per extra GPU) and is reported as a fault in the verdict. This cap sits above the largest of those
-# (8 GPUs: 4 + 65 s) and only catches an interpreter that never printed or an SSH channel that stalled;
+# working set. A hung card is caught INSIDE the probe: the workers share one wall-clock budget (--seconds
+# + 30 s + 5 s per extra GPU) and are drained together, so every card gets the whole budget and a verdict —
+# a hang in setup is an error (scored UNKNOWN), a hang in the kernels is a fault. This cap sits above the
+# largest budget (8 GPUs: 4 + 65 s) and only catches an interpreter that never printed or an SSH channel that stalled;
 # the runner sets error_type "timeout" for any asyncio.TimeoutError around ssh.run, so that path cannot
 # tell a transport stall from a hung host and is scored UNKNOWN, like the other no-report outcomes.
 PROBE_TIMEOUT_SECONDS = 120

--- a/neurons/validators/src/services/task/checks/gpu_fault_probe.py
+++ b/neurons/validators/src/services/task/checks/gpu_fault_probe.py
@@ -122,14 +122,14 @@ class GpuFaultProbeCheck:
                 if isinstance(faults, list)
                 else ""
             )
-            return self._fault(ctx, what, error=error or "fault", report=report)
+            return self._fault_verdict(ctx, what, error=error or "fault", report=report)
         what["error"] = _cap(report.get("error")) or f"probe status {_cap(status)!r}"
         return CheckResult(
             passed=True,
             event=render_message(Msg.UNKNOWN, ctx=ctx, check_id=self.check_id, what=what),
         )
 
-    def _fault(
+    def _fault_verdict(
         self, ctx: Context, what: dict[str, Any], *, error: str, report: dict[str, Any] | None
     ) -> CheckResult:
         enforce = settings.GPU_FAULT_PROBE_ENFORCEMENT_ENABLED

--- a/neurons/validators/src/services/task/checks/gpu_fault_probe.py
+++ b/neurons/validators/src/services/task/checks/gpu_fault_probe.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shlex
 from pathlib import Path
+from typing import Any
 
 from core.config import settings
 
@@ -17,11 +18,20 @@ PROBE_SOURCE_PATH = Path(__file__).resolve().parents[3] / "miner_jobs" / "gpu_fa
 PROBE_SOURCE = PROBE_SOURCE_PATH.read_text()
 PROBE_JSON_MARKER = "GPU_FAULT_PROBE_JSON:"
 # Measured on a healthy 1x RTX 4090 (driver 580): 5.3 s in-script, 6.6 s over SSH, 7 rounds on a 2 GB
-# working set. The probe's own per-GPU deadline is --seconds + 30 s; this cap only catches an interpreter
-# that never printed — a wedged card that hangs the driver is a fault, not a slow host.
-PROBE_TIMEOUT_SECONDS = 90
+# working set. A hung card is caught INSIDE the probe: every worker has its own deadline (--seconds + 30 s
+# + 5 s per extra GPU) and is reported as a fault in the verdict. This cap sits above the largest of those
+# (8 GPUs: 4 + 65 s) and only catches an interpreter that never printed or an SSH channel that stalled;
+# the runner sets error_type "timeout" for any asyncio.TimeoutError around ssh.run, so that path cannot
+# tell a transport stall from a hung host and is scored UNKNOWN, like the other no-report outcomes.
+PROBE_TIMEOUT_SECONDS = 120
 PROBE_SECONDS = 4
 OUTPUT_TAIL_CHARS = 800
+# the report is executor-controlled: bound what is copied into the event
+MAX_FAULT_LINES = 16
+MAX_FAULT_CHARS = 300
+MAX_NVML_GPUS = 16
+MAX_XID_LINES = 5
+MAX_XID_CHARS = 200
 
 
 class GpuFaultProbeCheck:
@@ -63,15 +73,23 @@ class GpuFaultProbeCheck:
             command, timeout=PROBE_TIMEOUT_SECONDS, retryable=False, stdin_text=PROBE_SOURCE
         )
         report = _parse_report(run.stdout)
-        what = {
+        what: dict[str, Any] = {
             "executor_uuid": ctx.executor.uuid,
             "duration_ms": run.duration_ms,
             "exit_code": run.exit_code,
         }
 
         if run.error_type == "timeout":
-            return self._fault(
-                ctx, what, error=f"probe did not finish in {PROBE_TIMEOUT_SECONDS}s", report=None
+            # no verdict came back: the SSH channel stalled or the interpreter hung outside its workers.
+            # A card that hangs its worker is reported by the probe itself, so this is not a GPU fault.
+            what.update(
+                error=f"probe did not finish in {PROBE_TIMEOUT_SECONDS}s (SSH timeout, no verdict)",
+                stdout_tail=run.stdout[-OUTPUT_TAIL_CHARS:],
+                stderr_tail=run.stderr[-OUTPUT_TAIL_CHARS:],
+            )
+            return CheckResult(
+                passed=True,
+                event=render_message(Msg.UNKNOWN, ctx=ctx, check_id=self.check_id, what=what),
             )
         if report is None:
             # the interpreter never printed a verdict: an SSH error, a python that could not run stdlib
@@ -103,11 +121,13 @@ class GpuFaultProbeCheck:
             event=render_message(Msg.UNKNOWN, ctx=ctx, check_id=self.check_id, what=what),
         )
 
-    def _fault(self, ctx: Context, what: dict, *, error: str, report: dict | None) -> CheckResult:
+    def _fault(
+        self, ctx: Context, what: dict[str, Any], *, error: str, report: dict[str, Any] | None
+    ) -> CheckResult:
         enforce = settings.GPU_FAULT_PROBE_ENFORCEMENT_ENABLED
-        what["error"] = error
+        what["error"] = error[: MAX_FAULT_LINES * MAX_FAULT_CHARS]
         if report is not None:
-            what["xid"] = report.get("xid")
+            what["xid"] = _capped_xid(report.get("xid"))
         event = render_message(
             Msg.PROBE_FAILED,
             ctx=ctx,
@@ -119,7 +139,7 @@ class GpuFaultProbeCheck:
         return CheckResult(passed=not enforce, event=event)
 
 
-def _parse_report(stdout: str) -> dict | None:
+def _parse_report(stdout: str) -> dict[str, Any] | None:
     # the last marker line wins; the probe prints exactly one, but stdout is executor-controlled
     for line in reversed(stdout.splitlines()):
         if line.startswith(PROBE_JSON_MARKER):
@@ -131,10 +151,11 @@ def _parse_report(stdout: str) -> dict | None:
     return None
 
 
-def _summary(report: dict) -> dict:
-    # what the operator needs from the report without the per-round noise: verdict, timing, devices, NVML deltas
+def _summary(report: dict[str, Any]) -> dict[str, Any]:
+    # what the operator needs from the report without the per-round noise: verdict, timing, devices, NVML
+    # deltas — every list and string bounded, since the executor wrote the report
     devices = []
-    for device in report.get("devices") or []:
+    for device in (report.get("devices") or [])[:MAX_NVML_GPUS]:
         if not isinstance(device, dict):
             continue
         devices.append(
@@ -154,10 +175,55 @@ def _summary(report: dict) -> dict:
                 if key in device
             }
         )
+    faults = report.get("faults")
     return {
         "status": report.get("status"),
         "elapsed_s": report.get("elapsed_s"),
         "devices": devices,
-        "faults": report.get("faults"),
-        "nvml_after": report.get("nvml_after"),
+        "faults": (
+            [str(fault)[:MAX_FAULT_CHARS] for fault in faults[:MAX_FAULT_LINES]]
+            if isinstance(faults, list)
+            else faults
+        ),
+        "nvml_after": _capped_nvml(report.get("nvml_after")),
     }
+
+
+def _capped_nvml(snapshot: Any) -> dict[str, Any] | None:
+    if not isinstance(snapshot, dict):
+        return None
+    gpus = []
+    for gpu in (snapshot.get("gpus") or [])[:MAX_NVML_GPUS]:
+        if isinstance(gpu, dict):
+            gpus.append(
+                {
+                    key: (
+                        str(gpu[key])[:MAX_FAULT_CHARS] if isinstance(gpu[key], str) else gpu[key]
+                    )
+                    for key in (
+                        "index",
+                        "uuid",
+                        "ecc_uncorrected",
+                        "remapped_rows",
+                        "recovery_action",
+                    )
+                    if key in gpu
+                }
+            )
+    capped: dict[str, Any] = {"available": bool(snapshot.get("available")), "gpus": gpus}
+    if snapshot.get("error") is not None:
+        capped["error"] = str(snapshot["error"])[:MAX_FAULT_CHARS]
+    return capped
+
+
+def _capped_xid(xid: Any) -> dict[str, Any] | None:
+    if not isinstance(xid, dict):
+        return None
+    capped: dict[str, Any] = {"available": bool(xid.get("available"))}
+    if isinstance(xid.get("count"), int):
+        capped["count"] = xid["count"]
+    if isinstance(xid.get("last"), list):
+        capped["last"] = [str(line)[:MAX_XID_CHARS] for line in xid["last"][-MAX_XID_LINES:]]
+    if xid.get("error") is not None:
+        capped["error"] = str(xid["error"])[:MAX_FAULT_CHARS]
+    return capped

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1013,6 +1013,53 @@ class CapabilityMessages:
     )
 
 
+class GpuFaultProbeMessages:
+    """DAH-3035 — the kernel-fault probe that follows the matmul. Shadow (GPU_FAULT_PROBE_CHECK_ENABLED
+    without enforcement) emits PROBE_FAILED as a warning and keeps passed=True; only
+    GPU_FAULT_PROBE_ENFORCEMENT_ENABLED renders it error/score-zeroing."""
+
+    DISABLED = MessageTemplate(
+        event="GPU kernel-fault probe disabled",
+        reason="GPU_FAULT_PROBE_DISABLED",
+        severity="info",
+        category="env",
+        impact="Proceed",
+    )
+    FILLER_SKIPPED = MessageTemplate(
+        event="GPU kernel-fault probe skipped for active filler",
+        reason="GPU_FAULT_PROBE_SKIPPED_ACTIVE_FILLER",
+        severity="info",
+        category="policy",
+        impact="Active filler runtime preserved; the probe would compete for VRAM.",
+    )
+    PROBE_OK = MessageTemplate(
+        event="GPU kernel-fault probe passed",
+        reason="GPU_FAULT_PROBE_OK",
+        severity="info",
+        category="env",
+        impact="Proceed",
+    )
+    PROBE_FAILED = MessageTemplate(
+        event="GPU kernel-fault probe failed",
+        reason="GPU_FAULT_PROBE_FAILED",
+        severity="error",
+        category="env",
+        impact="Score set to 0",
+        remediation=(
+            "A GPU returned a CUDA error, wrong data or hung under indexed memory access, or NVML reported "
+            "new uncorrected ECC errors / remapped rows. Check `nvidia-smi -q -d ECC,ROW_REMAPPER` and the host "
+            "`dmesg` for NVRM Xid lines; reseat or replace the card, or reset it (`nvidia-smi -r`) and wait one cycle."
+        ),
+    )
+    UNKNOWN = MessageTemplate(
+        event="GPU kernel-fault probe could not run",
+        reason="GPU_FAULT_PROBE_UNKNOWN",
+        severity="info",
+        category="env",
+        impact="Proceed without penalty",
+    )
+
+
 class ScoreMessages:
     SCORE_COMPUTED = MessageTemplate(
         event="Scores computed",

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -39,6 +39,7 @@ from .checks import (
     ExecutorImageCheck,
     FinalizeCheck,
     GpuCountCheck,
+    GpuFaultProbeCheck,
     GpuFingerprintCheck,
     GpuModelValidCheck,
     GpuPowerLimitCheck,
@@ -317,6 +318,9 @@ class PipelineFactory:
                 VerifyXCheck(),
                 TdxHostCheck(),
                 CapabilityCheck(),
+                # DAH-3035: the kernel-fault probe right after the matmul it complements — same idle,
+                # capability-verified population, same filler skip. Flag-gated, shadow-first, off by default.
+                GpuFaultProbeCheck(),
                 # DAH-2265 Plan 2: advisory, non-fatal — observes whether the executor has
                 # the recommended default image pre-pulled (DOCKER_PULL no-op). Runs here,
                 # after specs/gpu_model/driver are populated and the GPU is validated, on the
@@ -381,6 +385,7 @@ class PipelineFactory:
                 # VerifyXCheck(),
                 TdxHostCheck(),
                 CapabilityCheck(),
+                GpuFaultProbeCheck(),
                 RentalVerificationCheck(),
                 ScoreCheck(),
                 FinalizeCheck(),

--- a/neurons/validators/tests/test_gpu_fault_probe_check.py
+++ b/neurons/validators/tests/test_gpu_fault_probe_check.py
@@ -1,0 +1,316 @@
+import ast
+import json
+from contextlib import contextmanager
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from neurons.validators.src.protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from neurons.validators.src.services.const import FILLER_CONTAINER_PREFIX
+from neurons.validators.src.services.task import pipeline_factory
+from neurons.validators.src.services.task.checks import gpu_fault_probe as module
+from neurons.validators.src.services.task.checks.gpu_fault_probe import (
+    PROBE_JSON_MARKER,
+    PROBE_SECONDS,
+    PROBE_SOURCE,
+    PROBE_TIMEOUT_SECONDS,
+    GpuFaultProbeCheck,
+)
+from neurons.validators.src.services.task.messages import GpuFaultProbeMessages as Msg
+from neurons.validators.src.services.task.runner import SSHCommandResult
+
+from tests.helpers import build_context_config, build_services, build_state, default_executor
+
+
+@contextmanager
+def probe_gate(*, check_enabled: bool = True, enforce: bool = False):
+    # shadow-first like every score-zeroing gate: the check runs and logs, enforcement fails the node
+    with patch("neurons.validators.src.services.task.checks.gpu_fault_probe.settings") as s:
+        s.GPU_FAULT_PROBE_CHECK_ENABLED = check_enabled
+        s.GPU_FAULT_PROBE_ENFORCEMENT_ENABLED = enforce
+        yield s
+
+
+class FakeRunner:
+    """Records the command the check sends and answers with a canned SSHCommandResult."""
+
+    def __init__(
+        self,
+        stdout: str = "",
+        *,
+        exit_code: int = 0,
+        error_type: str | None = None,
+        stderr: str = "",
+    ):
+        self.stdout = stdout
+        self.exit_code = exit_code
+        self.error_type = error_type
+        self.stderr = stderr
+        self.calls: list[dict] = []
+
+    async def run(self, cmd, *, timeout=60, check=False, retryable=True, stdin_text=None):
+        self.calls.append(
+            {"cmd": cmd, "timeout": timeout, "retryable": retryable, "stdin_text": stdin_text}
+        )
+        now = datetime.now(UTC)
+        return SSHCommandResult(
+            command=cmd,
+            command_id="cid",
+            exit_code=self.exit_code,
+            stdout=self.stdout,
+            stderr=self.stderr,
+            duration_ms=5340,
+            started_at=now,
+            finished_at=now,
+            success=self.exit_code == 0,
+            error_type=self.error_type,
+            error_message="timed out" if self.error_type == "timeout" else None,
+        )
+
+
+def probe_stdout(status: str, **extra) -> str:
+    report = {
+        "status": status,
+        "elapsed_s": 5.34,
+        "faults": [],
+        "devices": [
+            {
+                "index": 0,
+                "name": "NVIDIA GeForce RTX 4090",
+                "status": "ok",
+                "rounds": 7,
+                "work_s": 4.55,
+                "elapsed_s": 5.2,
+                "working_set_mb": 2048,
+                "jit_ms": 79,
+                "elements": 134217728,
+            }
+        ],
+        "nvml_before": {
+            "available": True,
+            "gpus": [{"index": 0, "ecc_uncorrected": None, "remapped_rows": [0, 0, 0, 0]}],
+        },
+        "nvml_after": {
+            "available": True,
+            "gpus": [{"index": 0, "ecc_uncorrected": None, "remapped_rows": [0, 0, 0, 0]}],
+        },
+        "xid": {"available": False},
+    }
+    report.update(extra)
+    # the library the executor's interpreter loads prints debug lines around the verdict; only the marker counts
+    return "some driver noise\n" + PROBE_JSON_MARKER + " " + json.dumps(report) + "\n"
+
+
+def make_ctx(context_factory, runner, *, rented_data=None):
+    state = build_state(specs={"gpu": {"count": 1}}, rented_data=rented_data)
+    return context_factory(
+        services=build_services(), config=build_context_config(), state=state, runner=runner
+    )
+
+
+@pytest.mark.asyncio
+async def test_disabled_by_default_runs_nothing(context_factory):
+    runner = FakeRunner()
+    ctx = make_ctx(context_factory, runner)
+
+    with probe_gate(check_enabled=False):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.DISABLED.reason
+    assert runner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_probe_source_goes_over_stdin_to_the_executor_interpreter(context_factory):
+    runner = FakeRunner(probe_stdout("ok"))
+    ctx = make_ctx(context_factory, runner)
+
+    with probe_gate():
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.PROBE_OK.reason
+    (call,) = runner.calls
+    assert call["cmd"] == f"{default_executor().python_path} -I - --seconds {PROBE_SECONDS}"
+    assert call["stdin_text"] == PROBE_SOURCE
+    assert call["timeout"] == PROBE_TIMEOUT_SECONDS
+    assert call["retryable"] is False
+    probe = result.event.what_we_saw["probe"]
+    assert probe["status"] == "ok"
+    assert probe["devices"][0]["rounds"] == 7
+    assert result.event.what_we_saw["duration_ms"] == 5340
+
+
+@pytest.mark.asyncio
+async def test_fault_in_shadow_warns_and_passes(context_factory):
+    stdout = probe_stdout(
+        "fault",
+        faults=["gpu 0: cuStreamSynchronize -> CUDA_ERROR_ILLEGAL_ADDRESS (700)"],
+        devices=[
+            {
+                "index": 0,
+                "status": "fault",
+                "error": "cuStreamSynchronize -> CUDA_ERROR_ILLEGAL_ADDRESS (700)",
+            }
+        ],
+    )
+    ctx = make_ctx(context_factory, FakeRunner(stdout, exit_code=1))
+
+    with probe_gate(enforce=False):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.PROBE_FAILED.reason
+    assert result.event.severity == "warning"
+    assert "NOT changed" in result.event.impact
+    assert "CUDA_ERROR_ILLEGAL_ADDRESS" in result.event.what_we_saw["error"]
+
+
+@pytest.mark.asyncio
+async def test_fault_under_enforcement_fails_the_fatal_check(context_factory):
+    stdout = probe_stdout("fault", faults=["gpu 0: gather: 1 of 134217728 elements wrong"])
+    ctx = make_ctx(context_factory, FakeRunner(stdout, exit_code=1))
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert GpuFaultProbeCheck.fatal is True
+    assert result.passed is False
+    assert result.event.reason_code == Msg.PROBE_FAILED.reason
+    assert result.event.severity == "error"
+    assert result.event.what_we_saw["error"] == "gpu 0: gather: 1 of 134217728 elements wrong"
+
+
+@pytest.mark.asyncio
+async def test_nvml_delta_is_a_fault_even_when_every_kernel_passed(context_factory):
+    stdout = probe_stdout("fault", faults=["gpu 0: uncorrected ECC errors 0 -> 2"])
+    ctx = make_ctx(context_factory, FakeRunner(stdout, exit_code=1))
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.what_we_saw["error"] == "gpu 0: uncorrected ECC errors 0 -> 2"
+
+
+@pytest.mark.asyncio
+async def test_ssh_timeout_is_a_fault(context_factory):
+    ctx = make_ctx(context_factory, FakeRunner("", exit_code=-1, error_type="timeout"))
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.PROBE_FAILED.reason
+    assert f"{PROBE_TIMEOUT_SECONDS}s" in result.event.what_we_saw["error"]
+
+
+@pytest.mark.asyncio
+async def test_probe_that_could_not_start_passes_as_unknown(context_factory):
+    stdout = probe_stdout(
+        "error", error="gpu 0: PTX JIT failed: CUDA_ERROR_INVALID_PTX", devices=[]
+    )
+    ctx = make_ctx(context_factory, FakeRunner(stdout, exit_code=2))
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.UNKNOWN.reason
+    assert "PTX JIT failed" in result.event.what_we_saw["error"]
+
+
+@pytest.mark.asyncio
+async def test_no_report_in_output_passes_as_unknown_with_the_tails(context_factory):
+    ctx = make_ctx(
+        context_factory,
+        FakeRunner("Traceback ...\n", exit_code=1, stderr="ModuleNotFoundError: ctypes"),
+    )
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.UNKNOWN.reason
+    assert result.event.what_we_saw["stderr_tail"] == "ModuleNotFoundError: ctypes"
+
+
+@pytest.mark.asyncio
+async def test_malformed_marker_line_is_unknown_not_a_crash(context_factory):
+    ctx = make_ctx(context_factory, FakeRunner(PROBE_JSON_MARKER + " [1, 2\n"))
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.UNKNOWN.reason
+
+
+@pytest.mark.asyncio
+async def test_active_filler_skips_the_probe(context_factory):
+    rented_data = RentedExecutorsResponse(
+        executors={},
+        banned_guids=[],
+        filler_containers_by_executor={default_executor().uuid: f"{FILLER_CONTAINER_PREFIX}active"},
+    )
+    runner = FakeRunner(probe_stdout("ok"))
+    ctx = make_ctx(context_factory, runner, rented_data=rented_data)
+
+    with probe_gate():
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.FILLER_SKIPPED.reason
+    assert runner.calls == []
+
+
+def test_probe_follows_the_matmul_in_both_pipelines():
+    for build in (
+        pipeline_factory.PipelineFactory.build_checks,
+        pipeline_factory.PipelineFactory.build_dry_run_checks,
+    ):
+        ids = [check.check_id for check in build()]
+        assert ids.index("gpu.validate.fault_probe") == ids.index("gpu.validate.capability") + 1
+
+
+def test_probe_source_is_standard_library_only_and_prints_the_marker():
+    # the executor image is python:3.11-slim plus the executor's own dependencies; the probe must not
+    # assume anything beyond the standard library (nvidia-ml-py is imported inside a try)
+    tree = ast.parse(PROBE_SOURCE)
+    imported = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            imported |= {alias.name.split(".")[0] for alias in node.names}
+        elif isinstance(node, ast.ImportFrom):
+            imported.add(node.module.split(".")[0])
+    assert imported <= {
+        "__future__",
+        "argparse",
+        "ctypes",
+        "json",
+        "multiprocessing",
+        "os",
+        "subprocess",
+        "sys",
+        "time",
+    }
+    assert f'JSON_MARKER = "{PROBE_JSON_MARKER}"' in PROBE_SOURCE
+    assert module.PROBE_SOURCE_PATH.name == "gpu_fault_probe.py"
+
+
+def test_permutation_is_a_bijection_for_every_seed():
+    # the host replays this permutation to check the pointer chase; a collision would blame the GPU
+    namespace: dict = {}
+    kept = [
+        node
+        for node in ast.parse(PROBE_SOURCE).body
+        if (isinstance(node, ast.FunctionDef) and node.name == "perm")
+        or (isinstance(node, ast.Assign) and node.targets[0].id in {"PERM_MUL", "PERM_SHIFT"})
+    ]
+    exec(compile(ast.Module(body=kept, type_ignores=[]), "probe", "exec"), namespace)
+    perm = namespace["perm"]
+    for log2_n in (4, 12, 20):
+        n = 1 << log2_n
+        for seed in (0, 12345, 0x9E37 * 6 + 12345):
+            assert len({perm(i, seed & (n - 1), n - 1) for i in range(n)}) == n

--- a/neurons/validators/tests/test_gpu_fault_probe_check.py
+++ b/neurons/validators/tests/test_gpu_fault_probe_check.py
@@ -218,7 +218,7 @@ def test_the_ssh_cap_sits_above_the_probes_own_largest_deadline():
     namespace = _probe_namespace(
         "WORKER_GRACE_SECONDS",
         "WORKER_GRACE_PER_GPU_SECONDS",
-        "WORKER_REAP_SECONDS",
+        "WORKER_REAP_AFTER_KILL_SECONDS",
         "NVML_GRACE_SECONDS",
         "DMESG_TIMEOUT_SECONDS",
     )
@@ -228,7 +228,11 @@ def test_the_ssh_cap_sits_above_the_probes_own_largest_deadline():
         + namespace["WORKER_GRACE_PER_GPU_SECONDS"] * 7
     )
     nvml_fork = namespace["NVML_GRACE_SECONDS"] + 1 + 5  # poll, join(1), kill + join(5)
-    tail = namespace["WORKER_REAP_SECONDS"] + 2 * nvml_fork + 2 * namespace["DMESG_TIMEOUT_SECONDS"]
+    tail = (
+        namespace["WORKER_REAP_AFTER_KILL_SECONDS"]
+        + 2 * nvml_fork
+        + 2 * namespace["DMESG_TIMEOUT_SECONDS"]
+    )
     assert PROBE_TIMEOUT_SECONDS > drain + tail + 5
 
 
@@ -406,6 +410,7 @@ def test_probe_source_is_standard_library_only_and_prints_the_marker():
         "__future__",
         "argparse",
         "ctypes",
+        "dataclasses",
         "json",
         "multiprocessing",
         "os",
@@ -508,21 +513,33 @@ def test_a_remap_already_pending_before_the_run_is_not_a_fault_on_every_cycle():
 def test_nvml_snapshots_are_paired_by_uuid_not_by_position():
     # a card that fell off the bus mid-run must not be read as the card that took its index
     nvml_faults = _probe_namespace("nvml_faults")["nvml_faults"]
-    gpu_a = {"index": 0, "uuid": "GPU-a", "ecc_uncorrected": 0, "remapped_rows": [3, 0, 0, 0], "recovery_action": 0}
-    gpu_b = {"index": 1, "uuid": "GPU-b", "ecc_uncorrected": 5, "remapped_rows": [0, 0, 0, 0], "recovery_action": 0}
+    gpu_a = {
+        "index": 0,
+        "uuid": "GPU-a",
+        "ecc_uncorrected": 0,
+        "remapped_rows": [3, 0, 0, 0],
+        "recovery_action": 0,
+    }
+    gpu_b = {
+        "index": 1,
+        "uuid": "GPU-b",
+        "ecc_uncorrected": 5,
+        "remapped_rows": [0, 0, 0, 0],
+        "recovery_action": 0,
+    }
     before = {"gpus": [gpu_a, gpu_b]}
     # GPU-a is gone; GPU-b now sits at index 0 with its own (unchanged) counters
     after = {"gpus": [{**gpu_b, "index": 0}]}
 
-    assert nvml_faults(before, after) == ["gpu 0 (GPU-a): missing from the NVML snapshot after the run"]
+    assert nvml_faults(before, after) == [
+        "gpu 0 (GPU-a): missing from the NVML snapshot after the run"
+    ]
 
     # without UUIDs (an old binding) the position still pairs them
-    assert (
-        nvml_faults(
-            {"gpus": [{"index": 0, "ecc_uncorrected": 0}]}, {"gpus": [{"index": 0, "ecc_uncorrected": 1}]}
-        )
-        == ["gpu 0: uncorrected ECC errors 0 -> 1"]
-    )
+    assert nvml_faults(
+        {"gpus": [{"index": 0, "ecc_uncorrected": 0}]},
+        {"gpus": [{"index": 0, "ecc_uncorrected": 1}]},
+    ) == ["gpu 0: uncorrected ECC errors 0 -> 1"]
 
 
 def test_a_dead_nvml_child_is_an_unavailable_snapshot_not_a_crash():
@@ -530,7 +547,9 @@ def test_a_dead_nvml_child_is_an_unavailable_snapshot_not_a_crash():
     # and the probe must still print its verdict
     import multiprocessing
 
-    ns = _probe_namespace("nvml_snapshot_forked", "_nvml_worker", "NVML_GRACE_SECONDS", "_exit_code")
+    ns = _probe_namespace(
+        "nvml_snapshot_forked", "_nvml_worker", "NVML_GRACE_SECONDS", "_exit_code"
+    )
 
     class DeadProcess:
         exitcode = -6
@@ -586,7 +605,7 @@ def test_a_hung_worker_does_not_swallow_the_verdicts_of_the_others():
     import multiprocessing
     import time
 
-    namespace = _probe_namespace("drain_workers", "_exit_code", "WORKER_REAP_SECONDS")
+    namespace = _probe_namespace("drain_workers", "_exit_code", "WORKER_REAP_AFTER_KILL_SECONDS")
     namespace["multiprocessing"] = multiprocessing
     namespace["time"] = time
     drain_workers = namespace["drain_workers"]
@@ -618,11 +637,25 @@ def test_a_hung_worker_does_not_swallow_the_verdicts_of_the_others():
 
 def test_setup_calls_in_the_probe_are_errors_not_faults():
     # an out-of-memory card, a busy card or a memlock cap must not be written up as broken hardware: every CUDA
-    # call before the first kernel launch is fault=False, and a budget below the smallest working set is a ProbeError
+    # call before the first kernel launch is raise_as_fault=False, and a budget below the smallest working set is
+    # a ProbeError. The allocation phase is its own function (_setup_device); probe_device runs the kernels.
     tree = ast.parse(PROBE_SOURCE)
+    setup_device = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_setup_device"
+    )
     probe_device = next(
         n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "probe_device"
     )
+    # the kernel phase makes none of the setup calls: a CudaFault there is the card's
+    kernel_phase_calls = {
+        node.args[0].value
+        for node in ast.walk(probe_device)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "call"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+    }
     setup_calls = {
         "cuCtxCreate_v2",
         "cuMemGetInfo_v2",
@@ -630,21 +663,22 @@ def test_setup_calls_in_the_probe_are_errors_not_faults():
         "cuMemAlloc_v2",
         "cuMemAllocHost_v2",
     }
+    assert not (kernel_phase_calls & setup_calls), kernel_phase_calls & setup_calls
     seen = set()
-    for node in ast.walk(probe_device):
+    for node in ast.walk(setup_device):
         if (
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Attribute)
             and node.func.attr == "call"
             and node.args
             and isinstance(node.args[0], ast.Constant)
-            and node.args[0].value in setup_calls
         ):
-            seen.add(node.args[0].value)
-            fault = [kw for kw in node.keywords if kw.arg == "fault"]
-            assert fault and fault[0].value.value is False, (
+            flag = [kw for kw in node.keywords if kw.arg == "raise_as_fault"]
+            assert flag and flag[0].value.value is False, (
                 f"{node.args[0].value} would raise CudaFault"
             )
+            if node.args[0].value in setup_calls:
+                seen.add(node.args[0].value)
     assert seen == setup_calls
     assert "not enough free VRAM" in PROBE_SOURCE
     assert 'on_phase("kernels")' in PROBE_SOURCE
@@ -674,6 +708,7 @@ def test_new_xid_lines_count_only_for_probed_cards_and_hardware_types():
             "NVRM: Xid (PCI:0000:c1:00): 79, pid=0, GPU has fallen off the bus.",  # another card
             "NVRM: Xid (PCI:0000:81:00): 31, pid=4242, name=python, Ch 00000008",  # ours, application
             "NVRM: Xid 48 with no PCI id at all",
+            "NVRM: Xid (PCI:0000:81:00): garbled, no number after the colon",  # ours, Xid unreadable: not scored
         ],
     }
     faults, other = xid_faults(before, after, {"0000:81:00"})

--- a/neurons/validators/tests/test_gpu_fault_probe_check.py
+++ b/neurons/validators/tests/test_gpu_fault_probe_check.py
@@ -211,14 +211,25 @@ async def test_ssh_timeout_is_unknown_not_a_fault(context_factory):
 
 
 def test_the_ssh_cap_sits_above_the_probes_own_largest_deadline():
-    # otherwise the SSH timeout fires first and a hung 8th GPU is never reported as a fault by the probe
-    namespace = _probe_namespace("WORKER_GRACE_SECONDS", "WORKER_GRACE_PER_GPU_SECONDS")
-    largest = (
+    # otherwise the SSH timeout fires first and a hung 8th GPU is never reported as a fault by the probe.
+    # The whole worst path counts, not the drain alone: eight workers hung once their kernels run, killed and
+    # still held by the driver, then the reap grace, the NVML snapshot fork hanging on the wedged card (before
+    # and after), and two dmesg reads at their timeout.
+    namespace = _probe_namespace(
+        "WORKER_GRACE_SECONDS",
+        "WORKER_GRACE_PER_GPU_SECONDS",
+        "WORKER_REAP_SECONDS",
+        "NVML_GRACE_SECONDS",
+        "DMESG_TIMEOUT_SECONDS",
+    )
+    drain = (
         PROBE_SECONDS
         + namespace["WORKER_GRACE_SECONDS"]
         + namespace["WORKER_GRACE_PER_GPU_SECONDS"] * 7
     )
-    assert PROBE_TIMEOUT_SECONDS > largest + 10
+    nvml_fork = namespace["NVML_GRACE_SECONDS"] + 1 + 5  # poll, join(1), kill + join(5)
+    tail = namespace["WORKER_REAP_SECONDS"] + 2 * nvml_fork + 2 * namespace["DMESG_TIMEOUT_SECONDS"]
+    assert PROBE_TIMEOUT_SECONDS > drain + tail + 5
 
 
 @pytest.mark.asyncio
@@ -226,12 +237,36 @@ async def test_executor_controlled_report_fields_are_capped_in_the_event(context
     # faults, nvml_after and xid come from the executor: a hostile or noisy report must not blow up the event
     stdout = probe_stdout(
         "fault",
-        faults=[f"gpu 0: {'x' * 5000}"] * 100,
+        faults=[f"gpu 0: {'x' * 5000}"] * 100 + [{"not": "a string"}, 7],
+        devices=[
+            {
+                "index": 0,
+                "name": "n" * 5000,
+                "status": "fault",
+                "error": "e" * 5000,
+                "rounds": {"nested": "dict"},
+                "elapsed_s": ["l"] * 5000,
+            }
+        ],
         nvml_after={
             "available": True,
-            "gpus": [{"index": i, "uuid": "u" * 5000, "junk": "y" * 5000} for i in range(64)],
+            "gpus": [
+                {
+                    "index": i,
+                    "uuid": "u" * 5000,
+                    "junk": "y" * 5000,
+                    "remapped_rows": list(range(5000)),
+                    "recovery_action": {"deep": ["x" * 5000]},
+                }
+                for i in range(64)
+            ],
         },
-        xid={"available": True, "count": 3, "last": ["z" * 5000] * 50},
+        xid={
+            "available": True,
+            "count": 3,
+            "last": ["z" * 5000] * 50,
+            "other_new": ["o" * 5000] * 50,
+        },
     )
     ctx = make_ctx(context_factory, FakeRunner(stdout, exit_code=1))
 
@@ -241,13 +276,52 @@ async def test_executor_controlled_report_fields_are_capped_in_the_event(context
     seen = result.event.what_we_saw
     assert len(seen["probe"]["faults"]) == module.MAX_FAULT_LINES
     assert all(len(fault) <= module.MAX_FAULT_CHARS for fault in seen["probe"]["faults"])
+    device = seen["probe"]["devices"][0]
+    assert len(device["name"]) == module.MAX_FAULT_CHARS
+    assert len(device["error"]) == module.MAX_FAULT_CHARS
+    assert device["rounds"] is None  # a dict where a number belongs is dropped
+    assert len(device["elapsed_s"]) == module.MAX_FAULT_LINES
     assert len(seen["probe"]["nvml_after"]["gpus"]) == module.MAX_NVML_GPUS
-    assert "junk" not in seen["probe"]["nvml_after"]["gpus"][0]
-    assert len(seen["probe"]["nvml_after"]["gpus"][0]["uuid"]) == module.MAX_FAULT_CHARS
+    gpu = seen["probe"]["nvml_after"]["gpus"][0]
+    assert "junk" not in gpu
+    assert len(gpu["uuid"]) == module.MAX_FAULT_CHARS
+    assert len(gpu["remapped_rows"]) == module.MAX_FAULT_LINES
+    assert gpu["recovery_action"] is None
     assert len(seen["xid"]["last"]) == module.MAX_XID_LINES
     assert all(len(line) <= module.MAX_XID_CHARS for line in seen["xid"]["last"])
+    assert len(seen["xid"]["other_new"]) == module.MAX_XID_LINES
     assert len(seen["error"]) <= module.MAX_FAULT_LINES * module.MAX_FAULT_CHARS
     assert len(json.dumps(seen)) < 30_000
+
+
+@pytest.mark.asyncio
+async def test_a_fault_report_with_non_string_faults_still_fails_the_check(context_factory):
+    # the fault path joins the faults list into the error line: an int, a None or a dict in it must not raise
+    # (an exception here scores the executor 0 as a pipeline error, in shadow mode too)
+    stdout = probe_stdout("fault", faults=["gpu 0: Xid 79", 7, None, {"x": 1}, True])
+    ctx = make_ctx(context_factory, FakeRunner(stdout, exit_code=1))
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.event.reason_code == Msg.PROBE_FAILED.reason
+    assert result.event.what_we_saw["error"] == "gpu 0: Xid 79; 7; True"
+
+
+@pytest.mark.asyncio
+async def test_a_hostile_report_on_the_unknown_path_is_capped_too(context_factory):
+    # status=error carries report["error"] straight into the event; a non-string faults list must not raise
+    stdout = probe_stdout("error", error="E" * 5000, devices=[], faults=[7, None, {"x": 1}])
+    ctx = make_ctx(context_factory, FakeRunner(stdout, exit_code=2))
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.UNKNOWN.reason
+    assert len(result.event.what_we_saw["error"]) == module.MAX_FAULT_CHARS
+    assert result.event.what_we_saw["probe"]["faults"] == [7, None, None]
 
 
 @pytest.mark.asyncio
@@ -335,6 +409,7 @@ def test_probe_source_is_standard_library_only_and_prints_the_marker():
         "json",
         "multiprocessing",
         "os",
+        "re",
         "subprocess",
         "sys",
         "time",
@@ -457,7 +532,7 @@ def test_a_hung_worker_does_not_swallow_the_verdicts_of_the_others():
     import multiprocessing
     import time
 
-    namespace = _probe_namespace("drain_workers", "_exit_code")
+    namespace = _probe_namespace("drain_workers", "_exit_code", "WORKER_REAP_SECONDS")
     namespace["multiprocessing"] = multiprocessing
     namespace["time"] = time
     drain_workers = namespace["drain_workers"]
@@ -519,3 +594,124 @@ def test_setup_calls_in_the_probe_are_errors_not_faults():
     assert seen == setup_calls
     assert "not enough free VRAM" in PROBE_SOURCE
     assert 'on_phase("kernels")' in PROBE_SOURCE
+
+
+def test_new_xid_lines_count_only_for_probed_cards_and_hardware_types():
+    # dmesg is host-wide: a rented pod's illegal address on another card (Xid 31) or a sibling executor's
+    # fault must not be scored against this executor; an application Xid on our own card is not hardware either
+    namespace = _probe_namespace("xid_faults", "pci_key", "SOFTWARE_XIDS")
+    import re as _re
+
+    namespace["re"] = _re
+    xid_faults, pci_key = namespace["xid_faults"], namespace["pci_key"]
+
+    assert pci_key("0000:81:00.0") == "0000:81:00"
+    assert pci_key("00000000:81:00.0") == "0000:81:00"
+    assert pci_key("0000:81:00") == "0000:81:00"
+    assert pci_key("81:00.0") == "0000:81:00"
+    assert pci_key(None) is None and pci_key("garbage") is None
+
+    before = {"available": True, "lines": ["NVRM: Xid (PCI:0000:01:00): 31, pid=1, old line"]}
+    after = {
+        "available": True,
+        "lines": before["lines"]
+        + [
+            "NVRM: Xid (PCI:0000:81:00): 79, pid=0, GPU has fallen off the bus.",  # ours, hardware
+            "NVRM: Xid (PCI:0000:c1:00): 79, pid=0, GPU has fallen off the bus.",  # another card
+            "NVRM: Xid (PCI:0000:81:00): 31, pid=4242, name=python, Ch 00000008",  # ours, application
+            "NVRM: Xid 48 with no PCI id at all",
+        ],
+    }
+    faults, other = xid_faults(before, after, {"0000:81:00"})
+
+    assert faults == ["new NVRM Xid on a probed GPU: " + after["lines"][1]]
+    assert other == after["lines"][2:]
+    assert xid_faults({"available": False}, after, {"0000:81:00"}) == ([], [])
+    assert xid_faults(before, before, {"0000:81:00"}) == ([], [])
+
+
+def test_nvml_snapshot_runs_in_a_fork_with_a_deadline():
+    # nvmlInit blocks on a card that wedged the driver: the snapshot must come back (as unavailable) in time,
+    # and the parent must not be left with a live child
+    import multiprocessing
+    import time
+
+    namespace = _probe_namespace(
+        "nvml_snapshot_forked", "_nvml_worker", "_quiet_child", "NVML_GRACE_SECONDS"
+    )
+    namespace["multiprocessing"] = multiprocessing
+    namespace["time"] = time
+    import os as _os
+
+    namespace["os"] = _os
+    namespace["NVML_GRACE_SECONDS"] = 1
+    namespace["nvml_snapshot"] = lambda: time.sleep(30)
+
+    started = time.perf_counter()
+    snapshot = namespace["nvml_snapshot_forked"](multiprocessing.get_context("fork"))
+
+    assert snapshot["available"] is False and "hung" in snapshot["error"]
+    assert time.perf_counter() - started < 10
+    assert not multiprocessing.active_children()
+
+    namespace["nvml_snapshot"] = lambda: {"available": True, "gpus": [{"index": 0}]}
+    assert namespace["nvml_snapshot_forked"](multiprocessing.get_context("fork")) == {
+        "available": True,
+        "gpus": [{"index": 0}],
+    }
+
+
+def test_the_verdict_reaches_stdout_even_with_a_child_the_driver_still_holds(tmp_path):
+    # the probe prints into a block-buffered pipe and multiprocessing joins live children at exit without a
+    # timeout: a SIGKILLed worker the driver has not released would keep the verdict from the validator.
+    # Run a stand-in with the probe's own exit sequence: a child that ignores SIGTERM and sleeps, then main()
+    # prints and leaves via os._exit — the marker must arrive within seconds and the pipe must close.
+    import subprocess
+    import sys as _sys
+    import textwrap
+
+    tree = ast.parse(PROBE_SOURCE)
+    main_guard = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.If)
+        and getattr(getattr(node.test, "left", None), "id", None) == "__name__"
+    )
+    exit_sequence = ast.get_source_segment(PROBE_SOURCE, main_guard)
+    assert "os._exit(code)" in exit_sequence and "sys.stdout.flush()" in exit_sequence
+
+    quiet_child = ast.get_source_segment(
+        PROBE_SOURCE,
+        next(n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "_quiet_child"),
+    )
+    script = textwrap.dedent(
+        """
+        import multiprocessing, os, signal, sys, time
+        JSON_MARKER = "GPU_FAULT_PROBE_JSON:"
+        %s
+
+        def _stuck(conn):
+            _quiet_child()
+            signal.signal(signal.SIGTERM, signal.SIG_IGN)
+            conn.send({"phase": "kernels"})
+            time.sleep(20)
+
+        def main(argv):
+            mp = multiprocessing.get_context("fork")
+            parent, child = mp.Pipe(duplex=False)
+            mp.Process(target=_stuck, args=(child,)).start()
+            child.close()
+            parent.recv()
+            print(JSON_MARKER, '{"status": "fault"}')
+            return 1
+
+        %s
+        """
+    ) % (quiet_child, exit_sequence)
+    started = __import__("time").perf_counter()
+    run = subprocess.run(
+        [_sys.executable, "-I", "-"], input=script, capture_output=True, text=True, timeout=20
+    )
+    assert run.returncode == 1
+    assert run.stdout.strip() == 'GPU_FAULT_PROBE_JSON: {"status": "fault"}'
+    assert __import__("time").perf_counter() - started < 15

--- a/neurons/validators/tests/test_gpu_fault_probe_check.py
+++ b/neurons/validators/tests/test_gpu_fault_probe_check.py
@@ -197,8 +197,9 @@ async def test_nvml_delta_is_a_fault_even_when_every_kernel_passed(context_facto
 @pytest.mark.asyncio
 async def test_ssh_timeout_is_unknown_not_a_fault(context_factory):
     # the runner sets "timeout" for any asyncio.TimeoutError around ssh.run, a stalled channel included; a card
-    # that hangs is caught by the probe's own per-worker deadline and comes back as a verdict, so no verdict
-    # means the probe could not be measured, like the sibling no-report path
+    # that hangs is caught inside the probe (one budget, every worker drained until it) and comes back as a
+    # verdict — error in setup, fault in the kernels — so no verdict means the probe could not be measured,
+    # like the sibling no-report path
     ctx = make_ctx(context_factory, FakeRunner("", exit_code=-1, error_type="timeout"))
 
     with probe_gate(enforce=True):
@@ -400,7 +401,90 @@ def test_a_row_remapped_during_the_run_is_a_fault_even_without_a_pending_or_fail
     assert nvml_faults(before, uncorrected) == [
         "gpu 0: remapped rows corrected 3 -> 3, uncorrected 0 -> 1"
     ]
-    assert nvml_faults(before, pending) == ["gpu 0: remapped rows pending=1 failure=0"]
+    assert nvml_faults(before, pending) == ["gpu 0: remapped rows pending=0 -> 1, failure=0 -> 0"]
+
+
+def test_a_remap_already_pending_before_the_run_is_not_a_fault_on_every_cycle():
+    # isPending stays set until the GPU is reset: a card that was pending a remap before the probe must fault
+    # once (the 0 -> 1 transition), not on every cycle after it
+    nvml_faults = _probe_namespace("nvml_faults")["nvml_faults"]
+    already_pending = {
+        "gpus": [
+            {"index": 0, "ecc_uncorrected": 0, "remapped_rows": [3, 0, 1, 0], "recovery_action": 0}
+        ]
+    }
+    still_pending = {
+        "gpus": [
+            {"index": 0, "ecc_uncorrected": 0, "remapped_rows": [3, 0, 1, 0], "recovery_action": 0}
+        ]
+    }
+    now_failed = {
+        "gpus": [
+            {"index": 0, "ecc_uncorrected": 0, "remapped_rows": [3, 0, 1, 1], "recovery_action": 0}
+        ]
+    }
+
+    assert nvml_faults(already_pending, still_pending) == []
+    assert nvml_faults(already_pending, now_failed) == [
+        "gpu 0: remapped rows pending=1 -> 1, failure=0 -> 1"
+    ]
+
+
+def _fake_worker(index, behaviour, conn):
+    # stands in for the probe's _worker: same pipe protocol ({"phase": ...} then one report), scripted
+    import time as _time
+
+    conn.send({"phase": "setup"})
+    if behaviour == "hang-in-setup":
+        _time.sleep(60)
+    conn.send({"phase": "kernels"})
+    if behaviour == "hang-in-kernels":
+        _time.sleep(60)
+    if behaviour == "die":
+        import os as _os
+
+        _os._exit(3)
+    status = "fault" if behaviour == "fault" else "ok"
+    conn.send({"index": index, "status": status, "error": "Xid 79" if status == "fault" else None})
+    conn.close()
+
+
+def test_a_hung_worker_does_not_swallow_the_verdicts_of_the_others():
+    # taiberium on #1297: one shared deadline drained worker by worker meant a hang on GPU 0 left zero
+    # iterations for GPU 1..n — their reports (a real fault included) were discarded as "died in setup".
+    # Every pipe is polled together until the deadline, so each worker gets the whole budget and every
+    # report already sent is read.
+    import multiprocessing
+    import time
+
+    namespace = _probe_namespace("drain_workers", "_exit_code")
+    namespace["multiprocessing"] = multiprocessing
+    namespace["time"] = time
+    drain_workers = namespace["drain_workers"]
+    mp = multiprocessing.get_context("fork")
+    workers = []
+    for index, behaviour in enumerate(["hang-in-kernels", "fault", "ok", "die", "hang-in-setup"]):
+        parent_conn, child_conn = mp.Pipe(duplex=False)
+        process = mp.Process(target=_fake_worker, args=(index, behaviour, child_conn))
+        process.start()
+        child_conn.close()
+        workers.append((index, process, parent_conn))
+
+    started = time.perf_counter()
+    reports = drain_workers(workers, started + 3.0, 3.0)
+    elapsed = time.perf_counter() - started
+
+    assert [r["index"] for r in reports] == [0, 1, 2, 3, 4]
+    assert reports[0]["status"] == "fault" and "hung in kernels" in reports[0]["error"]
+    assert reports[1] == {"index": 1, "status": "fault", "error": "Xid 79"}
+    assert reports[2]["status"] == "ok"
+    assert (
+        reports[3]["status"] == "fault"
+        and "died in kernels with exit code 3" in reports[3]["error"]
+    )
+    assert reports[4]["status"] == "error" and "hung in setup" in reports[4]["error"]
+    assert 3.0 <= elapsed < 10.0  # the two hangs cost one budget, not one budget each
+    assert not any(process.is_alive() for _, process, _ in workers)
 
 
 def test_setup_calls_in_the_probe_are_errors_not_faults():

--- a/neurons/validators/tests/test_gpu_fault_probe_check.py
+++ b/neurons/validators/tests/test_gpu_fault_probe_check.py
@@ -505,6 +505,60 @@ def test_a_remap_already_pending_before_the_run_is_not_a_fault_on_every_cycle():
     ]
 
 
+def test_nvml_snapshots_are_paired_by_uuid_not_by_position():
+    # a card that fell off the bus mid-run must not be read as the card that took its index
+    nvml_faults = _probe_namespace("nvml_faults")["nvml_faults"]
+    gpu_a = {"index": 0, "uuid": "GPU-a", "ecc_uncorrected": 0, "remapped_rows": [3, 0, 0, 0], "recovery_action": 0}
+    gpu_b = {"index": 1, "uuid": "GPU-b", "ecc_uncorrected": 5, "remapped_rows": [0, 0, 0, 0], "recovery_action": 0}
+    before = {"gpus": [gpu_a, gpu_b]}
+    # GPU-a is gone; GPU-b now sits at index 0 with its own (unchanged) counters
+    after = {"gpus": [{**gpu_b, "index": 0}]}
+
+    assert nvml_faults(before, after) == ["gpu 0 (GPU-a): missing from the NVML snapshot after the run"]
+
+    # without UUIDs (an old binding) the position still pairs them
+    assert (
+        nvml_faults(
+            {"gpus": [{"index": 0, "ecc_uncorrected": 0}]}, {"gpus": [{"index": 0, "ecc_uncorrected": 1}]}
+        )
+        == ["gpu 0: uncorrected ECC errors 0 -> 1"]
+    )
+
+
+def test_a_dead_nvml_child_is_an_unavailable_snapshot_not_a_crash():
+    # the child closes its pipe without sending (a driver call aborted the process): recv() raises EOFError
+    # and the probe must still print its verdict
+    import multiprocessing
+
+    ns = _probe_namespace("nvml_snapshot_forked", "_nvml_worker", "NVML_GRACE_SECONDS", "_exit_code")
+
+    class DeadProcess:
+        exitcode = -6
+
+        def __init__(self, target, args):
+            self._conn = args[0]
+
+        def start(self):
+            self._conn.close()
+
+        def join(self, timeout=None):
+            pass
+
+        def is_alive(self):
+            return False
+
+        def kill(self):
+            raise AssertionError("a dead child is not killed again")
+
+    class FakeMp:
+        Pipe = staticmethod(multiprocessing.Pipe)
+        Process = DeadProcess
+
+    snapshot = ns["nvml_snapshot_forked"](FakeMp)
+
+    assert snapshot == {"available": False, "error": "NVML snapshot worker died with exit code -6"}
+
+
 def _fake_worker(index, behaviour, conn):
     # stands in for the probe's _worker: same pipe protocol ({"phase": ...} then one report), scripted
     import time as _time

--- a/neurons/validators/tests/test_gpu_fault_probe_check.py
+++ b/neurons/validators/tests/test_gpu_fault_probe_check.py
@@ -195,15 +195,58 @@ async def test_nvml_delta_is_a_fault_even_when_every_kernel_passed(context_facto
 
 
 @pytest.mark.asyncio
-async def test_ssh_timeout_is_a_fault(context_factory):
+async def test_ssh_timeout_is_unknown_not_a_fault(context_factory):
+    # the runner sets "timeout" for any asyncio.TimeoutError around ssh.run, a stalled channel included; a card
+    # that hangs is caught by the probe's own per-worker deadline and comes back as a verdict, so no verdict
+    # means the probe could not be measured, like the sibling no-report path
     ctx = make_ctx(context_factory, FakeRunner("", exit_code=-1, error_type="timeout"))
 
     with probe_gate(enforce=True):
         result = await GpuFaultProbeCheck().run(ctx)
 
-    assert result.passed is False
-    assert result.event.reason_code == Msg.PROBE_FAILED.reason
+    assert result.passed is True
+    assert result.event.reason_code == Msg.UNKNOWN.reason
     assert f"{PROBE_TIMEOUT_SECONDS}s" in result.event.what_we_saw["error"]
+
+
+def test_the_ssh_cap_sits_above_the_probes_own_largest_deadline():
+    # otherwise the SSH timeout fires first and a hung 8th GPU is never reported as a fault by the probe
+    namespace = _probe_namespace("WORKER_GRACE_SECONDS", "WORKER_GRACE_PER_GPU_SECONDS")
+    largest = (
+        PROBE_SECONDS
+        + namespace["WORKER_GRACE_SECONDS"]
+        + namespace["WORKER_GRACE_PER_GPU_SECONDS"] * 7
+    )
+    assert PROBE_TIMEOUT_SECONDS > largest + 10
+
+
+@pytest.mark.asyncio
+async def test_executor_controlled_report_fields_are_capped_in_the_event(context_factory):
+    # faults, nvml_after and xid come from the executor: a hostile or noisy report must not blow up the event
+    stdout = probe_stdout(
+        "fault",
+        faults=[f"gpu 0: {'x' * 5000}"] * 100,
+        nvml_after={
+            "available": True,
+            "gpus": [{"index": i, "uuid": "u" * 5000, "junk": "y" * 5000} for i in range(64)],
+        },
+        xid={"available": True, "count": 3, "last": ["z" * 5000] * 50},
+    )
+    ctx = make_ctx(context_factory, FakeRunner(stdout, exit_code=1))
+
+    with probe_gate(enforce=True):
+        result = await GpuFaultProbeCheck().run(ctx)
+
+    seen = result.event.what_we_saw
+    assert len(seen["probe"]["faults"]) == module.MAX_FAULT_LINES
+    assert all(len(fault) <= module.MAX_FAULT_CHARS for fault in seen["probe"]["faults"])
+    assert len(seen["probe"]["nvml_after"]["gpus"]) == module.MAX_NVML_GPUS
+    assert "junk" not in seen["probe"]["nvml_after"]["gpus"][0]
+    assert len(seen["probe"]["nvml_after"]["gpus"][0]["uuid"]) == module.MAX_FAULT_CHARS
+    assert len(seen["xid"]["last"]) == module.MAX_XID_LINES
+    assert all(len(line) <= module.MAX_XID_CHARS for line in seen["xid"]["last"])
+    assert len(seen["error"]) <= module.MAX_FAULT_LINES * module.MAX_FAULT_CHARS
+    assert len(json.dumps(seen)) < 30_000
 
 
 @pytest.mark.asyncio
@@ -299,18 +342,96 @@ def test_probe_source_is_standard_library_only_and_prints_the_marker():
     assert module.PROBE_SOURCE_PATH.name == "gpu_fault_probe.py"
 
 
-def test_permutation_is_a_bijection_for_every_seed():
-    # the host replays this permutation to check the pointer chase; a collision would blame the GPU
+def _probe_namespace(*names: str) -> dict:
+    # the probe is stdin-shipped source, not an importable module: lift the named functions and constants
     namespace: dict = {}
     kept = [
         node
         for node in ast.parse(PROBE_SOURCE).body
-        if (isinstance(node, ast.FunctionDef) and node.name == "perm")
-        or (isinstance(node, ast.Assign) and node.targets[0].id in {"PERM_MUL", "PERM_SHIFT"})
+        if (isinstance(node, ast.FunctionDef) and node.name in names)
+        or (isinstance(node, ast.Assign) and node.targets[0].id in names)
     ]
     exec(compile(ast.Module(body=kept, type_ignores=[]), "probe", "exec"), namespace)
-    perm = namespace["perm"]
+    return namespace
+
+
+def test_permutation_is_a_bijection_for_every_seed():
+    # the host replays this permutation to check the pointer chase; a collision would blame the GPU
+    perm = _probe_namespace("perm", "PERM_MUL", "PERM_SHIFT")["perm"]
     for log2_n in (4, 12, 20):
         n = 1 << log2_n
         for seed in (0, 12345, 0x9E37 * 6 + 12345):
             assert len({perm(i, seed & (n - 1), n - 1) for i in range(n)}) == n
+
+
+def test_a_row_remapped_during_the_run_is_a_fault_even_without_a_pending_or_failed_remap():
+    # NVML remapped_rows = (corrected, uncorrected, isPending, failureOccurred): the counts moving is the event
+    nvml_faults = _probe_namespace("nvml_faults")["nvml_faults"]
+    before = {
+        "gpus": [
+            {"index": 0, "ecc_uncorrected": 0, "remapped_rows": [3, 0, 0, 0], "recovery_action": 0}
+        ]
+    }
+    quiet = {
+        "gpus": [
+            {"index": 0, "ecc_uncorrected": 0, "remapped_rows": [3, 0, 0, 0], "recovery_action": 0}
+        ]
+    }
+    corrected = {
+        "gpus": [
+            {"index": 0, "ecc_uncorrected": 0, "remapped_rows": [4, 0, 0, 0], "recovery_action": 0}
+        ]
+    }
+    uncorrected = {
+        "gpus": [
+            {"index": 0, "ecc_uncorrected": 0, "remapped_rows": [3, 1, 0, 0], "recovery_action": 0}
+        ]
+    }
+    pending = {
+        "gpus": [
+            {"index": 0, "ecc_uncorrected": 0, "remapped_rows": [3, 0, 1, 0], "recovery_action": 0}
+        ]
+    }
+
+    assert nvml_faults(before, quiet) == []
+    assert nvml_faults(before, corrected) == [
+        "gpu 0: remapped rows corrected 3 -> 4, uncorrected 0 -> 0"
+    ]
+    assert nvml_faults(before, uncorrected) == [
+        "gpu 0: remapped rows corrected 3 -> 3, uncorrected 0 -> 1"
+    ]
+    assert nvml_faults(before, pending) == ["gpu 0: remapped rows pending=1 failure=0"]
+
+
+def test_setup_calls_in_the_probe_are_errors_not_faults():
+    # an out-of-memory card, a busy card or a memlock cap must not be written up as broken hardware: every CUDA
+    # call before the first kernel launch is fault=False, and a budget below the smallest working set is a ProbeError
+    tree = ast.parse(PROBE_SOURCE)
+    probe_device = next(
+        n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "probe_device"
+    )
+    setup_calls = {
+        "cuCtxCreate_v2",
+        "cuMemGetInfo_v2",
+        "cuStreamCreate",
+        "cuMemAlloc_v2",
+        "cuMemAllocHost_v2",
+    }
+    seen = set()
+    for node in ast.walk(probe_device):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "call"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and node.args[0].value in setup_calls
+        ):
+            seen.add(node.args[0].value)
+            fault = [kw for kw in node.keywords if kw.arg == "fault"]
+            assert fault and fault[0].value.value is False, (
+                f"{node.args[0].value} would raise CudaFault"
+            )
+    assert seen == setup_calls
+    assert "not enough free VRAM" in PROBE_SOURCE
+    assert 'on_phase("kernels")' in PROBE_SOURCE


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3035](https://app.notion.com/p/Validator-a-kernel-fault-probe-after-the-GPU-matmul-so-a-card-that-faults-under-indexed-access-Ble-3d3b8bfdbde9810cb41dda954630561a) · reviewer: @taiberium

**TL;DR** — A rented 1× RTX 4090 failed every Blender render with `Illegal address in CUDA queue` after passing validation. `GpuFaultProbeCheck` runs a random-access kernel probe right after the capability matmul; both flags default off (shadow first).

**What changed**
- `miner_jobs/gpu_fault_probe.py`: standard-library CUDA probe (`ctypes`, PTX) — gather/scatter/chase over random permutations, a pinned copy, NVML before/after
- A fault (`_worker`, `xid_faults`, `nvml_faults`): a `CUresult` once the kernels run, a mismatch, a hung worker, an NVML delta, a hardware Xid on a probed card
- `GPU_FAULT_PROBE_CHECK_ENABLED` reports `GPU_FAULT_PROBE_FAILED` as a warning; `GPU_FAULT_PROBE_ENFORCEMENT_ENABLED` fails the fatal check (`checks/gpu_fault_probe.py`, `config.py`)
- `_cap()` in `checks/gpu_fault_probe.py` bounds every value copied from the report; `test_the_ssh_cap_sits_above_the_probes_own_largest_deadline` proves the 150 s cap

**How to verify**
- `cd neurons/validators && pdm run pytest -q tests/test_gpu_fault_probe_check.py` → 26 passed

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1958 passed · Result: PASS bff447d1 · Gate: PASS 3530649

**Ran it:** `python3 -I - < gpu_fault_probe.py` on a healthy rented 1× RTX 4090 → `status ok`, 5.34 s; 4 injected faults each caught · pod run at 95339c6; later commits covered by the 26 tests (26 passed at 3530649, EC2 lcv1), not re-run on a GPU

**Self-review:** clean at 3530649 (15 checks, 2 low)

**Parts:** backend ✓ validator check + probe · migration n/a — no schema · frontend n/a — existing reason codes · CLI/SDK n/a — nothing renter-facing · docs ✓ `.env.template`; lium-docs n/a until DAH-2994 (lium-docs#217) lands · tests ✓ 26 · dashboards n/a — existing panels

**Docs:** `neurons/validators/.env.template` (GPU_FAULT_PROBE_*) here · lium-docs: none yet — the reason-code page (DAH-2994, now in lium-docs#217) is not on main; the five codes go in when it lands

<details><summary>Details</summary>

[DAH-3035](https://app.notion.com/p/Validator-a-kernel-fault-probe-after-the-GPU-matmul-so-a-card-that-faults-under-indexed-access-Ble-3d3b8bfdbde9810cb41dda954630561a).

## Origin
A rented 1× RTX 4090 (6 Sep, ~18:20Z) failed every Blender Cycles render with `Illegal address in CUDA queue` — on the OptiX backend and on the CUDA backend — while PyTorch on the same card ran fine. The node had passed validation that cycle and went back into the pool after the rental; the renter paid for the discovery. The validator's only GPU workload, `gpu.validate.capability`, is a cuBLAS matmul: sequential reads and writes of two operands and one result, verified by one number. A memory subsystem that faults under indexed access — the access pattern of a BVH traversal, of an embedding lookup, of any sparse workload — passes it.

## Change
`GpuFaultProbeCheck` (`gpu.validate.fault_probe`, fatal), placed right after `CapabilityCheck` in `build_checks` and `build_dry_run_checks`: same idle, capability-verified population, same active-filler skip (`_get_filler_only_container` reused). It pipes `miner_jobs/gpu_fault_probe.py` to the executor's own interpreter over stdin (`python -I - --seconds 4`, the DAH-2794 delivery: nothing to upload, nothing the miner has to update) and reads one `GPU_FAULT_PROBE_JSON:` line back.

The probe is standard-library Python: the CUDA driver API through `ctypes` (`libcuda.so.1` is in every container the NVIDIA runtime prepares, and the matmul already proves it loads there), kernels as PTX the driver JIT-compiles (`.target sm_50`, 79 ms), NVML through `nvidia-ml-py` when importable (it is, in the executor image). One forked worker per GPU, all concurrently, so a driver crash or hang takes the worker and becomes the verdict rather than a missing report. Per GPU, on a 2 GB working set (four 512 MB `uint32` buffers, or less when the card is small — `min(2 GB, free − 1 GB)`), rounds until 4 s of work:

| step | what runs | verified by |
|---|---|---|
| `k_perm` | a bijective fmix32-style permutation of `[0, n)` built on the device, new seed per round | host replays the same function |
| `k_gather` | `out[i] = in[perm[i]]` — 128 M random reads | `k_count_neq(out, perm) == 0` on the device |
| `k_scatter_add` | `cnt[perm[i]] += 1` — 128 M random atomics | every slot `== 1` |
| `k_scatter` | `inv[perm[i]] = i` — 128 M random writes | `inv[perm[i]] == i` for all i |
| `k_chase` | 32 dependent random loads per thread (4 G loads) | 64 chains replayed on the host |
| `cuMemcpyHtoDAsync` / `DtoHAsync` | 32 MB pinned-memory round trip through both copy engines | byte compare on the host |
| NVML before/after | uncorrected ECC (volatile), remapped rows pending/failure, GPU recovery action | any increase / pending / non-zero |
| `dmesg` before/after | `NVRM: Xid` lines, when the container may read the kernel log (best effort) | new lines whose PCI id is a probed card, whose Xid number is readable and is not an application type |

Any non-zero `CUresult` once the kernels run (`CUDA_ERROR_ILLEGAL_ADDRESS` is what Blender prints as "Illegal address in CUDA queue"; the setup calls up to the first launch are errors, not faults), a mismatch counter, a worker that dies or does not answer within the shared budget of `--seconds` + 30 s (+ 5 s per extra GPU) once its kernels run, an NVML delta, or a new `NVRM: Xid` line on one of the probed cards of a hardware type (application Xids 13/31/43/45, other cards' lines and lines whose Xid number cannot be read are kept as evidence only) is a **fault**. A probe that cannot start (no `libcuda`, `cuInit`, PTX JIT rejected) is an **error** and passes as `GPU_FAULT_PROBE_UNKNOWN` with the reason: inability to measure is not a fault, the same rule `CPU_TRUTH_UNKNOWN` follows.

Flags (both default **False**), the shadow-first pattern of every score-zeroing gate here:
- `GPU_FAULT_PROBE_CHECK_ENABLED` — run the probe and emit the verdict; a fault is `GPU_FAULT_PROBE_FAILED` as a *warning*, `passed=True`, "Shadow observation only: score was NOT changed".
- `GPU_FAULT_PROBE_ENFORCEMENT_ENABLED` — a fault is `GPU_FAULT_PROBE_FAILED` as an *error* and fails the fatal check, like `GPU_VERIFY_FAILED`.

Off, the check emits `GPU_FAULT_PROBE_DISABLED` and runs nothing; every scored verification is byte-for-byte today's. Reason codes: `GPU_FAULT_PROBE_OK`, `GPU_FAULT_PROBE_FAILED`, `GPU_FAULT_PROBE_UNKNOWN`, `GPU_FAULT_PROBE_DISABLED`, `GPU_FAULT_PROBE_SKIPPED_ACTIVE_FILLER`. The event's `what` carries the probe summary (per-device status, rounds, work seconds, JIT ms, faults, NVML after) and, on a fault, the Xid lines.

Cost per idle node per cycle when the check flag is on: ≈ 6 s of wall clock and one SSH session; 2 GB of VRAM and 64 MB of pinned host memory for those seconds; nothing is written to disk.

## Verification
- **Healthy pod, real run** (1× RTX 4090, driver 580.173.02, Python 3.12, `python3 -I -` with the file on stdin, exactly the check's command): `status ok`, **5.34 s in-script, 6.6 s over SSH**, 7 rounds in 4.55 s of work on 2 048 MB, JIT 79 ms (2–6 ms warm), 32 MB copy; same on three repeats. Fault injection on the same card, each caught and named: an out-of-range index (`mask = 4n−1`) → `cuStreamSynchronize -> CUDA_ERROR_INVALID_ADDRESS_SPACE (717)`, `status fault`, exit 1, 1.2 s; a deliberately wrong gather comparison → `gather: 134217727 of 134217728 elements wrong`; a corrupted copy comparison → `async memcpy round trip: data differs`; a 200 000-step chase → `hung: no result after 31s`, worker killed, verdict still printed, exit 1, 31.3 s. With `nvidia-ml-py` installed the NVML block reads `remapped_rows [0,0,0,0]`, `ecc_uncorrected null` (consumer card), `recovery_action null`; without it, `available: false` and the CUDA verdict stands alone. Pod removed after the runs (≈ 15 min, ≈ $0.08).
- `cd neurons/validators && pdm run pytest -q tests/test_gpu_fault_probe_check.py` — 26 tests with a fake runner: disabled runs nothing; the command, stdin source, 150 s cap and `retryable=False` are what the check sends; the cap is proven against the drain budget plus the parent's tail (reap grace, two forked NVML snapshots, two dmesg reads); a new Xid counts only on a probed card and only for hardware types; a hostile report (5 000-char strings, dicts and ints where strings belong) is capped on the fault and the UNKNOWN paths without an exception; the NVML snapshot fork comes back in time when NVML hangs; the exit sequence prints the verdict and closes stdout with a child the driver still holds; ok → `PROBE_OK` with the summary; fault in shadow → warning, passes; fault under enforcement → error, fails the fatal check; an NVML-only fault fails; an SSH timeout is `UNKNOWN` (no verdict — the transport cannot tell a stall from a hung host; a hung card is caught inside the probe by its own budget); `status error` (JIT refused) passes as `UNKNOWN`; no marker line passes as `UNKNOWN` with stdout/stderr tails; a malformed marker line is `UNKNOWN`, not an exception; an active filler skips; the check follows `gpu.validate.capability` in both pipelines; the probe imports only the standard library (so the `python:3.11-slim` executor image runs it); the permutation is a bijection for three sizes × three seeds (a collision would blame the GPU for a host bug); NVML snapshots are paired by UUID and a card gone from the after-snapshot is a fault; a forked NVML child that dies without a snapshot is an unavailable snapshot, not a crash.
- Full validator suite as CI runs it: **1934 passed, 15 skipped** (Python 3.11; `test_sshd_bootstrap_script.py` / `test_port_mapping_dao.py` excluded — Linux-only tooling / DB fixture, identical on `origin/main`). `ruff check` clean on the three new files.

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `bff447d1` merged onto `main` `07ec64cd` (clean merge), then: pytest: validators (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1958 passed, 15 skipped, 151 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers
- Why a new check and not a bigger matmul: the matmul is a *capacity and identity* proof (fills VRAM, seals a UUID); the failure here is a *pattern* the matmul never produces. The probe deliberately touches only 2 GB — the matmul already sweeps the card — but with 128 M random accesses per kernel across it.
- Why PTX and not a compiled binary or `compute-sanitizer`: the executor image is `python:3.11-slim` plus the driver libraries the runtime mounts; no toolkit, no `nvcc`, no sanitizer. PTX is forward-compatible and JIT-compiled by whatever driver the host has (proved on 580 / Ada). `compute-sanitizer` would also multiply the runtime ~10–100×.
- Trust model: the probe's output is executor-controlled, as the matmul's plaintext `UUID:` line was before sealing. A miner who forges `status ok` gets exactly what he has today (an unprobed node); the probe cannot be worse than its absence and is not an anti-fraud proof. Sealing it like the matmul is possible later (the `.so` is not touched here).
- Coordination with lium-io#1291 (DAH-3011, `FIRST_PASS_FAST_PATH_ENABLED`): independent. The probe reads no first-pass state and runs on both the express first pass and scored cycles when its flag is on — 6 s is the one thing a never-validated node should prove before it is listed. If #1291 lands first nothing here changes; if the team prefers to skip the probe on the first pass, it is one `ctx.config.first_pass` line in `run()`.
- Coordination with lium#120 (DAH-2877, `lium up --verify-gpus`): the CLI counts GPUs over SSH after `up`. The probe file is standard-library and stdin-deliverable, so the CLI can pipe the same file to a pod's `python3` for a renter-side health check; not done here (separate repo, separate ticket).
Docs: neurons/validators/.env.template (GPU_FAULT_PROBE_*) (this PR) · lium-docs#176 (companion)
- `build_dry_run_checks` gets the check too, next to the `CapabilityCheck` it already runs; a dry-run validator is where the shadow verdict is cheapest to read.
- Not proposed: a per-check setting for `--seconds`/working set — the numbers are measured once here and the same everywhere; make them settings when a second card class needs different ones.

**Verified by the loop (7 Sep 2026, sandbox EC2 Linux, run `20260907T143030Z-dsxg`):** head `bff447d1` — ruff check + format on the three files PASS; `tests/test_gpu_fault_probe_check.py` 19 passed (incl. the five-worker drain test: hang-in-kernels, fault, ok, die, hang-in-setup → five verdicts in one 3 s budget); Validators 1958 passed, 15 skipped, 2 failed as root-on-the-box artefacts (`test_scrape_infiniband` unreadable sysfs, `test_sshd_bootstrap_script` adopt path), unrelated to the probe. Result: PASS. Gate: not run.

### Self-review

Verdict `findings` at `3530649` · 15 checks · by subagent-responder-r58-1297 · 2026-09-10 10:17Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `PR body:117` | The Details fault definition still reads 'a new `NVRM: Xid` line on one of the probed cards of a hardware type (application Xids 13/31/43/45, other cards' lines and lines whose Xid number cannot be read are kept as evidence only)' and the dmesg table row 'new lines whose PCI id is a probed card and whose Xid is not an application type'; at this head `xid_faults` (gpu_fault_probe.py:928) also requires a readable Xid number (`xid is not None`), so a probed-card line whose number the regex misses is evidence only, which the body does not say. | In the override JSON append to the evidence-only list 'and lines whose Xid number cannot be read'; the sentence 'Self-review: clean at 62de2f5' is re-recorded by tools/pr_self_review.py --record at this head. |
| low | STACK-HYGIENE | `neurons/validators/src/services/task/pipeline_factory.py:321` | Carried forward from the 62de2f5 verdict: the branch still sits on merge-base 55be0e9, now 25 commits behind origin/main (1a815a00); `git merge-tree --write-tree origin/main HEAD` still merges clean, so nothing blocks, but the reviewed tree is not the tree the merge builds. | Rebase onto origin/main before or after the push (a rebase-only push carries this verdict via --carry), or accept the clean merge. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/src/miner_jobs/gpu_fault_probe.py:505` Property (a) verified: `_setup_device` lines 508-589 are, statement for statement and in the same order, old probe_device lines 480-559 (HEAD~1) with `fault=` renamed and `d_in, d_idx, d_out, d_aux = device_buffers` moved to probe_device:621, before `on_phase("kernels")`; the only new statements are the `return ProbeSetup(...)` and the unpack at 610-620. · `neurons/validators/src/miner_jobs/gpu_fault_probe.py:483` Property (a) verified: the kernel phase and the free-up section (624-683) reference report, cuda, context, n, mask, funcs, stream, device_buffers, d_ctr, h_ctr, copy_bytes, h_src, h_dst, pattern, h_sample and the four unpacked buffer names plus the parameter `seconds` and module constants; all 15 are ProbeSetup fields and all are unpacked; `lib`, `module`, `device`, `error_log`, `free`, `total`, `budget`, `t_jit` are used only in setup (old and new) and are correctly not carried. · `neurons/validators/src/miner_jobs/gpu_fault_probe.py:31` Property (b) verified: `from __future__ import annotations` is at line 19 so the ProbeSetup annotations are strings; the class is nonetheless defined at 483, after Cuda (373) and DevPtr (402); dataclasses is a python:3.11 standard-library module and is in the stdlib allow-list of test_probe_source_is_standard_library_only (test:413); `_probe_namespace` (test:426) lifts only FunctionDef/Assign nodes so the ClassDef is skipped, and no test lifts probe_device, _setup_device or ProbeSetup, so nothing exec'd references the skipped class. · `neurons/validators/src/miner_jobs/gpu_fault_probe.py:704` Property (c) verified: `_worker` is unchanged (`report = probe_device(index, seconds, vram_mb, on_phase)`); the same `report` dict object built in _setup_device is carried in ProbeSetup and returned, with keys index, name, pci_bus_id (when readable), vram_free_mb, elements, working_set_mb, jit_ms, copy_mb from setup and rounds, work_s from the kernel phase — the same set as HEAD~1; status/elapsed_s are added by _worker as before. · `neurons/validators/tests/test_gpu_fault_probe_check.py:638` Property (d) verified: setup_calls is still exactly {cuCtxCreate_v2, cuMemGetInfo_v2, cuModuleGetFunction, cuMemAlloc_v2, cuMemAllocHost_v2}; the test now asserts every `cuda.call` in _setup_device (12 sites) carries raise_as_fault=False (stronger than before, which checked only the five), that `seen == setup_calls` over _setup_device, and that probe_device's `cuda.call` names are disjoint from setup_calls (they are: cuMemsetD32Async, cuMemcpyHtoDAsync_v2, cuMemcpyDtoHAsync_v2, cuStreamSynchronize, cuCtxSynchronize, cuMemFree_v2, cuMemFreeHost, cuCtxDestroy_v2); `on_phase("kernels")` is at gpu_fault_probe.py:623 inside probe_device and the literal assertion against PROBE_SOURCE holds; 14 keyword call sites renamed (12 + 2 in _count_worker), `rg '\bfault='` finds none left. · `neurons/validators/tests/test_gpu_fault_probe_check.py:711` Property (e) verified: new_lines is the after-list sliced past len(before) so after["lines"][1:] are the five new lines in order; the garbled line matches the PCI regex on a probed card but `Xid \([^)]*\): (\d+)` fails so xid is None and the new `xid is not None` guard sends it to `other`; faults == [line 1] and other == lines 2..5 in order, so `other == after["lines"][2:]` holds with the appended line; at HEAD~1 this line would have been scored as a hardware fault (None not in SOFTWARE_XIDS), so the test fails without the change. · `neurons/validators/src/services/task/checks/gpu_fault_probe.py:132` Property (f) verified: the one caller at 125 is `self._fault_verdict(`, the def at 132; `rg '\b_fault\b'` over neurons/validators/src and tests returns nothing, so no test or caller references the old name. · `neurons/validators/src/miner_jobs/gpu_fault_probe.py:49` Property (g) verified: ruff 0.16.6 `format --check` reports the three files already formatted and `ruff check` passes; WORKER_REAP_AFTER_KILL_SECONDS has one reader (drain_workers:990) and the two test lifts (test:221, 608) were renamed, `rg WORKER_REAP` finds no old name; the lcv1 tree_hash.txt equals `git rev-parse HEAD^{tree}` (a9e05cd8) and its summary is 26 passed.

### Verified

Gate: PASS (3530649) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1297)

EC2 verify at 3530649: `20260910T101325Z-lcv1` (`tests/test_gpu_fault_probe_check.py` 26 passed; full suites at the previous amend `20260910T100956Z-o83d`: validators 1964 passed + the two box-bound failures every lium-io run on the box shows, executor 145 passed). Gate: re-run at 3530649 after the review nits.

</details>
