### PR TITLE
DAH-3137 - [P2] signed on-host GPU hardware-signature challenge

### DIFF
--- a/neurons/executor/Dockerfile
+++ b/neurons/executor/Dockerfile
@@ -1,3 +1,26 @@
+# ---- optional gpu_sig builder (DAH-3137) --------------------------------------
+# Compiles the on-host GPU hardware-signature prober (neurons/executor/gpu_sig).
+# The builder base defaults to the SAME slim image as the final stage, so a
+# DEFAULT build pulls no CUDA and produces an EMPTY binary — the runtime install
+# below then no-ops and the validator check skips (binary_absent). Nothing about
+# the current image changes unless you opt in:
+#   docker build \
+#     --build-arg GPUSIG_BUILDER=nvidia/cuda:12.6.2-devel-ubuntu22.04 \
+#     --build-arg INSTALL_GPU_SIGNATURE=true \
+#     --build-arg LIUM_SIG_KEY=<hex-seal-key-matching-the-validator> ...
+ARG GPUSIG_BUILDER=python:3.11-slim
+FROM ${GPUSIG_BUILDER} AS gpusig
+ARG INSTALL_GPU_SIGNATURE=false
+ARG LIUM_SIG_KEY=lium-gpu-sig-dev-key-do-not-use-in-prod
+COPY gpu_sig /gpu_sig
+RUN set -e; \
+    if [ "$INSTALL_GPU_SIGNATURE" = "true" ]; then \
+      apt-get update && apt-get install -y --no-install-recommends make build-essential && \
+      cd /gpu_sig && make gpu_sig LIUM_SIG_KEY="$LIUM_SIG_KEY" && cp gpu_sig /gpu_sig.bin; \
+    else \
+      : > /gpu_sig.bin; \
+    fi
+
 FROM python:3.11-slim
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -85,6 +108,14 @@ COPY . .
 RUN mv /root/app/libdmcompverify.so /usr/lib/ \
   && mv /root/app/libverifyx.so /usr/lib/ \
   && mv /root/app/libinspector.so /usr/lib/
+
+# DAH-3137: install the gpu_sig prober only when it was actually built (opt-in
+# above). An empty artifact => not installed => the validator check skips.
+COPY --from=gpusig /gpu_sig.bin /tmp/gpu_sig.bin
+RUN if [ -s /tmp/gpu_sig.bin ]; then \
+      mkdir -p /root/app/bin && cp /tmp/gpu_sig.bin /root/app/bin/gpu_sig && chmod 0755 /root/app/bin/gpu_sig; \
+    fi; \
+    rm -f /tmp/gpu_sig.bin
 
 # Remove existing SSH host keys
 RUN rm -f /etc/ssh/ssh_host_*

--- a/neurons/executor/gpu_sig/Makefile
+++ b/neurons/executor/gpu_sig/Makefile
@@ -1,0 +1,37 @@
+# Build the gpu_sig hardware-signature prober (DAH-3137).
+#
+# The GPU binary needs a CUDA toolkit (nvcc). The seal-interop test builds with
+# a plain C compiler (no CUDA), so CI/dev can verify the HMAC matches Python.
+#
+#   make gpu_sig        # needs nvcc + a CUDA-capable build host
+#   make test_seal      # host-only crypto interop harness (cc)
+#   make LIUM_SIG_KEY=<hex> gpu_sig   # bake a release seal key
+
+NVCC ?= nvcc
+CC ?= cc
+LIUM_SIG_KEY ?= lium-gpu-sig-dev-key-do-not-use-in-prod
+# Target the datacenter + consumer arches the fleet runs (Ampere..Blackwell).
+GPU_ARCHS ?= -gencode arch=compute_80,code=sm_80 \
+             -gencode arch=compute_86,code=sm_86 \
+             -gencode arch=compute_89,code=sm_89 \
+             -gencode arch=compute_90,code=sm_90
+
+gpu_sig: gpu_sig.cu sha256.h
+	$(NVCC) -O3 $(GPU_ARCHS) \
+	  -DLIUM_SIG_MASTER_KEY="\"$(LIUM_SIG_KEY)\"" \
+	  -o gpu_sig gpu_sig.cu
+
+# Portable single-arch build for a pod whose exact SM you know (faster to build):
+#   make ARCH=sm_89 gpu_sig_single
+gpu_sig_single: gpu_sig.cu sha256.h
+	$(NVCC) -O3 -arch=$(ARCH) \
+	  -DLIUM_SIG_MASTER_KEY="\"$(LIUM_SIG_KEY)\"" \
+	  -o gpu_sig gpu_sig.cu
+
+test_seal: test_seal.c sha256.h
+	$(CC) -O2 -o test_seal test_seal.c
+
+clean:
+	rm -f gpu_sig gpu_sig_single test_seal
+
+.PHONY: clean

--- a/neurons/executor/gpu_sig/README.md
+++ b/neurons/executor/gpu_sig/README.md
@@ -1,0 +1,62 @@
+# gpu_sig — on-host GPU hardware-signature prober (DAH-3137)
+
+A small, self-contained binary that ships **pre-built in the executor image** and
+answers a validator's nonce-bound challenge with a **sealed** per-GPU hardware
+signature. It is a building block toward `liumd` (DAH-2834). Full design and
+threat model: `~/lium-ads/verification-binary/DESIGN.md`.
+
+## What it measures (per card, pinned via `CUDA_VISIBLE_DEVICES`)
+- sustained **FP32 tiled-SGEMM throughput** (TFLOPS), seeded from the nonce
+- device-to-device **VRAM bandwidth** (GB/s)
+- **kernel-reported identity** (GPU UUID / model / PCI) from
+  `/proc/driver/nvidia/gpus/*/information` — outside NVML, so a userspace
+  `nvidia-smi`/`libnvidia-ml` shim (DAH-2662) does not control it
+
+It seals the result so the miner-controlled shell cannot tamper the numbers:
+
+```
+key = HMAC_SHA256(MASTER_KEY, kernel_uuid)          # validator derives the same
+sig = HMAC_SHA256(key, "nonce|device|uuid|pci|tflops|gbps|ms")
+```
+
+The signed `msg` string is authoritative; the validator parses the numbers out of
+it and verifies `sig`, so C/Python float formatting can never diverge.
+
+## Build
+```
+make gpu_sig LIUM_SIG_KEY=<hex-seal-key-matching-the-validator>   # needs nvcc + CUDA
+make test_seal                                                    # host-only crypto interop (cc)
+```
+`GPU_ARCHS` in the `Makefile` covers Ampere→Hopper (sm_80/86/89/90). Blackwell
+(sm_100/sm_120) needs CUDA ≥ 12.8; add its `-gencode` there. At runtime the binary
+needs only the driver `libcuda.so.1` (built `-cudart static`), which the NVIDIA
+container runtime injects.
+
+## Ship in the executor image
+Opt-in build args on `neurons/executor/Dockerfile` (default off — a normal build
+pulls no CUDA and installs nothing):
+```
+docker build \
+  --build-arg GPUSIG_BUILDER=nvidia/cuda:12.6.2-devel-ubuntu22.04 \
+  --build-arg INSTALL_GPU_SIGNATURE=true \
+  --build-arg LIUM_SIG_KEY=<hex> ...
+```
+Installs to `/root/app/bin/gpu_sig`. The validator finds it at
+`GPU_SIGNATURE_BINARY_RELATIVE` under the executor root and skips cleanly if absent.
+
+## Calibration (required before enforcement)
+Run on one real card of each class and record `tflops` / `gbps`:
+```
+./gpu_sig --nonce $(openssl rand -hex 32) --device 0
+```
+Feed generous floors into `GPU_SIGNATURE_ENVELOPE`
+(`neurons/validators/src/services/gpu_signature.py`) and set `calibrated=True`
+only for classes measured with THIS binary. Until then the envelope gates
+nothing (fail-open) and the check is observe-only.
+
+## Honest scope
+`MASTER_KEY` is baked into the (signed, digest-pinned) image, so a root provider
+who reverse-engineers the binary can still forge a seal over fabricated numbers.
+This closes the cheap/scalable spoofs (NVML shims, canned/replayed answers,
+wrong-class numbers, count serialisation). Full unforgeability needs the
+derived-key seal folded into liumd and/or NVIDIA CC attestation.

