### PR TITLE
DAH-2768 - [P1] sysbox installer adds NVIDIA's apt repo and shows apt errors

### DIFF
--- a/neurons/executor/nvidia_docker_sysbox_setup.sh
+++ b/neurons/executor/nvidia_docker_sysbox_setup.sh
@@ -40,6 +40,45 @@ kernel_supports_idmapped() {
     version_ge "$(uname -r)" 5 19
 }
 
+apt_install() {
+    # apt's output is kept and shown on failure: with `set -e` a silenced apt-get ended the
+    # script after "Installing packages" with nothing on screen (DAH-2768)
+    local log
+    log=$(mktemp)
+    if ! apt-get "$@" > "$log" 2>&1; then
+        fail "apt-get $* failed:"
+        tail -n 20 "$log" | sed 's/^/      /'
+        rm -f "$log"
+        return 1
+    fi
+    rm -f "$log"
+}
+
+ensure_nvidia_container_toolkit_repo() {
+    # nvidia-container-toolkit ships from NVIDIA's apt repository, not Ubuntu's. Drivers installed
+    # from the Ubuntu archive or a .run file leave no such repository behind, so add it (NVIDIA's
+    # documented sequence) unless any apt source already points at it.
+    local root="${APT_ROOT:-}"
+    local keyring="$root/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+    local list="$root/etc/apt/sources.list.d/nvidia-container-toolkit.list"
+    if grep -rqs "nvidia.github.io/libnvidia-container" "$root/etc/apt/sources.list.d/" "$root/etc/apt/sources.list"; then
+        ok "NVIDIA container toolkit apt repository already configured."
+        return 0
+    fi
+    # downloads land in a temp file first: in a `curl | gpg` pipeline a failed curl is invisible
+    local tmp
+    tmp=$(mktemp)
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey -o "$tmp" \
+        || { rm -f "$tmp"; fail "Could not fetch the NVIDIA container toolkit signing key (https://nvidia.github.io/libnvidia-container/gpgkey)."; return 1; }
+    gpg --dearmor --yes -o "$keyring" "$tmp" \
+        || { rm -f "$tmp"; fail "Could not import the NVIDIA container toolkit signing key into $keyring."; return 1; }
+    curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list -o "$tmp" \
+        || { rm -f "$tmp"; fail "Could not fetch the NVIDIA container toolkit apt source list."; return 1; }
+    sed "s#deb https://#deb [signed-by=$keyring] https://#g" "$tmp" > "$list"
+    rm -f "$tmp"
+    ok "NVIDIA container toolkit apt repository added."
+}
+
 sysbox_idmapped_report() {
     # what sysbox-mgr itself decided this boot: "yes", "no", or empty when unavailable
     journalctl -u sysbox-mgr -b --no-pager 2>/dev/null \
@@ -221,8 +260,9 @@ ok "Docker is clear for sysbox installation."
 
 step 3 7 "Installing packages"
 
-apt-get update -qq 2>/dev/null
-apt-get install -y -qq nvidia-container-toolkit jq > /dev/null 2>&1
+ensure_nvidia_container_toolkit_repo || exit 1
+apt_install update -qq || exit 1
+apt_install install -y -qq nvidia-container-toolkit jq || exit 1
 ok "nvidia-container-toolkit, jq"
 
 if [ "$SKIP_INSTALL" = false ]; then
@@ -237,7 +277,7 @@ if [ "$SKIP_INSTALL" = false ]; then
         actual=$(sha256sum "$SYSBOX_DEB" | cut -d' ' -f1)
         [ "$actual" = "$SYSBOX_SHA" ] || { fail "Checksum mismatch!"; exit 1; }
     fi
-    apt-get install -y -qq "$SYSBOX_DEB" > /dev/null 2>&1
+    apt_install install -y -qq "$SYSBOX_DEB" || exit 1
     ok "Sysbox v${SYSBOX_VERSION} installed."
 else
     ok "Sysbox already installed, skipping."

--- a/neurons/executor/tests/test_sysbox_setup_apt_repo.py
+++ b/neurons/executor/tests/test_sysbox_setup_apt_repo.py
@@ -1,0 +1,164 @@
+"""DAH-2768: nvidia_docker_sysbox_setup.sh apt-installed nvidia-container-toolkit without
+adding NVIDIA's apt repository and sent apt's output to /dev/null, so on a host whose drivers
+did not come from that repository the installer stopped after "Installing packages" with
+nothing on screen (ticket-0286: a provider read the script and added the repo himself).
+
+The installer's package step is run here under bash with stub apt-get/curl/gpg on PATH.
+"""
+
+import os
+import re
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "nvidia_docker_sysbox_setup.sh")
+
+# A host without the NVIDIA repository: apt only knows nvidia-container-toolkit once the list
+# file the installer is supposed to write exists.
+APT_GET_STUB = textwrap.dedent(
+    """\
+    #!/bin/bash
+    echo "apt-get $*" >> "$APT_ROOT/apt.log"
+    if [ "$1" = install ] && [[ " $* " == *" nvidia-container-toolkit "* ]] \\
+       && ! grep -rqs "nvidia.github.io/libnvidia-container" "$APT_ROOT/etc/apt/sources.list.d/"; then
+        echo "E: Unable to locate package nvidia-container-toolkit" >&2
+        exit 100
+    fi
+    exit 0
+    """
+)
+CURL_STUB = textwrap.dedent(
+    """\
+    #!/bin/bash
+    [ -z "${CURL_FAIL:-}" ] || { echo "curl: (6) Could not resolve host" >&2; exit 6; }
+    out=/dev/stdout; url=""
+    while [ $# -gt 0 ]; do
+        case "$1" in -o) out="$2"; shift ;; http*) url="$1" ;; esac
+        shift
+    done
+    case "$url" in
+        *gpgkey) echo "FAKE-PGP-KEY" > "$out" ;;
+        *nvidia-container-toolkit.list) echo "deb https://nvidia.github.io/libnvidia-container/stable/deb/\\$(ARCH) /" > "$out" ;;
+        *) exit 22 ;;
+    esac
+    """
+)
+GPG_STUB = textwrap.dedent(
+    """\
+    #!/bin/bash
+    out=""; src=""
+    while [ $# -gt 0 ]; do
+        case "$1" in -o) out="$2"; shift ;; --dearmor|--yes) ;; *) src="$1" ;; esac
+        shift
+    done
+    [ -n "$out" ] && [ -s "$src" ] && cat "$src" > "$out"
+    """
+)
+
+
+def _functions(*names: str) -> str:
+    """The named shell functions, verbatim, from the installer."""
+    with open(SCRIPT) as fh:
+        text = fh.read()
+    out = []
+    for name in names:
+        # one-line helpers (`ok() { ...; }`) or a block closed by a `}` line of its own
+        match = re.search(rf"^{name}\(\)\s*\{{[^\n]*\}}\s*$", text, re.M) or re.search(
+            rf"^{name}\(\)\s*\{{\n.*?^\}}", text, re.S | re.M
+        )
+        assert match, f"{name}() is not defined in nvidia_docker_sysbox_setup.sh"
+        out.append(match.group(0))
+    return "\n".join(out)
+
+
+def _run_package_step(tmp_path, env=None):
+    root = tmp_path / "root"
+    (root / "etc/apt/sources.list.d").mkdir(parents=True, exist_ok=True)
+    (root / "usr/share/keyrings").mkdir(parents=True, exist_ok=True)
+    stubs = tmp_path / "bin"
+    stubs.mkdir()
+    for name, body in ("apt-get", APT_GET_STUB), ("curl", CURL_STUB), ("gpg", GPG_STUB):
+        path = stubs / name
+        path.write_text(body)
+        path.chmod(0o755)
+    program = (
+        "set -e\n"
+        + _functions("ok", "warn", "fail", "apt_install", "ensure_nvidia_container_toolkit_repo")
+        + "\nensure_nvidia_container_toolkit_repo || exit 1\n"
+        "apt_install update -qq || exit 1\n"
+        "apt_install install -y -qq nvidia-container-toolkit jq || exit 1\n"
+        'echo INSTALLED\n'
+    )
+    proc = subprocess.run(
+        ["bash", "-c", program],
+        capture_output=True,
+        text=True,
+        env={
+            "PATH": f"{stubs}:{os.environ['PATH']}",
+            "APT_ROOT": str(root),
+            **(env or {}),
+        },
+    )
+    return proc, root
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="bash installer")
+def test_repo_is_added_before_the_toolkit_is_installed(tmp_path):
+    proc, root = _run_package_step(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "INSTALLED" in proc.stdout
+    list_file = root / "etc/apt/sources.list.d/nvidia-container-toolkit.list"
+    keyring = root / "usr/share/keyrings/nvidia-container-toolkit-keyring.gpg"
+    assert keyring.read_text().strip() == "FAKE-PGP-KEY"
+    assert list_file.read_text().startswith(f"deb [signed-by={keyring}] https://nvidia.github.io/libnvidia-container/")
+    apt_log = (root / "apt.log").read_text().splitlines()
+    assert apt_log == ["apt-get update -qq", "apt-get install -y -qq nvidia-container-toolkit jq"]
+
+
+def test_rerun_on_a_host_that_has_the_repo_is_a_no_op(tmp_path):
+    root = tmp_path / "root"
+    (root / "etc/apt/sources.list.d").mkdir(parents=True)
+    # the provider added it under his own file name (ticket-0286 did exactly this)
+    (root / "etc/apt/sources.list.d/libnvidia-container.list").write_text(
+        "deb https://nvidia.github.io/libnvidia-container/stable/deb/amd64 /\n"
+    )
+    proc, root = _run_package_step(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "already configured" in proc.stdout
+    assert not (root / "etc/apt/sources.list.d/nvidia-container-toolkit.list").exists()
+
+
+def test_key_download_failure_is_reported_not_silent(tmp_path):
+    proc, root = _run_package_step(tmp_path, env={"CURL_FAIL": "1"})
+    assert proc.returncode == 1
+    assert "Could not fetch the NVIDIA container toolkit signing key" in proc.stdout
+    assert "INSTALLED" not in proc.stdout
+    assert not (root / "apt.log").exists(), "apt must not run without the repository"
+
+
+def test_apt_failure_shows_apts_own_error(tmp_path):
+    # the pre-fix behaviour: apt fails, and the operator must see why
+    root = tmp_path / "root"
+    (root / "etc/apt/sources.list.d").mkdir(parents=True)
+    (root / "etc/apt/sources.list.d/broken.list").write_text(
+        "deb https://nvidia.github.io/libnvidia-container/stable/deb/amd64 /\n"
+    )
+    stubs = tmp_path / "bin"
+    stubs.mkdir()
+    apt = stubs / "apt-get"
+    apt.write_text("#!/bin/bash\necho 'E: The repository is not signed.' >&2\nexit 100\n")
+    apt.chmod(0o755)
+    program = "set -e\n" + _functions("ok", "fail", "apt_install") + "\napt_install update -qq || exit 1\necho INSTALLED\n"
+    proc = subprocess.run(
+        ["bash", "-c", program],
+        capture_output=True,
+        text=True,
+        env={"PATH": f"{stubs}:{os.environ['PATH']}", "APT_ROOT": str(root)},
+    )
+    assert proc.returncode == 1
+    assert "apt-get update -qq failed" in proc.stdout
+    assert "E: The repository is not signed." in proc.stdout
+    assert "INSTALLED" not in proc.stdout


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-2768](https://app.notion.com/p/The-Sysbox-installer-apt-installs-nvidia-container-toolkit-without-adding-the-NVIDIA-repository-and--3c7b8bfdbde981f19029ff45420366e0) · reviewer: @jam6099

**TL;DR** — `neurons/executor/nvidia_docker_sysbox_setup.sh` — the first thing a new provider runs (`sysbox.md:18`, `quickstart.md:33` pipe it into `sudo bash`). Sysbox installer adds NVIDIA's apt repo and shows apt errors. Not proven by the loop: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

**What changed**
- `ensure_nvidia_container_toolkit_repo()`: NVIDIA's documented sequence — key to `/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`, list to `/etc/apt/sources.list.d/nvidia-container-toolkit.list` with `signed-by`.
- `apt_install()`: every `apt-get` (update, toolkit+jq, sysbox `.deb`) keeps its output and prints the last 20 lines on failure.
- `APT_ROOT` (default empty) prefixes the four paths so the functions can be exercised against a temp tree.

**How to verify**
- `gh pr checks 1304 -R Datura-ai/lium-io` → all green
- re-run the loop's suites (Details → Verification) → executor 132 passed

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · executor 132 passed · Result: PASS a5272766 · Gate: not run

**Docs:** lium-docs#215 (companion)

<details><summary>Details</summary>

Origin: Discord ticket-0286 (provider HornsWithAHalo, 22 Aug 2026: "The script failed the first time … It is missing adding the nvidia container toolkit repo"; node off market 2026-08-21 23:29 → 08-25 13:33 UTC); ticket [DAH-2768](https://app.notion.com/p/The-Sysbox-installer-apt-installs-nvidia-container-toolkit-without-adding-the-NVIDIA-repository-and--3c7b8bfdbde981f19029ff45420366e0) (Oxygen 68).

## Problem
`neurons/executor/nvidia_docker_sysbox_setup.sh` — the first thing a new provider runs (`sysbox.md:18`, `quickstart.md:33` pipe it into `sudo bash`) — did
```
apt-get update -qq 2>/dev/null
apt-get install -y -qq nvidia-container-toolkit jq > /dev/null 2>&1
```
`nvidia-container-toolkit` is not in the Ubuntu archive; it ships from NVIDIA's apt repository, which the script never added. On a host whose drivers came from the Ubuntu archive or a `.run` file (no NVIDIA repo left behind) apt fails, `set -e` ends the script after "[3/7] Installing packages", and both streams went to `/dev/null` — nothing on screen, no `fail()` line. The preflight (`nvidia-smi`, `/proc/driver/nvidia`) passes on exactly those hosts. The sysbox `.deb` install on line 240 was silenced the same way.

## Change (script only, +51 −3)
- `ensure_nvidia_container_toolkit_repo()`: NVIDIA's documented sequence — key to `/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`, list to `/etc/apt/sources.list.d/nvidia-container-toolkit.list` with `signed-by`. Idempotent: skipped when any apt source already points at `nvidia.github.io/libnvidia-container` (the provider in the ticket had added it under his own file name). Downloads go to a temp file first so a failed `curl` cannot hide behind `gpg` in a pipeline; each step fails through `fail()` with the URL/path involved.
- `apt_install()`: every `apt-get` (update, toolkit+jq, sysbox `.deb`) keeps its output and prints the last 20 lines on failure, then exits 1 — instead of a silent `set -e` exit.
- `APT_ROOT` (default empty) prefixes the four paths so the functions can be exercised against a temp tree; production behaviour is unchanged.

## Verification
- `neurons/executor/tests/test_sysbox_setup_apt_repo.py` runs the package step under bash with stub `apt-get`/`curl`/`gpg` on PATH: (1) on a host without the repo the list + keyring are written before `apt-get install nvidia-container-toolkit` and the stub apt (which 100s without the list, like the real one) succeeds; (2) a host that already has the repo under another file name is a no-op; (3) a failed key download is reported and apt never runs; (4) an apt failure prints apt's own `E:` line. Red on main (functions absent), green here.
- Executor suite on a Lium pod (python 3.11, `pdm run pytest tests/`): **132 passed**. `bash -n` and `shellcheck -S warning` clean.
- Live on the pod against the real endpoints: key fetched and dearmored (`public key packet … created 1506629681`), list written with `signed-by=…/nvidia-container-toolkit-keyring.gpg`, second run → "already configured".

Docs: lium-docs#215 (companion)

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `a5272766` merged onto `main` `07ec64cd` (clean merge), then: pytest: executor (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Executor 132 passed, 18 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 3 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

</details>
