### PR TITLE
DAH-3145 - [P1] route by changed package: tests-ok always reports

### DIFF
--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -52,8 +52,10 @@ runs:
             // the checkout is shallow at head_sha; two commits are all a diff needs
             const mg = context.payload.merge_group;
             await exec.exec('git', ['fetch', '--no-tags', '--depth=1', 'origin', mg.base_sha]);
-            const { stdout } = await exec.getExecOutput('git', ['diff', '--name-only', '--no-renames', mg.base_sha, mg.head_sha]);
-            files = stdout.split('\n').filter(f => f && !isDoc(f));
+            // -z: NUL-separated, unquoted paths — with core.quotePath a name holding a byte >= 0x80, `"` or `\`
+            // comes back quoted and would miss every prefix, silently skipping that package
+            const { stdout } = await exec.getExecOutput('git', ['diff', '--name-only', '-z', '--no-renames', mg.base_sha, mg.head_sha]);
+            files = stdout.split('\0').filter(f => f && !isDoc(f));
             why = `merge group ${mg.base_sha.slice(0, 7)}..${mg.head_sha.slice(0, 7)}: ${files.length} files`;
           }
 

--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -1,0 +1,63 @@
+name: Changed packages
+description: >-
+  Which packages the current event touches. One output per package, "true" or "false", so every
+  test job can be skipped when its package is untouched while the aggregate check (tests-ok) still
+  reports on every PR — a required status check that never reports blocks the merge button and
+  stalls a merge queue. On a PR the diff is the PR's file list. On a merge-queue entry
+  (merge_group) it is base_sha..head_sha, exactly the files the queued PR adds on top of main and
+  the entries ahead of it. Any other event (push to main, workflow_dispatch) has no diff and
+  selects every package. datura/ is the protocol package every neuron installs from a path, so a
+  change there selects all three; a change under .github/ selects all three too — a router bug
+  must not hide behind its own filter. Files that never reach a package (*.md, .gitignore, docs)
+  select nothing.
+
+outputs:
+  validators:
+    value: ${{ steps.route.outputs.validators }}
+  executor:
+    value: ${{ steps.route.outputs.executor }}
+  miners:
+    value: ${{ steps.route.outputs.miners }}
+
+runs:
+  using: composite
+  steps:
+    - id: route
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const PACKAGES = { validators: 'neurons/validators/', executor: 'neurons/executor/', miners: 'neurons/miners/' };
+          // a change to any of these selects every package
+          const SHARED = ['datura/', '.github/'];
+          const isDoc = f => /\.md$|(^|\/)\.gitignore$|^docs\//.test(f);
+          const touches = (files, prefix) =>
+            files.some(f => f.startsWith(prefix)) || files.some(f => SHARED.some(s => f.startsWith(s)));
+
+          let files = null, why = 'no diff for this event';
+          const prNumber = context.payload.pull_request?.number;
+          if (prNumber) {
+            const listed = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber, per_page: 100,
+            });
+            // a rename out of a package is still a change to that package
+            files = listed.flatMap(f => [f.filename, f.previous_filename].filter(Boolean)).filter(f => !isDoc(f));
+            why = `PR #${prNumber}: ${files.length} files`;
+          } else if (context.eventName === 'merge_group') {
+            // the checkout is shallow at head_sha; two commits are all a diff needs
+            const mg = context.payload.merge_group;
+            await exec.exec('git', ['fetch', '--no-tags', '--depth=1', 'origin', mg.base_sha]);
+            const { stdout } = await exec.getExecOutput('git', ['diff', '--name-only', '--no-renames', mg.base_sha, mg.head_sha]);
+            files = stdout.split('\n').filter(f => f && !isDoc(f));
+            why = `merge group ${mg.base_sha.slice(0, 7)}..${mg.head_sha.slice(0, 7)}: ${files.length} files`;
+          }
+
+          const rows = [];
+          for (const [pkg, prefix] of Object.entries(PACKAGES)) {
+            const changed = files ? touches(files, prefix) : true;
+            core.setOutput(pkg, changed);
+            rows.push([pkg, changed ? 'changed' : 'unchanged', why]);
+          }
+          core.summary
+            .addHeading('Route', 3)
+            .addTable([[{data: 'package', header: true}, {data: 'result', header: true}, {data: 'why', header: true}], ...rows])
+            .write();