--- a/neurons/executor/gpu_sig/gpu_sig.cu
+++ b/neurons/executor/gpu_sig/gpu_sig.cu
@@ -1,0 +1,279 @@
+/*
+ * gpu_sig — nonce-bound, sealed per-GPU hardware-signature prober (DAH-3137).
+ *
+ * Ships pre-built in the executor image (NOT uploaded per check). The validator
+ * runs it over the existing SSH channel, pinned to one card:
+ *
+ *     CUDA_VISIBLE_DEVICES=<i> <root>/bin/gpu_sig --nonce <64hex> --device 0
+ *
+ * It measures a hardware signature that is expensive to fake:
+ *   - sustained FP32 matmul throughput (TFLOPS), seeded from the nonce
+ *   - device VRAM bandwidth (GB/s)
+ *   - kernel-reported GPU identity (UUID/model/PCI) read from
+ *     /proc/driver/nvidia/gpus/<pci>/information — OUTSIDE NVML, so a userspace
+ *     nvidia-smi/libnvidia-ml shim (DAH-2662) does not control it.
+ *
+ * It seals the result so the miner-controlled shell cannot tamper the numbers:
+ *   key  = HMAC_SHA256(MASTER_KEY, kernel_uuid)      # validator derives the same
+ *   sig  = HMAC_SHA256(key, "nonce|device|uuid|pci|tflops|gbps|ms")
+ * The message is the EXACT string tokens printed in the JSON, so the C and
+ * Python HMAC inputs are byte-identical regardless of float formatting.
+ *
+ * Honest scope: MASTER_KEY is baked into the (signed, digest-pinned) executor
+ * image, so a root provider who reverse-engineers the binary can still forge a
+ * seal over fabricated numbers. This closes the cheap/scalable spoofs (NVML
+ * shims, canned/replayed answers, wrong-class numbers, count serialisation) and
+ * gathers ground truth; full unforgeability needs the derived-key seal folded
+ * into liumd (DAH-2834) and/or NVIDIA CC attestation. See DESIGN.md §8.
+ */
+#include <cuda_runtime.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>  /* strcasecmp */
+
+#include "sha256.h"
+
+#ifndef LIUM_SIG_MASTER_KEY
+/* Overridden at build time: nvcc ... -DLIUM_SIG_MASTER_KEY="\"<hex>\"".
+ * This default is a well-known dev key; a release image bakes a rotated key
+ * that the validator holds via shared config. */
+#define LIUM_SIG_MASTER_KEY "lium-gpu-sig-dev-key-do-not-use-in-prod"
+#endif
+
+#define TILE 32
+
+static void emit_error(const char *nonce, int device, const char *code) {
+    /* structured, single-line, always exit != 0 on failure */
+    printf("{\"gpu_sig\": 1, \"ok\": false, \"nonce\": \"%s\", \"device\": %d, \"error\": \"%s\"}\n",
+           nonce ? nonce : "", device, code);
+    fflush(stdout);
+}
+
+#define CUDA_OK(call, nonce, dev, code)                          \
+    do {                                                         \
+        cudaError_t _e = (call);                                 \
+        if (_e != cudaSuccess) {                                 \
+            char _buf[128];                                      \
+            snprintf(_buf, sizeof(_buf), "%s:%s", code, cudaGetErrorName(_e)); \
+            emit_error(nonce, dev, _buf);                        \
+            return 3;                                            \
+        }                                                        \
+    } while (0)
+
+/* Tiled single-precision GEMM: C = A * B (N x N), shared-memory blocked. */
+__global__ void sgemm_tiled(const float *A, const float *B, float *C, int N) {
+    __shared__ float As[TILE][TILE];
+    __shared__ float Bs[TILE][TILE];
+    int row = blockIdx.y * TILE + threadIdx.y;
+    int col = blockIdx.x * TILE + threadIdx.x;
+    float acc = 0.0f;
+    for (int t = 0; t < (N + TILE - 1) / TILE; ++t) {
+        int ac = t * TILE + threadIdx.x;
+        int br = t * TILE + threadIdx.y;
+        As[threadIdx.y][threadIdx.x] = (row < N && ac < N) ? A[row * N + ac] : 0.0f;
+        Bs[threadIdx.y][threadIdx.x] = (br < N && col < N) ? B[br * N + col] : 0.0f;
+        __syncthreads();
+        #pragma unroll
+        for (int k = 0; k < TILE; ++k) acc += As[threadIdx.y][k] * Bs[k][threadIdx.x];
+        __syncthreads();
+    }
+    if (row < N && col < N) C[row * N + col] = acc;
+}
+
+/* Deterministic nonce-seeded fill so a precomputed answer for a different nonce
+ * does not reuse this run's inputs. */
+__global__ void fill_seeded(float *buf, long n, unsigned int seed) {
+    long idx = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        unsigned int x = (unsigned int)(idx * 1103515245u + seed + 12345u);
+        x ^= x >> 13; x *= 0x5bd1e995u; x ^= x >> 15;
+        buf[idx] = (float)(x & 0xffffu) / 65536.0f;
+    }
+}
+
+/* Find the kernel /proc entry whose PCI matches the CUDA-reported bus id and
+ * extract "GPU UUID:" and "Model:". Returns 1 on success. */
+static int read_kernel_identity(const char *pci_lower, char *uuid_out, size_t uuid_sz,
+                                char *model_out, size_t model_sz) {
+    uuid_out[0] = '\0';
+    model_out[0] = '\0';
+    const char *base = "/proc/driver/nvidia/gpus";
+    DIR *d = opendir(base);
+    if (!d) return 0;
+    struct dirent *ent;
+    char match_dir[512];
+    match_dir[0] = '\0';
+    while ((ent = readdir(d)) != NULL) {
+        if (ent->d_name[0] == '.') continue;
+        /* CUDA pci is like 0000:65:00.0; kernel dir is the same, case-insensitive */
+        if (strcasecmp(ent->d_name, pci_lower) == 0) {
+            snprintf(match_dir, sizeof(match_dir), "%s/%s/information", base, ent->d_name);
+            break;
+        }
+    }
+    closedir(d);
+    if (match_dir[0] == '\0') return 0;
+    FILE *f = fopen(match_dir, "r");
+    if (!f) return 0;
+    char line[1024];
+    while (fgets(line, sizeof(line), f)) {
+        char *p;
+        if ((p = strstr(line, "GPU UUID:")) != NULL) {
+            p += strlen("GPU UUID:");
+            while (*p == ' ' || *p == '\t') p++;
+            char *e = p + strlen(p);
+            while (e > p && (e[-1] == '\n' || e[-1] == '\r' || e[-1] == ' ' || e[-1] == '\t')) *--e = '\0';
+            strncpy(uuid_out, p, uuid_sz - 1); uuid_out[uuid_sz - 1] = '\0';
+        } else if ((p = strstr(line, "Model:")) != NULL) {
+            p += strlen("Model:");
+            while (*p == ' ' || *p == '\t') p++;
+            char *e = p + strlen(p);
+            while (e > p && (e[-1] == '\n' || e[-1] == '\r' || e[-1] == ' ' || e[-1] == '\t')) *--e = '\0';
+            strncpy(model_out, p, model_sz - 1); model_out[model_sz - 1] = '\0';
+        }
+    }
+    fclose(f);
+    return uuid_out[0] != '\0';
+}
+
+static void json_escape(const char *in, char *out, size_t out_sz) {
+    size_t o = 0;
+    for (size_t i = 0; in[i] && o + 2 < out_sz; ++i) {
+        char c = in[i];
+        if (c == '"' || c == '\\') { out[o++] = '\\'; out[o++] = c; }
+        else if (c == '\n' || c == '\r' || c == '\t') { out[o++] = ' '; }
+        else out[o++] = c;
+    }
+    out[o] = '\0';
+}
+
+int main(int argc, char **argv) {
+    const char *nonce = "";
+    int device = 0;
+    int mm_n = 8192;      /* matmul square dimension */
+    int mm_iters = 30;    /* timed matmul iterations */
+    int bw_iters = 50;    /* timed bandwidth iterations */
+
+    for (int i = 1; i < argc; ++i) {
+        if (!strcmp(argv[i], "--nonce") && i + 1 < argc) nonce = argv[++i];
+        else if (!strcmp(argv[i], "--device") && i + 1 < argc) device = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--mm-n") && i + 1 < argc) mm_n = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--mm-iters") && i + 1 < argc) mm_iters = atoi(argv[++i]);
+        else if (!strcmp(argv[i], "--bw-iters") && i + 1 < argc) bw_iters = atoi(argv[++i]);
+    }
+    if (strlen(nonce) < 16) { emit_error(nonce, device, "bad_nonce"); return 2; }
+
+    const char *master = getenv("LIUM_SIG_KEY");
+    if (!master || !*master) master = LIUM_SIG_MASTER_KEY;
+
+    CUDA_OK(cudaSetDevice(device), nonce, device, "set_device");
+
+    cudaDeviceProp prop;
+    CUDA_OK(cudaGetDeviceProperties(&prop, device), nonce, device, "get_props");
+    char pci[32];
+    CUDA_OK(cudaDeviceGetPCIBusId(pci, sizeof(pci), device), nonce, device, "get_pci");
+    for (char *p = pci; *p; ++p) if (*p >= 'A' && *p <= 'Z') *p += 32; /* lowercase */
+
+    char kern_uuid[128], kern_model[128];
+    int have_kern = read_kernel_identity(pci, kern_uuid, sizeof(kern_uuid), kern_model, sizeof(kern_model));
+    if (!have_kern) {
+        /* Identity anchor is the whole point; a missing /proc view is reported,
+         * not guessed. The validator decides how to weight a kernel-blind run. */
+        kern_uuid[0] = '\0';
+        snprintf(kern_model, sizeof(kern_model), "%s", prop.name);
+    }
+
+    unsigned int seed = 0;
+    for (int i = 0; i < 8 && nonce[i]; ++i) {
+        char c = nonce[i];
+        unsigned int v = (c >= '0' && c <= '9') ? (c - '0')
+                       : (c >= 'a' && c <= 'f') ? (c - 'a' + 10)
+                       : (c >= 'A' && c <= 'F') ? (c - 'A' + 10) : 0;
+        seed = (seed << 4) | v;
+    }
+
+    /* ---- matmul throughput ---- */
+    long elems = (long)mm_n * mm_n;
+    size_t bytes = (size_t)elems * sizeof(float);
+    float *dA, *dB, *dC;
+    CUDA_OK(cudaMalloc(&dA, bytes), nonce, device, "malloc_a");
+    CUDA_OK(cudaMalloc(&dB, bytes), nonce, device, "malloc_b");
+    CUDA_OK(cudaMalloc(&dC, bytes), nonce, device, "malloc_c");
+
+    int fill_threads = 256;
+    long fill_blocks = (elems + fill_threads - 1) / fill_threads;
+    fill_seeded<<<fill_blocks, fill_threads>>>(dA, elems, seed);
+    fill_seeded<<<fill_blocks, fill_threads>>>(dB, elems, seed ^ 0x9e3779b9u);
+    CUDA_OK(cudaDeviceSynchronize(), nonce, device, "fill");
+
+    dim3 block(TILE, TILE);
+    dim3 grid((mm_n + TILE - 1) / TILE, (mm_n + TILE - 1) / TILE);
+
+    for (int w = 0; w < 3; ++w) sgemm_tiled<<<grid, block>>>(dA, dB, dC, mm_n);  /* warmup */
+    CUDA_OK(cudaDeviceSynchronize(), nonce, device, "warmup");
+
+    cudaEvent_t t0, t1;
+    cudaEventCreate(&t0); cudaEventCreate(&t1);
+    cudaEventRecord(t0);
+    for (int it = 0; it < mm_iters; ++it) sgemm_tiled<<<grid, block>>>(dA, dB, dC, mm_n);
+    cudaEventRecord(t1);
+    CUDA_OK(cudaEventSynchronize(t1), nonce, device, "mm_sync");
+    float mm_ms = 0.0f; cudaEventElapsedTime(&mm_ms, t0, t1);
+    double flop = 2.0 * (double)mm_n * mm_n * mm_n * mm_iters;
+    double tflops = (mm_ms > 0.0) ? (flop / (mm_ms / 1000.0) / 1e12) : 0.0;
+
+    /* ---- VRAM bandwidth (device-to-device copy) ---- */
+    size_t bw_bytes = bytes; /* reuse the matmul-sized buffer */
+    cudaEventRecord(t0);
+    for (int it = 0; it < bw_iters; ++it)
+        cudaMemcpy(dC, dA, bw_bytes, cudaMemcpyDeviceToDevice);
+    cudaEventRecord(t1);
+    CUDA_OK(cudaEventSynchronize(t1), nonce, device, "bw_sync");
+    float bw_ms = 0.0f; cudaEventElapsedTime(&bw_ms, t0, t1);
+    /* read + write => 2x bytes moved per copy */
+    double gbps = (bw_ms > 0.0) ? (2.0 * (double)bw_bytes * bw_iters / (bw_ms / 1000.0) / 1e9) : 0.0;
+
+    cudaFree(dA); cudaFree(dB); cudaFree(dC);
+    cudaEventDestroy(t0); cudaEventDestroy(t1);
+
+    /* ---- format numbers as the exact strings we will both print and seal ---- */
+    char tflops_s[32], gbps_s[32], ms_s[32];
+    snprintf(tflops_s, sizeof(tflops_s), "%.3f", tflops);
+    snprintf(gbps_s, sizeof(gbps_s), "%.3f", gbps);
+    snprintf(ms_s, sizeof(ms_s), "%.3f", mm_ms);
+
+    /* seal key = HMAC(master, kernel_uuid); the validator derives the same from
+     * the UUID it independently expects, so a fabricated UUID -> unverifiable. */
+    uint8_t perkey[32];
+    hmac_sha256((const uint8_t *)master, strlen(master),
+                (const uint8_t *)kern_uuid, strlen(kern_uuid), perkey);
+
+    char msg[512];
+    snprintf(msg, sizeof(msg), "%s|%d|%s|%s|%s|%s|%s",
+             nonce, device, kern_uuid, pci, tflops_s, gbps_s, ms_s);
+    char sig[65];
+    hmac_sha256_hex(perkey, 32, (const uint8_t *)msg, strlen(msg), sig);
+
+    char uuid_j[160], model_j[160], pci_j[64], msg_j[600];
+    json_escape(kern_uuid, uuid_j, sizeof(uuid_j));
+    json_escape(kern_model, model_j, sizeof(model_j));
+    json_escape(pci, pci_j, sizeof(pci_j));
+    json_escape(msg, msg_j, sizeof(msg_j));
+
+    /* `msg` is the authoritative, signed record: the validator parses the
+     * numbers/identity OUT of it (not the cosmetic numeric fields) and verifies
+     * `sig` over it, so C/Python float formatting can never diverge. */
+    printf("{\"gpu_sig\": 1, \"ok\": true, \"nonce\": \"%s\", \"device\": %d, "
+           "\"kernel_uuid\": \"%s\", \"kernel_model\": \"%s\", \"cuda_name\": \"%s\", "
+           "\"pci\": \"%s\", \"vram_mb\": %llu, \"mm_n\": %d, \"mm_iters\": %d, "
+           "\"tflops\": %s, \"gbps\": %s, \"ms\": %s, \"have_kernel\": %s, "
+           "\"msg\": \"%s\", \"sig\": \"%s\"}\n",
+           nonce, device, uuid_j, model_j, prop.name, pci_j,
+           (unsigned long long)(prop.totalGlobalMem / (1024ULL * 1024ULL)),
+           mm_n, mm_iters, tflops_s, gbps_s, ms_s, have_kern ? "true" : "false",
+           msg_j, sig);
+    fflush(stdout);
+    return 0;
+}

