### PR TITLE
DAH-3143 - [P1] run required checks on merge_group so the merge queue can merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,15 @@ on:
   push:
     branches: [main]
   # merge queue: a queued group (main + the PRs ahead + this one) is merged only when the checks required
-  # on main report on the merge_group ref; without this trigger an enqueued PR waits forever. `paths:`
-  # does not apply to merge_group, so every group runs the whole workflow (job names unchanged, so the
-  # check names match the ones a ruleset requires).
+  # on main report on the merge_group ref; without this trigger an enqueued PR waits forever.
   merge_group:
     branches: [main]
 
 permissions:
   contents: read
 
-# one run per PR head — a second push cancels the first. A merge-group run is never cancelled: each group
-# has its own ref, and cancelling one would drop its PRs from the queue.
+# a merge-group run is never cancelled: each group has its own ref, and cancelling one would drop its
+# PRs from the queue.
 concurrency:
   group: tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,14 +8,21 @@ on:
     branches: [main, dev]
   push:
     branches: [main]
+  # merge queue: a queued group (main + the PRs ahead + this one) is merged only when the checks required
+  # on main report on the merge_group ref; without this trigger an enqueued PR waits forever. `paths:`
+  # does not apply to merge_group, so every group runs the whole workflow (job names unchanged, so the
+  # check names match the ones a ruleset requires).
+  merge_group:
+    branches: [main]
 
 permissions:
   contents: read
 
