### PR TITLE
DAH-3095 - [P3] validators/README says who runs the SN51 validator (Lium

### DIFF
--- a/neurons/miners/README.md
+++ b/neurons/miners/README.md
@@ -1,6 +1,11 @@
 # Miner
 
-**[Miner Documentation](https://docs.lium.io/bittensor-subnet/miner/overview)**
+**[Provider Documentation](https://docs.lium.io/providers)** — docs.lium.io calls a miner a *provider*, the
+central miner the *self-hosted provider* ([setup guide](https://docs.lium.io/providers/self-hosted-provider)),
+and an executor a *node*. Most providers do not run this service themselves: opting into the
+[Lium.io Central Provider Server](https://docs.lium.io/providers/provider-configuration) from the
+[Provider Portal](https://provider.lium.io) lets Lium run it for you, and nodes are then set up with
+`lium mine` ([Node Quickstart](https://docs.lium.io/providers/nodes/quickstart)).
 
 ## Overview
 
@@ -19,7 +24,7 @@ To run the central miner, you only need a CPU server with the following specific
 
 Executors are GPU-equipped machines that perform the computational tasks. The central miner manages these executors, which can be easily added or removed from the network.
 
-To see the compatible GPUs to mine with and their relative rewards, see this dict [here](https://github.com/Datura-ai/compute-subnet/blob/main/neurons/validators/src/services/const.py#L3).
+To see the compatible GPUs to mine with and their relative rewards, see this dict [here](https://github.com/Datura-ai/lium-io/blob/main/neurons/validators/src/services/const.py).
 
 ## Installation
 
@@ -28,13 +33,13 @@ To see the compatible GPUs to mine with and their relative rewards, see this dic
 #### Step 1: Clone the Git Repository
 
 ```
-git clone https://github.com/Datura-ai/compute-subnet.git
+git clone https://github.com/Datura-ai/lium-io.git
 ```
 
 #### Step 2: Install Required Tools
 
 ```
-cd compute-subnet && chmod +x scripts/install_miner_on_ubuntu.sh && ./scripts/install_miner_on_ubuntu.sh
+cd lium-io && chmod +x scripts/install_miner_on_ubuntu.sh && ./scripts/install_miner_on_ubuntu.sh
 ```
 
 Verify if bittensor and docker installed: 

--- a/neurons/validators/README.md
+++ b/neurons/validators/README.md
@@ -1,6 +1,11 @@
 # Validator
 
-**[Validator Documentation](https://docs.lium.io/bittensor-subnet/validator)**
+**[Validator Documentation](https://docs.lium.io/validators)**
+
+Subnet 51 has one validator, operated by the Lium team (hotkey `5F7X5UpKSr26KU3jKfpLmT8kuKtBNyHhEnfS8xtxPCqCb13p`).
+This directory is its source. If you want to verify what the validator does, use the community
+[sn51-auditor](https://github.com/Datura-ai/sn51-auditor) instead of running a second validator.
+The steps below are for the Lium team's own deployments and for testnet.
 
 ## System Requirements
 
@@ -33,13 +38,13 @@ btcli w regen_hotkey
 #### Step 1: Clone Git repo
 
 ```
-git clone https://github.com/Datura-ai/compute-subnet.git
+git clone https://github.com/Datura-ai/lium-io.git
 ```
 
 #### Step 2: Install Required Tools
 
 ```
-cd compute-subnet && chmod +x scripts/install_validator_on_ubuntu.sh && ./scripts/install_validator_on_ubuntu.sh
+cd lium-io && chmod +x scripts/install_validator_on_ubuntu.sh && ./scripts/install_validator_on_ubuntu.sh
 ```
 
 Verify docker installation


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3095](https://app.notion.com/p/lium-io-validators-README-tells-anyone-to-run-a-validator-Lium-runs-the-only-one-miner-validator-3d4b8bfdbde9813e86bde42a36dbffb0) · reviewer: @jam6099

**TL;DR** — Docs review, 7 Sep 2026 (`docs-review/DOCS_REVIEW.md`): the neuron READMEs read against docs.lium.io and the repository. Validators/README says who runs the SN51 validator (Lium; audit with sn51-auditor); miner + validator READMEs use the lium-io repo name, live docs URLs and the provider vocabulary. Touches validator/executor (`neurons/miners/README.md`) — read that file first.

**What changed**
- `validators/README.md`: three sentences under the title — one validator, its hotkey, use sn51-auditor to audit.
- `miners/README.md`: the docs link becomes a short glossary paragraph (miner = provider, central miner = self-hosted provider.
- No setup step changed.

**How to verify**
- `curl -sI` → on 7 Sep: `docs.lium.io/bittensor-subnet/validator` → 308 → `/validators`; `/bittensor-subnet/miner/overview` → 308 → `/providers/architecture`.

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1939 passed · miners 26 passed · Result: PASS 6cf71aa1 · Gate: not run

**Docs:** this PR is the docs change.

<details><summary>Details</summary>

[DAH-3095](https://app.notion.com/p/lium-io-validators-README-tells-anyone-to-run-a-validator-Lium-runs-the-only-one-miner-validator-3d4b8bfdbde9813e86bde42a36dbffb0) · DAH-2968.
## Origin

Docs review, 7 Sep 2026 (`docs-review/DOCS_REVIEW.md`): the neuron READMEs read against docs.lium.io and the repository. #1293 (root README) and #1277 (executor README) are already open; this is the two remaining neuron READMEs.

## Problem

1. `neurons/validators/README.md` is a public "register a hotkey on netuid 51 and run the validator" guide. docs.lium.io/validators says Subnet 51 has one validator, run by the Lium team, and sends other neurons to `Datura-ai/sn51-auditor`; the README never says so, so an outsider following it burns a registration for a neuron that will not set weights.
2. Both `neurons/validators/README.md` and `neurons/miners/README.md` clone `github.com/Datura-ai/compute-subnet` and `cd compute-subnet` (the repository is `lium-io`; the old URL only redirects), link `docs.lium.io/bittensor-subnet/validator` and `/bittensor-subnet/miner/overview` (redirects), and the miner README links the GPU rate table inside the old repo name.
3. `neurons/miners/README.md` never says that a "miner" is what docs.lium.io calls a *provider*, that the central miner is the *self-hosted provider*, or that most providers do not run it at all (the Lium.io Central Provider Server + `lium mine` path) — a provider arriving from the docs cannot map the words.

## Change

- `validators/README.md`: three sentences under the title — one validator, its hotkey, use sn51-auditor to audit, the steps below are for the team's deployments and testnet; docs link → `/validators`; clone URL and `cd` → `lium-io`. (+8 / −3)
- `miners/README.md`: the docs link becomes a short glossary paragraph (miner = provider, central miner = self-hosted provider, executor = node) with the Central Provider Server and `lium mine` alternative; clone URL, `cd`, and the `const.py` link → `lium-io`. (+9 / −4)

No setup step changed.

## Verification

- `curl -sI` on 7 Sep: `docs.lium.io/bittensor-subnet/validator` → 308 → `/validators`; `/bittensor-subnet/miner/overview` → 308 → `/providers/architecture`; `github.com/Datura-ai/compute-subnet` → 301 → `lium-io`; `github.com/Datura-ai/sn51-auditor` → 200; all new targets → 200.
- Validator hotkey and the one-validator statement copied from `lium-docs` `docs/validators/index.md` on `main`.

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `6cf71aa1` merged onto `main` `07ec64cd` (clean merge), then: pytest: validators, miners (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1939 passed, 15 skipped, 149 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); Miners 26 passed, 21 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 6 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Notes for reviewers

- `neurons/miners/assigning_validator_hotkeys.md` (assign executors across validators by stake) reads as moot with a single validator; left untouched pending your call — delete or mark historical.
- `datura/README.md` is two words; not touched here.

---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-3095.

Docs: this PR is the docs change.

</details>