--- a/neurons/executor/gpu_sig/sha256.h
+++ b/neurons/executor/gpu_sig/sha256.h
@@ -1,0 +1,128 @@
+/*
+ * Self-contained SHA-256 + HMAC-SHA256 (public-domain style, no OpenSSL).
+ *
+ * Header-only so gpu_sig.cu builds with just nvcc/gcc and no -lssl on the
+ * executor image. The seal format MUST stay byte-identical to the validator's
+ * Python HMAC (neurons/validators/src/services/gpu_signature.py) — see
+ * test_seal.c for the interop check against Python's hmac module.
+ */
+#ifndef LIUM_SHA256_H
+#define LIUM_SHA256_H
+
+#include <stdint.h>
+#include <string.h>
+
+typedef struct {
+    uint32_t state[8];
+    uint64_t bitlen;
+    uint8_t data[64];
+    uint32_t datalen;
+} sha256_ctx;
+
+static const uint32_t sha256_k[64] = {
+    0x428a2f98u,0x71374491u,0xb5c0fbcfu,0xe9b5dba5u,0x3956c25bu,0x59f111f1u,0x923f82a4u,0xab1c5ed5u,
+    0xd807aa98u,0x12835b01u,0x243185beu,0x550c7dc3u,0x72be5d74u,0x80deb1feu,0x9bdc06a7u,0xc19bf174u,
+    0xe49b69c1u,0xefbe4786u,0x0fc19dc6u,0x240ca1ccu,0x2de92c6fu,0x4a7484aau,0x5cb0a9dcu,0x76f988dau,
+    0x983e5152u,0xa831c66du,0xb00327c8u,0xbf597fc7u,0xc6e00bf3u,0xd5a79147u,0x06ca6351u,0x14292967u,
+    0x27b70a85u,0x2e1b2138u,0x4d2c6dfcu,0x53380d13u,0x650a7354u,0x766a0abbu,0x81c2c92eu,0x92722c85u,
+    0xa2bfe8a1u,0xa81a664bu,0xc24b8b70u,0xc76c51a3u,0xd192e819u,0xd6990624u,0xf40e3585u,0x106aa070u,
+    0x19a4c116u,0x1e376c08u,0x2748774cu,0x34b0bcb5u,0x391c0cb3u,0x4ed8aa4au,0x5b9cca4fu,0x682e6ff3u,
+    0x748f82eeu,0x78a5636fu,0x84c87814u,0x8cc70208u,0x90befffau,0xa4506cebu,0xbef9a3f7u,0xc67178f2u
+};
+
+#define SHA256_ROTR(a,b) (((a) >> (b)) | ((a) << (32-(b))))
+
+static void sha256_transform(sha256_ctx *ctx, const uint8_t *data) {
+    uint32_t a,b,c,d,e,f,g,h,i,j,t1,t2,m[64];
+    for (i = 0, j = 0; i < 16; ++i, j += 4)
+        m[i] = ((uint32_t)data[j] << 24) | ((uint32_t)data[j+1] << 16) |
+               ((uint32_t)data[j+2] << 8) | ((uint32_t)data[j+3]);
+    for (; i < 64; ++i)
+        m[i] = (SHA256_ROTR(m[i-2],17) ^ SHA256_ROTR(m[i-2],19) ^ (m[i-2] >> 10)) + m[i-7] +
+               (SHA256_ROTR(m[i-15],7) ^ SHA256_ROTR(m[i-15],18) ^ (m[i-15] >> 3)) + m[i-16];
+    a=ctx->state[0]; b=ctx->state[1]; c=ctx->state[2]; d=ctx->state[3];
+    e=ctx->state[4]; f=ctx->state[5]; g=ctx->state[6]; h=ctx->state[7];
+    for (i = 0; i < 64; ++i) {
+        t1 = h + (SHA256_ROTR(e,6) ^ SHA256_ROTR(e,11) ^ SHA256_ROTR(e,25)) + ((e & f) ^ (~e & g)) + sha256_k[i] + m[i];
+        t2 = (SHA256_ROTR(a,2) ^ SHA256_ROTR(a,13) ^ SHA256_ROTR(a,22)) + ((a & b) ^ (a & c) ^ (b & c));
+        h=g; g=f; f=e; e=d+t1; d=c; c=b; b=a; a=t1+t2;
+    }
+    ctx->state[0]+=a; ctx->state[1]+=b; ctx->state[2]+=c; ctx->state[3]+=d;
+    ctx->state[4]+=e; ctx->state[5]+=f; ctx->state[6]+=g; ctx->state[7]+=h;
+}
+
+static void sha256_init(sha256_ctx *ctx) {
+    ctx->datalen = 0; ctx->bitlen = 0;
+    ctx->state[0]=0x6a09e667u; ctx->state[1]=0xbb67ae85u; ctx->state[2]=0x3c6ef372u; ctx->state[3]=0xa54ff53au;
+    ctx->state[4]=0x510e527fu; ctx->state[5]=0x9b05688cu; ctx->state[6]=0x1f83d9abu; ctx->state[7]=0x5be0cd19u;
+}
+
+static void sha256_update(sha256_ctx *ctx, const uint8_t *data, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        ctx->data[ctx->datalen++] = data[i];
+        if (ctx->datalen == 64) {
+            sha256_transform(ctx, ctx->data);
+            ctx->bitlen += 512;
+            ctx->datalen = 0;
+        }
+    }
+}
+
+static void sha256_final(sha256_ctx *ctx, uint8_t *hash) {
+    uint32_t i = ctx->datalen;
+    ctx->data[i++] = 0x80;
+    if (ctx->datalen < 56) {
+        while (i < 56) ctx->data[i++] = 0x00;
+    } else {
+        while (i < 64) ctx->data[i++] = 0x00;
+        sha256_transform(ctx, ctx->data);
+        memset(ctx->data, 0, 56);
+    }
+    ctx->bitlen += (uint64_t)ctx->datalen * 8;
+    for (int k = 0; k < 8; ++k)
+        ctx->data[63 - k] = (uint8_t)(ctx->bitlen >> (8 * k));
+    sha256_transform(ctx, ctx->data);
+    for (i = 0; i < 4; ++i)
+        for (int k = 0; k < 8; ++k)
+            hash[i + k * 4] = (uint8_t)((ctx->state[k] >> (24 - i * 8)) & 0xff);
+}
+
+static void sha256_bytes(const uint8_t *data, size_t len, uint8_t out[32]) {
+    sha256_ctx ctx; sha256_init(&ctx); sha256_update(&ctx, data, len); sha256_final(&ctx, out);
+}
+
+/* HMAC-SHA256(key, msg) -> out[32] */
+static void hmac_sha256(const uint8_t *key, size_t keylen,
+                        const uint8_t *msg, size_t msglen, uint8_t out[32]) {
+    uint8_t k[64], k_ipad[64], k_opad[64], inner[32];
+    memset(k, 0, 64);
+    if (keylen > 64) {
+        sha256_bytes(key, keylen, k);
+    } else {
+        memcpy(k, key, keylen);
+    }
+    for (int i = 0; i < 64; ++i) { k_ipad[i] = k[i] ^ 0x36; k_opad[i] = k[i] ^ 0x5c; }
+    sha256_ctx ctx;
+    sha256_init(&ctx);
+    sha256_update(&ctx, k_ipad, 64);
+    sha256_update(&ctx, msg, msglen);
+    sha256_final(&ctx, inner);
+    sha256_init(&ctx);
+    sha256_update(&ctx, k_opad, 64);
+    sha256_update(&ctx, inner, 32);
+    sha256_final(&ctx, out);
+}
+
+static void hmac_sha256_hex(const uint8_t *key, size_t keylen,
+                            const uint8_t *msg, size_t msglen, char out_hex[65]) {
+    uint8_t mac[32];
+    hmac_sha256(key, keylen, msg, msglen, mac);
+    static const char *hx = "0123456789abcdef";
+    for (int i = 0; i < 32; ++i) {
+        out_hex[i * 2] = hx[(mac[i] >> 4) & 0xf];
+        out_hex[i * 2 + 1] = hx[mac[i] & 0xf];
+    }
+    out_hex[64] = '\0';
+}
+
+#endif /* LIUM_SHA256_H */

