### PR TITLE
DAH-3131 - [P3] describe the datura package; drop the bittensor placeholders

### DIFF
--- a/contrib/CONTRIBUTING.md
+++ b/contrib/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Bittensor Subnet Development
+# Contributing to lium-io
 
-The following is a set of guidelines for contributing to the Bittensor ecosystem. These are **HIGHLY RECOMMENDED** guidelines, but not hard-and-fast rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to `lium-io`, the Subnet 51 validator, executor and miner. These are **HIGHLY RECOMMENDED** guidelines, but not hard-and-fast rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
 ## Table Of Contents
 1. [How Can I Contribute?](#how-can-i-contribute)
@@ -16,10 +16,10 @@ The following is a set of guidelines for contributing to the Bittensor ecosystem
 
 
 ## How Can I Contribute?
-TODO(developer): Define your desired contribution procedure.
+Open an issue on [Datura-ai/lium-io](https://github.com/Datura-ai/lium-io/issues) describing the bug or the change you want, or pick one that is open. Fork the repository, branch from `main`, and open a pull request against `main` — the [README](../README.md) lists the layout and the exact test command for each neuron. Every pull request needs one approving review before it merges; the **Tests** workflow (validator and executor suites) runs on pull requests that touch `neurons/validators`, `neurons/executor` or `datura` — keep it green.
 
 ## Communication Channels
-TODO(developer): Place your communication channels here
+GitHub issues and pull requests on this repository. Providers running a node reach the team in the Lium Discord (linked from [docs.lium.io](https://docs.lium.io/providers/)); questions about the code belong in an issue so the answer stays findable.
 
 > Please follow the Bittensor Subnet [style guide](./STYLE.md) regardless of your contribution type. 
 
@@ -99,7 +99,7 @@ After you submit a pull request, it will be reviewed by the maintainers. They ma
 > Note: Be sure to merge the latest from "upstream" before making a pull request:
 
 ```bash
-git remote add upstream https://github.com/opentensor/bittensor.git # TODO(developer): replace with your repo URL
+git remote add upstream https://github.com/Datura-ai/lium-io.git
 git fetch upstream
 git merge upstream/<your-branch-name>
 git push origin <your-branch-name>

--- a/datura/README.md
+++ b/datura/README.md
@@ -1,1 +1,23 @@
 # datura
+
+The protocol package shared by the three neurons in this repository. It has no
+dependencies of its own and is installed from the working tree by
+`neurons/validators`, `neurons/executor` and `neurons/miners`
+(`datura @ file:///…/datura` in each `pyproject.toml`), so a change here is
+picked up by all three on their next `pdm install`.
+
+What lives here:
+
+- `datura/requests/` — the WebSocket message types the validator and the miner
+  exchange, as pydantic models: `validator_requests.py` (what the validator
+  sends: authentication, SSH-key submit/remove, pod-log requests) and
+  `miner_requests.py` (what the miner answers: accept/decline job, executor SSH
+  info, generic error). `base.py` holds `BaseRequest`, which parses an incoming
+  JSON frame into the right subclass by its `message_type`.
+- `datura/consumers/base.py` — `BaseConsumer`, the FastAPI WebSocket
+  receive/send loop both sides build their consumers on.
+- `datura/errors/protocol.py` — the protocol-level exceptions.
+
+Adding a message type means adding a model in the right `*_requests.py` and a
+member to its `RequestType` enum; the validator and the miner must ship the
+change together, since neither side tolerates an unknown type.


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3131](https://app.notion.com/p/lium-io-contributor-docs-datura-README-md-is-two-words-CONTRIBUTING-md-still-carries-the-bittensor-3d4b8bfdbde98129ba88db09f6916ef6) · reviewer: @jam6099

**TL;DR** — `datura/README.md` is `# datura` and nothing else, although the package is the protocol layer all three neurons install from the tree (`datura @ file:///…/datura` in each `pyproject.toml`). Describe the datura package; drop the bittensor-template placeholders from CONTRIBUTING. Biggest change: `datura/README.md` (+22 −0).

**What changed**
- `datura/README.md`: what lives where (`requests/validator_requests.py`, `requests/miner_requests.py`, `requests/base.py` → `BaseRequest.parse` dispatches on `message_type`; `consumers/base.py` → `BaseConsumer`; `errors/protocol.py`), who installs it.
- `contrib/CONTRIBUTING.md`: title, "How Can I Contribute?"

**How to verify**
- `rg 'TODO\(developer\)|opentensor' contrib/` → → nothing. Claims checked against `datura/datura/requests/base.py`, the three `pyproject.toml` files and `.github/workflows/test.yml`. No code change.

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1939 passed · executor 128 passed · miners 26 passed · Result: PASS d4043b20 · Gate: not run

**Docs:** this PR is the docs change.

<details><summary>Details</summary>

[DAH-3131](https://app.notion.com/p/lium-io-contributor-docs-datura-README-md-is-two-words-CONTRIBUTING-md-still-carries-the-bittensor-3d4b8bfdbde98129ba88db09f6916ef6) — docs only, from the 7 Sep docs review.

## Problem
- `datura/README.md` is `# datura` and nothing else, although the package is the protocol layer all three neurons install from the tree (`datura @ file:///…/datura` in each `pyproject.toml`).
- `contrib/CONTRIBUTING.md` is still the bittensor subnet template: titled "Contributing to Bittensor Subnet Development", two `TODO(developer)` placeholders (contribution procedure, communication channels), and `git remote add upstream https://github.com/opentensor/bittensor.git # TODO(developer): replace with your repo URL`.

## Change
- `datura/README.md`: what lives where (`requests/validator_requests.py`, `requests/miner_requests.py`, `requests/base.py` → `BaseRequest.parse` dispatches on `message_type`; `consumers/base.py` → `BaseConsumer`; `errors/protocol.py`), who installs it, and that adding a message type means a model + a `RequestType` member shipped to validator and miner together (an unknown type fails `parse`).
- `contrib/CONTRIBUTING.md`: title, "How Can I Contribute?" (issues/PRs against `main`, one approving review, the Tests workflow and what triggers it), "Communication Channels" (issues; Lium Discord via docs.lium.io for providers), and the upstream remote → `Datura-ai/lium-io`. Nothing else on the page touched.

## Verification
`rg 'TODO\(developer\)|opentensor' contrib/` → nothing. Claims checked against `datura/datura/requests/base.py`, the three `pyproject.toml` files and `.github/workflows/test.yml`. No code change; lium-io#1293 (root README) is untouched.

Docs: this PR is the docs change.

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `d4043b20` merged onto `main` `07ec64cd` (clean merge), then: pytest: validators, executor, miners (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1939 passed, 15 skipped, 149 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); Executor 128 passed, 18 warnings; Miners 26 passed, 21 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 6 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

</details>
