### PR TITLE
DAH-2771 - [P2] scrape disk capacity from the partition under docker's data root

### DIFF
--- a/neurons/validators/src/miner_jobs/machine_scrape.py
+++ b/neurons/validators/src/miner_jobs/machine_scrape.py
@@ -841,6 +841,22 @@ def get_container_log_bytes(docker_root_dir: str) -> int:
     return total
 
 
+def get_host_disk_usage():
+    # total/used/free of the filesystem that holds docker's data root — where rented containers,
+    # images and volumes land — read through PID 1's root like the walks above. `/` is this
+    # container's own overlay: on a host with /var/lib/docker on its own partition it reported the
+    # root partition, so a 5 TB docker volume listed as 1.8 TB (ticket-0286, DAH-2771). Without a
+    # docker answer, or outside the executor container, `/` stays the measurement.
+    try:
+        docker_root_dir = (docker_api_get("/info") or {}).get("DockerRootDir") or "/var/lib/docker"
+    except Exception:
+        docker_root_dir = "/var/lib/docker"
+    host_docker_root = f"/proc/1/root{docker_root_dir}"
+    if os.path.isdir(host_docker_root):
+        return shutil.disk_usage(host_docker_root)
+    return shutil.disk_usage("/")
+
+
 def get_docker_disk_usage():
     # what actually filled the disk, split by kind, in kB to match the other hard_disk fields
     df = docker_api_get("/system/df")
@@ -1496,7 +1512,7 @@ def get_machine_specs():
 
     data["data_hard_disk"] = {}
     try:
-        disk_usage = shutil.disk_usage("/")
+        disk_usage = get_host_disk_usage()
         data["data_hard_disk"] = {
             "hard_disk_total": disk_usage.total // 1024,  # in kB
             "hard_disk_used": disk_usage.used // 1024,

--- a/neurons/validators/tests/test_scrape_disk_breakdown.py
+++ b/neurons/validators/tests/test_scrape_disk_breakdown.py
@@ -13,7 +13,9 @@ import glob
 import http.client
 import json
 import os
+import shutil
 import socket
+from collections import namedtuple
 from pathlib import Path
 
 import pytest
@@ -29,6 +31,7 @@ DISK_HELPERS = {
     "docker_api_get",
     "get_vloopback_volume_bytes",
     "get_container_log_bytes",
+    "get_host_disk_usage",
     "get_docker_disk_usage",
 }
 
@@ -39,7 +42,7 @@ def scrape() -> dict:
     return build_scrape_namespace(
         SRC / "miner_jobs" / "machine_scrape.py",
         DISK_HELPERS,
-        {"glob": glob, "http": http, "json": json, "os": os, "socket": socket},
+        {"glob": glob, "http": http, "json": json, "os": os, "shutil": shutil, "socket": socket},
     )
 
 
@@ -317,3 +320,85 @@ def test_a_host_without_json_logs_reports_zero(scrape: dict[str, object], monkey
 
     # Act / Assert
     assert scrape["get_container_log_bytes"]("/var/lib/docker") == 0
+
+
+def _stub_filesystem(scrape: dict, monkeypatch, *, host_dirs: set[str], usage_by_path: dict) -> list[str]:
+    """isdir answers from `host_dirs`; disk_usage answers from `usage_by_path` and records the path asked."""
+    asked: list[str] = []
+
+    def disk_usage(path):
+        asked.append(path)
+        return usage_by_path[path]
+
+    monkeypatch.setitem(
+        scrape,
+        "os",
+        type("_Os", (), {"path": type("_Path", (), {"isdir": staticmethod(lambda path: path in host_dirs)})}),
+    )
+    monkeypatch.setitem(scrape, "shutil", type("_Shutil", (), {"disk_usage": staticmethod(disk_usage)}))
+    return asked
+
+
+_Usage = namedtuple("_Usage", "total used free")
+_ROOT_PARTITION = _Usage(2_112_647_088 * 1024, 28_045_744 * 1024, 1_977_210_780 * 1024)
+_DOCKER_PARTITION = _Usage(5_368_709_120 * 1024, 139_377_768 * 1024, 5_229_331_352 * 1024)
+
+
+def test_disk_usage_is_measured_on_dockers_data_root(scrape: dict, monkeypatch) -> None:
+    # Arrange — ticket-0286: a 2 TB root partition and /var/lib/docker on its own 5 TB partition.
+    # The scrape runs in the executor container, so `/` is the container overlay; the host's
+    # docker root is only reachable through PID 1's root.
+    _stub_docker_api(scrape, {"/info": {"DockerRootDir": "/var/lib/docker"}})
+    asked = _stub_filesystem(
+        scrape,
+        monkeypatch,
+        host_dirs={"/proc/1/root/var/lib/docker"},
+        usage_by_path={"/proc/1/root/var/lib/docker": _DOCKER_PARTITION, "/": _ROOT_PARTITION},
+    )
+
+    # Act
+    usage = scrape["get_host_disk_usage"]()
+
+    # Assert — the partition that holds the containers, not the one that holds the OS
+    assert usage == _DOCKER_PARTITION
+    assert asked == ["/proc/1/root/var/lib/docker"]
+
+
+def test_disk_usage_follows_a_custom_docker_data_root(scrape: dict, monkeypatch) -> None:
+    _stub_docker_api(scrape, {"/info": {"DockerRootDir": "/mnt/nvme/docker"}})
+    asked = _stub_filesystem(
+        scrape,
+        monkeypatch,
+        host_dirs={"/proc/1/root/mnt/nvme/docker", "/proc/1/root/var/lib/docker"},
+        usage_by_path={"/proc/1/root/mnt/nvme/docker": _DOCKER_PARTITION, "/proc/1/root/var/lib/docker": _ROOT_PARTITION},
+    )
+
+    assert scrape["get_host_disk_usage"]() == _DOCKER_PARTITION
+    assert asked == ["/proc/1/root/mnt/nvme/docker"]
+
+
+def test_disk_usage_falls_back_to_root_without_a_reachable_docker_root(scrape: dict, monkeypatch) -> None:
+    # outside the executor container (no pid: host) the host path does not exist; `/` is what there is
+    _stub_docker_api(scrape, {"/info": {"DockerRootDir": "/var/lib/docker"}})
+    asked = _stub_filesystem(scrape, monkeypatch, host_dirs=set(), usage_by_path={"/": _ROOT_PARTITION})
+
+    assert scrape["get_host_disk_usage"]() == _ROOT_PARTITION
+    assert asked == ["/"]
+
+
+def test_disk_usage_survives_a_silent_docker_socket(scrape: dict, monkeypatch) -> None:
+    # the docker socket is the fragile half (hard_disk_docker_scrape_error); total/used/free must
+    # still be reported, from the default data root when the host has it
+    def _no_docker(path):
+        raise RuntimeError("docker api: connection refused")
+
+    scrape["docker_api_get"] = _no_docker
+    asked = _stub_filesystem(
+        scrape,
+        monkeypatch,
+        host_dirs={"/proc/1/root/var/lib/docker"},
+        usage_by_path={"/proc/1/root/var/lib/docker": _DOCKER_PARTITION},
+    )
+
+    assert scrape["get_host_disk_usage"]() == _DOCKER_PARTITION
+    assert asked == ["/proc/1/root/var/lib/docker"]


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-2771](https://app.notion.com/p/The-machine-scrape-measures-disk-with-shutil-disk-usage-so-a-node-with-a-dedicated-var-lib-docker-vo-3c7b8bfdbde981598f9cf6a8c5cd39a8) · reviewer: @jam6099

**TL;DR** — The scrape measured disk with `shutil.disk_usage("/")` inside the executor container, so a host whose docker data root sits on its own partition could list the wrong size (ticket-0286: a 5 TB docker volume shown as 1.8 TB). `get_host_disk_usage()` measures `/proc/1/root<DockerRootDir>` explicitly and falls back to `/` when that path is not there or docker does not answer. Validator scrape only; no new field.

**What changed**
- `get_host_disk_usage()` in `machine_scrape.py`: `DockerRootDir` from `docker info` (default `/var/lib/docker`), measured as `/proc/1/root<DockerRootDir>`, `/` as the fallback
- `get_machine_specs()` builds `data_hard_disk` from it; no new `data_*` key, obfuscator tables and key order untouched
- `test_scrape_disk_breakdown.py` +4: ticket-0286's layout, a custom data root, no reachable host root, docker socket down

**How to verify**
- `pytest neurons/validators/tests/test_scrape_disk_breakdown.py` → 13 passed
- On a host with `/var/lib/docker` on its own mount, compare `get_host_disk_usage()` with `df -B1 /var/lib/docker`

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1943 passed · Result: PASS 07ec64cd · Gate: PASS 4bc672d

**Ran it:** throwaway EC2 (AL2023, docker, a 512 MB tmpfs mounted on `/var/lib/docker`) at 4bc672d: the real `get_host_disk_usage()` body → `total_kB=524288 used_kB=160`, equal to `df /var/lib/docker`; old `shutil.disk_usage('/')` → `total_kB=62836716` · run 20260909T025445Z-51ye

**Self-review:** clean at 4bc672d (12 checks, 2 low)

**Parts:** backend n/a — validator scrape only, the listing reads the same `hard_disk` fields · migration n/a — no schema · frontend n/a — no UI · CLI/SDK n/a — no client change · docs n/a — nothing a provider sees or sets changes · tests ✓ 4 in `test_scrape_disk_breakdown.py` · dashboards n/a — no new metric

**Docs:** none needed because nothing a provider sees or sets changes; the fix is inside the validator's machine scrape.

<details><summary>Details</summary>

Origin: Discord ticket-0286 (provider HornsWithAHalo, 25 Aug 2026: node lists 1.8 TB after giving `/var/lib/docker` a 5 TB partition; `lsblk`: `sda3 ext4 2T /`, `sda4 xfs 5T /var/lib/docker`; scrape `hard_disk.total 2112647088 kB`); ticket [DAH-2771](https://app.notion.com/p/The-machine-scrape-measures-disk-with-shutil-disk-usage-so-a-node-with-a-dedicated-var-lib-docker-vo-3c7b8bfdbde981598f9cf6a8c5cd39a8).

## Problem
`machine_scrape.py` built the whole `data_hard_disk` block from `shutil.disk_usage("/")`. The scrape runs inside the executor container, where `/` is the container's overlay: what it reports depends on where the overlay's upper layer sits, never on an explicit choice of the partition that holds images, containers and volumes — docker's data root on the host. On the ticket's host the 5 TB docker volume listed as 1.8 TB (the root partition's size; why the overlay answered with it is not established — data root not on that partition at the time, snap docker or mount order are candidates). Downstream `get_available_disk_size` (`hard_disk.free`) decides rental capacity from the same figure, and the node mapper feeds it to the public listing. A provider with a dedicated volume for `/var/lib/docker` (`docker-storage.md`, required for GPU splitting) can be mis-listed in either direction when the overlay's answer and the data root differ.

## Change (+17 −1 in the script)
`get_host_disk_usage()`: the data-root mount is measured explicitly instead of relying on the overlay's upper-layer statfs — `DockerRootDir` from `docker info` (default `/var/lib/docker`), measured as `/proc/1/root<DockerRootDir>`, the host path the volume walk (`get_vloopback_volume_bytes`) and the container-log walk already use in the same function; `/` remains the measurement when that path is not there (no `pid: host`) or docker does not answer (the breakdown is already the "fragile half" — total/used/free keep coming). No new `data_*` key, so the obfuscator tables and the encryption key order (`test_scrape_encryption_key_order.py`) are untouched. The old `gpu_info.py` copy in lium-platform measures `"."` and is not the source of `hard_disk` in the listing; left alone.

## Verification
- `tests/test_scrape_disk_breakdown.py` +4 (helper compiled out of the script like the other disk tests): ticket-0286's layout → the docker partition's numbers, `/` never asked; a custom `DockerRootDir` is followed; no reachable host docker root → `/`; docker socket down → default data root still measured. Red on main (the fixture asserts `get_host_disk_usage` is defined, so the whole file errors there), green here.
- Validator suite on a Lium pod (python 3.11, pdm): **1942 passed, 15 skipped**, 3 failures that are the pod's, not the branch's: `test_scrape_infiniband::…unreadable_sysfs…` (the pod runs as root, so the "unreadable" tree is readable) and two `test_sshd_bootstrap_script` cases that pass when the file runs alone (order-dependent). Every `test_scrape_*` file green (16/16 for disk + key order + obfuscation names).

Docs: none changed in this PR — executor/validator internals; nothing a provider sees or sets changes.

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — the earlier head merged onto `main` `07ec64cd` (clean merge), then: pytest: validators (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1943 passed, 15 skipped, 149 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

### Self-review

Verdict `clean` at `4bc672d` · 12 checks · by subagent-r34fresh2 · 2026-09-09 02:59Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | CORRECTNESS | `neurons/validators/src/miner_jobs/machine_scrape.py:856` | Known low carried from round 1: if `os.path.isdir` succeeds but `shutil.disk_usage(host_docker_root)` raises, the exception reaches the outer try in get_machine_specs and total/used/free are dropped (hard_disk_scrape_error) where the old code reported `/`; nothing crashes. | Post-merge nit: `try/except OSError` around the host-path `shutil.disk_usage`, falling back to `shutil.disk_usage("/")`. |
| low | STALE-BODY | `neurons/validators/src/miner_jobs/machine_scrape.py:845` | The Problem paragraph names the downstream consumer as `get_available_disk_size`; the lium-platform method is `Executor.get_available_disk_size_in_bytes` (apps/lium/backend/apps/server/src/models/executor.py), which does read `hard_disk.free` as stated — the behaviour claim holds, the identifier is abbreviated. | Optional: write `get_available_disk_size_in_bytes`. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/src/miner_jobs/machine_scrape.py:845` Round-1 medium resolved: the Problem paragraph now says the overlay's answer depends on where the upper layer sits (true of overlayfs statfs), states that why the ticket's host answered with the root partition's size is not established and lists candidates rather than asserting a mechanism, and the 'every provider ... is in this shape' generalisation is replaced by 'can be mis-listed in either direction when the overlay's answer and the data root differ', which is exactly the condition under which old and new code disagree. · `neurons/validators/src/miner_jobs/machine_scrape.py:844` 'the data-root mount is measured explicitly instead of relying on the overlay's upper-layer statfs' matches lines 851-856 (DockerRootDir from /info, `/proc/1/root<DockerRootDir>`, isdir gate, `/` fallback); heading '+17 −1' matches `git diff origin/main...HEAD --numstat` (17/1). · `neurons/validators/tests/test_scrape_disk_breakdown.py:34` 'the fixture asserts get_host_disk_usage is defined, so the whole file errors there' matches build_scrape_namespace's DISK_HELPERS assertion (tests/helpers.py:36); '13 passed' matches the 13 `def test_` in the file at 4bc672d. · `neurons/validators/src/miner_jobs/machine_scrape.py:851` Scanner note: "/var/lib/docker" is the default DockerRootDir string used as a statvfs path prefix, not a volume mounted into any container. · `neurons/validators/src/miner_jobs/machine_scrape.py:853` Scanner note: same literal on the docker-unreachable fallback branch; only concatenated into `/proc/1/root...` for isdir/disk_usage, never passed to docker as a bind mount. · `neurons/validators/tests/test_scrape_disk_breakdown.py:351` Scanner note: test fixture data — a stubbed `/info` answer and an in-memory dict key; no container is started. · `neurons/validators/tests/test_scrape_disk_breakdown.py:382` Scanner note: same test-fixture string in the docker-socket-down case; stubs only, no mount. · `neurons/validators/src/miner_jobs/machine_scrape.py:1514` Code unchanged since round 1 (HEAD 4bc672d, worktree clean, base main, one commit ahead, MERGEABLE); the round-1 code-level dismissals (docker_api_get raises rather than returning None, non-dict /info caught, os/shutil imported at file top, pid: host + privileged in the executor compose, no new data_* key, consumers want the data-root partition) still stand.

### Verified

Gate: PASS (4bc672d) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1305)

</details>