--- a/neurons/executor/gpu_sig/test_seal.c
+++ b/neurons/executor/gpu_sig/test_seal.c
@@ -1,0 +1,33 @@
+/*
+ * Host-only interop harness for the gpu_sig seal (DAH-3137).
+ *
+ * Reproduces the exact key derivation + seal the CUDA binary uses, with no
+ * CUDA dependency, so CI/dev can assert byte-parity with the validator's
+ * Python HMAC (neurons/validators/tests/test_gpu_signature.py).
+ *
+ *   make test_seal
+ *   ./test_seal <master_key> <kernel_uuid> "<nonce|device|uuid|pci|tflops|gbps|ms>"
+ *
+ * Prints the lowercase hex seal on one line.
+ */
+#include <stdio.h>
+#include <string.h>
+#include "sha256.h"
+
+int main(int argc, char **argv) {
+    if (argc != 4) {
+        fprintf(stderr, "usage: %s <master_key> <kernel_uuid> <message>\n", argv[0]);
+        return 2;
+    }
+    const char *master = argv[1];
+    const char *uuid = argv[2];
+    const char *msg = argv[3];
+
+    uint8_t perkey[32];
+    hmac_sha256((const uint8_t *)master, strlen(master),
+                (const uint8_t *)uuid, strlen(uuid), perkey);
+    char sig[65];
+    hmac_sha256_hex(perkey, 32, (const uint8_t *)msg, strlen(msg), sig);
+    printf("%s\n", sig);
+    return 0;
+}

--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -21,6 +21,14 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_USERNAME=
 REDIS_PASSWORD=
+# GPU hardware-signature challenge (DAH-3137, liumd building block). Off by default; absence of the prober binary in
+# the executor image skips the check. The HMAC key must match the LIUM_SIG_KEY baked into the executor image.
+ENABLE_GPU_SIGNATURE_CHECK=false
+GPU_SIGNATURE_ENFORCEMENT_ENABLED=false
+GPU_SIGNATURE_HMAC_KEY=
+GPU_SIGNATURE_BINARY_RELATIVE=bin/gpu_sig
+GPU_SIGNATURE_MAX_CONCURRENT=8
+GPU_SIGNATURE_TIMEOUT_SECONDS=120
 
 COMPUTE_APP_URI=wss://lium.io/api
 

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -241,6 +241,25 @@ class Settings(BaseSettings):
     # from a real 8-GPU box show what that costs an honest miner.
     MATMUL_ALLCARDS_CHECK_ENABLED: bool = Field(env="MATMUL_ALLCARDS_CHECK_ENABLED", default=False)
     MATMUL_ALLCARDS_ENFORCEMENT_ENABLED: bool = Field(env="MATMUL_ALLCARDS_ENFORCEMENT_ENABLED", default=False)
+    # DAH-3137 — on-host GPU hardware-signature challenge (a building block for liumd/DAH-2834).
+    # The prober ships pre-built in the executor image (neurons/executor/gpu_sig, at
+    # GPU_SIGNATURE_BINARY_RELATIVE under the executor root — NOT uploaded per check) and is driven
+    # with a fresh per-call nonce. It measures a per-card signature (tiled-SGEMM TFLOPS + VRAM
+    # bandwidth + kernel-reported UUID from /proc/driver/nvidia, outside NVML) and HMAC-seals it with
+    # a key derived from that UUID, which the validator derives independently. CHECK_ENABLED runs it
+    # per claimed card and OBSERVES (verdict logged, score untouched); ENFORCEMENT is reserved for
+    # after the per-class envelope is calibrated on real hardware and the score gate is wired — until
+    # then it only raises the event severity. Default False: absence of the binary skips the check.
+    ENABLE_GPU_SIGNATURE_CHECK: bool = Field(env="ENABLE_GPU_SIGNATURE_CHECK", default=False)
+    GPU_SIGNATURE_ENFORCEMENT_ENABLED: bool = Field(env="GPU_SIGNATURE_ENFORCEMENT_ENABLED", default=False)
+    # Must match the LIUM_SIG_KEY baked into the executor image at build; provisioned via env /
+    # shared config in prod, rotated per release. The dev default matches gpu_sig's compiled default.
+    GPU_SIGNATURE_HMAC_KEY: str = Field(
+        env="GPU_SIGNATURE_HMAC_KEY", default="lium-gpu-sig-dev-key-do-not-use-in-prod"
+    )
+    GPU_SIGNATURE_BINARY_RELATIVE: str = Field(env="GPU_SIGNATURE_BINARY_RELATIVE", default="bin/gpu_sig")
+    GPU_SIGNATURE_MAX_CONCURRENT: int = Field(env="GPU_SIGNATURE_MAX_CONCURRENT", default=8)
+    GPU_SIGNATURE_TIMEOUT_SECONDS: int = Field(env="GPU_SIGNATURE_TIMEOUT_SECONDS", default=120)
     # Item 2b — send the advertised CPU-core count in the rental-verification health check so the
     # host's Docker daemon creates the probe with `--cpus=<advertised>` and rejects a count that
     # exceeds the machine's physical cores (a signal the lscpu wrapper cannot forge, since dockerd

