### PR TITLE
DAH-3113 - [P2] validator — quote DockerCommand.exec_command

### DIFF
--- a/neurons/validators/src/core/docker_utils.py
+++ b/neurons/validators/src/core/docker_utils.py
@@ -100,8 +100,16 @@ class DockerCommand:
         `-u 0` because the exec would otherwise inherit the image's USER and lose
         access to the root-owned paths we write to. Numeric, so it does not need a
         root entry in the image's /etc/passwd (DAH-2534).
+
+        The result runs through the executor host's root shell over SSH, so both
+        values are quoted: the container name stays one argv token and the command
+        reaches the container's `sh -c` verbatim (a single quote inside it cannot
+        end the quoting and continue on the host).
         """
-        return f"/usr/bin/docker exec -u 0 -i {container_name} sh -c '{command}'"
+        return (
+            f"/usr/bin/docker exec -u 0 -i {shlex.quote(container_name)} "
+            f"sh -c {shlex.quote(command)}"
+        )
 
 
 @dataclass

--- a/neurons/validators/src/miner_jobs/restore_storage.py
+++ b/neurons/validators/src/miner_jobs/restore_storage.py
@@ -10,7 +10,6 @@ from workspace_mount import VolumeAccess, detect_volume_access
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("restore_storage")
 
-plugin_name = "s3fs-restore"
 MAX_ERROR_DETAIL_CHARS = 1200
 # These scripts are copied to executor hosts and report status through the public API.
 # Some diagnostic path strings can be rejected before they reach the backend, so
@@ -69,19 +68,6 @@ def restore_failure_message(
     if len(message) > MAX_ERROR_DETAIL_CHARS:
         message = f"{message[:MAX_ERROR_DETAIL_CHARS]}...<truncated>"
     return message
-
-
-def run_command(command, command_label: str = "command"):
-    result = subprocess.run(command, shell=True, capture_output=True, text=True)
-    if result.returncode != 0:
-        logger.error(f"Command failed: {command_label}")
-        raise RuntimeError(
-            f"{command_label} failed with exit code {result.returncode}\n"
-            f"{compact_output('stderr', result.stderr)}"
-        )
-    else:
-        logger.info(f"Command succeeded: {command_label}")
-    return result
 
 
 def run_command_args(command: list[str], command_label: str = "command"):

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -655,29 +655,6 @@ fi
 """
 
 