-# a second push to the same PR cancels the first run
+# one run per PR head — a second push cancels the first. A merge-group run is never cancelled: each group
+# has its own ref, and cancelling one would drop its PRs from the queue.
 concurrency:
   group: tests-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   validators:


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3143](https://app.notion.com/p/Merge-queues-on-all-Lium-repos-merge_group-CI-triggers-per-repo-then-merge_queue-in-each-default-b-3d4b8bfdbde98170afa7c0b577f6e5f7) · reviewer: @pixel29913

**TL;DR** — Adds the `merge_group` trigger (base `main`) to `.github/workflows/test.yml` and a concurrency group that cancels superseded PR runs but never a merge-group run, so a merge queue on `main` can see the required checks. Job names and steps unchanged. Approved by pixel29913 at `2d2370f`.

**What changed**
- `.github/workflows/test.yml` (+7 −2): `merge_group: branches: [main]`; `concurrency` keyed on the PR number or ref, `cancel-in-progress` only for `pull_request`

**How to verify**
- `gh pr checks 1310 -R Datura-ai/lium-io` → all green (this PR's own run is the unchanged `pull_request` path)
- `git diff origin/main...2d2370f -- .github/workflows/test.yml`: only the `on:` block and the `concurrency` block change; job names `Validators Tests` / `Executor Tests` / `tests-ok` stay

**Verified by the loop:** workflow YAML parses; the PR's own `pull_request` run is green at `2d2370f` (tests-ok, CodeQL); merge onto today's `main` is conflict-free (10 commits behind, `git merge-tree`)

**Ran it:** the workflow's own run at `2d2370f` is the test: CI green (`tests-ok`, CodeQL); the `merge_group` path runs only once a queue is on, which is the step after this merge

**Self-review:** clean at 2d2370f (17 checks, 2 low)

**Parts:** backend n/a — CI trigger only · migration n/a — no database · frontend n/a — no UI in this repo · CLI/SDK n/a — no surface touched · docs ✓ lium-docs#192 · tests n/a — the workflow's own run is the test · dashboards n/a — no metric

**Docs:** lium-docs#192 (companion)

<details><summary>Details</summary>

[DAH-3143](https://app.notion.com/p/Merge-queues-on-all-Lium-repos-merge_group-CI-triggers-per-repo-then-merge_queue-in-each-default-b-3d4b8bfdbde98170afa7c0b577f6e5f7) — merge queues on all Lium repos (umbrella; one trigger PR per repo).

**What.** Adds `merge_group:` (base `main`) to `.github/workflows/test.yml` — the workflow that produces `Validators Tests` / `Executor Tests` — and a `concurrency` group that cancels superseded PR runs but never a merge-group run. Job names and steps are unchanged, so the check names stay the ones a ruleset requires. Rebased onto #1289 (merged): the workflow has no `paths:` filters and `tests-ok` is the aggregate check.

**Why this merges first.** A merge queue merges a group only when the checks required on `main` report on the `merge_group` ref (= `main` + the PRs ahead in the queue + this one). CI here triggers only on `pull_request`/`push`, so enabling the queue before this is on `main` would leave every enqueued PR waiting on a check that never comes. Order: **(1)** a dev merges this like any PR; **(2)** the cycle after, the loop flips `merge_queue` on in the existing ruleset (`main-and-prod-branches-rule` 6184174 targets `main` and `prod*`, so the queue rule goes into the loop's `loop-default-protection` 22353209 (default branch only) — the 1-review rule stays) — `tools/merge_queue_enable.sh lium-io`, idempotent, refuses to touch the ruleset until the trigger is at HEAD of `main` — turns *delete branch on merge* on so stacked PRs retarget to `main` as their bases merge, and posts one line in #lium-agents. No human step for (2).

**What changes for reviewers.** The merge button becomes **Merge when ready**. Click it in the [CHANGES_FOR_REVIEW.md](https://github.com/Datura-ai/lium-loop/blob/main/improvements/CHANGES_FOR_REVIEW.md) order (position = priority *and* dependency); the queue serialises the merges and runs the required checks on the combined result, so a PR is never merged untested against what lands before it. Stacked PRs (↳) become queue-eligible one at a time: when the base merges and its branch is deleted, GitHub retargets the next one to `main`. Queue params: squash (the only merge method this repo allows), only-green groups (ALLGREEN), 60-min check timeout, 1–5 PRs per merge, 5-min wait. No check is *required* on `main` today, so at first the queue only serialises; `tests-ok` (the aggregate #1289 adds) becomes the required check the cycle after #1289 is on `main` — that is when the queue starts gating on CI.

**Verified.** Workflow YAML parses; `on` = the previous triggers + `merge_group(branches: [main])`; this PR's own run is the unchanged `pull_request` path. Plan and per-repo status: [ci/REQUIRED_CHECKS.md](https://github.com/Datura-ai/lium-loop/blob/main/ci/REQUIRED_CHECKS.md).

Docs: lium-docs#192 (companion)

## Verification

**Verified by the loop on 7 Sep 2026:** checked on sandbox EC2 (the CI shape) — branch head `0c3ecda9` merged onto that day's `main` (clean merge), then: workflow yaml parse; e2e: skipped (no neuron touched). Run time 1 min. Result: PASS. Head `2d2370fa` (19:31Z) changes two workflow comments after that run and nothing else; the YAML parses and CI is green at `2d2370fa` (Validators, Executor, Miners, ruff ×3, tests-ok, CodeQL). Not proven here: a real chain and real GPU hosts (the #1312 stack runs the executor without a GPU).

### Self-review

Verdict `clean` at `2d2370f` · 17 checks · by subagent-r33rev · 2026-09-09 02:37Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `.github/workflows/test.yml:1` | The body's 'What changed' line says `.github/workflows/test.yml (+12 −0)`; `git diff --numstat origin/main...2d2370f` is `7 2` (+7 −2: two comment lines and `cancel-in-progress: true` are removed). | Re-render the count from the numstat: `(+7 −2)`. |
| low | STALE-BODY | `.github/workflows/test.yml:22` | The Verification paragraph reports the clean merge onto `main` `07ec64cd`; `main` is now 10 commits ahead (#1311 rewrote test.yml with the `route` job and #1308 landed). `git merge-tree --write-tree origin/main 2d2370f` is still conflict-free and #1311's changed-packages action already branches on `merge_group` (base_sha..head_sha), so the merged workflow is coherent — the sentence is merely dated. | Add one clause: 'still merges clean onto the current `main` (#1311's router handles `merge_group`)'. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `.github/workflows/test.yml:13` `merge_group: branches: [main]` is a valid GitHub Actions filter (merge_group supports `branches`/`branches-ignore` on the target branch); YAML parses and CI at this head is green (Validators, Executor, Miners, ruff x3, tests-ok, CodeQL). · `.github/workflows/test.yml:22` Concurrency: on merge_group `github.event.pull_request` is null so the group is `tests-refs/heads/gh-readonly-queue/main/pr-N-<sha>` (unique per group); `cancel-in-progress` evaluates false for merge_group and push, so no merge-group run is ever cancelled and two groups never share a key; a push to main uses `tests-refs/heads/main`, a different key, so push and merge_group cannot cancel each other. · `.github/workflows/test.yml:26` Job names `Validators Tests`, `Executor Tests`, `Miners Tests`, `tests-ok` are untouched by the diff and identical to origin/main, so required-check contexts keep matching; the diff has no `paths:` filter and `tests-ok` is the aggregate. · `.github/workflows/test.yml:1` Body claims verified: merge-base is 07ec64cd (#1289, merged) so 'Rebased onto #1289' holds; 2d2370fa, 0c3ecda9, 07ec64cd are all reachable from the head; 2d2370fa vs 0c3ecda9 is comments only (3+/5−) as the body says; 6184174 and 22353209 are real ruleset ids (`main-and-prod-branches-rule` targets default+`prod*`, `loop-default-protection` default only) not commit shas; no ruleset has a required_status_checks rule, so 'No check is required on main today' holds; lium-docs#192 exists and is open; pixel29913 APPROVED at 2d2370fa; mergeStateStatus CLEAN. · `.github/workflows/test.yml:22` Side effect not in the body: `cancel-in-progress` is now also false for `push` to main, so back-to-back pushes queue instead of cancelling; with a merge queue that is the desired behaviour (main always gets a completed run) and not worth a finding.

</details>