--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -6,10 +6,12 @@ description: >-
   stalls a merge queue. On a PR the diff is the PR's file list. On a merge-queue entry
   (merge_group) it is base_sha..head_sha, exactly the files the queued PR adds on top of main and
   the entries ahead of it. Any other event (push to main, workflow_dispatch) has no diff and
-  selects every package. datura/ is the protocol package every neuron installs from a path, so a
-  change there selects all three; a change under .github/ selects all three too — a router bug
-  must not hide behind its own filter. Files that never reach a package (*.md, .gitignore, docs)
-  select nothing.
+  selects every package. Only three prefixes select anything: neurons/<pkg>/ selects that
+  package; datura/ (the protocol package every neuron installs from a path) and .github/ (a
+  router bug must not hide behind its own filter) select all three. Every other path — the root
+  pyproject.toml and pdm.lock (dev tooling only), scripts/, contrib/, watchtower/, tests/ (an
+  empty package), *.md, .gitignore, docs/ — selects nothing; the isDoc filter only keeps those
+  files out of the "why" count.
 
 outputs:
   validators:

--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -6,10 +6,12 @@ description: >-
   stalls a merge queue. On a PR the diff is the PR's file list. On a merge-queue entry
   (merge_group) it is base_sha..head_sha, exactly the files the queued PR adds on top of main and
   the entries ahead of it. Any other event (push to main, workflow_dispatch) has no diff and
-  selects every package. Documentation never selects a package, wherever it sits: *.md,
-  .gitignore and docs/ are dropped from the file list before routing (isDoc), so a PR that only
-  edits neurons/validators/README.md runs no tests and tests-ok still reports green — the tests
-  exercise code, and none of those files is code. Of the rest, only three prefixes select
+  selects every package. Documentation never selects a package: *.md and .gitignore files
+  wherever they sit, and the root docs/ tree, are dropped from the file list before routing
+  (isDoc), so a PR that only edits neurons/validators/README.md runs no tests and tests-ok still
+  reports green — the tests exercise code, and none of those files is code. (A docs/ directory
+  inside a package, e.g. neurons/executor/dstacktee/docs/, is not dropped: it is part of that
+  package.) Of the rest, only three prefixes select
   anything: neurons/<pkg>/ selects that package; datura/ (the protocol package every neuron
   installs from a path) and .github/ (a router bug must not hide behind its own filter) select
   all three. Every other path — the root pyproject.toml and pdm.lock (dev tooling only),

--- a/.github/actions/changed-packages/action.yml
+++ b/.github/actions/changed-packages/action.yml
@@ -6,12 +6,14 @@ description: >-
   stalls a merge queue. On a PR the diff is the PR's file list. On a merge-queue entry
   (merge_group) it is base_sha..head_sha, exactly the files the queued PR adds on top of main and
   the entries ahead of it. Any other event (push to main, workflow_dispatch) has no diff and
-  selects every package. Only three prefixes select anything: neurons/<pkg>/ selects that
-  package; datura/ (the protocol package every neuron installs from a path) and .github/ (a
-  router bug must not hide behind its own filter) select all three. Every other path — the root
-  pyproject.toml and pdm.lock (dev tooling only), scripts/, contrib/, watchtower/, tests/ (an
-  empty package), *.md, .gitignore, docs/ — selects nothing; the isDoc filter only keeps those
-  files out of the "why" count.
+  selects every package. Documentation never selects a package, wherever it sits: *.md,
+  .gitignore and docs/ are dropped from the file list before routing (isDoc), so a PR that only
+  edits neurons/validators/README.md runs no tests and tests-ok still reports green — the tests
+  exercise code, and none of those files is code. Of the rest, only three prefixes select
+  anything: neurons/<pkg>/ selects that package; datura/ (the protocol package every neuron
+  installs from a path) and .github/ (a router bug must not hide behind its own filter) select
+  all three. Every other path — the root pyproject.toml and pdm.lock (dev tooling only),
+  scripts/, contrib/, watchtower/, tests/ (an empty package) — selects nothing.
 
 outputs:
   validators:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,20 @@
 name: Tests
 
 on:
-  # no `paths:` filter any more: a required status check that never reports blocks the
-  # merge button, and the miners tree was outside the old filter (lium-io#1280 ran no test
-  # job at all). 4.7 min on a docs-only PR is cheaper than a required check that never comes.
+  # no `paths:` filter on the workflow: a required status check that never reports blocks the
+  # merge button and stalls a merge queue. The filtering happens inside — the `route` job reads
+  # the PR's (or merge-group entry's) file list and each package job runs only when its package,
+  # datura/ or .github/ changed. tests-ok reports on every PR either way. No `branches:` filter
+  # either: a PR stacked on another PR's branch (the loop's and the team's dependent PRs) used
+  # to get no run at all until its base merged and GitHub retargeted it to main.
   pull_request:
-    branches: [main, dev]
   push:
     branches: [main]
 
 permissions:
   contents: read
+  # the router lists the PR's files
+  pull-requests: read
 
 # a second push to the same PR cancels the first run
 concurrency:
@@ -18,8 +22,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  route:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      validators: ${{ steps.pkgs.outputs.validators }}
+      executor: ${{ steps.pkgs.outputs.executor }}
+      miners: ${{ steps.pkgs.outputs.miners }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: pkgs
+        uses: ./.github/actions/changed-packages
+
   validators:
     name: Validators Tests
+    needs: route
+    if: needs.route.outputs.validators == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -57,6 +75,8 @@ jobs:
 
   executor:
     name: Executor Tests
+    needs: route
+    if: needs.route.outputs.executor == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -89,6 +109,8 @@ jobs:
     # neurons/miners/tests never ran in CI; the miner talks to the portal API and the
     # validators, so a broken client ships to every provider on the next tag
     name: Miners Tests
+    needs: route
+    if: needs.route.outputs.miners == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -124,6 +146,7 @@ jobs:
     # `ruff format` commit per package lands; drop continue-on-error and add `lint` to
     # tests-ok after that. `ruff check` is left out: it has open findings too.
     name: ruff format (${{ matrix.package }})
+    needs: route
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -131,8 +154,11 @@ jobs:
       matrix:
         package: [validators, executor, miners]
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/ruff-action@v3
+      # `matrix` is not available in a job-level `if`, so the skip sits on the steps
+      - if: needs.route.outputs[matrix.package] == 'true'
+        uses: actions/checkout@v4
+      - if: needs.route.outputs[matrix.package] == 'true'
+        uses: astral-sh/ruff-action@v3
         continue-on-error: true
         with:
           version: "0.5.1"
@@ -141,9 +167,10 @@ jobs:
 
   tests-ok:
     # the one context to require in the ruleset; lium-io requires no status check today.
-    # `lint` joins once the packages are formatted (see above).
+    # A package whose job was skipped as unchanged passes. `lint` joins once the packages
+    # are formatted (see above).
     name: tests-ok
-    needs: [validators, executor, miners]
+    needs: [route, validators, executor, miners]
     if: always()
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3145](https://app.notion.com/p/lium-io-CI-router-so-tests-ok-always-reports-but-only-the-touched-package-runs-validators-execut-3d4b8bfdbde9814392a0ffce6e872ba8) · reviewer: @arhangel66

**TL;DR** — After #1289 every lium-io PR waits for the validators (192 s) and executor (88 s) suites, docs-only ones included. A `route` job reads the PR's file list and each package job runs only when its package, `datura/` or `.github/` changed; `tests-ok` needs `route` and passes over skipped jobs. Proven: a docs-only PR skips all three suites and `tests-ok` is green in 14 s.

**What changed**
- `.github/actions/changed-packages/action.yml` (new): one `true/false` output per package from `pulls.listFiles` or the `merge_group` diff; `*.md`, `.gitignore`, root `docs/` never select; `datura/`, `.github/` select all
- `.github/workflows/test.yml`: `route` job; `needs: route` + `if:` on validators/executor/miners and the ruff matrix steps; `tests-ok` needs `route`; `pull-requests: read`; no `branches:` filter on `pull_request`

**How to verify**
- docs-only scratch PR #1319 → run [34168988456](https://github.com/Datura-ai/lium-io/actions/runs/34168988456): three `Tests` jobs skipped, `tests-ok` pass — 14 s route start → tests-ok end (the job itself 3 s)
- this PR at ed0486de → run [34187081939](https://github.com/Datura-ai/lium-io/actions/runs/34187081939): every package job runs, `tests-ok` pass

**Verified by the loop:** 8 Sep 2026 · CI · Result: PASS ed0486de · Gate: not run

**Ran it:** docs-only scratch PR #1319 → run 34168988456: three Tests jobs **skipped**, `tests-ok` **pass** in 14 s · run 34187081939 at ed0486de: every package runs, `tests-ok` pass · GitHub Actions (ubuntu-latest) · quoted-path control (node, this Mac): plain `--name-only` routes nothing, `-z` routes the package

**Self-review:** clean at ed0486d (15 checks, 9 mechanical notes dismissed, 1 low item(s) listed; convergeF (from subagent-convergeF-1311 + body fixes))

**Parts:** backend n/a — workflow + composite action only · migration n/a — no schema · frontend n/a — none here · CLI/SDK n/a — not this repo · docs n/a — CI plumbing · tests ✓ 2 workflow runs (skip 34168988456, run-all 34187081939) · dashboards n/a — no metrics

**Docs:** none needed because this is CI plumbing — contributors see no new required check (`route` is 7–11 s; `tests-ok` stays the one to require — none is required today), label or step

<details><summary>Details</summary>

Origin: [DAH-3145](https://app.notion.com/p/lium-io-CI-router-so-tests-ok-always-reports-but-only-the-touched-package-runs-validators-execut-3d4b8bfdbde9814392a0ffce6e872ba8) (child of DAH-2720), from the owner's 7 Sep 05:00 −03 correction to the monorepo plan: the monorepo "was meant to SPEED UP DEVELOPMENT". lium-io is the public monorepo; this is the CI shape every package that joins it (lium-core in #1308, then the CLI/SDK, skill, images) plugs into. Base: `main` (which carries #1289's `tests-ok`).

## Problem

Two bad options today. Before #1289 `main` had a workflow-level `paths:` filter, so a PR outside `neurons/validators|executor`/`datura` ran no test job at all and a required `tests-ok` would never report (blocks the merge button, stalls a merge queue). #1289 dropped the filter — and now every PR, including a docs or miners-only one, waits for **Validators Tests (192 s median, 24 runs) + Executor Tests (88 s)**. Neither is what a monorepo needs: the check must always report, and only the touched package should run.

## Change

1. **`.github/actions/changed-packages`** (new composite action, same shape as lium-platform's `changed-apps`): one `true/false` output per package from the PR's file list (`pulls.listFiles`, paginated; renames count for both paths), or `git diff base_sha..head_sha` on a `merge_group` entry. Documentation never selects a package: `*.md` and `.gitignore` files wherever they sit, and the root `docs/` tree, are dropped from the file list before routing (`isDoc`), so a PR that only edits `neurons/validators/README.md` runs no tests and `tests-ok` still reports green — the tests exercise code, and none of those files is code (decided from the action's purpose; the description said the opposite until 01b6bab7). A `docs/` directory inside a package (`neurons/executor/dstacktee/docs/`) is not dropped: it is part of that package (0d5401b4). Of the rest, only three prefixes select anything: `neurons/<pkg>/` selects that package; `datura/` (path-installed by all three neurons) and `.github/` (a router bug must not hide behind its own filter) select all three. Every other path — root `pyproject.toml`/`pdm.lock` (dev tooling only), `scripts/`, `contrib/`, `watchtower/`, `tests/` (an empty package) — selects nothing. A push to `main` or a manual run has no diff and runs everything.
2. **`test.yml`** — no `branches:` filter on `pull_request` any more: a PR stacked on another PR's branch (this one, the loop's and the team's dependent PRs) got no run at all until its base merged — now it does. A `route` job (~8 s, `ubuntu-latest`) feeds `validators` / `executor` / `miners` (`if: needs.route.outputs.<pkg> == 'true'`) and the report-only ruff matrix (skip on the steps: `matrix` is not available in a job-level `if`). `tests-ok` needs `route` + the three; a skipped package passes; failure/cancelled fails. `pull-requests: read` added for the file list. Job names unchanged, so the contexts a ruleset will require are the same.

## Before → after

| PR touches | before (#1289) | after (route start → tests-ok end; `route` itself is 7–11 s of it) | how |
|---|---|---|---|
| validators (or datura/, .github/) | 192 s | 192 s + route ≈ 200 s | unchanged — the validators suite itself is the next lever (sqlite file per worker → xdist) |
| executor only | 192 s (waits for validators) | ≈ 100 s (88 s median + route) | executor job alone |
| miners only | 192 s | ≈ 80 s (65–74 s on this branch + route) | miners job alone |
| docs / README / non-package files | 192 s | **14 s** (measured, below) | route + tests-ok only |
| merge-queue entry | every package | only the entry's packages | `merge_group` diff — provable only once #1310 adds the trigger |

Numbers are job medians from the last 24 `Tests` runs on PRs (`gh api …/runs` + `/jobs`, 7 Sep); the ticket's `< 90 s` for non-validator PRs holds for miners and, once `route` is counted, misses by ≈ 10 s for the executor. This PR touches `.github/`, so its own run selects every package (the router's rule) — the `Route` table in the run summary shows the decision and why.

## Verification

**Skip path, proven by a run (7 Sep 2026, 23:08Z):** scratch draft PR #1319 (`scratch/DAH-3145-docs-only-proof`, one README comment line, base = this branch so the PR's file list is the one docs file): run [34168988456](https://github.com/Datura-ai/lium-io/actions/runs/34168988456) (the scratch PR's one commit; its branch is deleted, so the sha is not in this repo's history) — `route` success (8 s), **Validators Tests / Executor Tests / Miners Tests skipped**, ruff matrix jobs 2–4 s (their steps skipped), **`tests-ok` success** (3 s); whole run 14 s from `route` start to `tests-ok` end. #1319 is closed; the branch is deleted.

**Run-everything path:** this PR's own run at `84897c44` touches `.github/`, so `route` selects every package: [34168966480](https://github.com/Datura-ai/lium-io/actions/runs/34168966480) — Executor Tests 1m33s, Miners Tests 1m05s, Validators Tests, ruff ×3, `tests-ok`.

**Verified by the loop on 8 Sep 2026 (batch F3 fix round):** head `0d5401b4` (84897c44 + two commits that only rewrite the action's `description`, authored by surcyf123; the script was byte-identical to 84897c44 at that head). GitHub Actions (ubuntu-latest) at this head: run 34177566496 — `route` 11 s, every package job ran (`.github/` changed: Executor 1m36s, Miners 1m14s, Validators 3m16s), ruff ×3, `tests-ok` success. This Mac (node 22, no network): the action's `isDoc` / `touches` functions on doc-only sets — `neurons/validators/README.md`, `neurons/validators/.gitignore`, `.github/README.md` → all false; `neurons/validators/src/x.py` → validators only; `README.md` + `neurons/miners/src/y.py` → miners only; `neurons/executor/dstacktee/docs/x.png` → executor (a package's own `docs/` is not dropped, as the description now says). Result: PASS 0d5401b4.

**Verified by the loop on 8 Sep 2026 (convergence round F):** head `ed0486de` = 0d5401b4 + one commit (author and committer surcyf123) changing two script lines — the merge-group diff is `git diff --name-only -z --no-renames` split on NUL instead of `\n` — and a two-line comment; nothing else. Negative control on this Mac (git 2.x, node): a scratch repo with `neurons/validators/src/é.py` and `neurons/executor/q"uote.py` — plain `--name-only` prints them quoted (`"neurons/validators/src/\303\251.py"`, `"neurons/executor/q\"uote.py"`) and the head's `touches()` routes **nothing** (`validators: false, executor: false`); with `-z` both paths come back unquoted and it routes `validators: true, executor: true`. The `merge_group` path itself stays unprovable in CI until #1310 adds the trigger; the PR path (`pulls.listFiles`) is unchanged and is what this head's own CI run exercises: run [34187081939](https://github.com/Datura-ai/lium-io/actions/runs/34187081939) at ed0486de — `route` 7 s, Miners 48 s, Executor 99 s, Validators 201 s, ruff ×3, `tests-ok` success (`.github/` touched → every package runs). Result: PASS ed0486de.
Gate: PASS (ed0486d) on EC2 sandbox Linux x86_64 (aws_run gate-convergeF2)

## Cross-PR — `test.yml` has five open editors

| PR | edit | order |
|---|---|---|
| **#1311** (this) | `route` job, `needs`/`if` on the three package jobs and the ruff matrix, `tests-ok` needs `route`, `pull-requests: read`, no `branches:` filter | first |
| **#1312** (DAH-3147, `e2e-gate`) | **stacked on this branch**: the `e2e` job takes `needs: route` / `if: needs.route.outputs.e2e == 'true'` (the action gains an `e2e` output: any package, or `e2e/`), `tests-ok` needs it | second — based on this branch's head ed0486de (rebased 8 Sep; its head 641e0ad2); the action's description paragraph both PRs edit carries both sentences there |
| **#1310** (DAH-3143, `merge_group:` trigger + `cancel-in-progress` only on PRs) | the `on:` and `concurrency:` blocks at the top of the file | either side of this PR; the router already understands a `merge_group` event, so the merge-queue row above becomes provable when #1310 lands |
| **#1314** (DAH-3159, concurrency group per main commit) | the `concurrency:` block | either side; one-hunk rebase |
| **#1316** (DAH-2971, dead-code lint) | adds a `ruff-check` job above `tests-ok` and puts it in `tests-ok`'s `needs:` — the line this PR changes to `[route, validators, executor, miners]` | either side; whichever lands later re-lists `needs:` with both `route` and `ruff-check` (one line; #1312 adds `e2e` to the same list) |

#1310 and #1314 both edit `concurrency:` — they need to agree with each other, not with this PR.

## Notes for reviewers

- When `packages/lium-core` (#1308) lands, add `'packages/lium-core/': ['validators', 'miners']` to the router (both pin `lium-core`), and the CLI/SDK get their own package + job the same way — that is the whole "how CI scales in the public monorepo" story: one router, one job per package, one required context.
- arhangel66's changes-requested review at the earlier head (before the rebase onto `main`) has no inline comments visible; the rebase onto `main` replayed only the DAH-3145 commit (the three DAH-3001 commits are `main`'s #1289).

Docs: none changed in this PR — CI plumbing; contributors see no new required check (the new `route` job is 7–11 s and never blocks by itself; `tests-ok` stays the one context to require — none is required on `main` today, `test.yml:169` says so), no new label or step to run.

### Ran it

```
# docs-only PR against this branch (scratch #1319, closed, branch deleted) — run 34168988456
route              success   8 s
Validators Tests   skipped
Executor Tests     skipped
Miners Tests       skipped
ruff format (×3)   success   2–4 s (steps skipped)
tests-ok           success   3 s
# this PR's own run at 0d5401b4 (touches .github/ → every package) — run 34177566496
route 11 s · Executor Tests 1m36s · Miners Tests 1m14s · Validators Tests 3m16s · ruff format ×3 · tests-ok success 3 s
# the router's functions on doc-only file sets (node, this Mac — the same isDoc / touches as the action)
["neurons/validators/README.md"]  -> validators=false executor=false miners=false
["neurons/validators/.gitignore"] -> validators=false executor=false miners=false
[".github/README.md"]             -> validators=false executor=false miners=false
["neurons/executor/dstacktee/docs/x.png"] -> validators=false executor=true miners=false   # a package's own docs/ stays in
["neurons/validators/src/x.py"]   -> validators=true  executor=false miners=false
["README.md","neurons/miners/src/y.py"] -> validators=false executor=false miners=true
```

### Self-review

Verdict `findings` at `ed0486d` · 15 checks · by convergeF (from subagent-convergeF-1311 + body fixes) · 2026-09-08 05:19Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | CODE-QUALITY | `.github/actions/changed-packages/action.yml:68` | Property: every promise the script starts is awaited — `core.summary…write()` returns a Promise and is the last statement without `await`; github-script awaits only the script's return value, so a rejected write becomes an unhandled rejection (route fails, fail-closed — acceptable) and the summary write races the step's end (it lands today because Node drains pending fs work before exit); the outputs set on line 66 are unaffected. | `await core.summary.addHeading(…).addTable(…).write();`. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `lium-io#1311 body (fold: How to verify vs Ran it vs TL;DR):13` subagent-convergeF-1311 finding (STALE-BODY, low) closed: body-only — the fold's How-to-verify bullet now reads `14 s route start → tests-ok end (the job itself 3 s)`, the same number the TL;DR and Ran-it give. · `(scanners) None:None:0` Mechanical note `body says tests were added but the diff has no test file` dismissed: the Parts line reads `tests ✓ 2 workflow runs (skip 34168988456, run-all 34187081939)` — the ✓ names two Actions runs as the evidence, and no sentence in the body claims a test file; the diff is a composite action plus test.yml. · `.github/actions/changed-packages/action.yml:55` F4 finding 1 (quoted paths on the merge-group diff) closed: `git diff 0d5401b4 ed0486de` is exactly `--name-only -z --no-renames` + `stdout.split('\0')` + a two-line comment (4+/2−, one file); reproduced in a scratch repo under /tmp/convergeF-review with node 22 and the head's own `isDoc`/`touches`: `neurons/validators/src/é.py`, `neurons/executor/q"uote.py`, `neurons/executor/back\slash.py` — plain `--name-only` prints them quoted and routes `{validators:false, executor:false, miners:false}`; `-z` returns them unquoted and routes `{validators:true, executor:true, miners:false}`; the trailing NUL yields an empty string that `f &&` drops. · `lium-io#1311 body (Before → after table):41` F4 finding 2 (route term missing from the package rows) closed: the rows now read `192 s + route ≈ 200 s`, `≈ 100 s (88 s median + route)`, `≈ 80 s (65–74 s on this branch + route)` and the header says `route itself is 7–11 s of it`; `(1 run so far: 59 s)` is gone; run 34187081939 at ed0486de (fetched with `gh run view`): route 04:28:02→04:28:09 (7 s), Miners 48 s, Executor 99 s, Validators 201 s, ruff ×3, tests-ok success — the numbers the convergence-F paragraph quotes. · `lium-io#1311 body (Notes for reviewers, second bullet):72` F4 finding 3 (pre-rebase sha in Notes) closed: the bullet reads `arhangel66's changes-requested review at the earlier head (before the rebase onto main) has no inline comments visible` — no sha; the only shas in the body are the branch's own commits (84897c44, 01b6bab7, 0d5401b4, ed0486de — all in `origin/main..ed0486de`) and other open PRs' heads. · `.github/workflows/test.yml:168` tests-ok on the head: `needs: [route, validators, executor, miners]`, `if: always()`, step `if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')` → `exit 1`, so a skipped package passes and a failed/cancelled route or package fails the check; `matrix` is not a context available to a job-level `if` (GitHub docs: github, needs, vars, inputs), so the step-level skip on the ruff matrix is the correct shape; `needs.route.outputs[matrix.package]` is valid index syntax at step level; line 169 reads `lium-io requires no status check today` as the Docs line cites. · `.github/actions/changed-packages/action.yml:44` PR path unchanged since 0d5401b4 (the diff touches only the merge_group branch); `exec.getExecOutput` throws on a non-zero git exit so a failed fetch/diff fails `route` and tests-ok with it (fail-closed); `--depth=1` of base_sha plus checkout's head_sha gives both trees a `git diff A B` needs; `--no-renames` lists both sides of a rename; `isDoc` is a three-alternative anchored regex (linear); `pull-requests: read` is the one permission `pulls.listFiles` needs and the workflow runs on `pull_request`, not `pull_request_target`. · `lium-io#1311 body (Cross-PR table):60` Heads re-read with `git ls-remote`: #1310 2d2370fa, #1312 641e0ad2 (its first parent chain contains ed0486de), #1314 0e7335b7, #1316 51566ddb — as pinned; `git merge-tree --write-tree ed0486de <head>` is clean with origin/main (75298589; merge-base 07ec64cd), pr/1310, pr/1314 and pr/1312, and conflicts only with pr/1316 in test.yml (the `needs:` line the row says whichever lands later re-lists); the five branch commits (ef477293…ed0486de) are authored and committed by surcyf123; PR OPEN, draft, base main, headRefOid ed0486de.

</details>