-def build_startup_command_args(startup_commands: str | None) -> str:
-    """Quote user-supplied startup_commands into a safe argv fragment.
-
-    The fragment is appended to the host-side ``docker run ... <image>`` command
-    that runs via ``/bin/sh -c`` over SSH as root on the executor. The user value
-    is split into tokens (honouring its own quoting) and each token is
-    ``shlex.quote``-d, so the host shell cannot interpret any metacharacter
-    inside it: the tokens become the container's command + args, never a host
-    command. Legitimate quoted commands such as ``bash -c "a && b"`` are
-    preserved (the ``&&`` runs inside the container); break-out attempts such as
-    a leading newline collapse to harmless container arguments. Unbalanced
-    quotes or an empty value fall back to the image default command.
-    """
-    if not startup_commands or not startup_commands.strip():
-        return ""
-    try:
-        tokens = shlex.split(startup_commands)
-    except ValueError:
-        # Unbalanced quotes etc. — don't risk a malformed/unsafe host command.
-        return ""
-    return " ".join(shlex.quote(token) for token in tokens)
-
-
 class DockerService:
     def __init__(
         self,

--- a/neurons/validators/tests/test_docker_exec_command_quoting.py
+++ b/neurons/validators/tests/test_docker_exec_command_quoting.py
@@ -1,0 +1,38 @@
+"""`DockerCommand.exec_command` runs as root on the executor host over SSH.
+
+Both the container name and the inner command must be shell-quoted so a value
+that ever carried a metacharacter would stay a single docker argument instead of
+starting a second host command.
+"""
+
+import shlex
+
+from core.docker_utils import DockerCommand
+
+
+def test_live_call_shape_unchanged():
+    # The one caller today: a UUID-derived name and a constant command.
+    command = DockerCommand.exec_command("pod_ab12cd34-0000", "cat /root/.ssh/authorized_keys")
+
+    assert shlex.split(command) == [
+        "/usr/bin/docker", "exec", "-u", "0", "-i", "pod_ab12cd34-0000",
+        "sh", "-c", "cat /root/.ssh/authorized_keys",
+    ]
+
+
+def test_metacharacters_in_container_name_stay_one_argument():
+    command = DockerCommand.exec_command("pod; touch /tmp/pwned", "true")
+
+    argv = shlex.split(command)
+    assert argv[5] == "pod; touch /tmp/pwned"
+    assert argv[6:] == ["sh", "-c", "true"]
+
+
+def test_single_quote_in_command_cannot_close_the_quoting():
+    inner = "echo 'a'; touch /tmp/pwned"
+
+    command = DockerCommand.exec_command("pod_x", inner)
+
+    # The host shell hands the whole inner command to the container's `sh -c`
+    # as one argument; nothing after the quote becomes a host command.
+    assert shlex.split(command)[-1] == inner

--- a/neurons/validators/tests/test_startup_command_quoting.py
+++ b/neurons/validators/tests/test_startup_command_quoting.py
@@ -1,77 +1,63 @@
-import shlex
+"""Renter `startup_commands` become the container's argv, never a host command.
 
-from services.docker_service import build_startup_command_args
+`build_container_command_argv` is what `DockerService._container_run_spec` hands
+to the Docker SDK as the container command (no host shell is involved), so the
+only way a renter value could reach the executor host is if it were ever
+rendered back into a shell line. These tests pin the argv contract for the
+payloads that matter: the real prod breakout attempt and the real top template.
+"""
+
+from services.rental_docker_sdk import build_container_command_argv
 
 
 def test_simple_command_preserved():
-    result = build_startup_command_args("python /app/main.py --epochs 5")
-
-    assert shlex.split(result) == ["python", "/app/main.py", "--epochs", "5"]
+    assert build_container_command_argv("python /app/main.py --epochs 5") == (
+        "python", "/app/main.py", "--epochs", "5",
+    )
 
 
 def test_legit_quoted_metacharacters_preserved():
     # The real top template (CUDA 13.0.2) — `&&` lives inside a quoted bash -c arg
-    # and must reach the container intact, not be dropped.
+    # and must reach the container intact as one argument, not be dropped.
     original = '/bin/bash -c "service ssh start && tail -f /dev/null"'
 
-    result = build_startup_command_args(original)
-
-    # Host shell re-tokenizes the quoted fragment back into the original argv,
-    # so the `&&` runs inside the container, not on the host.
-    assert shlex.split(result) == shlex.split(original)
-    assert shlex.split(result) == ["/bin/bash", "-c", "service ssh start && tail -f /dev/null"]
+    assert build_container_command_argv(original) == (
+        "/bin/bash", "-c", "service ssh start && tail -f /dev/null",
+    )
 
 
 def test_leading_newline_breakout_neutralized():
     # The real prod attack payload.
-    result = build_startup_command_args("\n\nsh /tmp/evil.sh")
+    argv = build_container_command_argv("\n\nsh /tmp/evil.sh")
 
-    # No raw newline survives, so the host `docker run` line cannot be terminated.
-    assert "\n" not in result
+    # No raw newline survives into any token, so nothing can terminate a host line.
+    assert all("\n" not in token for token in argv)
     # The remainder is reduced to harmless container arguments.
-    assert shlex.split(result) == ["sh", "/tmp/evil.sh"]
+    assert argv == ("sh", "/tmp/evil.sh")
 
 
 def test_semicolon_chaining_neutralized():
-    result = build_startup_command_args("echo hi; rm -rf /")
-
-    # The `;` is quoted (result is `echo 'hi;' rm -rf /`), so the host shell sees
-    # a single literal token rather than a command separator — it becomes a
-    # container argument and cannot start a new host command.
-    assert shlex.split(result) == ["echo", "hi;", "rm", "-rf", "/"]
+    # `;` is part of a single token (`hi;`) — a container argument, never a
+    # command separator anywhere.
+    assert build_container_command_argv("echo hi; rm -rf /") == (
+        "echo", "hi;", "rm", "-rf", "/",
+    )
 
 
 def test_env_expansion_kept_inside_container_shell():
     # `bash -c '... $MODEL_NAME'` expands against the CONTAINER env, not the host.
-    original = "bash -c 'vllm serve $MODEL_NAME'"
-
-    result = build_startup_command_args(original)
-
-    assert shlex.split(result) == ["bash", "-c", "vllm serve $MODEL_NAME"]
+    assert build_container_command_argv("bash -c 'vllm serve $MODEL_NAME'") == (
+        "bash", "-c", "vllm serve $MODEL_NAME",
+    )
 
 
 def test_empty_and_none_fall_back_to_default():
-    assert build_startup_command_args(None) == ""
-    assert build_startup_command_args("") == ""
-    assert build_startup_command_args("   ") == ""
-    assert build_startup_command_args("\n\n") == ""
+    assert build_container_command_argv(None) == ()
+    assert build_container_command_argv("") == ()
+    assert build_container_command_argv("   ") == ()
+    assert build_container_command_argv("\n\n") == ()
 
 
 def test_unbalanced_quotes_fall_back_to_default():
-    # shlex.split raises ValueError → drop to image default rather than risk a
-    # malformed host command.
-    assert build_startup_command_args('bash -c "unterminated') == ""
-
-
-def test_quoting_round_trips_for_arbitrary_payloads():
-    # General safety invariant: the quoted fragment, when interpreted by the host
-    # shell, yields exactly the same argv as the original — semantics preserved,
-    # host interpretation neutralized.
-    for payload in [
-        "python app.py",
-        '/bin/bash -c "a && b | c > /tmp/x"',
-        "jupyter lab --ip 0.0.0.0",
-        "sh -c 'while true; do sleep 1; done'",
-    ]:
-        result = build_startup_command_args(payload)
-        assert shlex.split(result) == shlex.split(payload), payload
+    # shlex.split raises ValueError → drop to the image default rather than guess.
+    assert build_container_command_argv('bash -c "unterminated') == ()


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3113](https://app.notion.com/p/lium-io-validator-quote-DockerCommand-exec_command-delete-the-dead-build_startup_command_args-and--3d4b8bfdbde9819aba3cdd3efe516275) · reviewer: @jam6099

**TL;DR** — External security review of `Datura-ai/lium-io` @ `55be0e9e` (2026-09-03, forwarded by the owner), findings #4 and #7 plus its correction note. Validator — quote DockerCommand.exec_command. Not proven by the loop: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

**What changed**
- `exec_command` → `shlex.quote` on both arguments.
- delete `build_startup_command_args`; `test_startup_command_quoting.py` now pins `build_container_command_argv` with the same payloads (argv assertions, since no host shell is involved).
- delete the orphan `run_command` + `plugin_name` in `restore_storage.py`.
- No live-path behaviour changes.

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_docker_exec_command_quoting.py tests/test_startup_command_quoting.py -q` → 10 passed
- `pdm run pytest tests/ -q --strict-markers` → whole suite, CI env vars, python 3.11, fresh pdm install on Linux (Lium pod)
- `ruff check: no new findings on the touched files vs main (the pre-existing I001 import-order notes are untouched).` → green

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1941 passed · Result: PASS · Gate: PASS bb92ee8

**Ran it:** rendered `exec_command` run through `bash -c` against a live alpine container: a command with `'`, `$HOME` and `;` reaches the container's `sh -c` verbatim; a name carrying `; touch /tmp/pwned` stays one docker argument (main's string creates the host file) · EC2 sandbox c6i.large, Docker 25.0.14 (aws_run 20260909T054741Z-fctf)

**Self-review:** clean at bb92ee8 (14 checks, 3 low)

**Parts:** backend ✓ validator `DockerCommand.exec_command` · migration n/a — no schema change · frontend n/a — validator-only · CLI/SDK n/a — validator-only · docs n/a — internal command builder, no renter-facing behaviour · tests ✓ 2 files · dashboards n/a — no metrics change

**Docs:** none changed in this PR — executor/validator internals; nothing a provider sees or sets changes.

<details><summary>Details</summary>

[DAH-3113](https://app.notion.com/p/lium-io-validator-quote-DockerCommand-exec_command-delete-the-dead-build_startup_command_args-and--3d4b8bfdbde9819aba3cdd3efe516275) — parent DAH-2868 (security follow-ups).

## Origin

External security review of `Datura-ai/lium-io` @ `55be0e9e` (2026-09-03, forwarded by the owner), findings #4 and #7 plus its correction note, each re-verified against current `main` (still `55be0e9e`) by tracing the flagged line to its callers and to who supplies the value. Full per-finding verdicts are in the loop's `redteam/LIUM_IO_FINDINGS.md`; the ticket carries the summary.

## Problem

1. `DockerCommand.exec_command` (`core/docker_utils.py`) renders `docker exec -u 0 -i {container_name} sh -c '{command}'` with neither value quoted, and the result runs through the executor host's **root** shell over SSH. The single caller (`rented_machine.py:467`) passes a UUID-derived name and a constant command, so nothing is exploitable today — but every other command builder in `docker_service.py` quotes its arguments and this one is the odd one out.
2. `build_startup_command_args` (`services/docker_service.py`) is dead: the container command is built by `rental_docker_sdk.build_container_command_argv` (`_build_rental_container_run_spec`) and handed to the Docker SDK as argv. Its only importer was `tests/test_startup_command_quoting.py`, so the regression tests for the real prod breakout payload (leading newline, `;` chaining, quoted `&&`) covered code that never runs.
3. `miner_jobs/restore_storage.py` still defines `run_command(..., shell=True)` and `plugin_name = "s3fs-restore"` with no callers — the streaming restore replaced the s3fs path and is argv-only (`run_command_args`, `Popen([...])`, launched over SSH with `shlex.join`). The matching dead callers in `backup_storage.py` are removed by #1316 (#1286 was closed unmerged); #1316 still keeps that file's `run_command(shell=True)` helper, which is out of scope here.

## Change (−43 lines net)

- `exec_command` → `shlex.quote` on both arguments. For the live caller the rendered line is byte-identical (`shlex.split` of before/after is the same argv — pinned by `test_live_call_shape_unchanged`).
- delete `build_startup_command_args`; `test_startup_command_quoting.py` now pins `build_container_command_argv` with the same payloads (argv assertions, since no host shell is involved).
- delete the orphan `run_command` + `plugin_name` in `restore_storage.py`.

No live-path behaviour changes.

## Verification

```
cd neurons/validators
pdm run pytest tests/test_docker_exec_command_quoting.py tests/test_startup_command_quoting.py -q   # 10 passed
# fails-before: the two metacharacter tests in test_docker_exec_command_quoting.py fail on main (2 failed, 1 passed)
pdm run pytest tests/ -q --strict-markers   # whole suite, CI env vars, python 3.11, fresh pdm install on Linux (Lium pod)
# 1941 passed, 15 skipped, 2 failed: test_scrape_infiniband::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices
#   (run as root, which can read a chmod-000 tree — also fails on unpatched main) and
#   test_sshd_bootstrap_script::test_fallback_adopt_after_bind_race_… (timing; passes on re-run). Neither touches this diff.
ruff check: no new findings on the touched files vs main (the pre-existing I001 import-order notes are untouched).
```

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — the earlier head merged onto the then `main` (clean merge), then: pytest: validators (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1941 passed, 15 skipped, 149 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

## Same report, verified NOT real (no change in this PR)

- #1 volume denylist: `custom_options.volumes` is consumed only at `docker_service.py:4417`, where just the *container-side* target survives as the mount point of the validator-created volume `volume_{pod_id}`; the renter's host path never becomes a bind source (every `VolumeMount(source=…)` is a validator-chosen docker volume or a fixed socket).
- #8 `machine_scrape.run_cmd(shell=True)`: constant / host-local inputs, pipes need a shell, runs on the host it inspects.
- #4 live path: already argv + `shlex.join`; only the commented-out s3fs code was injectable.

## Notes for reviewers

`shlex.quote` leaves UUID container names unquoted (safe charset) and wraps the constant `cat /root/.ssh/authorized_keys` in single quotes exactly as the f-string did, so the exec sent to executors does not change.

Docs: none changed in this PR — executor/validator internals; nothing a provider sees or sets changes.

Cross-PR: lium-io#1316 (dead-code sweep) deletes the dead s3fs `/usr/bin/docker` plugin commands in `backup_storage.py`; the `/usr/bin/docker` line in this PR's `test_docker_exec_command_quoting.py` is unrelated to that path. This PR lands first; #1316 is rebased right before its merge.

### Self-review

Verdict `findings` at `bb92ee8` · 14 checks · by subagent-r37fresh · 2026-09-09 05:42Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | PROSE-VS-CODE | `neurons/validators/tests/test_startup_command_quoting.py:4` | The module docstring (and the body's Problem #2, 'line 1048') names `DockerService._container_run_spec`, which does not exist on the head; the method that calls `build_container_command_argv` is `_build_rental_container_run_spec` (docker_service.py:967, call at line 1025). | Rename to `_build_rental_container_run_spec` in the docstring and the body, and drop the line number from the body. |
| low | STALE-BODY | `neurons/validators/src/miner_jobs/restore_storage.py:73` | Body Problem #3 says the dead `backup_storage.py` callers 'are removed by #1286' and that the orphan helper 'is asked for in a comment on that PR'; #1286 was closed unmerged on 7 Sep and the deletion now lives in open #1316, whose head still keeps `run_command(shell=True)` in backup_storage.py. | Point the sentence at #1316 and state that #1316 leaves backup_storage's `run_command` in place (or ask for it there). |
| low | SECURITY | `neurons/validators/src/core/docker_utils.py:95` | `ps_running(container_name)` renders `-f name={container_name}` unquoted and receives the identical `pod.container_name` from the same caller (`_check_pod_running`, rented_machine.py:459) two lines before the now-quoted `exec_command`, so the property 'a container name stays one argv token' holds for one of the two sibling builders fed the same value. | Quote it in this PR (`-f {shlex.quote(f'name={container_name}')}`) with one argv assertion, or add a body sentence saying why only `exec_command` is in scope (UUID-derived value; ticket names exec_command only). |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/src/core/docker_utils.py:110` Quoting checked concretely on the head vs main: a name with a space or `;`, a command with `'`, `$`, `;`, a newline, and an empty command each stay a single argv token under shlex.split; the live call (`pod_…`, `cat /root/.ssh/authorized_keys`) renders byte-identically; both metacharacter tests fail on main's f-string as the body says (2 failed, 1 passed). · `neurons/validators/src/services/task/checks/rented_machine.py:467` The only call site of `exec_command` on the head (grep over neurons/); both `_check_pod_running` callers (lines 168, 306) reach it with `pod.container_name`, so every consumer receives the quoted string — no unquoted call site remains. · `neurons/validators/src/services/docker_service.py:658` `build_startup_command_args` has no importer on the head besides the old test (grep); the live container command is `build_container_command_argv(custom_options.startup_commands)` at line 1025, handed to the Docker SDK as argv, so the deletion is dead code. · `neurons/validators/src/miner_jobs/restore_storage.py:2` ruff F401 `os` unused is pre-existing on main (and removed by #1316); the branch removes two lints (S602 shell=True, PLW1510) and adds none, so 'no new findings' holds. · `neurons/validators/src/miner_jobs/restore_storage.py:73` `run_command`/`plugin_name` have no callers on the head; the live restore path is `run_command_args` + `Popen([...])`, launched via `_nohup_command` = `shlex.join(argv)` (miner_service.py:81, 1619) as the body says. · `neurons/validators/tests/test_startup_command_quoting.py:1` Tests pin an unchanged function (by design, stated in the docstring); each assertion checked against `build_container_command_argv` (rental_docker_sdk.py:624): None/''/'   '/'\n\n' -> (), unbalanced quote -> (), payloads split as asserted. · `neurons/validators/src/services/docker_service.py:4394` Body's 'volume denylist not real' note holds: `custom_options.volumes` is only read for the container-side target (`split(':')[-1]`), never as a bind source. · `neurons/validators/src/services/docker_service.py:15` CROSS-PR: open #1316 touches restore_storage.py (drop `import os`, line 2) and docker_service.py (lines 15, 1310, 5307, 6323); its hunks are disjoint from this PR's (restore_storage 13/73-86, docker_service 658-680), so merge order is free; body's 'this lands first' is fine.

### Ran it

EC2 sandbox c6i.large, Amazon Linux 2023, Docker 25.0.14, lium-io at bb92ee8 (aws_run 20260909T054741Z-fctf). The rendered string was run through `bash -c` — the same path as the executor host's root SSH shell — against a live `alpine` container `pod_ranit_1300`.

```
rendered: /usr/bin/docker exec -u 0 -i pod_ranit_1300 sh -c 'cat /etc/alpine-release'
3.24.1
rc=0
rendered: /usr/bin/docker exec -u 0 -i pod_ranit_1300 sh -c 'echo "it'"'"'s $HOME"; id -u; hostname'
it's /root
0
ed9b353861d4            <- the container's hostname, not the host's (ip-172-31-42-80)
rc=0
rendered: /usr/bin/docker exec -u 0 -i 'pod_ranit_1300; touch /tmp/pwned_1300' sh -c true
Error response from daemon: No such container: pod_ranit_1300; touch /tmp/pwned_1300
rc=1
no /tmp/pwned_1300 on the host — quoting held
main renders: /usr/bin/docker exec -u 0 -i pod_ranit_1300; touch /tmp/pwned_main # sh -c 'true'
main's string: /tmp/pwned_main created on the host — the second command ran
```

### Verified

Gate: PASS (bb92ee8) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1300)

</details>