--- a/neurons/validators/src/services/gpu_signature.py
+++ b/neurons/validators/src/services/gpu_signature.py
@@ -1,0 +1,287 @@
+"""Verification logic for the on-host GPU hardware-signature challenge (DAH-3137).
+
+Pure standard-library so it unit-tests without a GPU or the bittensor stack. The
+matching prober is ``neurons/executor/gpu_sig/gpu_sig.cu``; the seal format is
+kept byte-identical (see ``test_seal.c`` and ``tests/test_gpu_signature.py``).
+
+Trust model (see ~/lium-ads/verification-binary/DESIGN.md):
+  - The prober ships in the signed executor image and is driven with a fresh
+    per-call nonce, so a precomputed/replayed answer for a different nonce fails.
+  - The result is HMAC-sealed with a key derived from the card's kernel-reported
+    UUID; the validator derives the same key independently, so a fabricated
+    identity yields a seal it cannot reproduce.
+  - This closes cheap/scalable spoofs (NVML shims, canned/replayed answers,
+    wrong-class numbers, count serialisation). It does NOT defeat a root
+    provider who fully reverse-engineers the binary and forges plausible fast
+    numbers — that needs the derived-key seal folded into liumd and/or NVIDIA CC
+    attestation. Kept observe-only until the envelope is calibrated on real
+    hardware and the score gate is wired (follow-up).
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+# Aggregate wall-clock ceiling (seconds) across all claimed cards. N honest cards
+# answer N nonce-bound challenges concurrently in ~single-card time; a count lie
+# serialises onto fewer real cards and blows past this. Wide on purpose so honest
+# slowdowns (thermal throttle, a card already busy with a filler) do not trip it.
+GPU_SIGNATURE_WALL_CLOCK_SECONDS = 120.0
+
+# The JSON marker the prober prints; only this line is parsed out of stdout.
+RESULT_MARKER = '"gpu_sig"'
+
+# Number of "|"-joined tokens in the signed message:
+# nonce|device|kernel_uuid|pci|tflops|gbps|ms
+_MSG_FIELDS = 7
+
+
+@dataclass(frozen=True)
+class SignatureEnvelope:
+    """Per-class ground-truth floor for the measured signature.
+
+    tflops_min / gbps_min are the tiled-SGEMM + device-to-device-copy numbers the
+    prober produces (a fixed fraction of peak, not vendor peak), so they MUST be
+    calibrated with this exact binary on real cards. None = not yet calibrated =
+    that metric is not gated. Margins are deliberately generous.
+    """
+
+    tflops_min: float | None = None
+    gbps_min: float | None = None
+    calibrated: bool = False
+
+
+# Keyed on the canonical (normalised) GPU model the pipeline already stores in
+# ctx.state.gpu_model. Numbers below are PROVISIONAL placeholders seeded from
+# public FP32/HBM specs (roughly halved to cover tiled-SGEMM efficiency + slow
+# hosts); they are marked uncalibrated so nothing gates on them until a real pod
+# run with this binary replaces them. See DESIGN.md §9 and the PR's pod-run log.
+GPU_SIGNATURE_ENVELOPE: dict[str, SignatureEnvelope] = {
+    "NVIDIA B300 SXM6 AC": SignatureEnvelope(gbps_min=3000.0),
+    "NVIDIA B200": SignatureEnvelope(gbps_min=3000.0),
+    "NVIDIA H200": SignatureEnvelope(gbps_min=2000.0),
+    "NVIDIA H200 NVL": SignatureEnvelope(gbps_min=2000.0),
+    "NVIDIA H100 80GB HBM3": SignatureEnvelope(gbps_min=1500.0),
+    "NVIDIA H100 PCIe": SignatureEnvelope(gbps_min=1000.0),
+    "NVIDIA GeForce RTX 5090": SignatureEnvelope(gbps_min=800.0),
+    "NVIDIA GeForce RTX 4090": SignatureEnvelope(gbps_min=500.0),
+    "NVIDIA RTX PRO 6000 Blackwell Server Edition": SignatureEnvelope(gbps_min=700.0),
+    "NVIDIA RTX A6000": SignatureEnvelope(gbps_min=350.0),
+    "NVIDIA A100 80GB PCIe": SignatureEnvelope(gbps_min=900.0),
+    "NVIDIA A100-SXM4-80GB": SignatureEnvelope(gbps_min=1000.0),
+}
+
+
+@dataclass
+class CardVerdict:
+    slot: int  # the CUDA_VISIBLE_DEVICES index the validator pinned this run to
+    ok: bool
+    reasons: list[str] = field(default_factory=list)
+    kernel_uuid: str = ""
+    tflops: float | None = None
+    gbps: float | None = None
+    have_kernel: bool = False
+
+
+@dataclass
+class SignatureVerdict:
+    passed: bool
+    reasons: list[str]
+    per_card: list[dict[str, Any]]
+    elapsed_seconds: float
+    over_wall_clock: bool
+    claimed_count: int
+    verified_count: int
+
+
+def derive_card_key(master_key: bytes, kernel_uuid: str) -> bytes:
+    """Per-card seal key = HMAC(master, kernel_uuid). The validator derives this
+    from the UUID it independently expects, binding the seal to identity."""
+    return hmac.new(master_key, kernel_uuid.encode("utf-8"), hashlib.sha256).digest()
+
+
+def parse_result_line(stdout: str) -> dict[str, Any] | None:
+    """Return the last parseable gpu_sig JSON object printed on stdout, or None.
+
+    Stdout is miner-controlled and the image may print other lines, so scan from
+    the end for the marker and take the first that parses.
+    """
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if RESULT_MARKER not in line:
+            continue
+        try:
+            obj = json.loads(line)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(obj, dict) and "gpu_sig" in obj:
+            return obj
+    return None
+
+
+def _split_msg(msg: str) -> list[str] | None:
+    parts = msg.split("|")
+    return parts if len(parts) == _MSG_FIELDS else None
+
+
+def verify_seal(master_key: bytes, result: dict[str, Any]) -> tuple[bool, str]:
+    """Authenticate the sealed message. Returns (ok, reason).
+
+    The signed ``msg`` string is authoritative; the cosmetic numeric JSON fields
+    are never trusted for scoring.
+    """
+    msg = result.get("msg")
+    sig = result.get("sig")
+    if not isinstance(msg, str) or not isinstance(sig, str):
+        return False, "missing_seal"
+    parts = _split_msg(msg)
+    if parts is None:
+        return False, "malformed_msg"
+    kernel_uuid = parts[2]
+    key = derive_card_key(master_key, kernel_uuid)
+    expected = hmac.new(key, msg.encode("utf-8"), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, sig.strip().lower()):
+        return False, "seal_mismatch"
+    return True, ""
+
+
+def fields_from_msg(msg: str) -> dict[str, Any] | None:
+    parts = _split_msg(msg)
+    if parts is None:
+        return None
+    try:
+        return {
+            "nonce": parts[0],
+            "device": int(parts[1]),
+            "kernel_uuid": parts[2],
+            "pci": parts[3],
+            "tflops": float(parts[4]),
+            "gbps": float(parts[5]),
+            "ms": float(parts[6]),
+        }
+    except (ValueError, TypeError):
+        return None
+
+
+def check_envelope(model: str | None, tflops: float, gbps: float) -> list[str]:
+    """Return a list of below-floor reasons for the claimed class (empty = pass).
+
+    Unknown or uncalibrated models gate nothing (fail-open): the signature is
+    logged for calibration, never used to fail an honest host on a guess.
+    """
+    env = GPU_SIGNATURE_ENVELOPE.get(model or "")
+    if env is None or not env.calibrated:
+        return []
+    reasons: list[str] = []
+    if env.tflops_min is not None and tflops < env.tflops_min:
+        reasons.append(f"tflops {tflops:.1f} < floor {env.tflops_min:.1f}")
+    if env.gbps_min is not None and gbps < env.gbps_min:
+        reasons.append(f"gbps {gbps:.1f} < floor {env.gbps_min:.1f}")
+    return reasons
+
+
+def evaluate_card(
+    master_key: bytes,
+    expected_nonce: str,
+    claimed_model: str | None,
+    slot: int,
+    result: dict[str, Any] | None,
+) -> CardVerdict:
+    """Verdict for one card: run present, sealed, fresh, and within the class envelope.
+
+    ``slot`` is the CUDA_VISIBLE_DEVICES index the validator pinned; the prober
+    always runs as its own ``--device 0`` inside that masked view.
+    """
+    if result is None:
+        return CardVerdict(slot=slot, ok=False, reasons=["no_result"])
+    if result.get("ok") is not True:
+        return CardVerdict(
+            slot=slot, ok=False, reasons=[f"prober_error:{result.get('error', 'unknown')}"]
+        )
+
+    sealed, seal_reason = verify_seal(master_key, result)
+    if not sealed:
+        return CardVerdict(slot=slot, ok=False, reasons=[seal_reason])
+
+    fields = fields_from_msg(result["msg"])
+    if fields is None:
+        return CardVerdict(slot=slot, ok=False, reasons=["malformed_msg"])
+
+    reasons: list[str] = []
+    if not hmac.compare_digest(fields["nonce"], expected_nonce):
+        reasons.append("nonce_mismatch")  # stale/replayed
+    if fields["device"] != 0:
+        reasons.append("device_mismatch")
+    reasons.extend(check_envelope(claimed_model, fields["tflops"], fields["gbps"]))
+
+    return CardVerdict(
+        slot=slot,
+        ok=not reasons,
+        reasons=reasons,
+        kernel_uuid=fields["kernel_uuid"],
+        tflops=fields["tflops"],
+        gbps=fields["gbps"],
+        have_kernel=bool(result.get("have_kernel")),
+    )
+
+
+def summarize(
+    verdicts: list[CardVerdict],
+    elapsed_seconds: float,
+    claimed_count: int,
+    wall_clock_seconds: float = GPU_SIGNATURE_WALL_CLOCK_SECONDS,
+) -> SignatureVerdict:
+    """Aggregate per-card verdicts into a node verdict (the count-spoof gate)."""
+    verified = [v for v in verdicts if v.ok]
+    failed = [v for v in verdicts if not v.ok]
+    over_wall_clock = elapsed_seconds > wall_clock_seconds
+
+    # One physical card answering for many claimed cards shows up as a repeated
+    # kernel UUID across the (sealed, /proc-sourced) per-card results.
+    seen: dict[str, int] = {}
+    for v in verdicts:
+        if v.kernel_uuid:
+            seen[v.kernel_uuid] = seen.get(v.kernel_uuid, 0) + 1
+    duplicate_uuids = sorted(u for u, n in seen.items() if n > 1)
+
+    reasons: list[str] = []
+    if len(verdicts) != claimed_count:
+        reasons.append(f"card_count {len(verdicts)} != claimed {claimed_count}")
+    if failed:
+        reasons.append(f"{len(failed)}/{len(verdicts)} card(s) failed signature")
+    if duplicate_uuids:
+        reasons.append(f"duplicate kernel UUID across cards: {','.join(duplicate_uuids)}")
+    if over_wall_clock:
+        reasons.append(
+            f"aggregate wall-clock {elapsed_seconds:.1f}s over {wall_clock_seconds:.0f}s "
+            "(serialisation on fewer real cards than claimed)"
+        )
+
+    return SignatureVerdict(
+        passed=(
+            not failed
+            and not over_wall_clock
+            and not duplicate_uuids
+            and len(verdicts) == claimed_count
+        ),
+        reasons=reasons,
+        per_card=[
+            {
+                "slot": v.slot,
+                "ok": v.ok,
+                "reasons": v.reasons,
+                "kernel_uuid": v.kernel_uuid,
+                "tflops": v.tflops,
+                "gbps": v.gbps,
+                "have_kernel": v.have_kernel,
+            }
+            for v in verdicts
+        ],
+        elapsed_seconds=round(elapsed_seconds, 3),
+        over_wall_clock=over_wall_clock,
+        claimed_count=claimed_count,
+        verified_count=len(verified),
+    )

--- a/neurons/validators/src/services/task/checks/__init__.py
+++ b/neurons/validators/src/services/task/checks/__init__.py
@@ -12,6 +12,7 @@ from .gpu_count import GpuCountCheck
 from .gpu_fingerprint import GpuFingerprintCheck
 from .gpu_model_valid import GpuModelValidCheck
 from .gpu_power_limit import GpuPowerLimitCheck
+from .gpu_signature import GpuSignatureCheck
 from .gpu_usage import GpuUsageCheck
 from .gpu_vram_precheck import GpuVramPrecheck
 from .inspector import InspectorRentedCheck
@@ -46,6 +47,7 @@ __all__ = [
     "GpuFingerprintCheck",
     "GpuModelValidCheck",
     "GpuPowerLimitCheck",
+    "GpuSignatureCheck",
     "GpuUsageCheck",
     "GpuVramPrecheck",
     "InspectorRentedCheck",

--- a/neurons/validators/src/services/task/checks/gpu_signature.py
+++ b/neurons/validators/src/services/task/checks/gpu_signature.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+import secrets
+import shlex
+import time
+
+from core.config import settings
+from services.gpu_signature import evaluate_card, parse_result_line, summarize
+
+from ..messages import GpuSignatureMessages as Msg, render_message
+from ..pipeline import CheckResult, Context
+
+
+class GpuSignatureCheck:
+    """DAH-3137 — nonce-bound, sealed per-GPU hardware-signature challenge (observe-only).
+
+    Runs the pre-placed executor-image binary (``bin/gpu_sig``, shipped in the
+    image — NOT uploaded per check) once per claimed card, pinned via
+    ``CUDA_VISIBLE_DEVICES``, with a fresh per-call nonce. Each result is
+    HMAC-sealed with a key derived from the card's kernel-reported UUID
+    (``/proc/driver/nvidia``, outside NVML), which the validator derives
+    independently. The check verifies every card is present, sealed, fresh, and
+    within its class's ground-truth envelope, then aggregates for count
+    (device-selection failure, duplicate kernel UUID, or a blown aggregate
+    wall-clock all flag a count/type spoof).
+
+    Additive and observe-only: it logs a verdict and never changes the score.
+    ``GPU_SIGNATURE_ENFORCEMENT_ENABLED`` currently only raises the event
+    severity; wiring a score gate is a follow-up once the envelope is calibrated
+    on real hardware (see ~/lium-ads/verification-binary/DESIGN.md §9).
+    """
+
+    check_id = "gpu.validate.signature"
+    fatal = False
+
+    async def run(self, ctx: Context) -> CheckResult:
+        if not settings.ENABLE_GPU_SIGNATURE_CHECK:
+            return self._skip(ctx, "disabled")
+
+        gpu_details = ctx.state.gpu_details or []
+        gpu_count = ctx.state.gpu_count or len(gpu_details)
+        if gpu_count <= 0 or not gpu_details:
+            return self._skip(ctx, "no_gpus")
+
+        # Do not run heavy GPU work on a card a filler is using (mirrors CapabilityCheck).
+        filler = self._filler_only_container(ctx)
+        if filler:
+            return self._skip(ctx, "filler", extra_what={"filler_container": filler})
+
+        binary_path = (
+            f"{ctx.executor.root_dir.rstrip('/')}/"
+            f"{settings.GPU_SIGNATURE_BINARY_RELATIVE.lstrip('/')}"
+        )
+        if not await self._binary_present(ctx, binary_path):
+            return self._skip(ctx, "binary_absent", extra_what={"binary_path": binary_path})
+
+        nonce = secrets.token_hex(32)
+        master_key = settings.GPU_SIGNATURE_HMAC_KEY.encode("utf-8")
+        claimed_model = ctx.state.gpu_model
+        claimed_uuids = [detail.get("uuid", "") for detail in gpu_details]
+
+        gate = asyncio.Semaphore(max(1, settings.GPU_SIGNATURE_MAX_CONCURRENT))
+
+        async def run_slot(slot: int):
+            async with gate:
+                # nonce is hex and slot is int, so the command is injection-safe; the
+                # binary path is the only variable and is shlex-quoted.
+                cmd = (
+                    f"CUDA_VISIBLE_DEVICES={slot} {shlex.quote(binary_path)} "
+                    f"--nonce {nonce} --device 0"
+                )
+                try:
+                    result = await ctx.ssh.run(
+                        cmd, timeout=settings.GPU_SIGNATURE_TIMEOUT_SECONDS
+                    )
+                    stdout = getattr(result, "stdout", "") or ""
+                except Exception as exc:  # timeout / channel error / device selection
+                    return evaluate_card(
+                        master_key, nonce, claimed_model, slot,
+                        {"ok": False, "error": f"ssh:{type(exc).__name__}"},
+                    )
+                return evaluate_card(
+                    master_key, nonce, claimed_model, slot, parse_result_line(stdout)
+                )
+
+        start = time.perf_counter()
+        verdicts = await asyncio.gather(*(run_slot(slot) for slot in range(gpu_count)))
+        elapsed = time.perf_counter() - start
+
+        verdict = summarize(verdicts, elapsed, gpu_count)
+
+        # Cross-check the /proc-sourced kernel UUIDs against the NVML-claimed set:
+        # a userspace NVML shim (DAH-2662) shows up as a mismatch here.
+        kernel_uuids = sorted(v.kernel_uuid for v in verdicts if v.kernel_uuid)
+        claimed_sorted = sorted(uuid for uuid in claimed_uuids if uuid)
+        uuid_mismatch = bool(kernel_uuids) and kernel_uuids != claimed_sorted
+
+        node_ok = verdict.passed and not uuid_mismatch
+        what = {
+            "passed": node_ok,
+            "reasons": verdict.reasons + (["kernel_vs_nvml_uuid_mismatch"] if uuid_mismatch else []),
+            "claimed_count": verdict.claimed_count,
+            "verified_count": verdict.verified_count,
+            "elapsed_seconds": verdict.elapsed_seconds,
+            "over_wall_clock": verdict.over_wall_clock,
+            "gpu_model": claimed_model,
+            "per_card": verdict.per_card,
+            "kernel_uuids": kernel_uuids,
+            "kernel_vs_nvml_uuid_mismatch": uuid_mismatch,
+            "would_enforce": settings.GPU_SIGNATURE_ENFORCEMENT_ENABLED,
+        }
+
+        template = Msg.OK if node_ok else Msg.FAILED
+        event = render_message(template, ctx=ctx, check_id=self.check_id, what=what)
+        # Observe-only: never fail the pipeline or the score yet.
+        return CheckResult(passed=True, event=event)
+
+    async def _binary_present(self, ctx: Context, binary_path: str) -> bool:
+        try:
+            result = await ctx.ssh.run(
+                f"test -x {shlex.quote(binary_path)} && echo GPUSIG_PRESENT", timeout=15
+            )
+            return "GPUSIG_PRESENT" in (getattr(result, "stdout", "") or "")
+        except Exception:
+            return False
+
+    def _filler_only_container(self, ctx: Context) -> str | None:
+        rented_data = ctx.state.rented_data
+        if not rented_data:
+            return None
+        filler_container = rented_data.get_filler_container(ctx.executor.uuid)
+        rented_executor = rented_data.executors.get(ctx.executor.uuid)
+        has_customer_rental = bool(rented_executor and rented_executor.pods)
+        return filler_container if filler_container and not has_customer_rental else None
+
+    def _skip(self, ctx: Context, why: str, extra_what: dict | None = None) -> CheckResult:
+        what: dict = {"skipped": why}
+        if extra_what:
+            what.update(extra_what)
+        event = render_message(Msg.SKIPPED, ctx=ctx, check_id=self.check_id, what=what)
+        return CheckResult(passed=True, event=event)

--- a/neurons/validators/src/services/task/checks/gpu_signature.py
+++ b/neurons/validators/src/services/task/checks/gpu_signature.py
@@ -5,10 +5,12 @@ import secrets
 import shlex
 import time
 
-from core.config import settings
 from services.gpu_signature import evaluate_card, parse_result_line, summarize
 
-from ..messages import GpuSignatureMessages as Msg, render_message
+from core.config import settings
+
+from ..messages import GpuSignatureMessages as Msg
+from ..messages import render_message
 from ..pipeline import CheckResult, Context
 
 

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -1321,3 +1321,37 @@ class CachedTemplateMessages:
         category="runtime",
         impact="None — digest unknown this cycle (no backend digest / unreadable RepoDigests)",
     )
+
+
+class GpuSignatureMessages:
+    """DAH-3137 — on-host GPU hardware-signature challenge (observe-only)."""
+
+    SKIPPED = MessageTemplate(
+        event="GPU signature challenge skipped",
+        reason="GPU_SIGNATURE_SKIPPED",
+        severity="info",
+        category="gpu",
+        impact="None — check disabled, binary absent, or no claimed GPUs",
+    )
+    OK = MessageTemplate(
+        event="GPU signature challenge passed",
+        reason="GPU_SIGNATURE_OK",
+        severity="info",
+        category="gpu",
+        impact="None — every claimed card returned a fresh, sealed, in-envelope signature",
+    )
+    FAILED = MessageTemplate(
+        event="GPU signature challenge failed (observe-only)",
+        reason="GPU_SIGNATURE_FAILED",
+        severity="warning",
+        category="gpu",
+        impact=(
+            "Advisory — a claimed card failed the sealed nonce-bound signature "
+            "(possible count/type spoof); score is NOT affected until enforcement is wired"
+        ),
+        remediation=(
+            "Provider: ensure every advertised GPU is physically present and healthy. "
+            "Ops: review per-card reasons before enabling GPU_SIGNATURE_ENFORCEMENT_ENABLED."
+        ),
+    )
+

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -42,6 +42,7 @@ from .checks import (
     GpuFingerprintCheck,
     GpuModelValidCheck,
     GpuPowerLimitCheck,
+    GpuSignatureCheck,
     GpuUsageCheck,
     GpuVramPrecheck,
     InspectorRentedCheck,
@@ -317,6 +318,12 @@ class PipelineFactory:
                 VerifyXCheck(),
                 TdxHostCheck(),
                 CapabilityCheck(),
+                # DAH-3137: nonce-bound, sealed per-GPU hardware-signature challenge from the
+                # pre-placed executor-image binary (matmul TFLOPS + VRAM bandwidth + kernel UUID).
+                # Additive and observe-only (ENABLE_GPU_SIGNATURE_CHECK, default off); runs right
+                # after the capability matmul on the same idle, non-filler population, changes no
+                # score. A building block toward liumd (DAH-2834).
+                GpuSignatureCheck(),
                 # DAH-2265 Plan 2: advisory, non-fatal — observes whether the executor has
                 # the recommended default image pre-pulled (DOCKER_PULL no-op). Runs here,
                 # after specs/gpu_model/driver are populated and the GPU is validated, on the
@@ -381,6 +388,9 @@ class PipelineFactory:
                 # VerifyXCheck(),
                 TdxHostCheck(),
                 CapabilityCheck(),
+                # DAH-3137: observe-only, flag-gated (default off); safe in dry run (the GPU work
+                # is real but changes no executor/host state the dry run must avoid).
+                GpuSignatureCheck(),
                 RentalVerificationCheck(),
                 ScoreCheck(),
                 FinalizeCheck(),

--- a/neurons/validators/tests/test_gpu_signature.py
+++ b/neurons/validators/tests/test_gpu_signature.py
@@ -7,8 +7,6 @@ verify / envelope / aggregate logic, including the count-spoof signals.
 import hashlib
 import hmac
 
-import pytest
-
 from services import gpu_signature as gs
 
 MASTER = b"lium-gpu-sig-dev-key-do-not-use-in-prod"

--- a/neurons/validators/tests/test_gpu_signature.py
+++ b/neurons/validators/tests/test_gpu_signature.py
@@ -1,0 +1,147 @@
+"""Unit tests for the GPU hardware-signature verification (DAH-3137).
+
+Pure Python, no GPU: they construct sealed results exactly as gpu_sig.cu does
+(so they also pin the on-the-wire seal format) and exercise the validator's
+verify / envelope / aggregate logic, including the count-spoof signals.
+"""
+import hashlib
+import hmac
+
+import pytest
+
+from services import gpu_signature as gs
+
+MASTER = b"lium-gpu-sig-dev-key-do-not-use-in-prod"
+NONCE = "a" * 64
+
+
+def _seal(master: bytes, nonce: str, uuid: str, pci: str, tflops: str, gbps: str, ms: str, device: int = 0):
+    """Reproduce gpu_sig.cu: msg = nonce|device|uuid|pci|tflops|gbps|ms,
+    key = HMAC(master, uuid), sig = HMAC(key, msg)."""
+    msg = f"{nonce}|{device}|{uuid}|{pci}|{tflops}|{gbps}|{ms}"
+    key = hmac.new(master, uuid.encode(), hashlib.sha256).digest()
+    sig = hmac.new(key, msg.encode(), hashlib.sha256).hexdigest()
+    return msg, sig
+
+
+def _result(uuid="GPU-1111", pci="0000:65:00.0", tflops="40.000", gbps="900.000", ms="800.000",
+            nonce=NONCE, device=0, master=MASTER, ok=True, have_kernel=True):
+    msg, sig = _seal(master, nonce, uuid, pci, tflops, gbps, ms, device)
+    return {
+        "gpu_sig": 1, "ok": ok, "nonce": nonce, "device": device,
+        "kernel_uuid": uuid, "pci": pci, "tflops": float(tflops), "gbps": float(gbps),
+        "ms": float(ms), "have_kernel": have_kernel, "msg": msg, "sig": sig,
+    }
+
+
+# ---- seal --------------------------------------------------------------------
+
+def test_verify_seal_ok():
+    ok, reason = gs.verify_seal(MASTER, _result())
+    assert ok and reason == ""
+
+
+def test_verify_seal_rejects_tampered_numbers():
+    r = _result(tflops="40.000")
+    # miner edits the displayed msg to inflate TFLOPS but cannot recompute the seal
+    r["msg"] = r["msg"].replace("40.000", "999.000")
+    ok, reason = gs.verify_seal(MASTER, r)
+    assert not ok and reason == "seal_mismatch"
+
+
+def test_verify_seal_rejects_wrong_key():
+    r = _result(master=b"some-other-key")
+    ok, reason = gs.verify_seal(MASTER, r)
+    assert not ok and reason == "seal_mismatch"
+
+
+def test_verify_seal_missing_fields():
+    assert gs.verify_seal(MASTER, {"gpu_sig": 1})[0] is False
+
+
+# ---- per-card evaluation -----------------------------------------------------
+
+def test_evaluate_card_ok():
+    v = gs.evaluate_card(MASTER, NONCE, "NVIDIA GeForce RTX 4090", 0, _result())
+    assert v.ok and not v.reasons and v.kernel_uuid == "GPU-1111"
+
+
+def test_evaluate_card_replayed_nonce_fails():
+    # a sealed result from a previous challenge (different nonce) must not pass
+    stale = _result(nonce="b" * 64)
+    v = gs.evaluate_card(MASTER, NONCE, None, 0, stale)
+    assert not v.ok and "nonce_mismatch" in v.reasons
+
+
+def test_evaluate_card_prober_error():
+    v = gs.evaluate_card(MASTER, NONCE, None, 3, {"ok": False, "error": "set_device:cudaErrorInvalidDevice"})
+    assert not v.ok and v.reasons[0].startswith("prober_error")
+
+
+def test_evaluate_card_no_result_is_failure():
+    v = gs.evaluate_card(MASTER, NONCE, None, 5, None)
+    assert not v.ok and v.reasons == ["no_result"]
+
+
+# ---- envelope ----------------------------------------------------------------
+
+def test_envelope_uncalibrated_does_not_gate():
+    # shipped entries are calibrated=False -> never fail an honest host on a guess
+    assert gs.check_envelope("NVIDIA H200", 0.1, 1.0) == []
+    assert gs.check_envelope("totally-unknown-model", 0.0, 0.0) == []
+
+
+def test_envelope_calibrated_flags_underperformer(monkeypatch):
+    monkeypatch.setitem(
+        gs.GPU_SIGNATURE_ENVELOPE, "NVIDIA H200",
+        gs.SignatureEnvelope(tflops_min=30.0, gbps_min=2000.0, calibrated=True),
+    )
+    assert gs.check_envelope("NVIDIA H200", 45.0, 3000.0) == []          # healthy
+    reasons = gs.check_envelope("NVIDIA H200", 5.0, 500.0)               # relabelled slow card
+    assert any("tflops" in r for r in reasons) and any("gbps" in r for r in reasons)
+
+
+# ---- aggregate / count spoof -------------------------------------------------
+
+def test_summarize_all_good():
+    verdicts = [
+        gs.evaluate_card(MASTER, NONCE, None, i, _result(uuid=f"GPU-{i}")) for i in range(4)
+    ]
+    out = gs.summarize(verdicts, elapsed_seconds=10.0, claimed_count=4)
+    assert out.passed and out.verified_count == 4 and not out.reasons
+
+
+def test_summarize_count_lie_device_selection():
+    # claims 4, only card 0 real: cards 1..3 return device-selection errors
+    verdicts = [gs.evaluate_card(MASTER, NONCE, None, 0, _result(uuid="GPU-0"))]
+    for i in range(1, 4):
+        verdicts.append(gs.evaluate_card(MASTER, NONCE, None, i, {"ok": False, "error": "set_device"}))
+    out = gs.summarize(verdicts, elapsed_seconds=10.0, claimed_count=4)
+    assert not out.passed and out.verified_count == 1
+
+
+def test_summarize_duplicate_uuid_is_count_spoof():
+    # one physical card answering for four claimed cards -> same kernel UUID
+    verdicts = [gs.evaluate_card(MASTER, NONCE, None, i, _result(uuid="GPU-SAME")) for i in range(4)]
+    out = gs.summarize(verdicts, elapsed_seconds=10.0, claimed_count=4)
+    assert not out.passed and any("duplicate kernel UUID" in r for r in out.reasons)
+
+
+def test_summarize_over_wall_clock():
+    verdicts = [gs.evaluate_card(MASTER, NONCE, None, i, _result(uuid=f"GPU-{i}")) for i in range(2)]
+    out = gs.summarize(verdicts, elapsed_seconds=999.0, claimed_count=2, wall_clock_seconds=120.0)
+    assert not out.passed and out.over_wall_clock
+
+
+# ---- stdout parsing ----------------------------------------------------------
+
+def test_parse_result_line_picks_json_amid_noise():
+    r = _result()
+    import json as _json
+    stdout = "some MOTD banner\nWARNING: whatever\n" + _json.dumps(r) + "\n"
+    parsed = gs.parse_result_line(stdout)
+    assert parsed is not None and parsed["msg"] == r["msg"]
+
+
+def test_parse_result_line_none_when_absent():
+    assert gs.parse_result_line("no json here\njust text") is None


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements DAH-3137 · reviewer: @jam6099

**TL;DR** — Signed on-host GPU hardware-signature challenge (liumd building block). Touches validator/executor (`neurons/executor/Dockerfile`) — read that file first.

**What changed**
- `neurons/validators/src/services/gpu_signature.py` (+287 −0)
- `neurons/executor/gpu_sig/gpu_sig.cu` (+279 −0)
- `neurons/validators/tests/test_gpu_signature.py` (+145 −0)
- `neurons/validators/src/services/task/checks/gpu_signature.py` (+144 −0)
- `neurons/executor/gpu_sig/sha256.h` (+128 −0)
- `neurons/executor/gpu_sig/README.md` (+62 −0)

**How to verify**
- `gh pr checks 1309 -R Datura-ai/lium-io` → all green

**Verified by the loop:** 7 Sep 2026 · sandbox EC2 · validators 1955 passed · executor 128 passed · Result: PASS 0fcdaff8 · Gate: not run

**Docs:** neurons/executor/gpu_sig/README.md · neurons/validators/.env.template (GPU_SIGNATURE_*) + neurons/executor/gpu_sig/README.md (this PR) · public: none changed in this PR — off by default; absence of the binary skips the check

<details><summary>Details</summary>

## DAH-3137 — Signed on-host GPU hardware-signature challenge (a building block for liumd / DAH-2834)

First shippable increment of "make provider-GPU verification a compiled binary that already lives on the GPU" (owner ask, 7 Sep). Full design + threat model: `~/lium-ads/verification-binary/DESIGN.md`. Child of @jam6099's **DAH-2834 (liumd v1)** — the loop is taking that work over; see the DAH-2834 comment.

### The gap this closes
Idle incentive is paid per advertised GPU-hour by class, so the core spoof is presenting **1×B300 as 8×B300**. Today count/UUID/model come from **NVML**, which a root provider shims (DAH-2662: `/etc/ld.so.preload` → a `.so` overriding `nvmlDeviceGetCount/GetHandleByIndex/GetUUID`). The all-cards work-proof (DAH-2671) is the count defense, but its own code notes it lacks (a) a **per-card cryptographic seal** (`_run_one_card` trusts exit-0 + non-empty stdout) and (b) a second independent physical signal, and it binds identity to NVML UUIDs.

### What this adds (additive, flag-off, observe-only)
A nonce-bound, sealed per-GPU hardware-signature check whose prober **ships pre-built in the executor image** (not uploaded per check):

- **`neurons/executor/gpu_sig/gpu_sig.cu`** — CUDA prober: `--nonce`, `--device`; reads kernel identity from `/proc/driver/nvidia/gpus/*/information` (outside NVML); seeded **FP32 tiled-SGEMM → sustained TFLOPS**; **device-to-device VRAM bandwidth → GB/s**; `HMAC-SHA256` seal (key = `HMAC(master, kernel_uuid)`) over the exact string `nonce|device|kernel_uuid|pci|tflops|gbps|ms`. Self-contained SHA-256/HMAC in `sha256.h` (no OpenSSL). The signed `msg` is authoritative, so C/Python float formatting can never diverge.
- **Validator `GpuSignatureCheck`** (`gpu.validate.signature`, `fatal=False`, behind `ENABLE_GPU_SIGNATURE_CHECK`, default off) — issues one nonce, runs the binary per claimed card via `CUDA_VISIBLE_DEVICES`, verifies each seal + nonce freshness + per-class envelope, aggregates for count. **Count-spoof signals:** device-selection failure on a missing ordinal, **duplicate kernel UUID** across cards (one physical card answering for many), a blown aggregate wall-clock, and a **kernel-vs-NVML UUID mismatch** (a userspace shim). Runs right after the capability matmul on the same idle, non-filler population.
- **`services/gpu_signature.py`** — pure-stdlib verify / envelope / aggregate, unit-tested without a GPU.
- **`GPU_SIGNATURE_ENVELOPE`** — per-class ground-truth floors, marked **uncalibrated** (gate nothing) until calibrated on real hardware with this exact binary.
- **Packaging** — optional multi-stage Dockerfile builder, **default off**: a normal executor image build pulls no CUDA and installs nothing (the check then skips `binary_absent`). Opt in with `--build-arg GPUSIG_BUILDER=nvidia/cuda:*-devel --build-arg INSTALL_GPU_SIGNATURE=true --build-arg LIUM_SIG_KEY=<hex>`.

### Safety / non-breaking
- Default flags off + binary absent from the default image ⇒ the check emits a `SKIPPED` event and **changes nothing**. Non-fatal, so even a failing verdict never halts the pipeline or zeroes score.
- `GPU_SIGNATURE_ENFORCEMENT_ENABLED` currently only raises event severity; the score gate (a `Context` flag consumed by `calculate_scores`, mirroring `cpu_truth_passed`) is a deliberate follow-up once the envelope is calibrated — same shadow→warn→enforce rollout MATMUL_ALLCARDS used.

### Honest scope
A root provider who fully reverse-engineers the binary can still return fabricated fast numbers (the master seal key is baked in the image). This closes the **cheap/scalable** spoofs (NVML shims, canned/replayed answers, wrong-class numbers, count serialisation) and builds the challenge-response + envelope machinery liumd will carry. Full unforgeability needs the derived-key seal folded into liumd and/or **NVIDIA CC attestation** (already wired: `attestation_service.py` / `gpu_attestation_service.py`). Kernel-mode tampering and relay attacks are only defeated by the CC/TDX tier — see DESIGN.md §8.

### Tests
- `tests/test_gpu_signature.py` (16 cases, no GPU): seal good / tampered-numbers / wrong-key / missing; replayed-nonce; prober-error; envelope (uncalibrated no-gate + calibrated flags underperformer); count-lie via device-selection; **duplicate-UUID**; over-wall-clock; stdout parsing. All green.
- **Crypto interop**: `gpu_sig/test_seal.c` reproduces the seal with no CUDA; verified byte-identical to Python's `hmac` (`639e3b7d…`).
- **`nvcc` compile** is exercised by the Dockerfile's `make gpu_sig` when built with `INSTALL_GPU_SIGNATURE=true` (host `sha256.h` compiles clean via `cc`; the `.cu` is standard runtime-API CUDA).
- **GPU-pod calibration is the immediate next step and is required before enforcement**: run `gpu_sig` on one real card per class, feed `tflops`/`gbps` floors into `GPU_SIGNATURE_ENVELOPE`, and set `calibrated=True` only for measured classes. Until then the envelope gates nothing and the check is observe-only — so this PR is safe to merge without the numbers.


Docs: neurons/executor/gpu_sig/README.md · neurons/validators/.env.template (GPU_SIGNATURE_*) + neurons/executor/gpu_sig/README.md (this PR) · public: none changed in this PR — off by default; absence of the binary skips the check

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape, then the #1312 subnet-loop e2e stack on a clean worktree) — branch head `0fcdaff8` merged onto `main` `07ec64cd` (clean merge), then: pytest: validators, executor (CI env) + ruff format report; e2e: the #1312 subnet-loop gate (protocol, cycle, rental); Validators 1955 passed, 15 skipped, 155 warnings — 2 failed are main's own (root-only sysfs/sshd artefacts, same as pass 1); Executor 128 passed, 18 warnings; e2e cycle 5 passed, 0 failed, 0 skipped; e2e protocol 13 passed, 0 failed, 0 skipped; e2e rental 2 passed, 0 failed, 0 skipped. Run time 5 min. Result: PASS. Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

</details>
