### PR TITLE
DAH-2958 - [P1] provider time-to-ready — 30 s portal snapshot, express lane

### DIFF
--- a/neurons/miners/src/clients/miner_portal_api.py
+++ b/neurons/miners/src/clients/miner_portal_api.py
@@ -11,7 +11,11 @@ from protocol.miner_request import AuthenticateRequest
 
 logger = logging.getLogger(__name__)
 
-SNAPSHOT_TTL_SECONDS = 300
+# Short on purpose: rental key-submits refresh the snapshot between waves, and a node
+# registered after such a refresh is invisible to a wave that starts inside the TTL --
+# it then waits a whole extra 15-min cycle (DAH-2957). The wave itself still collapses
+# into one bulk request through the single-flight lock below.
+SNAPSHOT_TTL_SECONDS = 30
 FAILED_REFRESH_RETRY_SECONDS = 30
 BULK_FETCH_TIMEOUT_SECONDS = 15
 

--- a/neurons/miners/tests/test_miner_portal_api.py
+++ b/neurons/miners/tests/test_miner_portal_api.py
@@ -90,6 +90,25 @@ async def test_expired_snapshot_is_fully_replaced(monkeypatch):
     assert bulk.await_count == 2
 
 
+async def test_wave_sees_node_added_after_a_recent_rental_refresh(monkeypatch):
+    # DAH-2957, prod 4 Sep: a rental refreshed the snapshot at T, the provider added a
+    # node at T+38s, the validator wave came at T+101s and was served the T snapshot.
+    clock = Mock(monotonic=lambda: 1000.0)
+    monkeypatch.setattr("clients.miner_portal_api.time", clock)
+    bulk = AsyncMock(return_value=SNAPSHOT)
+    monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)
+    await MinerPortalAPI.fetch_executors("hotkey-a", "aaaa-1")  # rental key-submit at T
+
+    added = {"id": "aaaa-new", "validator_hotkey": "v1"}
+    bulk.return_value = {**SNAPSHOT, "hotkey-a": SNAPSHOT["hotkey-a"] + [added]}
+    clock.monotonic = lambda: 1101.0  # wave start, T+101s
+
+    executors_a = await MinerPortalAPI.fetch_executors("hotkey-a", None)
+
+    assert added in executors_a
+    assert bulk.await_count == 2
+
+
 async def test_stale_snapshot_served_when_refresh_fails(monkeypatch):
     bulk = AsyncMock(return_value=SNAPSHOT)
     monkeypatch.setattr(MinerPortalAPI, "_fetch_bulk_snapshot", bulk)

--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -37,3 +37,10 @@ HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
 # DEBUG_MINER_PORT=
 # DEBUG_MINER_UID=
 # DEBUG_SKIP_STORAGE_CHECK
+
+# Express lane (DAH-2958): verify and publish never-validated executors ahead of the 15-min cycle. Off by default.
+# The in-flight caps bound the extra load a registration flood can add (per tick, and per miner).
+EXPRESS_LANE_ENABLED=false
+EXPRESS_LANE_TICK_SECONDS=30
+EXPRESS_LANE_MAX_IN_FLIGHT=4
+EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER=2

--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -25,6 +25,9 @@ REDIS_PASSWORD=
 COMPUTE_APP_URI=wss://lium.io/api
 
 HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
+# Cold-sample retry (DAH-2959): re-measure a never-validated node's cold VerifyX download sample once before failing it.
+# Gate, threshold and known-host EMA are unchanged. Off by default.
+VERIFYX_COLD_SAMPLE_RETRY_ENABLED=false
 
 # First-pass fast path (DAH-3011): a never-validated executor gets a right-sized matmul (min(card VRAM, this MB)) and a
 # smaller VerifyX write (GB of RAM / disk) on its first pass; scored verifications are unchanged. Off by default.

--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -26,6 +26,13 @@ COMPUTE_APP_URI=wss://lium.io/api
 
 HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
 
+# First-pass fast path (DAH-3011): a never-validated executor gets a right-sized matmul (min(card VRAM, this MB)) and a
+# smaller VerifyX write (GB of RAM / disk) on its first pass; scored verifications are unchanged. Off by default.
+FIRST_PASS_FAST_PATH_ENABLED=false
+FIRST_PASS_MATMUL_VRAM_MB=8192
+FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB=16
+FIRST_PASS_VERIFYX_STORAGE_TEST_GB=1
+
 #############################
 # Local Dev                 #
 #############################

--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -36,13 +36,6 @@ FIRST_PASS_MATMUL_VRAM_MB=8192
 FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB=16
 FIRST_PASS_VERIFYX_STORAGE_TEST_GB=1
 
-# First-pass fast path (DAH-3011): a never-validated executor gets a right-sized matmul (min(card VRAM, this MB)) and a
-# smaller VerifyX write (GB of RAM / disk) on its first pass; scored verifications are unchanged. Off by default.
-FIRST_PASS_FAST_PATH_ENABLED=false
-FIRST_PASS_MATMUL_VRAM_MB=8192
-FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB=16
-FIRST_PASS_VERIFYX_STORAGE_TEST_GB=1
-
 #############################
 # Local Dev                 #
 #############################

--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -36,6 +36,13 @@ FIRST_PASS_MATMUL_VRAM_MB=8192
 FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB=16
 FIRST_PASS_VERIFYX_STORAGE_TEST_GB=1
 
+# Express lane (DAH-2958): verify and publish never-validated executors ahead of the 15-min cycle. Off by default.
+# The in-flight caps bound the extra load a registration flood can add (per tick, and per miner).
+EXPRESS_LANE_ENABLED=false
+EXPRESS_LANE_TICK_SECONDS=30
+EXPRESS_LANE_MAX_IN_FLIGHT=4
+EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER=2
+
 #############################
 # Local Dev                 #
 #############################
@@ -47,10 +54,3 @@ FIRST_PASS_VERIFYX_STORAGE_TEST_GB=1
 # DEBUG_MINER_PORT=
 # DEBUG_MINER_UID=
 # DEBUG_SKIP_STORAGE_CHECK
-
-# Express lane (DAH-2958): verify and publish never-validated executors ahead of the 15-min cycle. Off by default.
-# The in-flight caps bound the extra load a registration flood can add (per tick, and per miner).
-EXPRESS_LANE_ENABLED=false
-EXPRESS_LANE_TICK_SECONDS=30
-EXPRESS_LANE_MAX_IN_FLIGHT=4
-EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER=2

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -1,17 +1,43 @@
 import asyncio
+import json
 import logging
 import time
 from collections.abc import Mapping
+from datetime import UTC, datetime
 
 import aiohttp
 import bittensor
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
 from core.config import settings
 from core.utils import _m, get_extra_info
 
 
 logger = logging.getLogger(__name__)
+
+
+class PortalExecutor(BaseModel):
+    """One row of the portal's bulk executor snapshot (DAH-2958). Only what the express lane reads."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str
+    validator_hotkey: str
+    # The portal stamps rows with a naive datetime.utcnow(); registration → AVAILABLE is measured
+    # from here, so it is read as UTC.
+    created_at: datetime | None = None
+
+    @field_validator("created_at")
+    @classmethod
+    def as_utc(cls, value: datetime | None) -> datetime | None:
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+
+
+def portal_miner_auth_blob(hotkey: str, timestamp: int) -> str:
+    """The exact bytes the portal's signature_auth_miner verifies (AuthenticationPayload)."""
+    return json.dumps({"miner_hotkey": hotkey, "timestamp": timestamp}, sort_keys=True)
 
 
 class OptedInMiner(BaseModel):
@@ -134,6 +160,61 @@ class ValidatorPortalAPI:
             logger.error(
                 _m(
                     "Error fetching opted-in miners from portal",
+                    extra=get_extra_info({"url": url, "error": str(exc)}),
+                )
+            )
+            return None
+
+    @staticmethod
+    async def get_all_executors() -> dict[str, list[PortalExecutor]] | None:
+        """{miner_hotkey: [executor]} for every opted-in miner; None on any failure.
+
+        DAH-2958: the express lane discovers never-validated executors here, between cycles.
+        This is the bulk snapshot the central miner already polls (DAH-2469); the endpoint is
+        guarded by signature_auth_miner, which verifies the signature over AuthenticationPayload
+        and nothing else, so the validator signs the same blob with its own hotkey.
+        """
+        api_base = (
+            settings.MINER_PORTAL_REST_API_URL.rstrip("/")
+            if settings.MINER_PORTAL_REST_API_URL
+            else ""
+        )
+        if not api_base:
+            return None
+
+        url = f"{api_base}/miners/executors"
+        try:
+            keypair: bittensor.Keypair = settings.get_bittensor_wallet().get_hotkey()
+            timestamp = int(time.time())
+            headers = {
+                "hotkey": keypair.ss58_address,
+                "timestamp": str(timestamp),
+                "signature": f"0x{keypair.sign(portal_miner_auth_blob(keypair.ss58_address, timestamp)).hex()}",
+            }
+            timeout = aiohttp.ClientTimeout(total=30)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(url, headers=headers) as response:
+                    if response.status != 200:
+                        logger.error(
+                            _m(
+                                "Failed to fetch executor snapshot from portal",
+                                extra=get_extra_info(
+                                    {"status": response.status, "body": await response.text(), "url": url}
+                                ),
+                            )
+                        )
+                        return None
+                    data = await response.json()
+            if not isinstance(data, dict):
+                raise ValueError(f"unexpected portal bulk response shape: {type(data).__name__}")
+            return {
+                miner_hotkey: [PortalExecutor.model_validate(item) for item in executors]
+                for miner_hotkey, executors in data.items()
+            }
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "Error fetching executor snapshot from portal",
                     extra=get_extra_info({"url": url, "error": str(exc)}),
                 )
             )

--- a/neurons/validators/src/clients/validator_portal_api.py
+++ b/neurons/validators/src/clients/validator_portal_api.py
@@ -171,8 +171,11 @@ class ValidatorPortalAPI:
 
         DAH-2958: the express lane discovers never-validated executors here, between cycles.
         This is the bulk snapshot the central miner already polls (DAH-2469); the endpoint is
-        guarded by signature_auth_miner, which verifies the signature over AuthenticationPayload
-        and nothing else, so the validator signs the same blob with its own hotkey.
+        guarded by signature_auth_miner, which verifies the signature over AuthenticationPayload,
+        so the validator signs the same blob with its own hotkey. The guard's subnet-registration
+        check (portal auth/signature_auth.py, commented out today with a note to restore it) is
+        SubtensorClient.get_miner, a lookup over every neuron of the subnet, which a registered
+        validator hotkey passes too.
         """
         api_base = (
             settings.MINER_PORTAL_REST_API_URL.rstrip("/")
@@ -199,7 +202,11 @@ class ValidatorPortalAPI:
                             _m(
                                 "Failed to fetch executor snapshot from portal",
                                 extra=get_extra_info(
-                                    {"status": response.status, "body": await response.text(), "url": url}
+                                    {
+                                        "status": response.status,
+                                        "body": await response.text(),
+                                        "url": url,
+                                    }
                                 ),
                             )
                         )

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -412,6 +412,23 @@ class Settings(BaseSettings):
     # Use REST API instead of WebSocket for miner communication
     USE_REST_API: bool = Field(env="USE_REST_API", default=False)
 
+    # DAH-2958 — express lane for never-validated executors. A new node is published only by
+    # the fleet-wide scored cycle today, so it waits for the 15-min boundary (mean 7.5 min) and
+    # then for the slowest miner in the fleet (2–9 min): node add → AVAILABLE p50 21.4 min over
+    # 175 onboardings, floor 8.2 min. With the flag on, core/express_lane.py polls the portal's
+    # executor snapshot every TICK seconds, runs the SAME pipeline the cycle runs on executors
+    # this validator has never published, and publishes the result spec-only (no scored_at, so
+    # no incentive ledger row); the next cycle scores and overwrites it as today. Off by default:
+    # flag off = today's behaviour, nothing else in this block is read.
+    EXPRESS_LANE_ENABLED: bool = Field(env="EXPRESS_LANE_ENABLED", default=False)
+    EXPRESS_LANE_TICK_SECONDS: int = Field(env="EXPRESS_LANE_TICK_SECONDS", default=30)
+    # Hard bound on the extra load a registration flood can add: at most this many express
+    # verifications in flight at once (so also per tick), and per miner.
+    EXPRESS_LANE_MAX_IN_FLIGHT: int = Field(env="EXPRESS_LANE_MAX_IN_FLIGHT", default=4)
+    EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER: int = Field(
+        env="EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER", default=2
+    )
+
     # DAH-2211 — custom-dockerfile pod build tunables (validator side).
     # These mirror the spec keys `features.custom_dockerfile_pod.*`; the route
     # is authoritative for the size cap but the validator double-checks it as

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -196,6 +196,12 @@ class Settings(BaseSettings):
 
     ENABLE_NO_COLLATERAL: bool = True
     ENABLE_VERIFYX: bool = True
+    # DAH-2959: a never-measured executor whose first VerifyX download sample is below the 100 Mbps
+    # EMA gate gets one more sample inside the same task, and the better one seeds the EMA. 11 of
+    # 80 fresh nodes (2–5 Sep) lost 1–3 cycles to a cold first sample (32–88 Mbps on one
+    # single-stream CDN object) and passed the next cycle at 205–760 Mbps. The gate, the threshold
+    # and known hosts (any prior EMA) are unchanged.
+    VERIFYX_COLD_SAMPLE_RETRY_ENABLED: bool = Field(env="VERIFYX_COLD_SAMPLE_RETRY_ENABLED", default=False)
     ENABLE_INSPECTOR: bool = True
     # DAH-2794: feed the obfuscated scrape to the executor's own interpreter over stdin
     # instead of freezing it into a ~13 MB onefile and uploading that every cycle.

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -205,6 +205,21 @@ class Settings(BaseSettings):
         default=True,
     )
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
+    # DAH-3011: a never-validated executor's FIRST verification (the express lane's, DAH-2958 —
+    # published spec-only, never scored) proves "this GPU exists, is the model claimed, the host is
+    # reachable and rentable"; the VRAM-filling matmul and the 128 GB RAM proof exist to make a
+    # SCORED cycle expensive to fake, and the next scored cycle runs them anyway. Only a caller that
+    # passes `first_pass=True` to TaskService.create_task gets the fast path, and only with this
+    # flag on; the wave never does, so every scored verification is unchanged. Measured (Loki,
+    # 2–6 Sep, idle runs): matmul p50 26 s (74 s on the fresh dogfood node), VerifyX p50 78 s.
+    FIRST_PASS_FAST_PATH_ENABLED: bool = Field(env="FIRST_PASS_FAST_PATH_ENABLED", default=False)
+    # The matmul is sized from min(card VRAM, this) instead of the whole card: same challenge,
+    # seal and UUID check, 5–17x less data to generate and copy.
+    FIRST_PASS_MATMUL_VRAM_MB: int = Field(env="FIRST_PASS_MATMUL_VRAM_MB", default=8192)
+    # VerifyX challenge config for the first pass (defaults 128 GB / 5 GB in VerifyXSettings). The
+    # measurements are still taken and published; only the amount of RAM/disk written shrinks.
+    FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB: int = Field(env="FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB", default=16)
+    FIRST_PASS_VERIFYX_STORAGE_TEST_GB: int = Field(env="FIRST_PASS_VERIFYX_STORAGE_TEST_GB", default=1)
     # DAH-2667: measure a RoCE fabric with ib_write_bw between the free hosts of one segment, rather
     # than inferring it from the addresses alone. The backend reads a flag of the SAME name to decide
     # whether a fabric must be measured before it is sold, so the feature has one switch across both

--- a/neurons/validators/src/core/express_lane.py
+++ b/neurons/validators/src/core/express_lane.py
@@ -1,0 +1,310 @@
+"""DAH-2958: verify and publish never-validated executors ahead of the 15-min cycle.
+
+A new node is published only by the fleet-wide scored cycle, so it waits for the cycle boundary
+(BLOCKS_FOR_JOB = 75 blocks, uniform 0–15 min) and then for the slowest miner in the fleet
+(publish_machine_specs runs after asyncio.wait over every miner: +2–9 min). Node add → AVAILABLE
+was p50 21.4 / p90 63.5 min over 175 onboardings, floor 8.2 min (RECOVERY report, 6 Sep 2026).
+
+This lane runs beside Validator.sync() in the same process. Every tick it reads the portal's bulk
+executor snapshot, picks the executors assigned to this validator that it has never published,
+and runs the SAME pipeline the cycle runs — same job files, digests and image snapshot, same
+checks — on each one, alone, then publishes the result spec-only (scored_at stays None, so the
+backend creates the executor row but writes no incentive ledger row). The next scored cycle
+overwrites it as today. Off by default (settings.EXPRESS_LANE_ENABLED).
+"""
+
+import asyncio
+import logging
+import time
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from clients.validator_portal_api import PortalExecutor, ValidatorPortalAPI
+from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+from services.executor_image_policy import ExpectedImageSnapshot
+from services.miner_service import EXPRESS_LANE, MinerService
+
+from core.config import settings
+from core.utils import _m, get_extra_info
+
+logger = logging.getLogger(__name__)
+
+# One line per express verification; its registration_to_publish_s is the deploy metric.
+EXPRESS_PUBLISHED_EVENT = "[express] Executor verified and published ahead of the cycle"
+# The miner did not return the executor (its portal snapshot is not refreshed yet, or the node is
+# unreachable): try again later, a bounded number of times, then leave it to the normal cycle.
+MAX_ATTEMPTS = 3
+RETRY_SECONDS = 120
+# job_batch_id format the backend parses into the prod_executors row's time.
+JOB_BATCH_ID_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass
+class CycleInputs:
+    """What the cycle prepared for its wave. The express lane reuses it verbatim, so an express
+    verification is the cycle's pipeline with the cycle's job files, digests and image snapshot."""
+
+    encrypted_files: MinerJobEnryptedFiles
+    default_image_digests: dict[str, str]
+    executor_image_snapshot: ExpectedImageSnapshot | None
+
+
+@dataclass
+class _Pending:
+    executor: PortalExecutor
+    miner_hotkey: str
+    first_seen_at: datetime
+    attempts: int = 0
+    not_before: float = 0.0  # monotonic
+
+
+class ExpressLane:
+    def __init__(
+        self,
+        *,
+        miner_service: MinerService,
+        redis_service,
+        backend_client,
+        subtensor_client,
+        cycle_inputs: Callable[[], CycleInputs | None],
+        portal_api=ValidatorPortalAPI,
+    ):
+        self.miner_service = miner_service
+        self.redis_service = redis_service
+        self.backend_client = backend_client
+        self.subtensor_client = subtensor_client
+        # None until the first cycle since start has completed: that cycle seeds the validated
+        # set with the whole fleet and produces the job files, so nothing runs before it.
+        self.cycle_inputs = cycle_inputs
+        self.portal_api = portal_api
+        self._pending: dict[str, _Pending] = {}
+        self._tasks: set[asyncio.Task] = set()
+        self._my_hotkey: str | None = None
+        # Given up on this process's watch (MAX_ATTEMPTS without the miner returning them); the
+        # normal cycle owns them from here. In memory on purpose: a restart may try again.
+        self._left_to_cycle: set[str] = set()
+
+    async def run(self, should_exit: Callable[[], bool]) -> None:
+        logger.info(
+            _m(
+                "[express] Express lane started",
+                extra=get_extra_info(
+                    {
+                        "tick_seconds": settings.EXPRESS_LANE_TICK_SECONDS,
+                        "max_in_flight": settings.EXPRESS_LANE_MAX_IN_FLIGHT,
+                        "max_in_flight_per_miner": settings.EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER,
+                    }
+                ),
+            )
+        )
+        while not should_exit():
+            try:
+                await self.tick()
+            except Exception as exc:
+                logger.error(
+                    _m("[express] Tick failed", extra=get_extra_info({"error": str(exc)})),
+                    exc_info=True,
+                )
+            await asyncio.sleep(settings.EXPRESS_LANE_TICK_SECONDS)
+
+    def _hotkey(self) -> str:
+        if self._my_hotkey is None:
+            self._my_hotkey = settings.get_bittensor_wallet().get_hotkey().ss58_address
+        return self._my_hotkey
+
+    async def tick(self) -> int:
+        """One pass: discover, select under the caps, launch. Returns how many were launched."""
+        inputs = self.cycle_inputs()
+        if inputs is None:
+            return 0
+
+        snapshot = await self.portal_api.get_all_executors()
+        if snapshot is None:
+            return 0
+
+        validated = await self.redis_service.get_validated_executors()
+        in_flight = self.miner_service.in_flight
+        my_hotkey = self._hotkey()
+        now = time.monotonic()
+        now_wall = datetime.now(UTC)
+
+        present: set[str] = set()
+        candidates: list[_Pending] = []
+        for miner_hotkey, executors in snapshot.items():
+            for executor in executors:
+                if (
+                    executor.validator_hotkey != my_hotkey
+                    or executor.id in validated
+                    or executor.id in self._left_to_cycle
+                ):
+                    continue
+                present.add(executor.id)
+                pending = self._pending.get(executor.id)
+                if pending is None:
+                    pending = self._pending[executor.id] = _Pending(
+                        executor=executor, miner_hotkey=miner_hotkey, first_seen_at=now_wall
+                    )
+                if executor.id in in_flight or pending.not_before > now:
+                    continue
+                candidates.append(pending)
+
+        # Removed from the portal (or validated by the cycle) before this lane got to it.
+        for executor_id in [e for e in self._pending if e not in present and e not in in_flight]:
+            del self._pending[executor_id]
+
+        if not candidates:
+            return 0
+
+        # Oldest registration first; then the two caps that bound a registration flood.
+        candidates.sort(key=lambda p: p.executor.created_at or p.first_seen_at)
+        express_in_flight = [e for e, lane in in_flight.items() if lane == EXPRESS_LANE]
+        room = settings.EXPRESS_LANE_MAX_IN_FLIGHT - len(express_in_flight)
+        per_miner: Counter[str] = Counter(
+            self._pending[e].miner_hotkey for e in express_in_flight if e in self._pending
+        )
+        chosen: list[_Pending] = []
+        for pending in candidates:
+            if room <= 0:
+                break
+            if per_miner[pending.miner_hotkey] >= settings.EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER:
+                continue
+            chosen.append(pending)
+            per_miner[pending.miner_hotkey] += 1
+            room -= 1
+        if not chosen:
+            return 0
+
+        miners = {miner.hotkey: miner for miner in await self.subtensor_client.get_miners()}
+        rented_data = await self.backend_client.get_all_rented_executors()
+        if rented_data is None:
+            logger.error(
+                _m("[express] Failed to fetch rented executors, skipping this tick", extra=get_extra_info({}))
+            )
+            return 0
+
+        launched = 0
+        for pending in chosen:
+            if pending.executor.id in in_flight:
+                # The wave accepted it during the awaits above; it publishes it at the wave's end.
+                continue
+            miner = miners.get(pending.miner_hotkey)
+            if miner is None:
+                pending.attempts += 1
+                self._defer(pending, "miner is not among the serving opted-in miners")
+                continue
+            in_flight[pending.executor.id] = EXPRESS_LANE
+            task = asyncio.create_task(self._verify(pending, miner, inputs, rented_data))
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
+            launched += 1
+        return launched
+
+    async def _verify(self, pending: _Pending, miner, inputs: CycleInputs, rented_data) -> None:
+        executor_id = pending.executor.id
+        pending.attempts += 1
+        started_wall = datetime.now(UTC)
+        started = time.monotonic()
+        extra = {
+            "executor_uuid": executor_id,
+            "miner_hotkey": miner.hotkey,
+            "attempt": pending.attempts,
+        }
+        try:
+            payload = MinerJobRequestPayload(
+                job_batch_id=started_wall.strftime(JOB_BATCH_ID_FORMAT),
+                miner_hotkey=miner.hotkey,
+                miner_coldkey=miner.coldkey,
+                miner_address=miner.axon_info.ip,
+                miner_port=miner.axon_info.port,
+            )
+            job = await asyncio.wait_for(
+                self.miner_service.request_job_to_miner(
+                    payload=payload,
+                    encrypted_files=inputs.encrypted_files,
+                    rented_data=rented_data,
+                    default_docker_image_digests=inputs.default_image_digests,
+                    executor_image_snapshot=inputs.executor_image_snapshot,
+                    executor_id=executor_id,
+                ),
+                timeout=settings.JOB_TIME_OUT,
+            )
+            # Only this executor's own result: a miner-level failure comes back under the
+            # failed-miner sentinel uuid and a manual rental elsewhere on the miner is not ours.
+            results = [
+                result
+                for result in (job or {}).get("results", [])
+                if result.executor_info.uuid == executor_id
+            ]
+            if not results:
+                self._defer(pending, "miner did not return the executor")
+                return
+
+            # Published as the pipeline produced it — no incentive, scored_at None — so the
+            # backend creates/updates the executor row (AVAILABLE when the score is positive)
+            # but writes no incentive_per_validator_cycle row: is_provider_emission_cycle_eligible
+            # needs scored_at. The next scored cycle overwrites the row as today.
+            await self.miner_service.publish_machine_specs(results, miner.hotkey, miner.coldkey)
+            await self.redis_service.mark_executors_validated([executor_id])
+            self._pending.pop(executor_id, None)
+
+            published_at = datetime.now(UTC)
+            result = results[0]
+            registered_at = pending.executor.created_at
+            logger.info(
+                _m(
+                    EXPRESS_PUBLISHED_EVENT,
+                    extra=get_extra_info(
+                        {
+                            **extra,
+                            "outcome": "passed" if (result.score > 0 or result.job_score > 0) else "failed",
+                            "score": result.score,
+                            "log_status": result.log_status,
+                            "registered_at": registered_at.isoformat() if registered_at else None,
+                            "first_seen_at": pending.first_seen_at.isoformat(),
+                            "published_at": published_at.isoformat(),
+                            "registration_to_publish_s": round(
+                                (published_at - registered_at).total_seconds(), 1
+                            )
+                            if registered_at
+                            else None,
+                            "first_seen_to_publish_s": round(
+                                (published_at - pending.first_seen_at).total_seconds(), 1
+                            ),
+                            "verification_s": round(time.monotonic() - started, 1),
+                        }
+                    ),
+                )
+            )
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "[express] Verification failed before a result could be published",
+                    extra=get_extra_info({**extra, "error": str(exc)}),
+                ),
+                exc_info=True,
+            )
+            self._defer(pending, str(exc))
+        finally:
+            if self.miner_service.in_flight.get(executor_id) == EXPRESS_LANE:
+                del self.miner_service.in_flight[executor_id]
+
+    def _defer(self, pending: _Pending, reason: str) -> None:
+        """Try again after RETRY_SECONDS, or after MAX_ATTEMPTS leave the executor to the cycle.
+
+        The caller has already counted the attempt.
+        """
+        extra = {
+            "executor_uuid": pending.executor.id,
+            "miner_hotkey": pending.miner_hotkey,
+            "attempt": pending.attempts,
+            "reason": reason,
+        }
+        if pending.attempts >= MAX_ATTEMPTS:
+            self._left_to_cycle.add(pending.executor.id)
+            self._pending.pop(pending.executor.id, None)
+            logger.warning(_m("[express] Executor left to the normal cycle", extra=get_extra_info(extra)))
+            return
+        pending.not_before = time.monotonic() + RETRY_SECONDS
+        logger.info(_m("[express] Executor not verified yet, will retry", extra=get_extra_info(extra)))

--- a/neurons/validators/src/core/express_lane.py
+++ b/neurons/validators/src/core/express_lane.py
@@ -16,6 +16,7 @@ today. Off by default (settings.EXPRESS_LANE_ENABLED).
 
 import asyncio
 import logging
+import os
 import time
 from collections import Counter
 from collections.abc import Callable
@@ -133,6 +134,7 @@ class ExpressLane:
         inputs = self.cycle_inputs()
         if inputs is None:
             return 0
+        fleet_known_since = inputs.fleet_known_since
 
         snapshot = await self.portal_api.get_all_executors()
         if snapshot is None:
@@ -156,7 +158,7 @@ class ExpressLane:
                     # time to go by): long-known to this validator even if never published since
                     # the flag went on — its miner failed or was offline. The cycle owns it.
                     or executor.created_at is None
-                    or executor.created_at < inputs.fleet_known_since
+                    or executor.created_at < fleet_known_since
                 ):
                     continue
                 present.add(executor.id)
@@ -203,6 +205,26 @@ class ExpressLane:
             )
             return 0
 
+        # Read the inputs again, after the last await: a cycle that started during the awaits
+        # above replaced them and removed the earlier job-files directory (nothing held it yet).
+        # The validator's prep is synchronous and there is no await between here and the holds
+        # below, so the directory these inputs name is the current one and each hold keeps it
+        # until its verification ends.
+        inputs = self.cycle_inputs()
+        if inputs is None:
+            return 0
+        directory = inputs.encrypted_files.tmp_directory
+        if not os.path.isdir(directory):
+            # Something outside the validator removed the current cycle's files. A verification
+            # without them fails as if the node had; skip the tick instead.
+            logger.warning(
+                _m(
+                    "[express] Job files directory is missing, skipping this tick",
+                    extra=get_extra_info({"directory": directory}),
+                )
+            )
+            return 0
+
         launched = 0
         for pending in chosen:
             if pending.executor.id in in_flight:
@@ -214,7 +236,7 @@ class ExpressLane:
                 self._defer(pending, "miner is not among the serving opted-in miners")
                 continue
             in_flight[pending.executor.id] = EXPRESS_LANE
-            self._directories_in_use[inputs.encrypted_files.tmp_directory] += 1
+            self._directories_in_use[directory] += 1
             task = asyncio.create_task(self._verify(pending, miner, inputs, rented_data))
             self._tasks.add(task)
             task.add_done_callback(self._tasks.discard)
@@ -223,13 +245,16 @@ class ExpressLane:
 
     async def _verify(self, pending: _Pending, miner, inputs: CycleInputs, rented_data) -> None:
         executor_id = pending.executor.id
-        pending.attempts += 1
+        directory = inputs.encrypted_files.tmp_directory
+        # Counted against the node once the outcome is the node's (below); a verification the
+        # validator itself spoiled is retried without spending one of MAX_ATTEMPTS.
+        attempt = pending.attempts + 1
         started_wall = datetime.now(UTC)
         started = time.monotonic()
         extra = {
             "executor_uuid": executor_id,
             "miner_hotkey": miner.hotkey,
-            "attempt": pending.attempts,
+            "attempt": attempt,
         }
         try:
             payload = MinerJobRequestPayload(
@@ -253,6 +278,19 @@ class ExpressLane:
                 ),
                 timeout=settings.JOB_TIME_OUT,
             )
+            if not os.path.isdir(directory):
+                # The hold keeps this directory across cycles, so it went away by another hand.
+                # The pipeline reports a missing upload (UploadFilesCheck, the scrape's binary
+                # fallback) as the node's failure; the node did nothing. Discard, retry later.
+                logger.warning(
+                    _m(
+                        "[express] Job files were removed during the verification, result discarded",
+                        extra=get_extra_info({**extra, "directory": directory}),
+                    )
+                )
+                pending.not_before = time.monotonic() + RETRY_SECONDS
+                return
+            pending.attempts = attempt
             # Only this executor's own result: a miner-level failure comes back under the
             # failed-miner sentinel uuid and a manual rental elsewhere on the miner is not ours.
             results = [
@@ -301,6 +339,7 @@ class ExpressLane:
                 )
             )
         except Exception as exc:
+            pending.attempts = attempt
             logger.error(
                 _m(
                     "[express] Verification failed before a result could be published",
@@ -312,7 +351,6 @@ class ExpressLane:
         finally:
             if self.miner_service.in_flight.get(executor_id) == EXPRESS_LANE:
                 del self.miner_service.in_flight[executor_id]
-            directory = inputs.encrypted_files.tmp_directory
             self._directories_in_use[directory] -= 1
             if self._directories_in_use[directory] <= 0:
                 del self._directories_in_use[directory]

--- a/neurons/validators/src/core/express_lane.py
+++ b/neurons/validators/src/core/express_lane.py
@@ -307,7 +307,19 @@ class ExpressLane:
             # but writes no incentive_per_validator_cycle row: is_provider_emission_cycle_eligible
             # needs scored_at. The next scored cycle overwrites the row as today.
             await self.miner_service.publish_machine_specs(results, miner.hotkey, miner.coldkey)
-            await self.redis_service.mark_executors_validated([executor_id])
+            try:
+                await self.redis_service.mark_executors_validated([executor_id])
+            except Exception as exc:
+                # The result is published; a Redis blip must not run the node again. The cycle
+                # owns it from here (its next seed records it), like a node that used up its
+                # attempts.
+                self._left_to_cycle.add(executor_id)
+                logger.error(
+                    _m(
+                        "[express] Published, but could not record the executor as validated; left to the cycle",
+                        extra=get_extra_info({**extra, "error": str(exc)}),
+                    ),
+                )
             self._pending.pop(executor_id, None)
 
             published_at = datetime.now(UTC)

--- a/neurons/validators/src/core/express_lane.py
+++ b/neurons/validators/src/core/express_lane.py
@@ -23,10 +23,13 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+import bittensor
 from clients.validator_portal_api import PortalExecutor, ValidatorPortalAPI
 from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.executor_image_policy import ExpectedImageSnapshot
 from services.miner_service import EXPRESS_LANE, MinerService
+from services.task_service import JobResult
 
 from core.config import settings
 from core.utils import _m, get_extra_info
@@ -134,13 +137,27 @@ class ExpressLane:
         inputs = self.cycle_inputs()
         if inputs is None:
             return 0
-        fleet_known_since = inputs.fleet_known_since
 
         snapshot = await self.portal_api.get_all_executors()
         if snapshot is None:
             return 0
 
         validated = await self.redis_service.get_validated_executors()
+        chosen = self._select(snapshot, validated, inputs.fleet_known_since)
+        if not chosen:
+            return 0
+        return await self._launch(chosen)
+
+    def _select(
+        self,
+        snapshot: dict[str, list[PortalExecutor]],
+        validated: set[str],
+        fleet_known_since: datetime,
+    ) -> list[_Pending]:
+        """Track this validator's never-validated executors; return the ones to launch now.
+
+        Oldest registration first, under the two in-flight caps.
+        """
         in_flight = self.miner_service.in_flight
         my_hotkey = self._hotkey()
         now = time.monotonic()
@@ -175,9 +192,6 @@ class ExpressLane:
         for executor_id in [e for e in self._pending if e not in present and e not in in_flight]:
             del self._pending[executor_id]
 
-        if not candidates:
-            return 0
-
         # Oldest registration first; then the two caps that bound a registration flood.
         candidates.sort(key=lambda p: p.executor.created_at or p.first_seen_at)
         express_in_flight = [e for e, lane in in_flight.items() if lane == EXPRESS_LANE]
@@ -194,14 +208,22 @@ class ExpressLane:
             chosen.append(pending)
             per_miner[pending.miner_hotkey] += 1
             room -= 1
-        if not chosen:
-            return 0
+        return chosen
 
+    async def _launch(self, chosen: list[_Pending]) -> int:
+        """Start one verification per chosen executor on the cycle's current job files.
+
+        Returns how many were started.
+        """
+        in_flight = self.miner_service.in_flight
         miners = {miner.hotkey: miner for miner in await self.subtensor_client.get_miners()}
         rented_data = await self.backend_client.get_all_rented_executors()
         if rented_data is None:
             logger.error(
-                _m("[express] Failed to fetch rented executors, skipping this tick", extra=get_extra_info({}))
+                _m(
+                    "[express] Failed to fetch rented executors, skipping this tick",
+                    extra=get_extra_info({}),
+                )
             )
             return 0
 
@@ -243,7 +265,13 @@ class ExpressLane:
             launched += 1
         return launched
 
-    async def _verify(self, pending: _Pending, miner, inputs: CycleInputs, rented_data) -> None:
+    async def _verify(
+        self,
+        pending: _Pending,
+        miner: bittensor.NeuronInfo,
+        inputs: CycleInputs,
+        rented_data: RentedExecutorsResponse,
+    ) -> None:
         executor_id = pending.executor.id
         directory = inputs.encrypted_files.tmp_directory
         # Counted against the node once the outcome is the node's (below); a verification the
@@ -251,7 +279,7 @@ class ExpressLane:
         attempt = pending.attempts + 1
         started_wall = datetime.now(UTC)
         started = time.monotonic()
-        extra = {
+        extra: dict[str, object] = {
             "executor_uuid": executor_id,
             "miner_hotkey": miner.hotkey,
             "attempt": attempt,
@@ -301,55 +329,7 @@ class ExpressLane:
             if not results:
                 self._defer(pending, "miner did not return the executor")
                 return
-
-            # Published as the pipeline produced it — no incentive, scored_at None — so the
-            # backend creates/updates the executor row (AVAILABLE when the score is positive)
-            # but writes no incentive_per_validator_cycle row: is_provider_emission_cycle_eligible
-            # needs scored_at. The next scored cycle overwrites the row as today.
-            await self.miner_service.publish_machine_specs(results, miner.hotkey, miner.coldkey)
-            try:
-                await self.redis_service.mark_executors_validated([executor_id])
-            except Exception as exc:
-                # The result is published; a Redis blip must not run the node again. The cycle
-                # owns it from here (its next seed records it), like a node that used up its
-                # attempts.
-                self._left_to_cycle.add(executor_id)
-                logger.error(
-                    _m(
-                        "[express] Published, but could not record the executor as validated; left to the cycle",
-                        extra=get_extra_info({**extra, "error": str(exc)}),
-                    ),
-                )
-            self._pending.pop(executor_id, None)
-
-            published_at = datetime.now(UTC)
-            result = results[0]
-            registered_at = pending.executor.created_at
-            logger.info(
-                _m(
-                    EXPRESS_PUBLISHED_EVENT,
-                    extra=get_extra_info(
-                        {
-                            **extra,
-                            "outcome": "passed" if (result.score > 0 or result.job_score > 0) else "failed",
-                            "score": result.score,
-                            "log_status": result.log_status,
-                            "registered_at": registered_at.isoformat() if registered_at else None,
-                            "first_seen_at": pending.first_seen_at.isoformat(),
-                            "published_at": published_at.isoformat(),
-                            "registration_to_publish_s": round(
-                                (published_at - registered_at).total_seconds(), 1
-                            )
-                            if registered_at
-                            else None,
-                            "first_seen_to_publish_s": round(
-                                (published_at - pending.first_seen_at).total_seconds(), 1
-                            ),
-                            "verification_s": round(time.monotonic() - started, 1),
-                        }
-                    ),
-                )
-            )
+            await self._publish(pending, miner, results, extra, started)
         except Exception as exc:
             pending.attempts = attempt
             logger.error(
@@ -367,6 +347,69 @@ class ExpressLane:
             if self._directories_in_use[directory] <= 0:
                 del self._directories_in_use[directory]
 
+    async def _publish(
+        self,
+        pending: _Pending,
+        miner: bittensor.NeuronInfo,
+        results: list[JobResult],
+        extra: dict[str, object],
+        started: float,
+    ) -> None:
+        """Publish the executor's own result spec-only, record it as validated, log the metric.
+
+        Published as the pipeline produced it — no incentive, scored_at None — so the backend
+        creates/updates the executor row (AVAILABLE when the score is positive) but writes no
+        incentive_per_validator_cycle row: is_provider_emission_cycle_eligible needs scored_at.
+        The next scored cycle overwrites the row as today.
+        """
+        executor_id = pending.executor.id
+        await self.miner_service.publish_machine_specs(results, miner.hotkey, miner.coldkey)
+        try:
+            await self.redis_service.mark_executors_validated([executor_id])
+        except Exception as exc:
+            # The result is published; a Redis blip must not run the node again. The cycle
+            # owns it from here (its next seed records it), like a node that used up its
+            # attempts.
+            self._left_to_cycle.add(executor_id)
+            logger.error(
+                _m(
+                    "[express] Published, but could not record the executor as validated; left to the cycle",
+                    extra=get_extra_info({**extra, "error": str(exc)}),
+                ),
+            )
+        self._pending.pop(executor_id, None)
+
+        published_at = datetime.now(UTC)
+        result = results[0]
+        registered_at = pending.executor.created_at
+        logger.info(
+            _m(
+                EXPRESS_PUBLISHED_EVENT,
+                extra=get_extra_info(
+                    {
+                        **extra,
+                        "outcome": "passed"
+                        if (result.score > 0 or result.job_score > 0)
+                        else "failed",
+                        "score": result.score,
+                        "log_status": result.log_status,
+                        "registered_at": registered_at.isoformat() if registered_at else None,
+                        "first_seen_at": pending.first_seen_at.isoformat(),
+                        "published_at": published_at.isoformat(),
+                        "registration_to_publish_s": round(
+                            (published_at - registered_at).total_seconds(), 1
+                        )
+                        if registered_at
+                        else None,
+                        "first_seen_to_publish_s": round(
+                            (published_at - pending.first_seen_at).total_seconds(), 1
+                        ),
+                        "verification_s": round(time.monotonic() - started, 1),
+                    }
+                ),
+            )
+        )
+
     def _defer(self, pending: _Pending, reason: str) -> None:
         """Try again after RETRY_SECONDS, or after MAX_ATTEMPTS leave the executor to the cycle.
 
@@ -381,7 +424,11 @@ class ExpressLane:
         if pending.attempts >= MAX_ATTEMPTS:
             self._left_to_cycle.add(pending.executor.id)
             self._pending.pop(pending.executor.id, None)
-            logger.warning(_m("[express] Executor left to the normal cycle", extra=get_extra_info(extra)))
+            logger.warning(
+                _m("[express] Executor left to the normal cycle", extra=get_extra_info(extra))
+            )
             return
         pending.not_before = time.monotonic() + RETRY_SECONDS
-        logger.info(_m("[express] Executor not verified yet, will retry", extra=get_extra_info(extra)))
+        logger.info(
+            _m("[express] Executor not verified yet, will retry", extra=get_extra_info(extra))
+        )

--- a/neurons/validators/src/core/express_lane.py
+++ b/neurons/validators/src/core/express_lane.py
@@ -6,11 +6,12 @@ A new node is published only by the fleet-wide scored cycle, so it waits for the
 was p50 21.4 / p90 63.5 min over 175 onboardings, floor 8.2 min (RECOVERY report, 6 Sep 2026).
 
 This lane runs beside Validator.sync() in the same process. Every tick it reads the portal's bulk
-executor snapshot, picks the executors assigned to this validator that it has never published,
-and runs the SAME pipeline the cycle runs — same job files, digests and image snapshot, same
-checks — on each one, alone, then publishes the result spec-only (scored_at stays None, so the
-backend creates the executor row but writes no incentive ledger row). The next scored cycle
-overwrites it as today. Off by default (settings.EXPRESS_LANE_ENABLED).
+executor snapshot, picks the executors assigned to this validator that registered after the first
+cycle since start began and that no cycle has published yet, and runs the SAME pipeline the cycle
+runs — same job files, digests and image snapshot, same checks, as a first pass (DAH-3011) — on
+each one, alone, then publishes the result spec-only (scored_at stays None, so the backend creates
+the executor row but writes no incentive ledger row). The next scored cycle overwrites it as
+today. Off by default (settings.EXPRESS_LANE_ENABLED).
 """
 
 import asyncio
@@ -49,6 +50,11 @@ class CycleInputs:
     encrypted_files: MinerJobEnryptedFiles
     default_image_digests: dict[str, str]
     executor_image_snapshot: ExpectedImageSnapshot | None
+    # When the first cycle since this process started began. That cycle asked every serving miner
+    # for its executors, so an executor registered before it is long-known even when its miner
+    # failed or was offline that cycle and it never reached the validated set; only executors
+    # registered after this instant can be new to this validator.
+    fleet_known_since: datetime
 
 
 @dataclass
@@ -75,8 +81,9 @@ class ExpressLane:
         self.redis_service = redis_service
         self.backend_client = backend_client
         self.subtensor_client = subtensor_client
-        # None until the first cycle since start has completed: that cycle seeds the validated
-        # set with the whole fleet and produces the job files, so nothing runs before it.
+        # None until the first cycle since start has completed: that cycle publishes every
+        # executor of every miner that answered and produces the job files, so nothing runs
+        # before it.
         self.cycle_inputs = cycle_inputs
         self.portal_api = portal_api
         self._pending: dict[str, _Pending] = {}
@@ -85,6 +92,13 @@ class ExpressLane:
         # Given up on this process's watch (MAX_ATTEMPTS without the miner returning them); the
         # normal cycle owns them from here. In memory on purpose: a restart may try again.
         self._left_to_cycle: set[str] = set()
+        # Job-files directory -> running verifications reading it. The validator keeps these
+        # directories when it prepares the next cycle's files (FileEncryptService).
+        self._directories_in_use: Counter[str] = Counter()
+
+    def directories_in_use(self) -> set[str]:
+        """Job-files directories a running express verification still reads."""
+        return {path for path, count in self._directories_in_use.items() if count > 0}
 
     async def run(self, should_exit: Callable[[], bool]) -> None:
         logger.info(
@@ -138,6 +152,11 @@ class ExpressLane:
                     executor.validator_hotkey != my_hotkey
                     or executor.id in validated
                     or executor.id in self._left_to_cycle
+                    # Registered before the first cycle since start (or with no registration
+                    # time to go by): long-known to this validator even if never published since
+                    # the flag went on — its miner failed or was offline. The cycle owns it.
+                    or executor.created_at is None
+                    or executor.created_at < inputs.fleet_known_since
                 ):
                     continue
                 present.add(executor.id)
@@ -195,6 +214,7 @@ class ExpressLane:
                 self._defer(pending, "miner is not among the serving opted-in miners")
                 continue
             in_flight[pending.executor.id] = EXPRESS_LANE
+            self._directories_in_use[inputs.encrypted_files.tmp_directory] += 1
             task = asyncio.create_task(self._verify(pending, miner, inputs, rented_data))
             self._tasks.add(task)
             task.add_done_callback(self._tasks.discard)
@@ -227,6 +247,9 @@ class ExpressLane:
                     default_docker_image_digests=inputs.default_image_digests,
                     executor_image_snapshot=inputs.executor_image_snapshot,
                     executor_id=executor_id,
+                    # Never scored, so the pipeline may right-size its probes (DAH-3011) — it
+                    # does only with FIRST_PASS_FAST_PATH_ENABLED on.
+                    first_pass=True,
                 ),
                 timeout=settings.JOB_TIME_OUT,
             )
@@ -289,6 +312,10 @@ class ExpressLane:
         finally:
             if self.miner_service.in_flight.get(executor_id) == EXPRESS_LANE:
                 del self.miner_service.in_flight[executor_id]
+            directory = inputs.encrypted_files.tmp_directory
+            self._directories_in_use[directory] -= 1
+            if self._directories_in_use[directory] <= 0:
+                del self._directories_in_use[directory]
 
     def _defer(self, pending: _Pending, reason: str) -> None:
         """Try again after RETRY_SECONDS, or after MAX_ATTEMPTS leave the executor to the cycle.

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -38,6 +38,7 @@ from services.task_service import JobResult, TaskService
 from services.verifyx_validation_service import VerifyXValidationService
 
 from core.config import settings
+from core.express_lane import CycleInputs, ExpressLane
 from core.utils import _m, get_extra_info, get_logger
 from services.ssh_service import SSHService
 
@@ -46,6 +47,8 @@ logger = get_logger(__name__)
 SYNC_CYCLE = 12
 WEIGHT_MAX_COUNTER = 6
 MINER_SCORES_KEY = "miner_scores"
+# Executor uuid request_job_to_miner reports a miner-level failure under (no real executor).
+FAILED_MINER_EXECUTOR_UUID = "11111111-1111-1111-1111-111111111111"
 
 
 class Validator:
@@ -54,6 +57,9 @@ class Validator:
         self.should_exit = False
         self.last_job_run_blocks = 0
         self.default_extra = {}
+        # DAH-2958: the current cycle's job files / digests / image snapshot, reused by the
+        # express lane so its verifications are the cycle's pipeline. None before the first cycle.
+        self.cycle_inputs: CycleInputs | None = None
 
         self.miner_scores = {}
         # Hotkeys with at least one live executor in the last completed cycle. Rebuilt
@@ -121,6 +127,13 @@ class Validator:
             redis_service=self.redis_service,
             attestation_service=self.attestation_service,
         )
+        self.express_lane = ExpressLane(
+            miner_service=self.miner_service,
+            redis_service=self.redis_service,
+            backend_client=self.backend_client,
+            subtensor_client=self.subtensor_client,
+            cycle_inputs=self.express_lane_cycle_inputs,
+        )
 
         # init miner_scores: always load from Redis if present so accumulated
         # scores survive an unclean restart (SIGKILL / OOM / liveness preempt).
@@ -159,6 +172,14 @@ class Validator:
                 ),
             ),
         )
+
+    def express_lane_cycle_inputs(self) -> CycleInputs | None:
+        """DAH-2958: the express lane runs only once a full cycle has completed since start —
+        that cycle seeds the validated-executor set with the whole fleet, so the lane never
+        mistakes a long-known executor for a new one after a deploy or restart."""
+        if self.completed_cycles_since_start < 1:
+            return None
+        return self.cycle_inputs
 
     async def an_operator_asked_for_a_cycle_now(self) -> bool:
         """Whether an operator asked for a cycle. Reads only -- the request stays pending.
@@ -335,6 +356,13 @@ class Validator:
                     await self.redis_service.clear_forced_validation_cycle_request()
 
                 encrypted_files = self.file_encrypt_service.ecrypt_miner_job_files()
+                # The line above replaced the job-files directory; the express lane must use
+                # the new one from here on.
+                self.cycle_inputs = CycleInputs(
+                    encrypted_files=encrypted_files,
+                    default_image_digests=default_image_digests,
+                    executor_image_snapshot=executor_image_snapshot,
+                )
 
                 task_info = {}
 
@@ -577,10 +605,30 @@ class Validator:
                         self.miner_scores[miner_hotkey] = self.miner_scores.get(miner_hotkey, 0) + score
 
                     # Publish machine specs
+                    published_executor_ids: list[str] = []
                     for miner_hotkey, results in incentive.job_results.items():
                         miner_coldkey = miner_coldkeys.get(miner_hotkey)
                         if miner_coldkey:
                             await self.miner_service.publish_machine_specs(results, miner_hotkey, miner_coldkey)
+                            published_executor_ids.extend(
+                                result.executor_info.uuid
+                                for result in results
+                                if result.executor_info.uuid != FAILED_MINER_EXECUTOR_UUID
+                            )
+
+                    if settings.EXPRESS_LANE_ENABLED:
+                        # DAH-2958: everything published by a cycle is "validated" for the
+                        # express lane; only what the portal lists beyond this set is new.
+                        # Never lets a Redis blip end the cycle: the next cycle seeds again.
+                        try:
+                            await self.redis_service.mark_executors_validated(published_executor_ids)
+                        except Exception as exc:
+                            logger.error(
+                                _m(
+                                    "[sync] Failed to record validated executors for the express lane",
+                                    extra=get_extra_info({**self.default_extra, "error": str(exc)}),
+                                ),
+                            )
 
                     self.completed_cycles_since_start += 1
 
@@ -676,6 +724,13 @@ class Validator:
         try:
             await self.initiate_services()
             self.should_exit = False
+
+            if settings.EXPRESS_LANE_ENABLED and not settings.DRY_RUN:
+                # DAH-2958: ticks beside the cycle on this loop; coordination through
+                # MinerService.in_flight. Flag off: the task is never created.
+                self.express_lane_task = asyncio.create_task(
+                    self.express_lane.run(lambda: self.should_exit)
+                )
 
             while not self.should_exit:
                 await self.sync()

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -629,9 +629,11 @@ class Validator:
                     if settings.EXPRESS_LANE_ENABLED:
                         # DAH-2958: everything published by a cycle is "validated" for the
                         # express lane; only what the portal lists beyond this set is new.
-                        # Never lets a Redis blip end the cycle: the next cycle seeds again.
+                        # Never lets a Redis blip end the cycle: the next cycle seeds again, and
+                        # the wave's CYCLE_DONE claims keep the lane off those executors until then.
                         try:
                             await self.redis_service.mark_executors_validated(published_executor_ids)
+                            self.miner_service.forget_cycle_done()
                         except Exception as exc:
                             logger.error(
                                 _m(

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -60,6 +60,8 @@ class Validator:
         # DAH-2958: the current cycle's job files / digests / image snapshot, reused by the
         # express lane so its verifications are the cycle's pipeline. None before the first cycle.
         self.cycle_inputs: CycleInputs | None = None
+        # When the first cycle since start began (CycleInputs.fleet_known_since).
+        self.first_cycle_started_at: datetime | None = None
 
         self.miner_scores = {}
         # Hotkeys with at least one live executor in the last completed cycle. Rebuilt
@@ -174,9 +176,10 @@ class Validator:
         )
 
     def express_lane_cycle_inputs(self) -> CycleInputs | None:
-        """DAH-2958: the express lane runs only once a full cycle has completed since start —
-        that cycle seeds the validated-executor set with the whole fleet, so the lane never
-        mistakes a long-known executor for a new one after a deploy or restart."""
+        """DAH-2958: the express lane runs only once a full cycle has completed since start.
+        That cycle marks validated every executor of every miner that answered it; an executor
+        registered before it began whose miner failed or was offline is not in that set, so the
+        lane also skips everything registered before `fleet_known_since` (the inputs carry it)."""
         if self.completed_cycles_since_start < 1:
             return None
         return self.cycle_inputs
@@ -355,13 +358,20 @@ class Validator:
                     # cycle started, and the operator's request must survive to the next tick.
                     await self.redis_service.clear_forced_validation_cycle_request()
 
-                encrypted_files = self.file_encrypt_service.ecrypt_miner_job_files()
-                # The line above replaced the job-files directory; the express lane must use
-                # the new one from here on.
+                if self.first_cycle_started_at is None:
+                    self.first_cycle_started_at = datetime.now(UTC)
+                # A fresh job-files directory for this cycle; the ones an express verification
+                # still reads are kept (DAH-2958). The express lane uses the new one from here on.
+                encrypted_files = self.file_encrypt_service.ecrypt_miner_job_files(
+                    keep_directories=(
+                        self.express_lane.directories_in_use() if settings.EXPRESS_LANE_ENABLED else ()
+                    )
+                )
                 self.cycle_inputs = CycleInputs(
                     encrypted_files=encrypted_files,
                     default_image_digests=default_image_digests,
                     executor_image_snapshot=executor_image_snapshot,
+                    fleet_known_since=self.first_cycle_started_at,
                 )
 
                 task_info = {}

--- a/neurons/validators/src/services/file_encrypt_service.py
+++ b/neurons/validators/src/services/file_encrypt_service.py
@@ -5,6 +5,7 @@ import string
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Annotated
 
@@ -13,6 +14,9 @@ from fastapi import Depends
 from payload_models.payloads import MinerJobEnryptedFiles
 
 from services.ssh_service import SSHService
+
+# Where each cycle's job files (the frozen scrape) are written: one `cycle-*` directory per cycle.
+JOB_FILES_ROOT = Path(__file__).parent / "temp"
 
 # ORDER IS LOAD-BEARING: machine_scrape derives its encryption key from the literal key order of
 # gpu_details[0], so this list must stay an exact mirror of that dict — same members, same order.
@@ -334,12 +338,35 @@ class FileEncryptService:
         encryption_key = "".join([all_keys[key] for key in KEYS_FOR_ENCRYPTION_KEY_GENERATION])
         return all_keys, encryption_key
 
-    def ecrypt_miner_job_files(self):
+    @staticmethod
+    def fresh_job_files_directory(keep: Iterable[str] = ()) -> Path:
+        """A new, empty directory for this cycle's job files under JOB_FILES_ROOT; every earlier
+        cycle's directory is removed unless its path is in `keep`.
+
+        DAH-2958: an express verification reads the job files of the cycle that prepared them
+        (UploadFilesCheck, the scrape's binary fallback) and may still be running when the next
+        cycle starts, so the validator passes the lane's directories in use and they survive
+        until the first cycle that starts after those verifications ended.
+        """
+        root = JOB_FILES_ROOT
+        root.mkdir(exist_ok=True)
+        kept = {Path(path).resolve() for path in keep}
+        for entry in root.iterdir():
+            if entry.resolve() in kept:
+                continue
+            if entry.is_dir():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+        return Path(tempfile.mkdtemp(prefix="cycle-", dir=root))
+
+    def ecrypt_miner_job_files(self, keep_directories: Iterable[str] = ()):
         """
         Encrypts and obfuscates miner job files for secure execution.
 
         This function performs the following steps:
-        1. Clears any existing temporary directory used for storing encrypted files.
+        1. Makes a fresh directory for this cycle's files and removes the earlier cycles' directories
+           (except `keep_directories`, still read by an express verification — DAH-2958).
         2. Defines file paths for the machine scrape script and its obfuscator.
         3. Runs the obfuscator script to generate an obfuscated version of the machine scrape script.
         4. Replaces dictionary keys in the obfuscated script with randomly generated names.
@@ -348,9 +375,7 @@ class FileEncryptService:
 
         Returns: MinerJobEnryptedFiles
         """
-        tmp_directory = Path(__file__).parent / "temp"
-        if tmp_directory.exists() and tmp_directory.is_dir():
-            shutil.rmtree(tmp_directory)
+        tmp_directory = self.fresh_job_files_directory(keep_directories)
 
         # file pathes
         machine_scrape_file_path = str(

--- a/neurons/validators/src/services/matrix_validation_service.py
+++ b/neurons/validators/src/services/matrix_validation_service.py
@@ -425,7 +425,11 @@ class ValidationService:
         executor_info,
         default_extra: dict,
         machine_spec: dict,
+        vram_budget_mb: int | None = None,
     ) -> ValidationResult:
+        # vram_budget_mb (DAH-3011): size the matmul from min(card VRAM, budget) instead of the whole
+        # card. Same challenge, seal and UUID check — a wrong/absent GPU or a spoofed UUID still
+        # fails; only the "fill the card" capacity proof is deferred. None = today's full-card size.
         # DAH-2671 item 3: all-claimed-cards work-proof. Shadow (MATMUL_ALLCARDS_CHECK_ENABLED
         # without enforcement) logs timing + per-card outcome and NEVER changes the returned result;
         # enforcement fails a count lie (device-selection error / OOM / serialised aggregate
@@ -479,6 +483,8 @@ class ValidationService:
             # GpuVramPrecheck (before the rented short-circuit), so it is NOT
             # repeated here. gpu_capacity_mb is still needed to size the matmul.
             gpu_capacity_mb = self.get_gpu_memory(machine_spec)
+            if vram_budget_mb and gpu_capacity_mb:
+                gpu_capacity_mb = min(gpu_capacity_mb, vram_budget_mb)
 
             verifier_params = VerifierParams()
             verifier_params.generate()
@@ -501,6 +507,7 @@ class ValidationService:
                 **default_extra,
                 "dim_n": verifier_params.dim_n,
                 "dim_k": verifier_params.dim_k,
+                "sized_vram_mb": gpu_capacity_mb,
                 "seed": verifier_params.seed,
                 "uuid": verifier_params.uuid,
                 "cipher_text": verifier_params.cipher_text,

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -184,6 +184,10 @@ REST_SSH_REMOVE_TIMEOUT = 10  # Timeout for SSH key removal requests
 # node that actually passed validation -- nothing about this node was verified.
 MANUAL_RENTAL_FORCED_PASS_EVENT = "Executor force-passed as special manual rental (not validated)"
 
+# DAH-2958: who is verifying an executor right now (values of MinerService.in_flight).
+CYCLE_LANE = "cycle"
+EXPRESS_LANE = "express"
+
 
 class MinerService:
     def __init__(
@@ -197,6 +201,41 @@ class MinerService:
         self.task_service = task_service
         self.redis_service = redis_service
         self.attestation_service = attestation_service
+        # DAH-2958: executor uuid -> CYCLE_LANE | EXPRESS_LANE while its pipeline is running. The
+        # wave and the express lane run in this one process, so a plain dict is the whole
+        # coordination: each lane skips what the other holds. Stays empty with the flag off.
+        self.in_flight: dict[str, str] = {}
+
+    def _claim_for_cycle(
+        self, executors: list[ExecutorSSHInfo], default_extra: dict
+    ) -> list[ExecutorSSHInfo]:
+        """The wave takes every executor the miner returned, minus those the express lane is
+        verifying at this moment, so a new node's hardware tests never run twice concurrently
+        (DAH-2958). Only a never-validated executor can be held by the express lane, so the
+        scoring of every already-validated executor is untouched. Flag off: list returned as is.
+        """
+        if not settings.EXPRESS_LANE_ENABLED:
+            return executors
+        claimed: list[ExecutorSSHInfo] = []
+        for executor in executors:
+            if self.in_flight.get(executor.uuid) == EXPRESS_LANE:
+                logger.info(
+                    _m(
+                        "Executor left to the express lane this cycle",
+                        extra=get_extra_info({**default_extra, "executor_uuid": executor.uuid}),
+                    ),
+                )
+                continue
+            self.in_flight[executor.uuid] = CYCLE_LANE
+            claimed.append(executor)
+        return claimed
+
+    def _release_cycle_claims(self, executors: list[ExecutorSSHInfo]) -> None:
+        if not settings.EXPRESS_LANE_ENABLED:
+            return
+        for executor in executors:
+            if self.in_flight.get(executor.uuid) == CYCLE_LANE:
+                del self.in_flight[executor.uuid]
 
     @staticmethod
     def _normalize_public_key(public_key: bytes | str) -> str:
@@ -224,8 +263,14 @@ class MinerService:
         rented_data: RentedExecutorsResponse,
         default_docker_image_digests: dict[str, str],
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
+        executor_id: str | None = None,
     ):
-        """Request job to miner - uses REST API if configured, otherwise WebSocket."""
+        """Request job to miner - uses REST API if configured, otherwise WebSocket.
+
+        executor_id (DAH-2958): None asks the miner for every executor it has for this validator
+        (the cycle); a uuid asks for that one executor only (the express lane) — the miner already
+        filters register_pubkey on it, exactly as it does for the rental key-submit.
+        """
         if settings.USE_REST_API:
             logger.info(
                 _m(
@@ -242,6 +287,7 @@ class MinerService:
                 rented_data,
                 default_docker_image_digests,
                 executor_image_snapshot,
+                executor_id=executor_id,
             )
         else:
             logger.info(
@@ -295,6 +341,7 @@ class MinerService:
                         public_key=public_key,
                         validator_signature=self._sign_validator_pubkey(my_key, public_key, nonce=nonce_hex),
                         miner_hotkey=payload.miner_hotkey, # include miner's hotkey in the request
+                        executor_id=executor_id,
                         nonce=nonce_hex,
                     )
                 )
@@ -357,29 +404,37 @@ class MinerService:
                             payload,
                             "Miner returned zero executors in AcceptSSHKeyRequest",
                         )
-                    tasks = [
-                        asyncio.create_task(
-                            asyncio.wait_for(
-                                self.task_service.create_task(
-                                    miner_info=payload,
-                                    executor_info=executor_info,
-                                    keypair=my_key,
-                                    private_key=private_key.decode("utf-8"),
-                                    public_key=public_key.decode("utf-8"),
-                                    encrypted_files=encrypted_files,
-                                    rented_data=rented_data,
-                                    default_docker_image_digests=default_docker_image_digests,
-                                    executor_image_snapshot=executor_image_snapshot,
-                                    attestation_nonce=attestation_nonce,
-                                ),
-                                timeout=settings.JOB_TIME_OUT - 120
+                    executors = (
+                        self._claim_for_cycle(msg.executors, default_extra)
+                        if executor_id is None
+                        else msg.executors
+                    )
+                    try:
+                        tasks = [
+                            asyncio.create_task(
+                                asyncio.wait_for(
+                                    self.task_service.create_task(
+                                        miner_info=payload,
+                                        executor_info=executor_info,
+                                        keypair=my_key,
+                                        private_key=private_key.decode("utf-8"),
+                                        public_key=public_key.decode("utf-8"),
+                                        encrypted_files=encrypted_files,
+                                        rented_data=rented_data,
+                                        default_docker_image_digests=default_docker_image_digests,
+                                        executor_image_snapshot=executor_image_snapshot,
+                                        attestation_nonce=attestation_nonce,
+                                    ),
+                                    timeout=settings.JOB_TIME_OUT - 120
+                                )
                             )
-                        )
-                        for executor_info in msg.executors
-                    ]
+                            for executor_info in executors
+                        ]
 
-                    raw_results = await asyncio.gather(*tasks, return_exceptions=True)
-                    results = self._filter_task_results(msg.executors, raw_results, default_extra)
+                        raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+                    finally:
+                        self._release_cycle_claims(executors)
+                    results = self._filter_task_results(executors, raw_results, default_extra)
                     results.extend(
                         self._build_manual_rental_results(payload, rented_data, existing=results)
                     )
@@ -407,7 +462,8 @@ class MinerService:
                         await miner_client.send_model(SSHPubKeyRemoveRequest(
                             public_key=public_key,
                             validator_signature=self._sign_validator_pubkey(my_key, public_key),
-                            miner_hotkey=payload.miner_hotkey
+                            miner_hotkey=payload.miner_hotkey,
+                            executor_id=executor_id,
                         ))
                     except Exception as e:
                         logger.warning(
@@ -1878,6 +1934,7 @@ class MinerService:
         rented_data: RentedExecutorsResponse,
         default_docker_image_digests: dict[str, str],
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
+        executor_id: str | None = None,
     ):
         """REST API version of request_job_to_miner."""
         # DAH-2667: see the WebSocket path — the RoCE probe measures the cycle's remaining time
@@ -1908,6 +1965,7 @@ class MinerService:
                 public_key=public_key,
                 validator_signature=self._sign_validator_pubkey(my_key, public_key, nonce=nonce_hex),
                 miner_hotkey=payload.miner_hotkey,
+                executor_id=executor_id,
                 nonce=nonce_hex,
             )
             
@@ -1956,29 +2014,37 @@ class MinerService:
                         payload,
                         "Miner returned zero executors in AcceptSSHKeyRequest",
                     )
-                tasks = [
-                    asyncio.create_task(
-                        asyncio.wait_for(
-                            self.task_service.create_task(
-                                miner_info=payload,
-                                executor_info=executor_info,
-                                keypair=my_key,
-                                private_key=private_key.decode("utf-8"),
-                                public_key=public_key.decode("utf-8"),
-                                encrypted_files=encrypted_files,
-                                rented_data=rented_data,
-                                default_docker_image_digests=default_docker_image_digests,
-                                executor_image_snapshot=executor_image_snapshot,
-                                attestation_nonce=attestation_nonce,
-                            ),
-                            timeout=settings.JOB_TIME_OUT - 120
+                executors = (
+                    self._claim_for_cycle(msg.executors, default_extra)
+                    if executor_id is None
+                    else msg.executors
+                )
+                try:
+                    tasks = [
+                        asyncio.create_task(
+                            asyncio.wait_for(
+                                self.task_service.create_task(
+                                    miner_info=payload,
+                                    executor_info=executor_info,
+                                    keypair=my_key,
+                                    private_key=private_key.decode("utf-8"),
+                                    public_key=public_key.decode("utf-8"),
+                                    encrypted_files=encrypted_files,
+                                    rented_data=rented_data,
+                                    default_docker_image_digests=default_docker_image_digests,
+                                    executor_image_snapshot=executor_image_snapshot,
+                                    attestation_nonce=attestation_nonce,
+                                ),
+                                timeout=settings.JOB_TIME_OUT - 120
+                            )
                         )
-                    )
-                    for executor_info in msg.executors
-                ]
+                        for executor_info in executors
+                    ]
 
-                raw_results = await asyncio.gather(*tasks, return_exceptions=True)
-                results = self._filter_task_results(msg.executors, raw_results, default_extra)
+                    raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+                finally:
+                    self._release_cycle_claims(executors)
+                results = self._filter_task_results(executors, raw_results, default_extra)
                 results.extend(
                     self._build_manual_rental_results(payload, rented_data, existing=results)
                 )
@@ -2009,7 +2075,7 @@ class MinerService:
                         my_key=my_key,
                         public_key=public_key,
                         miner_hotkey=payload.miner_hotkey,
-                        executor_id=None,
+                        executor_id=executor_id,
                         log_extra=default_extra,
                     )
 

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -230,6 +230,29 @@ class MinerService:
             claimed.append(executor)
         return claimed
 
+    def _only_requested(
+        self, executors: list[ExecutorSSHInfo], executor_id: str, default_extra: dict
+    ) -> list[ExecutorSSHInfo]:
+        """The express lane asked the miner for one executor; run the pipeline on that one only.
+        A miner that answers with more (an old miner ignoring the filter, or a misbehaving one)
+        would otherwise get every extra executor verified here, concurrently with the wave that
+        holds its claim, and the extra results are discarded by the caller anyway (DAH-2958)."""
+        requested = [executor for executor in executors if executor.uuid == executor_id]
+        if len(requested) != len(executors):
+            logger.warning(
+                _m(
+                    "Miner returned executors the express lane did not ask for; ignoring them",
+                    extra=get_extra_info(
+                        {
+                            **default_extra,
+                            "executor_uuid": executor_id,
+                            "ignored": [e.uuid for e in executors if e.uuid != executor_id],
+                        }
+                    ),
+                )
+            )
+        return requested
+
     def _release_cycle_claims(self, executors: list[ExecutorSSHInfo]) -> None:
         if not settings.EXPRESS_LANE_ENABLED:
             return
@@ -407,7 +430,7 @@ class MinerService:
                     executors = (
                         self._claim_for_cycle(msg.executors, default_extra)
                         if executor_id is None
-                        else msg.executors
+                        else self._only_requested(msg.executors, executor_id, default_extra)
                     )
                     try:
                         tasks = [
@@ -2017,7 +2040,7 @@ class MinerService:
                 executors = (
                     self._claim_for_cycle(msg.executors, default_extra)
                     if executor_id is None
-                    else msg.executors
+                    else self._only_requested(msg.executors, executor_id, default_extra)
                 )
                 try:
                     tasks = [

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -187,6 +187,10 @@ MANUAL_RENTAL_FORCED_PASS_EVENT = "Executor force-passed as special manual renta
 # DAH-2958: who is verifying an executor right now (values of MinerService.in_flight).
 CYCLE_LANE = "cycle"
 EXPRESS_LANE = "express"
+# The wave verified it this cycle and its result is not yet in the validated set (the cycle
+# seeds that set once, after scoring and publishing — minutes after the miner's wave returned).
+# Kept in in_flight so the express lane does not run the same node a second time meanwhile.
+CYCLE_DONE = "cycle-done"
 
 
 class MinerService:
@@ -201,9 +205,10 @@ class MinerService:
         self.task_service = task_service
         self.redis_service = redis_service
         self.attestation_service = attestation_service
-        # DAH-2958: executor uuid -> CYCLE_LANE | EXPRESS_LANE while its pipeline is running. The
-        # wave and the express lane run in this one process, so a plain dict is the whole
-        # coordination: each lane skips what the other holds. Stays empty with the flag off.
+        # DAH-2958: executor uuid -> CYCLE_LANE | EXPRESS_LANE while its pipeline is running, then
+        # CYCLE_DONE until the cycle's publish is recorded. The wave and the express lane run in
+        # this one process, so a plain dict is the whole coordination: each lane skips what the
+        # other holds. Stays empty with the flag off.
         self.in_flight: dict[str, str] = {}
 
     def _claim_for_cycle(
@@ -255,11 +260,18 @@ class MinerService:
         return requested
 
     def _release_cycle_claims(self, executors: list[ExecutorSSHInfo]) -> None:
+        """The wave is done with these executors; they stay in in_flight as CYCLE_DONE until the
+        cycle has seeded the validated set (forget_cycle_done), so the lane keeps skipping them."""
         if not settings.EXPRESS_LANE_ENABLED:
             return
         for executor in executors:
             if self.in_flight.get(executor.uuid) == CYCLE_LANE:
-                del self.in_flight[executor.uuid]
+                self.in_flight[executor.uuid] = CYCLE_DONE
+
+    def forget_cycle_done(self) -> None:
+        """Called by the cycle right after it recorded its published executors as validated."""
+        for executor_id in [e for e, lane in self.in_flight.items() if lane == CYCLE_DONE]:
+            del self.in_flight[executor_id]
 
     @staticmethod
     def _normalize_public_key(public_key: bytes | str) -> str:

--- a/neurons/validators/src/services/miner_service.py
+++ b/neurons/validators/src/services/miner_service.py
@@ -211,8 +211,9 @@ class MinerService:
     ) -> list[ExecutorSSHInfo]:
         """The wave takes every executor the miner returned, minus those the express lane is
         verifying at this moment, so a new node's hardware tests never run twice concurrently
-        (DAH-2958). Only a never-validated executor can be held by the express lane, so the
-        scoring of every already-validated executor is untouched. Flag off: list returned as is.
+        (DAH-2958). The lane holds only executors registered after the first cycle since start
+        that no cycle has published yet, so a long-known executor's scoring is untouched.
+        Flag off: list returned as is.
         """
         if not settings.EXPRESS_LANE_ENABLED:
             return executors
@@ -287,12 +288,16 @@ class MinerService:
         default_docker_image_digests: dict[str, str],
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
         executor_id: str | None = None,
+        first_pass: bool = False,
     ):
         """Request job to miner - uses REST API if configured, otherwise WebSocket.
 
         executor_id (DAH-2958): None asks the miner for every executor it has for this validator
         (the cycle); a uuid asks for that one executor only (the express lane) — the miner already
         filters register_pubkey on it, exactly as it does for the rental key-submit.
+        first_pass (DAH-3011): this is the executor's first, unscored verification; handed to
+        TaskService.create_task, where FIRST_PASS_FAST_PATH_ENABLED decides whether the probes
+        shrink. The cycle never sets it.
         """
         if settings.USE_REST_API:
             logger.info(
@@ -311,6 +316,7 @@ class MinerService:
                 default_docker_image_digests,
                 executor_image_snapshot,
                 executor_id=executor_id,
+                first_pass=first_pass,
             )
         else:
             logger.info(
@@ -447,6 +453,7 @@ class MinerService:
                                         default_docker_image_digests=default_docker_image_digests,
                                         executor_image_snapshot=executor_image_snapshot,
                                         attestation_nonce=attestation_nonce,
+                                        first_pass=first_pass,
                                     ),
                                     timeout=settings.JOB_TIME_OUT - 120
                                 )
@@ -1958,6 +1965,7 @@ class MinerService:
         default_docker_image_digests: dict[str, str],
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
         executor_id: str | None = None,
+        first_pass: bool = False,
     ):
         """REST API version of request_job_to_miner."""
         # DAH-2667: see the WebSocket path — the RoCE probe measures the cycle's remaining time
@@ -2057,6 +2065,7 @@ class MinerService:
                                     default_docker_image_digests=default_docker_image_digests,
                                     executor_image_snapshot=executor_image_snapshot,
                                     attestation_nonce=attestation_nonce,
+                                    first_pass=first_pass,
                                 ),
                                 timeout=settings.JOB_TIME_OUT - 120
                             )

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -38,6 +38,10 @@ FORCED_VALIDATION_CYCLE_KEY = "forced_validation_cycle"
 # One scheduled window is 75 blocks, about 15 minutes. A request older than a couple of sync
 # ticks is stale: the operator has moved on, or the scheduled cycle covered them anyway.
 FORCED_VALIDATION_CYCLE_TTL_SECONDS = 60
+# DAH-2958: every executor uuid this validator has ever published a spec for. The express lane
+# treats anything in the portal snapshot that is NOT here as never validated. Seeded by every
+# cycle's publish, so one completed cycle after deploy is enough to know the whole fleet.
+EXPRESS_LANE_VALIDATED_SET = "express_lane_validated_executors"
 
 # Distributed lock settings
 EXECUTOR_LOCK_TIMEOUT = 30  # TTL for lock auto-release (seconds)
@@ -153,6 +157,16 @@ class RedisService:
             await self.redis.set(
                 FORCED_VALIDATION_CYCLE_KEY, "1", ex=FORCED_VALIDATION_CYCLE_TTL_SECONDS
             )
+
+    async def mark_executors_validated(self, executor_ids: list[str]) -> None:
+        """DAH-2958: remember that a spec was published for these executors (one round-trip)."""
+        if executor_ids:
+            async with self.lock:
+                await self.redis.sadd(EXPRESS_LANE_VALIDATED_SET, *executor_ids)
+
+    async def get_validated_executors(self) -> set[str]:
+        members = await self.smembers(EXPRESS_LANE_VALIDATED_SET)
+        return {m.decode() if isinstance(m, bytes) else m for m in members}
 
     async def is_forced_validation_cycle_requested(self) -> bool:
         return await self.get(FORCED_VALIDATION_CYCLE_KEY) is not None

--- a/neurons/validators/src/services/task/checks/capability.py
+++ b/neurons/validators/src/services/task/checks/capability.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+from core.config import settings
+
 from ..messages import CapabilityMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 
@@ -39,6 +41,11 @@ class CapabilityCheck:
 
         validation_service = ctx.services.validation
 
+        # DAH-3011: a first, unscored verification sizes the matmul from a VRAM budget instead of
+        # the whole card (same challenge/seal/UUID check). The keyword is only passed on that path
+        # so the scored call is byte-for-byte today's.
+        sizing = {"vram_budget_mb": settings.FIRST_PASS_MATMUL_VRAM_MB} if ctx.config.first_pass else {}
+
         result = None
         failure_reason = None
         try:
@@ -47,16 +54,20 @@ class CapabilityCheck:
                 executor_info=ctx.executor,
                 default_extra=ctx.default_extra,
                 machine_spec=specs,
+                **sizing,
             )
         except Exception as exc:
             failure_reason = str(exc)
 
         if result and result.success:
+            what: dict = {"metrics": result.metrics}
+            if sizing:
+                what["first_pass_vram_budget_mb"] = sizing["vram_budget_mb"]
             event = render_message(
                 Msg.VERIFY_OK,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={"metrics": result.metrics},
+                what=what,
             )
             # Carry FP32 TFLOPS metrics into pipeline state so ResultHandler can nest them
             # in the published specs. Only on success and only when present (fail-safe:

--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -4,6 +4,8 @@ from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
+from core.config import settings
+
 from ..messages import VerifyXMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 from .network_ema import compute_ema
@@ -66,11 +68,18 @@ class VerifyXCheck:
                 updates={"state": replace(ctx.state, specs=updated_specs)},
             )
 
+        # DAH-3011: a first, unscored verification writes less RAM/disk (the measurements are still
+        # taken and published). The keyword is only passed on that path so the scored call is
+        # byte-for-byte today's.
+        sizing = (
+            {"challenge_config_overrides": _first_pass_challenge_config()} if ctx.config.first_pass else {}
+        )
         result = await verifyx_service.validate_verifyx_and_process_job(
             shell=ctx.services.shell,
             executor_info=ctx.executor,
             default_extra=ctx.default_extra,
             machine_spec=specs,
+            **sizing,
         )
 
         # Extract errors with clear priority: data.errors > result.error
@@ -135,10 +144,31 @@ class VerifyXCheck:
             )
             if errors:
                 event.what_we_saw["errors"] = errors
+            if sizing:
+                event.what_we_saw["first_pass_challenge_config"] = sizing["challenge_config_overrides"]
 
             updated_state = replace(ctx.state, specs=updated_specs)
 
             ema_download = updated_specs["network"]["ema_verifyx_download_speed"]
+            never_measured = prev_ema is None or prev_ema.ema_verifyx_download_speed is None
+            if ema_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS and ctx.config.first_pass and never_measured:
+                # DAH-3011: the first pass is never scored, and a fresh node's single cold sample fails
+                # this gate 14 % of the time (DAH-2959). Publish the raw sample, leave the EMA unseeded
+                # so the first SCORED cycle bootstraps from a warm sample and enforces the gate, and say
+                # so on the event. A known host, or any scored cycle, never takes this branch.
+                deferred_network = {
+                    key: value
+                    for key, value in updated_specs["network"].items()
+                    if key not in ("ema_verifyx_download_speed", "ema_verifyx_upload_speed")
+                }
+                updated_state = replace(
+                    ctx.state, specs={**updated_specs, "network": deferred_network}
+                )
+                event.what_we_saw["bandwidth_gate"] = "deferred_to_first_scored_cycle"
+                event.what_we_saw["first_sample_download_speed_mbps"] = download_speed
+                event.what_we_saw["min_download_speed_mbps"] = MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS
+                return CheckResult(passed=True, event=event, updates={"state": updated_state})
+
             if ema_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS:
                 slow_event = render_message(
                     Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW,
@@ -184,6 +214,13 @@ _FAILURE_TEMPLATE_BY_CLASS = {
     "EMPTY_RESPONSE": Msg.VERIFY_FAILED_EMPTY_RESPONSE,
     "CIPHER_REJECTED": Msg.VERIFY_FAILED_CIPHER_REJECTED,
 }
+
+
+def _first_pass_challenge_config() -> dict[str, int]:
+    return {
+        "memory_max_test_gb": settings.FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB,
+        "storage_throughput_test_gb": settings.FIRST_PASS_VERIFYX_STORAGE_TEST_GB,
+    }
 
 
 def _get_filler_only_container(ctx: Context) -> str | None:

--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
 from core.config import settings
+from core.utils import _m, get_extra_info
 
 from ..messages import VerifyXMessages as Msg, render_message
 from ..pipeline import CheckResult, Context
 from .network_ema import compute_ema
+
+logger = logging.getLogger(__name__)
 
 MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS = 100.0
 
@@ -82,13 +86,48 @@ class VerifyXCheck:
             **sizing,
         )
 
-        # Extract errors with clear priority: data.errors > result.error
-        errors = self._extract_errors(result)
-
         prev_ema = (
             ctx.state.rented_data.network_ema.get(ctx.executor.uuid)
             if ctx.state.rented_data else None
         )
+
+        cold_sample_retry: dict[str, Any] | None = None
+        if _is_cold_sample_below_gate(ctx, result, prev_ema):
+            # DAH-2959: a node's first sample decides its first cycle on its own (the EMA bootstraps
+            # from it). 11 of 80 fresh nodes (2–5 Sep) measured 32–88 Mbps on that one sample — one
+            # single-stream 260–500 MB CDN object, cold (the scrape's own speedtest read 0.7–1.7 Gbps
+            # on two of the traced hosts, 104 Mbps on the third whose link the executor's on-boot
+            # template pre-pull was sharing) — and passed the next cycle at 205–760 Mbps. One more
+            # sample inside the same task costs at most one VerifyX run; the failure costs the
+            # provider a whole cycle. Known hosts (any prior EMA) are not retried, and the gate is
+            # unchanged: one of the two samples must clear it.
+            retry = await verifyx_service.validate_verifyx_and_process_job(
+                shell=ctx.services.shell,
+                executor_info=ctx.executor,
+                default_extra=ctx.default_extra,
+                machine_spec=specs,
+            )
+            first_speed = _download_speed(result)
+            retry_speed = _download_speed(retry)
+            use_retry = retry.data is not None and bool(retry.data.get("success")) and (
+                retry_speed or 0.0
+            ) > (first_speed or 0.0)
+            cold_sample_retry = {
+                "first_download_speed_mbps": first_speed,
+                "retry_download_speed_mbps": retry_speed,
+                "used": "retry" if use_retry else "first",
+            }
+            logger.info(
+                _m(
+                    "VerifyX cold first sample below the gate, re-measured once",
+                    extra=get_extra_info({**ctx.default_extra, **cold_sample_retry}),
+                )
+            )
+            if use_retry:
+                result = retry
+
+        # Extract errors with clear priority: data.errors > result.error
+        errors = self._extract_errors(result)
 
         if result.data and result.data.get("success"):
             base_specs = ctx.state.specs
@@ -146,6 +185,8 @@ class VerifyXCheck:
                 event.what_we_saw["errors"] = errors
             if sizing:
                 event.what_we_saw["first_pass_challenge_config"] = sizing["challenge_config_overrides"]
+            if cold_sample_retry:
+                event.what_we_saw["cold_sample_retry"] = cold_sample_retry
 
             updated_state = replace(ctx.state, specs=updated_specs)
 
@@ -179,6 +220,8 @@ class VerifyXCheck:
                         "min_download_speed_mbps": MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS,
                     },
                 )
+                if cold_sample_retry:
+                    slow_event.what_we_saw["cold_sample_retry"] = cold_sample_retry
                 return CheckResult(passed=False, event=slow_event, updates={"state": updated_state})
 
             return CheckResult(
@@ -221,6 +264,29 @@ def _first_pass_challenge_config() -> dict[str, int]:
         "memory_max_test_gb": settings.FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB,
         "storage_throughput_test_gb": settings.FIRST_PASS_VERIFYX_STORAGE_TEST_GB,
     }
+def _download_speed(result) -> float | None:
+    if not result.data:
+        return None
+    return (result.data.get("network") or {}).get("download_speed")
+
+
+def _is_cold_sample_below_gate(ctx: Context, result, prev_ema) -> bool:
+    """The one case DAH-2959 re-measures: a never-measured executor whose probe otherwise passed
+    but whose single download sample would fail the EMA gate on its own.
+
+    `rented_data` present is required — without the backend's answer every executor looks
+    never-measured, and a backend blip must not double VerifyX for the whole fleet.
+    """
+    if not settings.VERIFYX_COLD_SAMPLE_RETRY_ENABLED:
+        return False
+    if ctx.state.rented_data is None:
+        return False
+    if prev_ema is not None and prev_ema.ema_verifyx_download_speed is not None:
+        return False
+    if not result.data or not result.data.get("success"):
+        return False
+    speed = _download_speed(result)
+    return speed is None or speed < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS
 
 
 def _get_filler_only_container(ctx: Context) -> str | None:

--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -106,6 +106,7 @@ class VerifyXCheck:
                 executor_info=ctx.executor,
                 default_extra=ctx.default_extra,
                 machine_spec=specs,
+                **sizing,
             )
             first_speed = _download_speed(result)
             retry_speed = _download_speed(retry)
@@ -264,6 +265,8 @@ def _first_pass_challenge_config() -> dict[str, int]:
         "memory_max_test_gb": settings.FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB,
         "storage_throughput_test_gb": settings.FIRST_PASS_VERIFYX_STORAGE_TEST_GB,
     }
+
+
 def _download_speed(result) -> float | None:
     if not result.data:
         return None

--- a/neurons/validators/src/services/task/checks/verifyx.py
+++ b/neurons/validators/src/services/task/checks/verifyx.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import replace
+from dataclasses import asdict, dataclass, replace
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from core.config import settings
 from core.utils import _m, get_extra_info
@@ -15,6 +15,18 @@ from .network_ema import compute_ema
 logger = logging.getLogger(__name__)
 
 MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS = 100.0
+
+
+@dataclass(frozen=True)
+class ColdSampleRetry:
+    """DAH-2959: a never-measured node's two download samples and the one the check kept.
+
+    Attached to the event with `asdict`, so it serializes like the rest of `what_we_saw`.
+    """
+
+    first_download_speed_mbps: float | None
+    retry_download_speed_mbps: float | None
+    used: Literal["first", "retry"]
 
 
 class VerifyXCheck:
@@ -76,7 +88,9 @@ class VerifyXCheck:
         # taken and published). The keyword is only passed on that path so the scored call is
         # byte-for-byte today's.
         sizing = (
-            {"challenge_config_overrides": _first_pass_challenge_config()} if ctx.config.first_pass else {}
+            {"challenge_config_overrides": _first_pass_challenge_config()}
+            if ctx.config.first_pass
+            else {}
         )
         result = await verifyx_service.validate_verifyx_and_process_job(
             shell=ctx.services.shell,
@@ -88,10 +102,11 @@ class VerifyXCheck:
 
         prev_ema = (
             ctx.state.rented_data.network_ema.get(ctx.executor.uuid)
-            if ctx.state.rented_data else None
+            if ctx.state.rented_data
+            else None
         )
 
-        cold_sample_retry: dict[str, Any] | None = None
+        cold_sample_retry: ColdSampleRetry | None = None
         if _is_cold_sample_below_gate(ctx, result, prev_ema):
             # DAH-2959: a node's first sample decides its first cycle on its own (the EMA bootstraps
             # from it). 11 of 80 fresh nodes (2–5 Sep) measured 32–88 Mbps on that one sample — one
@@ -110,18 +125,20 @@ class VerifyXCheck:
             )
             first_speed = _download_speed(result)
             retry_speed = _download_speed(retry)
-            use_retry = retry.data is not None and bool(retry.data.get("success")) and (
-                retry_speed or 0.0
-            ) > (first_speed or 0.0)
-            cold_sample_retry = {
-                "first_download_speed_mbps": first_speed,
-                "retry_download_speed_mbps": retry_speed,
-                "used": "retry" if use_retry else "first",
-            }
+            use_retry = (
+                retry.data is not None
+                and bool(retry.data.get("success"))
+                and (retry_speed or 0.0) > (first_speed or 0.0)
+            )
+            cold_sample_retry = ColdSampleRetry(
+                first_download_speed_mbps=first_speed,
+                retry_download_speed_mbps=retry_speed,
+                used="retry" if use_retry else "first",
+            )
             logger.info(
                 _m(
                     "VerifyX cold first sample below the gate, re-measured once",
-                    extra=get_extra_info({**ctx.default_extra, **cold_sample_retry}),
+                    extra=get_extra_info({**ctx.default_extra, **asdict(cold_sample_retry)}),
                 )
             )
             if use_retry:
@@ -185,15 +202,21 @@ class VerifyXCheck:
             if errors:
                 event.what_we_saw["errors"] = errors
             if sizing:
-                event.what_we_saw["first_pass_challenge_config"] = sizing["challenge_config_overrides"]
-            if cold_sample_retry:
-                event.what_we_saw["cold_sample_retry"] = cold_sample_retry
+                event.what_we_saw["first_pass_challenge_config"] = sizing[
+                    "challenge_config_overrides"
+                ]
+            if cold_sample_retry is not None:
+                event.what_we_saw["cold_sample_retry"] = asdict(cold_sample_retry)
 
             updated_state = replace(ctx.state, specs=updated_specs)
 
             ema_download = updated_specs["network"]["ema_verifyx_download_speed"]
             never_measured = prev_ema is None or prev_ema.ema_verifyx_download_speed is None
-            if ema_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS and ctx.config.first_pass and never_measured:
+            if (
+                ema_download < MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS
+                and ctx.config.first_pass
+                and never_measured
+            ):
                 # DAH-3011: the first pass is never scored, and a fresh node's single cold sample fails
                 # this gate 14 % of the time (DAH-2959). Publish the raw sample, leave the EMA unseeded
                 # so the first SCORED cycle bootstraps from a warm sample and enforces the gate, and say
@@ -221,8 +244,8 @@ class VerifyXCheck:
                         "min_download_speed_mbps": MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS,
                     },
                 )
-                if cold_sample_retry:
-                    slow_event.what_we_saw["cold_sample_retry"] = cold_sample_retry
+                if cold_sample_retry is not None:
+                    slow_event.what_we_saw["cold_sample_retry"] = asdict(cold_sample_retry)
                 return CheckResult(passed=False, event=slow_event, updates={"state": updated_state})
 
             return CheckResult(

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -89,6 +89,11 @@ class ContextConfig:
     # DAH-2794: obfuscated scrape source, piped to the executor's interpreter over stdin.
     # None => the legacy path, where the scrape is a binary uploaded by UploadFilesCheck.
     machine_scrape_source: Optional[str] = None
+    # DAH-3011: True only for a never-validated executor's first, unscored verification AND with
+    # FIRST_PASS_FAST_PATH_ENABLED on (resolved in PipelineFactory.build_context). The capability
+    # matmul and VerifyX right-size their probes and the bandwidth gate is deferred to the first
+    # scored cycle; every other check is the same.
+    first_pass: bool = False
 
 
 @dataclass(frozen=True)

--- a/neurons/validators/src/services/task/pipeline_factory.py
+++ b/neurons/validators/src/services/task/pipeline_factory.py
@@ -143,6 +143,7 @@ class PipelineFactory:
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
         tdx_attestation_passed: bool = False,
         gpu_attestation_passed: bool | None = None,
+        first_pass: bool = False,
     ) -> Context:
         """Build the base validation context with all configuration.
 
@@ -156,6 +157,8 @@ class PipelineFactory:
             encrypted_files: Encrypted validation files
             tdx_attestation_passed: Whether TDX attestation passed
             gpu_attestation_passed: NVIDIA CC GPU attestation outcome (None = not performed)
+            first_pass: the executor's first, unscored verification (DAH-3011); takes effect
+                only with settings.FIRST_PASS_FAST_PATH_ENABLED
 
         Returns:
             Configured Context ready for pipeline execution
@@ -243,6 +246,7 @@ class PipelineFactory:
                 port_private_key=private_key,
                 port_public_key=public_key,
                 job_batch_id=miner_info.job_batch_id,
+                first_pass=first_pass and settings.FIRST_PASS_FAST_PATH_ENABLED,
             ),
             state=ContextState(
                 upload_local_dir=encrypted_files.tmp_directory,

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -69,8 +69,13 @@ class TaskService:
         default_docker_image_digests: dict[str, str],
         executor_image_snapshot: ExpectedImageSnapshot | None = None,
         attestation_nonce: AttestationNonce | None = None,
+        first_pass: bool = False,
     ):
-        """New pipeline-based validation task implementation."""
+        """New pipeline-based validation task implementation.
+
+        `first_pass` (DAH-3011): the caller knows this is the executor's first, unscored verification
+        (the express lane, DAH-2958). The wave never sets it.
+        """
         attestation_digest = None
         tee_type = None
         attestation_passed = False
@@ -127,6 +132,7 @@ class TaskService:
                     executor_image_snapshot=executor_image_snapshot,
                     tdx_attestation_passed=attestation_passed,
                     gpu_attestation_passed=gpu_attestation_passed,
+                    first_pass=first_pass,
                 )
 
                 # Build and run validation pipeline

--- a/neurons/validators/src/services/verifyx_validation_service.py
+++ b/neurons/validators/src/services/verifyx_validation_service.py
@@ -152,7 +152,10 @@ class VerifyXValidationService:
         executor_info,
         default_extra: dict,
         machine_spec: dict,
+        challenge_config_overrides: dict | None = None,
     ):
+        # challenge_config_overrides (DAH-3011): keys of the challenge `config` block to replace for
+        # this run — a first, unscored verification writes less RAM/disk. None = today's config.
         try:
             # Verify checksum before proceeding with validation
             local_checksum = sha256_from_path(self.lib_name)
@@ -171,18 +174,21 @@ class VerifyXValidationService:
             seed = random.getrandbits(64)
             verifyx_validator = VerifyXValidator(self.lib_name, seed)
 
+            challenge_config = {
+                "memory_allocation_percentage": settings.verifyx.MEMORY_ALLOCATION_PERCENTAGE,
+                "memory_min_test_gb": settings.verifyx.MEMORY_MIN_TEST_GB,
+                "memory_max_test_gb": settings.verifyx.MEMORY_MAX_TEST_GB,
+                "storage_min_available_gb": settings.verifyx.STORAGE_MIN_AVAILABLE_GB,
+                "storage_throughput_test_gb": settings.verifyx.STORAGE_THROUGHPUT_TEST_GB,
+                "network_timeout_seconds": settings.verifyx.NETWORK_TIMEOUT_SECONDS,
+                "enable_xet_challenge": settings.verifyx.ENABLE_XET_CHALLENGE,
+            }
+            if challenge_config_overrides:
+                challenge_config.update(challenge_config_overrides)
             challenge_input = {
                 "seed": seed,
                 "machine_info": gpu_info,
-                "config": {
-                    "memory_allocation_percentage": settings.verifyx.MEMORY_ALLOCATION_PERCENTAGE,
-                    "memory_min_test_gb": settings.verifyx.MEMORY_MIN_TEST_GB,
-                    "memory_max_test_gb": settings.verifyx.MEMORY_MAX_TEST_GB,
-                    "storage_min_available_gb": settings.verifyx.STORAGE_MIN_AVAILABLE_GB,
-                    "storage_throughput_test_gb": settings.verifyx.STORAGE_THROUGHPUT_TEST_GB,
-                    "network_timeout_seconds": settings.verifyx.NETWORK_TIMEOUT_SECONDS,
-                    "enable_xet_challenge": settings.verifyx.ENABLE_XET_CHALLENGE,
-                },
+                "config": challenge_config,
             }
 
             cipher_text = verifyx_validator.generate_challenge(challenge_input)

--- a/neurons/validators/tests/test_express_lane.py
+++ b/neurons/validators/tests/test_express_lane.py
@@ -1,0 +1,514 @@
+"""DAH-2958: the express lane verifies never-validated executors ahead of the 15-min cycle.
+
+Flag off: request_job_to_miner asks the miner for every executor (executor_id=None) and claims
+nothing, exactly as before. Flag on: a portal executor this validator never published is verified
+alone with the cycle's own pipeline inputs and published spec-only; the wave and the lane never
+run on one executor at the same time; the in-flight caps bound a registration flood; an executor
+the miner does not return is retried a bounded number of times and then left to the cycle.
+"""
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
+
+import bittensor
+import pytest
+from fakeredis.aioredis import FakeRedis
+
+from clients.validator_portal_api import PortalExecutor, ValidatorPortalAPI, portal_miner_auth_blob
+from core.express_lane import EXPRESS_PUBLISHED_EVENT, MAX_ATTEMPTS, CycleInputs, ExpressLane
+from datura.requests.miner_requests import AcceptSSHKeyRequest, ExecutorSSHInfo
+from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
+from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.miner_service import CYCLE_LANE, EXPRESS_LANE, MinerService
+from services.redis_service import EXPRESS_LANE_VALIDATED_SET, RedisService
+from services.task.models import JobResult
+
+VALIDATOR_HOTKEY = "validator-hotkey"
+
+
+@dataclass
+class _AxonInfo:
+    ip: str = "192.0.2.10"
+    port: int = 8091
+
+
+@dataclass
+class _Neuron:
+    hotkey: str
+    coldkey: str = "miner-coldkey"
+    axon_info: _AxonInfo = field(default_factory=_AxonInfo)
+
+
+def _executor_info(executor_id: str) -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=executor_id,
+        address="198.51.100.7",
+        port=8001,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python3",
+        root_dir="/root/app",
+    )
+
+
+def _job_result(executor_id: str, score: float = 1.0) -> JobResult:
+    return JobResult(
+        spec={"gpu": {"count": 1}},
+        executor_info=_executor_info(executor_id),
+        score=score,
+        job_score=score,
+        job_batch_id="2026-09-06 16:40:00",
+        log_status="info",
+        log_text="Validation task completed",
+        gpu_model="NVIDIA H100 80GB HBM3",
+        gpu_count=1,
+    )
+
+
+def _portal_executor(executor_id: str, registered_seconds_ago: float = 40.0, validator: str = VALIDATOR_HOTKEY):
+    return PortalExecutor(
+        id=executor_id,
+        validator_hotkey=validator,
+        created_at=datetime.now(UTC) - timedelta(seconds=registered_seconds_ago),
+    )
+
+
+def _cycle_inputs() -> CycleInputs:
+    return CycleInputs(
+        encrypted_files=MinerJobEnryptedFiles(
+            encrypt_key="k",
+            all_keys={},
+            tmp_directory="/tmp/x",
+            machine_scrape_file_name="scrape",
+            machine_scrape_source="",
+        ),
+        default_image_digests={},
+        executor_image_snapshot=None,
+    )
+
+
+def _redis_service() -> RedisService:
+    service = RedisService.__new__(RedisService)
+    service.redis = FakeRedis()
+    service.lock = asyncio.Lock()
+    return service
+
+
+@pytest.fixture
+def wallet(mocker):
+    my_key = Mock(ss58_address=VALIDATOR_HOTKEY)
+    my_key.sign.return_value = b"\x01\x02\x03"
+    mocker.patch(
+        "core.config.Settings.get_bittensor_wallet",
+        return_value=Mock(get_hotkey=Mock(return_value=my_key)),
+    )
+    return my_key
+
+
+@pytest.fixture
+def rest_miner_service(mocker, wallet, monkeypatch):
+    """A MinerService whose REST boundary is mocked: the miner accepts the key and returns the
+    executors the test hands it; every executor task resolves to a passing JobResult."""
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "USE_REST_API", True)
+    ssh_service = mocker.Mock()
+    ssh_service.generate_ssh_key.return_value = (b"---PRIV---", b"ssh-ed25519 pub")
+    ssh_service.decrypt_payload.return_value = "---DECRYPTED-PRIV---"
+    task_service = mocker.Mock()
+
+    async def create_task(miner_info, executor_info, **_):
+        return _job_result(executor_info.uuid)
+
+    task_service.create_task = AsyncMock(side_effect=create_task)
+    service = MinerService(
+        ssh_service=ssh_service,
+        task_service=task_service,
+        redis_service=mocker.AsyncMock(),
+        attestation_service=Mock(maybe_issue_nonce=AsyncMock(return_value=None)),
+    )
+    mocker.patch("services.miner_service.measure_and_attach", AsyncMock())
+
+    def miner_returns(*executor_ids: str):
+        service.rest_calls = []
+
+        async def _make_rest_request(method, url, json_data, headers, timeout, log_extra, operation_name):
+            service.rest_calls.append((url.rsplit("/", 1)[-1], json_data))
+            if url.endswith("ssh-pubkey-submit"):
+                return 200, AcceptSSHKeyRequest(
+                    executors=[_executor_info(e) for e in executor_ids]
+                ).model_dump(mode="json")
+            return 200, {"message_type": "SSHKeyRemoved"}
+
+        service._make_rest_request = _make_rest_request
+
+    service.miner_returns = miner_returns
+    return service
+
+
+def _payload() -> MinerJobRequestPayload:
+    return MinerJobRequestPayload(
+        job_batch_id="2026-09-06 16:40:00",
+        miner_hotkey="miner-a",
+        miner_coldkey="miner-coldkey",
+        miner_address="192.0.2.10",
+        miner_port=8091,
+    )
+
+
+async def _request(service: MinerService, **kwargs):
+    return await service.request_job_to_miner(
+        payload=_payload(),
+        encrypted_files=_cycle_inputs().encrypted_files,
+        rented_data=RentedExecutorsResponse(executors={}),
+        default_docker_image_digests={},
+        **kwargs,
+    )
+
+
+# --- MinerService: what the miner is asked for, and who holds an executor -----------------
+
+
+@pytest.mark.asyncio
+async def test_flag_off_the_cycle_asks_for_every_executor_and_claims_nothing(rest_miner_service, monkeypatch):
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", False)
+    first, second = str(uuid4()), str(uuid4())
+    rest_miner_service.miner_returns(first, second)
+
+    job = await _request(rest_miner_service)
+
+    submit = dict(rest_miner_service.rest_calls)["ssh-pubkey-submit"]
+    assert submit["executor_id"] is None
+    assert {r.executor_info.uuid for r in job["results"]} == {first, second}
+    assert rest_miner_service.in_flight == {}
+
+
+@pytest.mark.asyncio
+async def test_the_express_lane_asks_the_miner_for_one_executor(rest_miner_service, monkeypatch):
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+    new_node = str(uuid4())
+    rest_miner_service.in_flight[new_node] = EXPRESS_LANE
+    rest_miner_service.miner_returns(new_node)
+
+    job = await _request(rest_miner_service, executor_id=new_node)
+
+    calls = dict(rest_miner_service.rest_calls)
+    assert calls["ssh-pubkey-submit"]["executor_id"] == new_node
+    assert calls["ssh-pubkey-remove"]["executor_id"] == new_node
+    assert [r.executor_info.uuid for r in job["results"]] == [new_node]
+    # the express lane, not the wave, owns the claim: the request must not touch it
+    assert rest_miner_service.in_flight == {new_node: EXPRESS_LANE}
+
+
+@pytest.mark.asyncio
+async def test_the_wave_skips_an_executor_the_express_lane_holds_and_releases_its_own(
+    rest_miner_service, monkeypatch, caplog
+):
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+    on_express, known = str(uuid4()), str(uuid4())
+    rest_miner_service.in_flight[on_express] = EXPRESS_LANE
+    rest_miner_service.miner_returns(on_express, known)
+    seen_during_wave = {}
+
+    async def create_task(miner_info, executor_info, **_):
+        seen_during_wave.update(rest_miner_service.in_flight)
+        if executor_info.uuid == known:
+            raise RuntimeError("ssh dropped")  # a failing task must still release the claim
+        return _job_result(executor_info.uuid)
+
+    rest_miner_service.task_service.create_task = AsyncMock(side_effect=create_task)
+
+    with caplog.at_level(logging.INFO):
+        job = await _request(rest_miner_service)
+
+    verified = [c.kwargs["executor_info"].uuid for c in rest_miner_service.task_service.create_task.call_args_list]
+    assert verified == [known]
+    assert seen_during_wave == {on_express: EXPRESS_LANE, known: CYCLE_LANE}
+    assert rest_miner_service.in_flight == {on_express: EXPRESS_LANE}
+    assert job["results"] == []
+    assert "Executor left to the express lane this cycle" in caplog.text
+
+
+# --- ExpressLane: discovery, caps, publish, retries -----------------------------------------
+
+
+class _Harness:
+    def __init__(self, monkeypatch, snapshot: dict[str, list[PortalExecutor]], miners: list[_Neuron]):
+        from core.config import settings
+
+        monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+        self.settings = settings
+        self.redis_service = _redis_service()
+        self.miner_service = MinerService.__new__(MinerService)
+        self.miner_service.in_flight = {}
+        self.miner_service.publish_machine_specs = AsyncMock()
+        self.release = asyncio.Event()
+        self.release.set()
+
+        async def request_job_to_miner(payload, executor_id, **_):
+            await self.release.wait()
+            return self.job_for(payload, executor_id)
+
+        self.miner_service.request_job_to_miner = AsyncMock(side_effect=request_job_to_miner)
+        self.job_for = lambda payload, executor_id: {
+            "miner_hotkey": payload.miner_hotkey,
+            "miner_coldkey": payload.miner_coldkey,
+            "results": [_job_result(executor_id)],
+        }
+        self.portal_api = Mock(get_all_executors=AsyncMock(return_value=snapshot))
+        self.inputs: CycleInputs | None = _cycle_inputs()
+        self.lane = ExpressLane(
+            miner_service=self.miner_service,
+            redis_service=self.redis_service,
+            backend_client=Mock(
+                get_all_rented_executors=AsyncMock(return_value=RentedExecutorsResponse(executors={}))
+            ),
+            subtensor_client=Mock(get_miners=AsyncMock(return_value=miners)),
+            cycle_inputs=lambda: self.inputs,
+            portal_api=self.portal_api,
+        )
+
+    async def tick_and_settle(self) -> int:
+        launched = await self.lane.tick()
+        if self.lane._tasks:
+            await asyncio.gather(*self.lane._tasks)
+        return launched
+
+
+@pytest.mark.asyncio
+async def test_nothing_runs_before_the_first_cycle_has_completed(monkeypatch, wallet):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    harness.inputs = None  # Validator.express_lane_cycle_inputs returns None until then
+
+    assert await harness.tick_and_settle() == 0
+    harness.portal_api.get_all_executors.assert_not_awaited()
+    harness.miner_service.request_job_to_miner.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_a_never_validated_executor_is_verified_alone_and_published_spec_only(
+    monkeypatch, wallet, caplog
+):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node, registered_seconds_ago=40)]}, [_Neuron("miner-a")])
+
+    with caplog.at_level(logging.INFO):
+        assert await harness.tick_and_settle() == 1
+
+    request = harness.miner_service.request_job_to_miner.await_args.kwargs
+    assert request["executor_id"] == new_node
+    assert (request["payload"].miner_hotkey, request["payload"].miner_address, request["payload"].miner_port) == (
+        "miner-a", "192.0.2.10", 8091
+    )
+    assert request["encrypted_files"] is harness.inputs.encrypted_files
+
+    (results, miner_hotkey, miner_coldkey), _ = harness.miner_service.publish_machine_specs.await_args
+    assert (miner_hotkey, miner_coldkey) == ("miner-a", "miner-coldkey")
+    assert [r.executor_info.uuid for r in results] == [new_node]
+    # spec-only: no incentive and no scored_at, so the backend writes no ledger row
+    assert results[0].incentive is None and results[0].scored_at is None
+    assert results[0].incentive_source == "unknown"
+    assert await harness.redis_service.get_validated_executors() == {new_node}
+    assert harness.miner_service.in_flight == {}
+
+    published = [r for r in caplog.records if r.getMessage() == EXPRESS_PUBLISHED_EVENT]
+    assert len(published) == 1
+    extra = published[0].msg.extra
+    assert extra["executor_uuid"] == new_node and extra["outcome"] == "passed" and extra["attempt"] == 1
+    assert 40 <= extra["registration_to_publish_s"] < 60
+    assert extra["first_seen_to_publish_s"] >= 0 and extra["verification_s"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_validated_foreign_and_wave_held_executors_are_not_touched(monkeypatch, wallet):
+    validated, foreign, on_wave = str(uuid4()), str(uuid4()), str(uuid4())
+    harness = _Harness(
+        monkeypatch,
+        {
+            "miner-a": [
+                _portal_executor(validated),
+                _portal_executor(foreign, validator="another-validator"),
+                _portal_executor(on_wave),
+            ]
+        },
+        [_Neuron("miner-a")],
+    )
+    await harness.redis_service.mark_executors_validated([validated])
+    harness.miner_service.in_flight[on_wave] = CYCLE_LANE
+
+    assert await harness.tick_and_settle() == 0
+    harness.miner_service.request_job_to_miner.assert_not_awaited()
+    harness.miner_service.publish_machine_specs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_in_flight_caps_bound_a_registration_flood(monkeypatch, wallet):
+    nodes = {
+        "miner-a": [_portal_executor(str(uuid4()), registered_seconds_ago=300 - i) for i in range(5)],
+        "miner-b": [_portal_executor(str(uuid4()), registered_seconds_ago=200 - i) for i in range(3)],
+        "miner-c": [_portal_executor(str(uuid4()), registered_seconds_ago=100 - i) for i in range(2)],
+    }
+    harness = _Harness(monkeypatch, nodes, [_Neuron("miner-a"), _Neuron("miner-b"), _Neuron("miner-c")])
+    monkeypatch.setattr(harness.settings, "EXPRESS_LANE_MAX_IN_FLIGHT", 4)
+    monkeypatch.setattr(harness.settings, "EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER", 2)
+    harness.release.clear()  # verifications block until released
+
+    assert await harness.lane.tick() == 4
+    in_flight = harness.miner_service.in_flight
+    assert all(lane == EXPRESS_LANE for lane in in_flight.values())
+    by_miner = {
+        hotkey: sum(e.id in in_flight for e in executors) for hotkey, executors in nodes.items()
+    }
+    assert by_miner == {"miner-a": 2, "miner-b": 2, "miner-c": 0}  # oldest registrations first
+    # a second tick while all four are still running launches nothing more
+    assert await harness.lane.tick() == 0
+    assert len(in_flight) == 4
+
+    harness.release.set()
+    await asyncio.gather(*harness.lane._tasks)
+    assert harness.miner_service.publish_machine_specs.await_count == 4
+    # the slots are free again: the next tick takes the next four
+    harness.release.clear()
+    assert await harness.lane.tick() == 4
+    harness.release.set()
+    await asyncio.gather(*harness.lane._tasks)
+    assert await harness.lane.tick() == 2
+    await asyncio.gather(*harness.lane._tasks)
+    assert len(await harness.redis_service.get_validated_executors()) == 10
+
+
+@pytest.mark.asyncio
+async def test_an_executor_the_miner_does_not_return_is_retried_then_left_to_the_cycle(
+    monkeypatch, wallet, caplog
+):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    # the miner's own portal snapshot has not caught up: it accepts the key for nobody
+    harness.job_for = lambda payload, executor_id: {"miner_hotkey": "miner-a", "miner_coldkey": "c", "results": []}
+
+    with caplog.at_level(logging.INFO):
+        assert await harness.tick_and_settle() == 1
+        assert await harness.tick_and_settle() == 0  # inside the retry backoff
+        for _ in range(MAX_ATTEMPTS - 1):
+            harness.lane._pending[new_node].not_before = 0.0  # backoff elapsed
+            assert await harness.tick_and_settle() == 1
+        assert await harness.tick_and_settle() == 0  # given up: the normal cycle owns it now
+
+    assert harness.miner_service.request_job_to_miner.await_count == MAX_ATTEMPTS
+    harness.miner_service.publish_machine_specs.assert_not_awaited()
+    assert await harness.redis_service.get_validated_executors() == set()
+    assert harness.miner_service.in_flight == {}
+    assert caplog.text.count("[express] Executor not verified yet, will retry") == MAX_ATTEMPTS - 1
+    assert "[express] Executor left to the normal cycle" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_failed_verification_is_published_so_the_provider_sees_why(monkeypatch, wallet, caplog):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    harness.job_for = lambda payload, executor_id: {
+        "miner_hotkey": "miner-a",
+        "miner_coldkey": "c",
+        "results": [_job_result(executor_id, score=0.0)],
+    }
+
+    with caplog.at_level(logging.INFO):
+        assert await harness.tick_and_settle() == 1
+
+    harness.miner_service.publish_machine_specs.assert_awaited_once()
+    assert await harness.redis_service.get_validated_executors() == {new_node}
+    published = [r for r in caplog.records if r.getMessage() == EXPRESS_PUBLISHED_EVENT]
+    assert published[0].msg.extra["outcome"] == "failed"
+
+
+# --- Redis seed and portal auth -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_validated_set_round_trips_through_redis():
+    redis_service = _redis_service()
+    ids = [str(uuid4()) for _ in range(3)]
+
+    await redis_service.mark_executors_validated(ids)
+    await redis_service.mark_executors_validated([])
+
+    assert await redis_service.get_validated_executors() == set(ids)
+    assert await redis_service.redis.scard(EXPRESS_LANE_VALIDATED_SET) == 3
+
+
+def test_the_portal_auth_blob_is_what_signature_auth_miner_verifies():
+    """lium-platform apps/portal/backend/src/auth/signature_auth.py builds
+    AuthenticationPayload(timestamp=..., miner_hotkey=...) and verifies json.dumps(model_dump(),
+    sort_keys=True); the two repos agree only on these bytes."""
+    keypair = bittensor.Keypair.create_from_uri("//LiumTestValidator")
+    blob = portal_miner_auth_blob(keypair.ss58_address, 1_757_174_400)
+
+    assert blob == json.dumps({"miner_hotkey": keypair.ss58_address, "timestamp": 1_757_174_400}, sort_keys=True)
+    assert keypair.verify(blob, f"0x{keypair.sign(blob).hex()}")
+
+
+@pytest.mark.asyncio
+async def test_get_all_executors_parses_the_bulk_snapshot_and_fails_soft(monkeypatch, wallet):
+    executor_id = str(uuid4())
+    responses = iter(
+        [
+            (200, {"miner-a": [{"id": executor_id, "validator_hotkey": VALIDATOR_HOTKEY,
+                                 "created_at": "2026-09-06T16:40:00", "executor_ip_address": "198.51.100.7",
+                                 "executor_ip_port": "8001", "price_per_gpu": 1.5}]}),
+            (503, "portal down"),
+        ]
+    )
+    sent_headers = {}
+
+    class _Response:
+        def __init__(self, status, body):
+            self.status, self._body = status, body
+
+        async def json(self):
+            return self._body
+
+        async def text(self):
+            return str(self._body)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+    class _Session:
+        def __init__(self, *_, **__):
+            pass
+
+        def get(self, url, headers):
+            sent_headers.update(headers)
+            return _Response(*next(responses))
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_):
+            return False
+
+    monkeypatch.setattr("clients.validator_portal_api.aiohttp.ClientSession", _Session)
+
+    snapshot = await ValidatorPortalAPI.get_all_executors()
+
+    assert sent_headers["hotkey"] == VALIDATOR_HOTKEY and sent_headers["signature"] == "0x010203"
+    assert list(snapshot) == ["miner-a"]
+    (executor,) = snapshot["miner-a"]
+    assert executor.id == executor_id and executor.validator_hotkey == VALIDATOR_HOTKEY
+    assert executor.created_at == datetime(2026, 9, 6, 16, 40, tzinfo=UTC)
+    assert await ValidatorPortalAPI.get_all_executors() is None

--- a/neurons/validators/tests/test_express_lane.py
+++ b/neurons/validators/tests/test_express_lane.py
@@ -4,11 +4,13 @@ Flag off: request_job_to_miner asks the miner for every executor (executor_id=No
 nothing, exactly as before. Flag on: a portal executor registered after the first cycle since
 start that this validator never published is verified alone, as a first pass, with the cycle's
 own pipeline inputs and published spec-only; an executor registered before that cycle is the
-cycle's; the wave and the lane never run on one executor at the same time; the next cycle keeps
-the job files a running express verification reads, and a cycle that starts during a tick moves
-the launch to its files; a verification without its job files is never published as the node's
-verdict; the in-flight caps bound a registration flood; an executor the miner does not return is
-retried a bounded number of times and then left to the cycle.
+cycle's; the wave and the lane never run on one executor at the same time, and one the wave
+verified is not run again before the cycle records it; the next cycle keeps the job files a
+running express verification reads, and a cycle that starts during a tick moves the launch to
+its files; a verification without its job files is never published as the node's verdict; a
+published result is never run again when recording it fails; the in-flight caps bound a
+registration flood; an executor the miner does not return is retried a bounded number of times
+and then left to the cycle.
 """
 
 import asyncio
@@ -32,7 +34,7 @@ from datura.requests.miner_requests import AcceptSSHKeyRequest, ExecutorSSHInfo
 from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
 from services.file_encrypt_service import FileEncryptService
-from services.miner_service import CYCLE_LANE, EXPRESS_LANE, MinerService
+from services.miner_service import CYCLE_DONE, CYCLE_LANE, EXPRESS_LANE, MinerService
 from services.redis_service import EXPRESS_LANE_VALIDATED_SET, RedisService
 from services.task.models import JobResult
 
@@ -281,9 +283,11 @@ async def test_first_pass_reaches_the_task_only_when_the_caller_asks_for_it(rest
 
 
 @pytest.mark.asyncio
-async def test_the_wave_skips_an_executor_the_express_lane_holds_and_releases_its_own(
+async def test_the_wave_skips_an_executor_the_express_lane_holds_and_marks_its_own_done(
     rest_miner_service, monkeypatch, caplog
 ):
+    """The wave's claim turns into CYCLE_DONE when its pipeline ends (pass or fail) and is dropped
+    only once the cycle has recorded its published executors — the lane skips it in between."""
     from core.config import settings
 
     monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
@@ -295,7 +299,7 @@ async def test_the_wave_skips_an_executor_the_express_lane_holds_and_releases_it
     async def create_task(miner_info, executor_info, **_):
         seen_during_wave.update(rest_miner_service.in_flight)
         if executor_info.uuid == known:
-            raise RuntimeError("ssh dropped")  # a failing task must still release the claim
+            raise RuntimeError("ssh dropped")  # a failing task must still end the claim
         return _job_result(executor_info.uuid)
 
     rest_miner_service.task_service.create_task = AsyncMock(side_effect=create_task)
@@ -306,23 +310,34 @@ async def test_the_wave_skips_an_executor_the_express_lane_holds_and_releases_it
     verified = [c.kwargs["executor_info"].uuid for c in rest_miner_service.task_service.create_task.call_args_list]
     assert verified == [known]
     assert seen_during_wave == {on_express: EXPRESS_LANE, known: CYCLE_LANE}
-    assert rest_miner_service.in_flight == {on_express: EXPRESS_LANE}
+    assert rest_miner_service.in_flight == {on_express: EXPRESS_LANE, known: CYCLE_DONE}
     assert job["results"] == []
     assert "Executor left to the express lane this cycle" in caplog.text
+
+    rest_miner_service.forget_cycle_done()  # Validator.sync(), right after mark_executors_validated
+    assert rest_miner_service.in_flight == {on_express: EXPRESS_LANE}
 
 
 # --- ExpressLane: discovery, caps, publish, retries -----------------------------------------
 
 
 class _Harness:
-    def __init__(self, monkeypatch, snapshot: dict[str, list[PortalExecutor]], miners: list[_Neuron]):
+    def __init__(
+        self,
+        monkeypatch,
+        snapshot: dict[str, list[PortalExecutor]],
+        miners: list[_Neuron],
+        miner_service: MinerService | None = None,
+    ):
         from core.config import settings
 
         monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
         self.settings = settings
         self.redis_service = _redis_service()
-        self.miner_service = MinerService.__new__(MinerService)
-        self.miner_service.in_flight = {}
+        if miner_service is None:
+            miner_service = MinerService.__new__(MinerService)
+            miner_service.in_flight = {}
+        self.miner_service = miner_service
         self.miner_service.publish_machine_specs = AsyncMock()
         self.release = asyncio.Event()
         self.release.set()
@@ -423,6 +438,39 @@ async def test_validated_foreign_and_wave_held_executors_are_not_touched(monkeyp
     assert await harness.tick_and_settle() == 0
     harness.miner_service.request_job_to_miner.assert_not_awaited()
     harness.miner_service.publish_machine_specs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_executor_the_wave_verified_is_not_run_again_before_the_cycle_records_it(
+    rest_miner_service, monkeypatch, wallet
+):
+    """The cycle records its published executors once, after scoring and publishing — minutes
+    after a miner's wave returned. A node registered after fleet_known_since that the wave reached
+    first is, in that window, neither validated nor running; the lane must still leave it alone."""
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+    new_node = str(uuid4())
+    rest_miner_service.miner_returns(new_node)
+
+    job = await _request(rest_miner_service)  # the wave, through the real request_job_to_miner
+    assert [r.executor_info.uuid for r in job["results"]] == [new_node]
+    assert rest_miner_service.in_flight == {new_node: CYCLE_DONE}
+
+    # the lane ticks before the cycle has published and seeded the validated set
+    harness = _Harness(
+        monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")], miner_service=rest_miner_service
+    )
+    assert await harness.tick_and_settle() == 0
+    harness.miner_service.request_job_to_miner.assert_not_awaited()
+
+    # the cycle's end: the publish is recorded, the wave's claims are dropped
+    await harness.redis_service.mark_executors_validated([new_node])
+    rest_miner_service.forget_cycle_done()
+    assert rest_miner_service.in_flight == {}
+    assert await harness.tick_and_settle() == 0
+    harness.miner_service.request_job_to_miner.assert_not_awaited()
+    assert new_node not in harness.lane._pending
 
 
 @pytest.mark.asyncio
@@ -668,6 +716,29 @@ async def test_an_executor_the_miner_does_not_return_is_retried_then_left_to_the
     assert harness.miner_service.in_flight == {}
     assert caplog.text.count("[express] Executor not verified yet, will retry") == MAX_ATTEMPTS - 1
     assert "[express] Executor left to the normal cycle" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_a_published_result_is_not_run_again_when_recording_it_fails(monkeypatch, wallet, caplog):
+    """Once the result reached the backend, a Redis error on the validated-set write must not
+    re-run the node: it is left to the cycle (whose next seed records it) and the metric line
+    is still emitted."""
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    harness.redis_service.mark_executors_validated = AsyncMock(side_effect=ConnectionError("redis down"))
+
+    with caplog.at_level(logging.INFO):
+        assert await harness.tick_and_settle() == 1
+
+    harness.miner_service.publish_machine_specs.assert_awaited_once()
+    assert "[express] Published, but could not record the executor as validated; left to the cycle" in caplog.text
+    assert [r for r in caplog.records if r.getMessage() == EXPRESS_PUBLISHED_EVENT]
+    assert new_node not in harness.lane._pending
+    assert new_node in harness.lane._left_to_cycle
+    assert harness.miner_service.in_flight == {}
+
+    assert await harness.tick_and_settle() == 0
+    harness.miner_service.request_job_to_miner.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_express_lane.py
+++ b/neurons/validators/tests/test_express_lane.py
@@ -210,6 +210,27 @@ async def test_the_express_lane_asks_the_miner_for_one_executor(rest_miner_servi
 
 
 @pytest.mark.asyncio
+async def test_the_express_lane_verifies_only_the_executor_it_asked_for(rest_miner_service, monkeypatch):
+    """A miner that ignores the executor filter must not get its other executors verified on the
+    express path — they may be held by the wave, and their results are discarded anyway."""
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+    new_node, extra = str(uuid4()), str(uuid4())
+    rest_miner_service.in_flight[new_node] = EXPRESS_LANE
+    rest_miner_service.in_flight[extra] = CYCLE_LANE
+    rest_miner_service.miner_returns(new_node, extra)
+
+    job = await _request(rest_miner_service, executor_id=new_node)
+
+    verified = [c.kwargs["executor_info"].uuid for c in rest_miner_service.task_service.create_task.call_args_list]
+    assert verified == [new_node]
+    assert [r.executor_info.uuid for r in job["results"]] == [new_node]
+    # the wave's claim on the extra executor is untouched
+    assert rest_miner_service.in_flight == {new_node: EXPRESS_LANE, extra: CYCLE_LANE}
+
+
+@pytest.mark.asyncio
 async def test_the_wave_skips_an_executor_the_express_lane_holds_and_releases_its_own(
     rest_miner_service, monkeypatch, caplog
 ):

--- a/neurons/validators/tests/test_express_lane.py
+++ b/neurons/validators/tests/test_express_lane.py
@@ -5,14 +5,17 @@ nothing, exactly as before. Flag on: a portal executor registered after the firs
 start that this validator never published is verified alone, as a first pass, with the cycle's
 own pipeline inputs and published spec-only; an executor registered before that cycle is the
 cycle's; the wave and the lane never run on one executor at the same time; the next cycle keeps
-the job files a running express verification reads; the in-flight caps bound a registration flood;
-an executor the miner does not return is retried a bounded number of times and then left to the
-cycle.
+the job files a running express verification reads, and a cycle that starts during a tick moves
+the launch to its files; a verification without its job files is never published as the node's
+verdict; the in-flight caps bound a registration flood; an executor the miner does not return is
+retried a bounded number of times and then left to the cycle.
 """
 
 import asyncio
 import json
 import logging
+import shutil
+import tempfile
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, Mock
@@ -93,7 +96,17 @@ def _portal_executor(
     )
 
 
-def _cycle_inputs(tmp_directory: str = "/tmp/x") -> CycleInputs:
+@pytest.fixture(autouse=True)
+def job_files_root(tmp_path, monkeypatch):
+    """Every cycle-* directory a test makes lands under pytest's tmp_path (the lane launches only
+    on a directory that exists, so the inputs name real ones)."""
+    monkeypatch.setattr(file_encrypt_service, "JOB_FILES_ROOT", tmp_path)
+    return tmp_path
+
+
+def _cycle_inputs(tmp_directory: str | None = None) -> CycleInputs:
+    if tmp_directory is None:
+        tmp_directory = tempfile.mkdtemp(prefix="cycle-", dir=file_encrypt_service.JOB_FILES_ROOT)
     return CycleInputs(
         encrypted_files=MinerJobEnryptedFiles(
             encrypt_key="k",
@@ -448,7 +461,6 @@ async def test_the_next_cycle_keeps_the_job_files_a_running_express_verification
 ):
     """Each cycle writes its job files to a fresh directory; the earlier ones are removed unless
     the lane still reads them. Without `keep`, the next cycle's prep is today's rmtree."""
-    monkeypatch.setattr(file_encrypt_service, "JOB_FILES_ROOT", tmp_path)
     first = FileEncryptService.fresh_job_files_directory()
     (first / "scrape").write_bytes(b"frozen")
     new_node = str(uuid4())
@@ -476,6 +488,111 @@ async def test_the_next_cycle_keeps_the_job_files_a_running_express_verification
     # negative control — the same prep without `keep` removes the directory mid-run
     fourth = FileEncryptService.fresh_job_files_directory()
     assert not third.exists() and fourth.exists()
+
+
+@pytest.mark.asyncio
+async def test_a_cycle_that_starts_during_the_tick_moves_the_launch_to_its_job_files(monkeypatch, wallet):
+    """tick() awaits the portal, Redis, the metagraph and the backend before it launches. A cycle
+    whose prep runs in that window removes the directory the tick read first (nothing held it yet)
+    and publishes new inputs; the launch must hold and use the directory that exists then."""
+    first = FileEncryptService.fresh_job_files_directory()
+    new_node = str(uuid4())
+    snapshot = {"miner-a": [_portal_executor(new_node)]}
+    harness = _Harness(monkeypatch, snapshot, [_Neuron("miner-a")])
+    harness.inputs = _cycle_inputs(tmp_directory=str(first))
+    prepared = []
+
+    async def portal_snapshot_while_a_cycle_starts():
+        # Validator.sync(): ecrypt_miner_job_files(keep_directories=directories_in_use()), then
+        # the new CycleInputs — one synchronous step from the lane's point of view
+        second = FileEncryptService.fresh_job_files_directory(keep=harness.lane.directories_in_use())
+        harness.inputs = _cycle_inputs(tmp_directory=str(second))
+        prepared.append(second)
+        return snapshot
+
+    harness.portal_api.get_all_executors = AsyncMock(side_effect=portal_snapshot_while_a_cycle_starts)
+    harness.release.clear()  # inspect the launch before the verification completes
+
+    assert await harness.lane.tick() == 1
+
+    (second,) = prepared
+    assert not first.exists() and second.exists()
+    assert harness.lane.directories_in_use() == {str(second)}
+    await asyncio.sleep(0)  # the verification task runs up to the miner request
+    request = harness.miner_service.request_job_to_miner.call_args.kwargs
+    assert request["encrypted_files"].tmp_directory == str(second)
+
+    harness.release.set()
+    await asyncio.gather(*harness.lane._tasks)
+    harness.miner_service.publish_machine_specs.assert_awaited_once()
+    assert await harness.redis_service.get_validated_executors() == {new_node}
+
+
+@pytest.mark.asyncio
+async def test_a_missing_job_files_directory_skips_the_tick_instead_of_verifying_without_it(
+    monkeypatch, wallet, caplog
+):
+    """A verification without its job files fails as if the node had (UploadFilesCheck, the
+    scrape's binary fallback). When the current directory is gone, nothing is launched and no
+    attempt is counted; the node is tried again once a cycle has written new files."""
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    shutil.rmtree(harness.inputs.encrypted_files.tmp_directory)
+
+    with caplog.at_level(logging.WARNING):
+        assert await harness.tick_and_settle() == 0
+
+    harness.miner_service.request_job_to_miner.assert_not_awaited()
+    harness.miner_service.publish_machine_specs.assert_not_awaited()
+    assert harness.lane._pending[new_node].attempts == 0
+    assert harness.miner_service.in_flight == {}
+    assert "[express] Job files directory is missing, skipping this tick" in caplog.text
+
+    # a cycle writes new files: the same node is verified on the next tick
+    harness.inputs = _cycle_inputs()
+    assert await harness.tick_and_settle() == 1
+    harness.miner_service.publish_machine_specs.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_a_result_produced_after_the_job_files_vanished_is_not_the_nodes_verdict(
+    monkeypatch, wallet, caplog
+):
+    """The hold keeps the directory across cycles; if it is removed anyway while the verification
+    runs, the pipeline's failure is the validator's. Nothing is published, the executor is not
+    marked validated, the attempt is not counted, and the lane retries after the backoff."""
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    directory = harness.inputs.encrypted_files.tmp_directory
+
+    def failed_job(payload, executor_id, **_):
+        return {"miner_hotkey": "miner-a", "miner_coldkey": "c", "results": [_job_result(executor_id, score=0.0)]}
+
+    async def request_job_to_miner(payload, executor_id, **_):
+        shutil.rmtree(directory)  # the upload finds no files; the pipeline scores the node 0
+        return failed_job(payload, executor_id)
+
+    harness.miner_service.request_job_to_miner = AsyncMock(side_effect=request_job_to_miner)
+
+    with caplog.at_level(logging.INFO):
+        assert await harness.tick_and_settle() == 1
+
+    harness.miner_service.publish_machine_specs.assert_not_awaited()
+    assert await harness.redis_service.get_validated_executors() == set()
+    assert harness.lane.directories_in_use() == set()
+    assert harness.miner_service.in_flight == {}
+    pending = harness.lane._pending[new_node]
+    assert pending.attempts == 0 and pending.not_before > 0
+    assert "[express] Job files were removed during the verification, result discarded" in caplog.text
+    assert not [r for r in caplog.records if r.getMessage() == EXPRESS_PUBLISHED_EVENT]
+
+    # negative control — the same 0 score with the files in place is the node's verdict
+    harness.inputs = _cycle_inputs()
+    harness.miner_service.request_job_to_miner = AsyncMock(side_effect=failed_job)
+    pending.not_before = 0.0
+    assert await harness.tick_and_settle() == 1
+    harness.miner_service.publish_machine_specs.assert_awaited_once()
+    assert await harness.redis_service.get_validated_executors() == {new_node}
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_express_lane.py
+++ b/neurons/validators/tests/test_express_lane.py
@@ -1,10 +1,13 @@
 """DAH-2958: the express lane verifies never-validated executors ahead of the 15-min cycle.
 
 Flag off: request_job_to_miner asks the miner for every executor (executor_id=None) and claims
-nothing, exactly as before. Flag on: a portal executor this validator never published is verified
-alone with the cycle's own pipeline inputs and published spec-only; the wave and the lane never
-run on one executor at the same time; the in-flight caps bound a registration flood; an executor
-the miner does not return is retried a bounded number of times and then left to the cycle.
+nothing, exactly as before. Flag on: a portal executor registered after the first cycle since
+start that this validator never published is verified alone, as a first pass, with the cycle's
+own pipeline inputs and published spec-only; an executor registered before that cycle is the
+cycle's; the wave and the lane never run on one executor at the same time; the next cycle keeps
+the job files a running express verification reads; the in-flight caps bound a registration flood;
+an executor the miner does not return is retried a bounded number of times and then left to the
+cycle.
 """
 
 import asyncio
@@ -19,16 +22,20 @@ import bittensor
 import pytest
 from fakeredis.aioredis import FakeRedis
 
+import services.file_encrypt_service as file_encrypt_service
 from clients.validator_portal_api import PortalExecutor, ValidatorPortalAPI, portal_miner_auth_blob
 from core.express_lane import EXPRESS_PUBLISHED_EVENT, MAX_ATTEMPTS, CycleInputs, ExpressLane
 from datura.requests.miner_requests import AcceptSSHKeyRequest, ExecutorSSHInfo
 from payload_models.payloads import MinerJobEnryptedFiles, MinerJobRequestPayload
 from protocol.vc_protocol.compute_requests import RentedExecutorsResponse
+from services.file_encrypt_service import FileEncryptService
 from services.miner_service import CYCLE_LANE, EXPRESS_LANE, MinerService
 from services.redis_service import EXPRESS_LANE_VALIDATED_SET, RedisService
 from services.task.models import JobResult
 
 VALIDATOR_HOTKEY = "validator-hotkey"
+# The first cycle since start began an hour ago; the test executors register after it.
+FLEET_KNOWN_SINCE = datetime.now(UTC) - timedelta(hours=1)
 
 
 @dataclass
@@ -70,25 +77,34 @@ def _job_result(executor_id: str, score: float = 1.0) -> JobResult:
     )
 
 
-def _portal_executor(executor_id: str, registered_seconds_ago: float = 40.0, validator: str = VALIDATOR_HOTKEY):
+def _portal_executor(
+    executor_id: str,
+    registered_seconds_ago: float | None = 40.0,
+    validator: str = VALIDATOR_HOTKEY,
+):
     return PortalExecutor(
         id=executor_id,
         validator_hotkey=validator,
-        created_at=datetime.now(UTC) - timedelta(seconds=registered_seconds_ago),
+        created_at=(
+            datetime.now(UTC) - timedelta(seconds=registered_seconds_ago)
+            if registered_seconds_ago is not None
+            else None
+        ),
     )
 
 
-def _cycle_inputs() -> CycleInputs:
+def _cycle_inputs(tmp_directory: str = "/tmp/x") -> CycleInputs:
     return CycleInputs(
         encrypted_files=MinerJobEnryptedFiles(
             encrypt_key="k",
             all_keys={},
-            tmp_directory="/tmp/x",
+            tmp_directory=tmp_directory,
             machine_scrape_file_name="scrape",
             machine_scrape_source="",
         ),
         default_image_digests={},
         executor_image_snapshot=None,
+        fleet_known_since=FLEET_KNOWN_SINCE,
     )
 
 
@@ -231,6 +247,27 @@ async def test_the_express_lane_verifies_only_the_executor_it_asked_for(rest_min
 
 
 @pytest.mark.asyncio
+async def test_first_pass_reaches_the_task_only_when_the_caller_asks_for_it(rest_miner_service, monkeypatch):
+    """DAH-3011: `first_pass` travels request_job_to_miner → create_task; the wave's request (no
+    argument) runs today's scored pipeline."""
+    from core.config import settings
+
+    monkeypatch.setattr(settings, "EXPRESS_LANE_ENABLED", True)
+    new_node, known = str(uuid4()), str(uuid4())
+    create_task = rest_miner_service.task_service.create_task
+
+    rest_miner_service.in_flight[new_node] = EXPRESS_LANE
+    rest_miner_service.miner_returns(new_node)
+    await _request(rest_miner_service, executor_id=new_node, first_pass=True)
+    assert create_task.await_args.kwargs["first_pass"] is True
+
+    rest_miner_service.in_flight.clear()
+    rest_miner_service.miner_returns(known)
+    await _request(rest_miner_service)
+    assert create_task.await_args.kwargs["first_pass"] is False
+
+
+@pytest.mark.asyncio
 async def test_the_wave_skips_an_executor_the_express_lane_holds_and_releases_its_own(
     rest_miner_service, monkeypatch, caplog
 ):
@@ -330,6 +367,7 @@ async def test_a_never_validated_executor_is_verified_alone_and_published_spec_o
 
     request = harness.miner_service.request_job_to_miner.await_args.kwargs
     assert request["executor_id"] == new_node
+    assert request["first_pass"] is True  # never scored: the DAH-3011 fast path may apply
     assert (request["payload"].miner_hotkey, request["payload"].miner_address, request["payload"].miner_port) == (
         "miner-a", "192.0.2.10", 8091
     )
@@ -372,6 +410,86 @@ async def test_validated_foreign_and_wave_held_executors_are_not_touched(monkeyp
     assert await harness.tick_and_settle() == 0
     harness.miner_service.request_job_to_miner.assert_not_awaited()
     harness.miner_service.publish_machine_specs.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_executor_registered_before_the_first_cycle_is_the_cycles_even_when_never_published(
+    monkeypatch, wallet
+):
+    """The validated set holds what cycles published since the flag went on. An executor of a miner
+    that failed or was offline in those cycles is not in it, yet it is long-known: its registration
+    predates the first cycle since start, so the lane leaves it to the cycle. One with no
+    registration time is left to the cycle too. A registration after that cycle is a candidate."""
+    seed_seconds_ago = (datetime.now(UTC) - FLEET_KNOWN_SINCE).total_seconds()
+    long_known, undated, new_node = str(uuid4()), str(uuid4()), str(uuid4())
+    harness = _Harness(
+        monkeypatch,
+        {
+            "miner-a": [
+                _portal_executor(long_known, registered_seconds_ago=seed_seconds_ago + 60),
+                _portal_executor(undated, registered_seconds_ago=None),
+                _portal_executor(new_node, registered_seconds_ago=seed_seconds_ago - 60),
+            ]
+        },
+        [_Neuron("miner-a")],
+    )
+
+    assert await harness.tick_and_settle() == 1
+
+    requested = [c.kwargs["executor_id"] for c in harness.miner_service.request_job_to_miner.await_args_list]
+    assert requested == [new_node]
+    assert await harness.redis_service.get_validated_executors() == {new_node}
+    assert set(harness.lane._pending) == set()  # the two skipped ones were never tracked
+
+
+@pytest.mark.asyncio
+async def test_the_next_cycle_keeps_the_job_files_a_running_express_verification_reads(
+    monkeypatch, wallet, tmp_path
+):
+    """Each cycle writes its job files to a fresh directory; the earlier ones are removed unless
+    the lane still reads them. Without `keep`, the next cycle's prep is today's rmtree."""
+    monkeypatch.setattr(file_encrypt_service, "JOB_FILES_ROOT", tmp_path)
+    first = FileEncryptService.fresh_job_files_directory()
+    (first / "scrape").write_bytes(b"frozen")
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    harness.inputs = _cycle_inputs(tmp_directory=str(first))
+    harness.release.clear()  # the verification is mid-run
+
+    assert await harness.lane.tick() == 1
+    assert harness.lane.directories_in_use() == {str(first)}
+
+    # the next cycle prepares its files while the verification is still running
+    second = FileEncryptService.fresh_job_files_directory(keep=harness.lane.directories_in_use())
+    assert (first / "scrape").read_bytes() == b"frozen"
+    assert second.exists() and second != first and second.parent == tmp_path
+
+    harness.release.set()
+    await asyncio.gather(*harness.lane._tasks)
+    harness.miner_service.publish_machine_specs.assert_awaited_once()
+    assert harness.lane.directories_in_use() == set()
+
+    # the cycle after that has nothing to keep and removes both
+    third = FileEncryptService.fresh_job_files_directory(keep=harness.lane.directories_in_use())
+    assert not first.exists() and not second.exists() and third.exists()
+
+    # negative control — the same prep without `keep` removes the directory mid-run
+    fourth = FileEncryptService.fresh_job_files_directory()
+    assert not third.exists() and fourth.exists()
+
+
+@pytest.mark.asyncio
+async def test_a_verification_that_raises_releases_its_job_files_directory(monkeypatch, wallet):
+    new_node = str(uuid4())
+    harness = _Harness(monkeypatch, {"miner-a": [_portal_executor(new_node)]}, [_Neuron("miner-a")])
+    harness.miner_service.request_job_to_miner = AsyncMock(side_effect=RuntimeError("ssh dropped"))
+
+    assert await harness.tick_and_settle() == 1
+
+    assert harness.lane.directories_in_use() == set()
+    assert harness.miner_service.in_flight == {}
+    harness.miner_service.publish_machine_specs.assert_not_awaited()
+    assert harness.lane._pending[new_node].attempts == 1  # deferred, retried next tick
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_first_pass_fast_path.py
+++ b/neurons/validators/tests/test_first_pass_fast_path.py
@@ -1,0 +1,362 @@
+"""DAH-3011: the fast first pass for a never-validated executor.
+
+Only a caller that passes `first_pass=True` (the express lane, DAH-2958 — spec-only, never scored)
+with FIRST_PASS_FAST_PATH_ENABLED on gets it: the capability matmul is sized from a VRAM budget,
+VerifyX writes less RAM/disk, and a cold bandwidth sample is published but not enforced. The wave
+never sets `first_pass`, so a scored verification is byte-for-byte today's.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import services.matrix_validation_service as mvs
+from core.config import settings
+from neurons.validators.src.services.task.checks.capability import CapabilityCheck
+from neurons.validators.src.services.task.checks.verifyx import VerifyXCheck
+from neurons.validators.src.services.task.messages import CapabilityMessages as CapMsg
+from neurons.validators.src.services.task.messages import VerifyXMessages as VxMsg
+from neurons.validators.src.services.task import pipeline_factory as pipeline_factory_module
+from neurons.validators.src.services.task.pipeline_factory import PipelineFactory
+from neurons.validators.src.services.verifyx_validation_service import VerifyXValidationService
+from protocol.vc_protocol.compute_requests import NetworkEMA, RentedExecutorsResponse
+
+from tests.helpers import build_context_config, build_services, build_state
+from tests.test_capability_check import DummyValidationService
+from tests.test_verifyx_check import MockVerifyXResponse
+
+EXECUTOR = "executor-123"
+
+
+@pytest.fixture
+def fast_path_on(monkeypatch):
+    monkeypatch.setattr(settings, "FIRST_PASS_FAST_PATH_ENABLED", True)
+
+
+# --- plumbing: the flag AND the caller's first_pass are both needed ---------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "flag,first_pass,expected",
+    [(False, False, False), (False, True, False), (True, False, False), (True, True, True)],
+)
+async def test_context_first_pass_needs_the_flag_and_the_caller(monkeypatch, flag, first_pass, expected):
+    monkeypatch.setattr(settings, "FIRST_PASS_FAST_PATH_ENABLED", flag)
+    # Context validates a live asyncssh connection; what is under test is the ContextConfig
+    # build_context assembles, so capture the kwargs instead of constructing the model.
+    monkeypatch.setattr(pipeline_factory_module, "Context", lambda **kw: SimpleNamespace(**kw))
+    redis = SimpleNamespace(
+        get_verified_job_info=AsyncMock(return_value={}),
+        is_elem_exists_in_set=AsyncMock(return_value=False),
+    )
+    factory = PipelineFactory.__new__(PipelineFactory)
+    factory.redis_service = redis
+    for name in (
+        "ssh_service",
+        "validation_service",
+        "verifyx_validation_service",
+        "inspector_validation_service",
+        "collateral_contract_service",
+        "executor_connectivity_service",
+        "backend_client",
+        "pod_recovery",
+        "container_cleanup",
+    ):
+        setattr(factory, name, MagicMock())
+    shell = SimpleNamespace(ssh_client=MagicMock())
+    executor = SimpleNamespace(
+        uuid=EXECUTOR, address="1.2.3.4", port=8000, ssh_username="root", ssh_port=22, root_dir="/root/app"
+    )
+    encrypted_files = SimpleNamespace(
+        encrypt_key="k", machine_scrape_file_name="scrape", machine_scrape_source=None,
+        all_keys={}, tmp_directory="/tmp/x",
+    )
+    miner_info = SimpleNamespace(
+        job_batch_id="b", miner_hotkey="m", miner_coldkey="c", miner_address="1.1.1.1", miner_port=1
+    )
+
+    ctx = await factory.build_context(
+        shell=shell,
+        miner_info=miner_info,
+        executor_info=executor,
+        keypair=None,
+        private_key="p",
+        public_key="q",
+        encrypted_files=encrypted_files,
+        rented_data=None,
+        default_docker_image_digests={},
+        first_pass=first_pass,
+    )
+
+    assert ctx.config.first_pass is expected
+
+
+def test_context_config_default_is_not_a_first_pass():
+    assert build_context_config().first_pass is False
+
+
+# --- capability matmul --------------------------------------------------------------------
+
+
+class _SizingAwareValidationService(DummyValidationService):
+    async def validate_gpu_model_and_process_job(self, *, ssh_client, executor_info, default_extra, machine_spec, **kw):
+        self.sizing_kwargs = kw
+        return await super().validate_gpu_model_and_process_job(
+            ssh_client=ssh_client, executor_info=executor_info, default_extra=default_extra, machine_spec=machine_spec
+        )
+
+
+@pytest.mark.asyncio
+async def test_scored_capability_call_passes_no_sizing(fast_path_on, context_factory):
+    service = _SizingAwareValidationService(success=True)
+    ctx = context_factory(
+        services=build_services(validation=service),
+        config=build_context_config(first_pass=False),
+        state=build_state(specs={"gpu": {"count": 1}}),
+    )
+
+    result = await CapabilityCheck().run(ctx)
+
+    assert result.passed is True
+    assert service.sizing_kwargs == {}
+    assert "first_pass_vram_budget_mb" not in result.event.what_we_saw
+
+
+@pytest.mark.asyncio
+async def test_first_pass_capability_call_sizes_the_matmul_from_the_budget(fast_path_on, context_factory):
+    service = _SizingAwareValidationService(success=True, metrics={"fp32_tflops": 1.0})
+    ctx = context_factory(
+        services=build_services(validation=service),
+        config=build_context_config(first_pass=True),
+        state=build_state(specs={"gpu": {"count": 1}}),
+    )
+
+    result = await CapabilityCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == CapMsg.VERIFY_OK.reason
+    assert service.sizing_kwargs == {"vram_budget_mb": settings.FIRST_PASS_MATMUL_VRAM_MB}
+    assert result.event.what_we_saw["first_pass_vram_budget_mb"] == 8192
+    # A failed matmul still fails the first pass: the check itself is not skipped.
+    failing = _SizingAwareValidationService(success=False)
+    ctx = context_factory(
+        services=build_services(validation=failing),
+        config=build_context_config(first_pass=True),
+        state=build_state(specs={"gpu": {"count": 1}}),
+    )
+    assert (await CapabilityCheck().run(ctx)).passed is False
+
+
+@pytest.fixture
+def matrix_service(monkeypatch):
+    wrapper = MagicMock(name="DMCompVerifyWrapper")
+    wrapper.DMCompVerify_new.return_value = "ptr"
+    wrapper.getCipherText.return_value = "deadbeef"
+    monkeypatch.setattr(mvs, "DMCompVerifyWrapper", lambda *_a, **_kw: wrapper)
+    return mvs.ValidationService(), wrapper
+
+
+def _h200_spec():
+    return {"gpu": {"count": 1, "details": [{"name": "NVIDIA H200", "uuid": "GPU-1", "capacity": 143771}]}}
+
+
+@pytest.mark.asyncio
+async def test_vram_budget_shrinks_dim_k_and_default_is_full_card(matrix_service):
+    svc, wrapper = matrix_service
+    ssh = SimpleNamespace(run=AsyncMock(return_value=SimpleNamespace(stdout="UUID: nope", stderr="")))
+    executor = SimpleNamespace(root_dir="/root/app", python_path="/usr/bin/python3")
+
+    async def sized_for(machine_spec, **kw) -> tuple[int, int]:
+        await svc.validate_gpu_model_and_process_job(
+            ssh_client=ssh, executor_info=executor, default_extra={}, machine_spec=machine_spec, **kw
+        )
+        _ptr, dim_n, dim_k = wrapper.setDimension.call_args_list[-1].args
+        return dim_n, dim_k
+
+    dim_n, full_dim_k = await sized_for(_h200_spec())
+    assert full_dim_k == int(svc.get_max_matrix_dimensions(143771, dim_n))
+    dim_n, budget_dim_k = await sized_for(_h200_spec(), vram_budget_mb=8192)
+    assert budget_dim_k == int(svc.get_max_matrix_dimensions(8192, dim_n))
+    # (143771 - 4096) MB vs (8192 - 2048) MB of matrices: 20x less to generate and copy.
+    assert full_dim_k > 15 * budget_dim_k
+    assert budget_dim_k > 100_000  # still a real matmul, not a no-op
+
+    # A card smaller than the budget is sized as today.
+    small = {"gpu": {"count": 1, "details": [{"name": "RTX 3070", "uuid": "GPU-2", "capacity": 8192}]}}
+    dim_n, small_dim_k = await sized_for(small, vram_budget_mb=16384)
+    assert small_dim_k == int(svc.get_max_matrix_dimensions(8192, dim_n))
+
+
+# --- VerifyX ------------------------------------------------------------------------------
+
+
+class _ConfigAwareVerifyX:
+    def __init__(self, response: MockVerifyXResponse):
+        self._response = response
+        self.kwargs: dict = {}
+
+    async def validate_verifyx_and_process_job(self, *, shell, executor_info, default_extra, machine_spec, **kw):
+        self.kwargs = kw
+        return self._response
+
+
+def _probe(download: float | None) -> MockVerifyXResponse:
+    network = {} if download is None else {"download_speed": download, "upload_speed": 30.0}
+    return MockVerifyXResponse(data={"success": True, "ram": {"total": 64}, "hard_disk": {"total": 900}, "network": network})
+
+
+def _ctx(context_factory, service, *, first_pass: bool, rented_data=None):
+    return context_factory(
+        services=build_services(verifyx=service),
+        config=build_context_config(verifyx_enabled=True, first_pass=first_pass),
+        state=build_state(specs={"gpu": {"count": 1}}, rented_data=rented_data),
+    )
+
+
+def _never_measured():
+    return RentedExecutorsResponse(executors={}, banned_guids=[], network_ema={})
+
+
+@pytest.mark.asyncio
+async def test_scored_verifyx_call_passes_no_overrides_and_keeps_the_gate(fast_path_on, context_factory):
+    service = _ConfigAwareVerifyX(_probe(59.9))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, first_pass=False, rented_data=_never_measured()))
+
+    assert service.kwargs == {}
+    assert result.passed is False
+    assert result.event.reason_code == VxMsg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+
+
+@pytest.mark.asyncio
+async def test_first_pass_verifyx_uses_the_smaller_challenge_config(fast_path_on, context_factory):
+    service = _ConfigAwareVerifyX(_probe(500.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, first_pass=True, rented_data=_never_measured()))
+
+    assert service.kwargs == {
+        "challenge_config_overrides": {"memory_max_test_gb": 16, "storage_throughput_test_gb": 1}
+    }
+    assert result.passed is True
+    assert result.event.what_we_saw["first_pass_challenge_config"] == {
+        "memory_max_test_gb": 16,
+        "storage_throughput_test_gb": 1,
+    }
+    # A warm sample seeds the EMA exactly as today.
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(500.0)
+
+
+@pytest.mark.asyncio
+async def test_first_pass_cold_sample_is_published_but_the_gate_is_deferred(fast_path_on, context_factory):
+    service = _ConfigAwareVerifyX(_probe(59.9))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, first_pass=True, rented_data=_never_measured()))
+
+    assert result.passed is True
+    assert result.event.reason_code == VxMsg.VERIFY_SUCCESS.reason
+    assert result.event.what_we_saw["bandwidth_gate"] == "deferred_to_first_scored_cycle"
+    assert result.event.what_we_saw["first_sample_download_speed_mbps"] == 59.9
+    network = result.updates["state"].specs["network"]
+    assert network["verifyx_download_speed"] == 59.9  # measured and published
+    assert "ema_verifyx_download_speed" not in network  # not seeded: the first scored cycle bootstraps
+    assert "ema_verifyx_upload_speed" not in network
+    assert result.updates["state"].specs["ram"] == {"total": 64}
+
+
+@pytest.mark.asyncio
+async def test_first_pass_failed_network_probe_is_deferred_too(fast_path_on, context_factory):
+    result = await VerifyXCheck().run(
+        _ctx(context_factory, _ConfigAwareVerifyX(_probe(None)), first_pass=True, rented_data=_never_measured())
+    )
+
+    assert result.passed is True
+    assert result.event.what_we_saw["bandwidth_gate"] == "deferred_to_first_scored_cycle"
+    assert result.event.what_we_saw["first_sample_download_speed_mbps"] is None
+
+
+@pytest.mark.asyncio
+async def test_first_pass_on_a_host_with_an_ema_keeps_the_gate(fast_path_on, context_factory):
+    known = RentedExecutorsResponse(
+        executors={}, banned_guids=[],
+        network_ema={EXECUTOR: NetworkEMA(ema_verifyx_download_speed=110.0, ema_verifyx_upload_speed=40.0)},
+    )
+
+    result = await VerifyXCheck().run(_ctx(context_factory, _ConfigAwareVerifyX(_probe(20.0)), first_pass=True, rented_data=known))
+
+    assert result.passed is False
+    assert result.event.reason_code == VxMsg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+
+
+@pytest.mark.asyncio
+async def test_first_pass_ram_or_disk_failure_still_fails(fast_path_on, context_factory):
+    failed = MockVerifyXResponse(data={"success": False, "errors": ["Insufficient memory: 6 GB allocated, 8 GB required"]})
+
+    result = await VerifyXCheck().run(_ctx(context_factory, _ConfigAwareVerifyX(failed), first_pass=True, rented_data=_never_measured()))
+
+    assert result.passed is False
+    assert result.event.reason_code == VxMsg.VERIFY_FAILED.reason
+
+
+@pytest.mark.asyncio
+async def test_flag_off_first_pass_is_todays_behaviour(monkeypatch, context_factory):
+    monkeypatch.setattr(settings, "FIRST_PASS_FAST_PATH_ENABLED", False)
+    # The flag is resolved in build_context, so ContextConfig.first_pass is False; here we assert
+    # the checks themselves also do nothing special when it is False.
+    verifyx = _ConfigAwareVerifyX(_probe(59.9))
+    result = await VerifyXCheck().run(_ctx(context_factory, verifyx, first_pass=False, rented_data=_never_measured()))
+    assert verifyx.kwargs == {}
+    assert result.passed is False
+
+    matmul = _SizingAwareValidationService(success=True)
+    ctx = context_factory(
+        services=build_services(validation=matmul),
+        config=build_context_config(first_pass=False),
+        state=build_state(specs={"gpu": {"count": 1}}),
+    )
+    await CapabilityCheck().run(ctx)
+    assert matmul.sizing_kwargs == {}
+
+
+@pytest.mark.asyncio
+async def test_verifyx_service_applies_overrides_to_the_challenge_config_only():
+    service = VerifyXValidationService()
+    seen: dict = {}
+
+    class _FakeValidator:
+        def __init__(self, lib_name, seed):
+            pass
+
+        def generate_challenge(self, challenge_input):
+            seen.update(challenge_input)
+            return "deadbeef"
+
+    with patch(
+        "neurons.validators.src.services.verifyx_validation_service.sha256_from_path", return_value="s"
+    ), patch(
+        "neurons.validators.src.services.verifyx_validation_service.VerifyXValidator", _FakeValidator
+    ):
+        shell = MagicMock()
+        shell.get_sha256_checksum_by_path = AsyncMock(return_value="s")
+        shell.get_checksums_over_scp = AsyncMock(return_value="md5:s")
+        shell.ssh_client = MagicMock()
+        shell.ssh_client.run = AsyncMock(return_value=SimpleNamespace(stdout="", stderr="", exit_status=0))
+        executor = SimpleNamespace(root_dir="/root/app", python_path="/usr/bin/python3")
+        spec = {"gpu": {"count": 1, "details": [{"uuid": "u", "name": "H100"}]}}
+
+        await service.validate_verifyx_and_process_job(shell=shell, executor_info=executor, default_extra={}, machine_spec=spec)
+        default_config = dict(seen["config"])
+        await service.validate_verifyx_and_process_job(
+            shell=shell, executor_info=executor, default_extra={}, machine_spec=spec,
+            challenge_config_overrides={"memory_max_test_gb": 16, "storage_throughput_test_gb": 1},
+        )
+        first_pass_config = dict(seen["config"])
+
+    assert default_config["memory_max_test_gb"] == settings.verifyx.MEMORY_MAX_TEST_GB
+    assert default_config["storage_throughput_test_gb"] == settings.verifyx.STORAGE_THROUGHPUT_TEST_GB
+    assert first_pass_config == {**default_config, "memory_max_test_gb": 16, "storage_throughput_test_gb": 1}
+    # Untouched: the RAM minimum the executor must still allocate, the disk minimum, the download.
+    assert first_pass_config["memory_min_test_gb"] == default_config["memory_min_test_gb"]
+    assert first_pass_config["storage_min_available_gb"] == default_config["storage_min_available_gb"]
+    assert first_pass_config["network_timeout_seconds"] == default_config["network_timeout_seconds"]

--- a/neurons/validators/tests/test_first_pass_fast_path.py
+++ b/neurons/validators/tests/test_first_pass_fast_path.py
@@ -276,6 +276,36 @@ async def test_first_pass_failed_network_probe_is_deferred_too(fast_path_on, con
     assert result.event.what_we_saw["first_sample_download_speed_mbps"] is None
 
 
+class _ConfigAwareSequence:
+    """Queued responses, and the keyword arguments of every call."""
+
+    def __init__(self, *responses: MockVerifyXResponse):
+        self._responses = list(responses)
+        self.kwargs_per_call: list[dict] = []
+
+    async def validate_verifyx_and_process_job(self, *, shell, executor_info, default_extra, machine_spec, **kw):
+        self.kwargs_per_call.append(kw)
+        return self._responses.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_first_pass_cold_sample_retry_measures_with_the_same_smaller_config(
+    fast_path_on, monkeypatch, context_factory
+):
+    """DAH-2959 + DAH-3011 compose: with both flags on, the cold-sample retry is a first-pass
+    probe too — the 128 GB / 5 GB write must not come back on the second sample."""
+    monkeypatch.setattr(settings, "VERIFYX_COLD_SAMPLE_RETRY_ENABLED", True)
+    service = _ConfigAwareSequence(_probe(59.9), _probe(500.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, first_pass=True, rented_data=_never_measured()))
+
+    first_pass_overrides = {"challenge_config_overrides": {"memory_max_test_gb": 16, "storage_throughput_test_gb": 1}}
+    assert service.kwargs_per_call == [first_pass_overrides, first_pass_overrides]
+    assert result.passed is True
+    assert result.event.what_we_saw["cold_sample_retry"]["used"] == "retry"
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(500.0)
+
+
 @pytest.mark.asyncio
 async def test_first_pass_on_a_host_with_an_ema_keeps_the_gate(fast_path_on, context_factory):
     known = RentedExecutorsResponse(

--- a/neurons/validators/tests/test_new_rentals_pause_filter.py
+++ b/neurons/validators/tests/test_new_rentals_pause_filter.py
@@ -101,6 +101,9 @@ def _miner_service() -> MinerService:
     # request_job_to_miner awaits this before submitting the SSH key (G3);
     # None = no attestation event, the legacy path.
     service.attestation_service.maybe_issue_nonce = AsyncMock(return_value=None)
+    # __new__ skips __init__: give the service the lane map _claim_for_cycle reads when
+    # EXPRESS_LANE_ENABLED is on (DAH-2958), so the suite also passes with the flag set
+    service.in_flight = {}
     return service
 
 

--- a/neurons/validators/tests/test_verifyx_cold_sample_retry.py
+++ b/neurons/validators/tests/test_verifyx_cold_sample_retry.py
@@ -1,0 +1,190 @@
+"""DAH-2959: a never-measured executor's first VerifyX download sample decides its first cycle alone
+(the EMA bootstraps from it). With VERIFYX_COLD_SAMPLE_RETRY_ENABLED the check takes one more sample
+inside the same task and gates on the better one; flag off is today's single sample."""
+
+import pytest
+
+from core.config import settings
+from neurons.validators.src.services.task.checks.verifyx import VerifyXCheck
+from neurons.validators.src.services.task.messages import VerifyXMessages as Msg
+from protocol.vc_protocol.compute_requests import NetworkEMA, RentedExecutorsResponse
+
+from tests.helpers import build_context_config, build_services, build_state
+from tests.test_verifyx_check import MockVerifyXResponse
+
+EXECUTOR = "executor-123"  # tests.helpers.default_executor().uuid
+
+
+def _probe(download: float | None, *, success: bool = True, upload: float | None = 40.0) -> MockVerifyXResponse:
+    network = {} if download is None else {"download_speed": download, "upload_speed": upload}
+    return MockVerifyXResponse(
+        data={"success": success, "ram": {"total": 64}, "hard_disk": {"total": 1000}, "network": network}
+    )
+
+
+class _ProbeSequence:
+    """Returns the queued responses in order and counts the calls."""
+
+    def __init__(self, *responses: MockVerifyXResponse):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def validate_verifyx_and_process_job(self, *, shell, executor_info, default_extra, machine_spec):
+        self.calls += 1
+        return self._responses.pop(0)
+
+
+def _never_measured() -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(executors={}, banned_guids=[], network_ema={})
+
+
+def _known(download: float) -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(
+        executors={},
+        banned_guids=[],
+        network_ema={EXECUTOR: NetworkEMA(ema_verifyx_download_speed=download, ema_verifyx_upload_speed=50.0)},
+    )
+
+
+def _ctx(context_factory, service, rented_data):
+    return context_factory(
+        services=build_services(verifyx=service),
+        config=build_context_config(verifyx_enabled=True),
+        state=build_state(specs={"gpu": {"count": 1}}, rented_data=rented_data),
+    )
+
+
+@pytest.fixture
+def retry_on(monkeypatch):
+    monkeypatch.setattr(settings, "VERIFYX_COLD_SAMPLE_RETRY_ENABLED", True)
+
+
+@pytest.mark.asyncio
+async def test_flag_off_is_todays_single_cold_sample(monkeypatch, context_factory):
+    monkeypatch.setattr(settings, "VERIFYX_COLD_SAMPLE_RETRY_ENABLED", False)
+    service = _ProbeSequence(_probe(59.9), _probe(760.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 1
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(59.9)
+    assert "cold_sample_retry" not in result.event.what_we_saw
+
+
+@pytest.mark.asyncio
+async def test_cold_first_sample_is_re_measured_and_the_better_one_seeds_the_ema(retry_on, context_factory):
+    # b3e4ca69, 4 Sep: 59.9 Mbps on the first sample, ~760 Mbps once the link was free.
+    service = _ProbeSequence(_probe(59.9, upload=20.0), _probe(760.0, upload=110.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is True
+    assert result.event.reason_code == Msg.VERIFY_SUCCESS.reason
+    network = result.updates["state"].specs["network"]
+    assert network["verifyx_download_speed"] == pytest.approx(760.0)
+    assert network["ema_verifyx_download_speed"] == pytest.approx(760.0)
+    assert network["verifyx_upload_speed"] == pytest.approx(110.0)
+    assert result.event.what_we_saw["cold_sample_retry"] == {
+        "first_download_speed_mbps": 59.9,
+        "retry_download_speed_mbps": 760.0,
+        "used": "retry",
+    }
+
+
+@pytest.mark.asyncio
+async def test_two_slow_samples_still_fail_the_unchanged_gate(retry_on, context_factory):
+    service = _ProbeSequence(_probe(40.0), _probe(88.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_FAILED_NETWORK_SPEED_TOO_SLOW.reason
+    # The better of the two is what the node is judged on and what seeds the EMA.
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(88.0)
+    assert result.event.what_we_saw["cold_sample_retry"]["used"] == "retry"
+
+
+@pytest.mark.asyncio
+async def test_failed_network_probe_on_first_sample_is_retried(retry_on, context_factory):
+    # download_speed None (probe timed out) would bootstrap the EMA to 0.0.
+    service = _ProbeSequence(_probe(None), _probe(300.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is True
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(300.0)
+    assert result.event.what_we_saw["cold_sample_retry"]["first_download_speed_mbps"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_worse_retry_keeps_the_first_sample(retry_on, context_factory):
+    service = _ProbeSequence(_probe(70.0), _probe(30.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is False
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(70.0)
+    assert result.event.what_we_saw["cold_sample_retry"]["used"] == "first"
+
+
+@pytest.mark.asyncio
+async def test_a_retry_whose_probe_failed_outright_is_not_used(retry_on, context_factory):
+    service = _ProbeSequence(_probe(70.0), _probe(900.0, success=False))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 2
+    assert result.passed is False
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(70.0)
+
+
+@pytest.mark.asyncio
+async def test_known_host_below_the_gate_is_not_retried(retry_on, context_factory):
+    # prev EMA 110 + sample 20 -> EMA 65: a real slow host, judged as today.
+    service = _ProbeSequence(_probe(20.0), _probe(900.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _known(110.0)))
+
+    assert service.calls == 1
+    assert result.passed is False
+    assert result.updates["state"].specs["network"]["ema_verifyx_download_speed"] == pytest.approx(65.0)
+
+
+@pytest.mark.asyncio
+async def test_fast_first_sample_is_not_retried(retry_on, context_factory):
+    service = _ProbeSequence(_probe(500.0), _probe(1.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 1
+    assert result.passed is True
+    assert "cold_sample_retry" not in result.event.what_we_saw
+
+
+@pytest.mark.asyncio
+async def test_without_backend_data_nobody_looks_new_and_nothing_is_retried(retry_on, context_factory):
+    # rented_data None: every executor would look never-measured; a backend blip must not double VerifyX fleet-wide.
+    service = _ProbeSequence(_probe(59.9), _probe(760.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, None))
+
+    assert service.calls == 1
+    assert result.passed is False
+
+
+@pytest.mark.asyncio
+async def test_ram_or_disk_failure_on_the_first_sample_is_not_retried(retry_on, context_factory):
+    # The retry is for the network sample only; a probe that failed on RAM/disk is judged as today.
+    service = _ProbeSequence(_probe(59.9, success=False), _probe(760.0))
+
+    result = await VerifyXCheck().run(_ctx(context_factory, service, _never_measured()))
+
+    assert service.calls == 1
+    assert result.passed is False
+    assert result.event.reason_code == Msg.VERIFY_FAILED.reason


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-2958](https://app.notion.com/p/Provider-time-to-ready-a-new-node-waits-for-the-15-min-cycle-boundary-and-then-for-the-slowest-mine-3d3b8bfdbde9816f907ac5ec52096c92) · reviewer: @taiberium

**TL;DR** — A new node waited a median 21 min for its first score: the 5-min portal snapshot hid it, publishing waited for the fleet-wide cycle, the first pass ran the full probes, a cold network sample failed the gate. Four changes, three behind flags off by default: 30 s snapshot, express lane, fast first pass, one VerifyX retry. Risk: flags off, nothing changes.

**What changed**
- `SNAPSHOT_TTL_SECONDS` 300 → 30 in the central miner's portal client (`miners/src/clients/miner_portal_api.py`)
- `EXPRESS_LANE_ENABLED` (off): verifies executors registered after the first cycle since start, alone; publishes spec-only (`core/express_lane.py`)
- `FIRST_PASS_FAST_PATH_ENABLED` (off): the express verification runs with `first_pass=True` → smaller probes (`services/miner_service.py`)
- `VERIFYX_COLD_SAMPLE_RETRY_ENABLED` (off): one more sample when a new node's first is under the gate (`checks/verifyx.py`)
- job files in a fresh `temp/cycle-*` per cycle; the lane's are kept while it reads them (`services/file_encrypt_service.py`)
- a wave-verified executor stays claimed until the cycle records its publish (`services/miner_service.py`)

**How to verify**
- `pdm run pytest tests/test_express_lane.py tests/test_first_pass_fast_path.py tests/test_verifyx_cold_sample_retry.py -q` → 49 passed
- `pdm run pytest tests/ -q --strict-markers` in validators → 1988 passed + main's own 2 failures; miners → 27 passed

**Verified by the loop:** 8 Sep 2026 · sandbox EC2 · validators 1988 passed · miners 27 passed · Result: PASS 284eb153 · Gate: PASS 0b5c576

**Ran it:** validators suite at 0b5c576 on sandbox EC2 (aws_run 20260908T073232Z-s20v) → 49 targeted, 1988 passed, main's own 2 fail · e2e stack at 284eb153 (aws_run 20260908T003721Z-7etq; this round changes no wire path) · not run on macOS (server code)

**Self-review:** clean at 0b5c576 (15 checks, 2 low)

**Parts:** backend ✓ validator + miner · migration n/a — no schema · frontend n/a — no UI · CLI/SDK n/a — server side · docs ✓ `.env.template`, lium-docs#217 · tests ✓ 49 in three files (+10), miners +1 · dashboards n/a — `[express]` log

**Docs:** `.env.template` names the three flags and their knobs · provider timing: lium-docs#217.

<details><summary>Details</summary>

**Consolidates** #1280, #1282, #1291, #1288 — one PR per feature (owner, daily call 7 Sep 2026; SO §40). Why one feature: one linear stack for one outcome (DAH-2957/2958/3011/2959: a new node is scored within minutes, not 21); flags default off. Base: `main`. Every slice's branch is merged with `--no-ff`, so its commits, authorship and history are intact; the slices are closed with a pointer here. The reviewer is the one named on line 1.

## Self-review round (7 Sep 2026, subagent-batchD) — 6 findings, fixed in `2fbcdae3`

| finding | fix | proof |
|---|---|---|
| `FIRST_PASS_FAST_PATH_ENABLED` had no caller | `first_pass` travels `request_job_to_miner` → `_request_job_to_miner` → both `create_task` call sites; `ExpressLane._verify` passes `first_pass=True`, the cycle never does (`miner_service.py`, `express_lane.py`) | `test_first_pass_reaches_the_task_only_when_the_caller_asks_for_it`; `test_a_never_validated_executor_is_verified_alone_and_published_spec_only` asserts `first_pass is True` |
| an express verification straddling the next cycle's `ecrypt_miner_job_files()` rmtree was published as the node's failure | each cycle writes its job files to a fresh `temp/cycle-*` directory (`FileEncryptService.fresh_job_files_directory`); the validator passes the directories the lane still reads (`ExpressLane.directories_in_use()`, flag on) and they are removed by the first cycle that starts after those verifications ended; flag off: every earlier directory is removed, as the rmtree did | `test_the_next_cycle_keeps_the_job_files_a_running_express_verification_reads` (with the no-`keep` negative control), `test_a_verification_that_raises_releases_its_job_files_directory` |
| "validated" meant "published since the flag went on": executors of a miner that failed or was offline in the seed cycle looked new | `CycleInputs.fleet_known_since` = when the first cycle since process start began; the lane skips executors registered before it or without `created_at` (`express_lane.py`, `validator.py`); docstrings in `validator.py` and `miner_service.py` rewritten | `test_an_executor_registered_before_the_first_cycle_is_the_cycles_even_when_never_published` |
| the DAH-2959 retry call omitted `**sizing` | the retry passes the same first-pass overrides (`checks/verifyx.py`) | `test_first_pass_cold_sample_retry_measures_with_the_same_smaller_config` |
| duplicate FIRST_PASS block in `.env.template` | second block deleted | `grep -c FIRST_PASS_FAST_PATH_ENABLED neurons/validators/.env.template` → 1 |
| stale suite counts and per-file test counts | this section and the fold | run below |

## Self-review round 4 (8 Sep 2026, subagent-batchD4) — 2 findings, fixed in `284eb153`

| finding | fix | proof |
|---|---|---|
| the wave dropped its `in_flight` claim the moment a miner's pipeline ended, but the cycle records its published executors once, minutes later; a node registered after `fleet_known_since` that the wave reached first was, in between, neither validated nor running, so the lane ran it a second time and its spec-only publish could land after the scored one | the claim becomes `CYCLE_DONE` and stays in `in_flight` until `Validator.sync()` has recorded the cycle's publish (`MinerService.forget_cycle_done`); the lane skips anything in `in_flight`; the next wave overwrites the marker (`services/miner_service.py`, `core/validator.py`) | `test_an_executor_the_wave_verified_is_not_run_again_before_the_cycle_records_it`, `test_the_wave_skips_an_executor_the_express_lane_holds_and_marks_its_own_done`; both fail with the old `del` |
| a Redis error on the lane's own `mark_executors_validated`, after the result was published, fell into the failed-verification path and re-ran the node after the backoff | the write has its own `except`: the node is left to the cycle (its next seed records it), `_pending` is dropped, the metric line is still emitted (`core/express_lane.py`) | `test_a_published_result_is_not_run_again_when_recording_it_fails`; fails on `ff87f057`'s `express_lane.py` |

## Self-review round 3 (8 Sep 2026, subagent-batchD3) — 4 findings, fixed in `ff87f057`

| finding | fix | proof |
|---|---|---|
| the `EXPRESS_LANE_*` block of `.env.template` sat under the *Local Dev* header, after the commented-out `DEBUG_*` lines | moved next to the other two flag blocks, above the header; no value changed | `.env.template` lines 39–44 on the head |
| *How to verify* still said 44 / 1983 (the fold is rendered from the readability override, which still held the old counts) | the override and the fold say 47 / 1986 | this body |
| the e2e per-step seconds under the kgar run were the earlier run's | kgar's `e2e-timings.txt`: build 3, up 36, cycle 57, protocol 24, rental 59 | this body |
| *Docs* said the template names four flags; it names three (and their knobs) | the line says three | `.env.template` |

## Self-review round 2 (7 Sep 2026, subagent-batchD2) — 2 findings, fixed in `da7cb78f`

| finding | fix | proof |
|---|---|---|
| `tick()` read the cycle inputs before four awaits and took the job-files hold after them; a cycle prepping in that window removed the directory, the lane verified on it, the pipeline's missing-upload failure was published as the node's and the executor marked validated | the inputs are read again after the last await and the hold is taken in the same synchronous step (`express_lane.py` `tick`); a tick whose current directory is missing skips; a result produced after the directory vanished is discarded and retried without counting an attempt against the node (`_verify`) | `test_a_cycle_that_starts_during_the_tick_moves_the_launch_to_its_job_files`, `test_a_missing_job_files_directory_skips_the_tick_instead_of_verifying_without_it`, `test_a_result_produced_after_the_job_files_vanished_is_not_the_nodes_verdict` (negative control inside); all three fail on `2fbcdae3`'s `express_lane.py` |
| the Details *Consolidates* paragraph named a reviewer other than line 1 | the paragraph names no reviewer; line 1 (the ledger) is the single source, and `consolidation/consolidate.py` no longer writes one | this body |

## Review round (8 Sep 2026, taiberium) — 3 nits, fixed in `0b5c576f`

- `core/express_lane.py`: `tick` is discovery, `_select` the caps, `_launch` the start; `_verify` runs the job, `_publish` publishes and logs. Same awaits in the same order, same in-flight and directory bookkeeping.
- `checks/verifyx.py`: `cold_sample_retry` is a frozen `ColdSampleRetry` dataclass, attached to the event and the log line with `asdict` (same JSON shape).
- `clients/validator_portal_api.py`: the docstring names the portal's commented-out registration check (`SubtensorClient.get_miner`, a lookup over every subnet neuron, which a registered validator hotkey passes).
- The three files are formatted with the repo's pinned ruff 0.5.1 (`.pre-commit-config.yaml`).

**Verified by the loop on 8 Sep 2026** (sandbox EC2 c6i.2xlarge, Python 3.11.11; aws_run `20260908T073232Z-s20v`, 3 m 41 s): head `0b5c576f` — `tests/test_express_lane.py tests/test_first_pass_fast_path.py tests/test_verifyx_cold_sample_retry.py` 49 passed; Validators suite 1988 passed, 15 skipped, 2 pre-existing failures = main (`test_scrape_infiniband`, `test_sshd_bootstrap_script`); `ruff format --check` (0.5.1) clean on the three files. Result: PASS 0b5c576f.

## Verification of the consolidated branch

**Verified by the loop on 8 Sep 2026** (sandbox EC2 c6i.4xlarge, Python 3.11.11; aws_run `20260908T003721Z-7etq`): head `284eb153` merged onto `main` `07ec64cd` — Validators 1988 passed, 15 skipped, 2 pre-existing failures = main; Miners 27 passed; Executor untouched (main: 128 passed); #1312 e2e stack PASS (cycle 5/5, protocol 13/13, rental 2/2). Result: PASS 284eb153.

Sandbox EC2 run `fixD2-lium-io-1315-r3` `20260908T003721Z-7etq` (`tools/aws_run_jobs/reverify_io.sh`, E2E=1, PAR=1, c6i.4xlarge, Python 3.11.11, CI env: sqlite, wallet/TDX vars, --strict-markers) on the pushed head `284eb153` (uploaded as a bundle before the push, SO §33) merged onto `main` `07ec64cd` cleanly:

- validators: **1988 passed**, 2 failed, 15 skipped in 114 s — the 2 failures are main's own (`test_scrape_infiniband::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices`, `test_sshd_bootstrap_script::test_adopt_path_hardens_config_for_key_only_auth`; root-on-the-box artefacts, main baseline in the same run: 1939 passed, the same 2 failed); 0 failures beyond main's.
- miners: **27 passed** (main: 26; `test_wave_sees_node_added_after_a_recent_rental_refresh` is the +1).
- executor: not touched by this PR (`neurons/executor/` unchanged), so the job ran it on main only: 128 passed.
- the #1312 e2e stack (`e2e/` from `pr/1312` overlaid on the merged tree, `gate.sh`): **PASS** — build 3 s, up 37 s, cycle 5/5 (57 s), protocol 13/13 (24 s), rental 2/2 (60 s); the same gate on main's own tree passed first.
- per file: `test_express_lane.py` 22 tests (13 from #1282 + 9), `test_first_pass_fast_path.py` 14 tests (13 from #1291 + 1; one is parametrized over the 4 flag combinations), `test_verifyx_cold_sample_retry.py` 10, `neurons/miners/tests/test_miner_portal_api.py` 14 (13 + 1).

Earlier runs: at `da7cb78f` (before the fourth self-review round) `20260907T233755Z-kgar`, E2E=1: validators 1986 passed with the same 2 pre-existing failures, miners 27, e2e PASS. At `2fbcdae3` (before the second) `20260907T220113Z-pw9u`, E2E=1: validators 1983 passed, miners 27, e2e PASS. At `118bce6` (before the first self-review round): `consol-lium-io-20260907T174547Z`, E2E=0: validators 1978 passed with the same 2 pre-existing failures, miners 27, executor 128. CI on GitHub at `118bce6`: every check green — https://github.com/Datura-ai/lium-io/actions/runs/34158197040, https://github.com/Datura-ai/lium-io/actions/runs/34158199068.
Gate: PASS (284eb15) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1315)

## #1280 — DAH-2957 - [P1] central miner refreshes the portal snapshot after 30 s

_head `1007b41c` (`DAH-2957-miner-snapshot-ttl`), was based on `main`._

Implements [DAH-2957](https://app.notion.com/p/New-nodes-miss-their-first-validator-cycle-the-central-miner-s-5-min-portal-snapshot-is-served-as-f-3d3b8bfdbde981cb9267e1cd046c6f46) · reviewer: @jam6099 @pixel29913

**TL;DR** — A node registered in the portal shortly after a rental refreshed the central miner's executor snapshot is invisible to the validator wave that starts inside the snapshot's 5-minute TTL. `neurons/miners/src/clients/miner_portal_api.py`: `SNAPSHOT_TTL_SECONDS` 300 → 30, with a comment saying why. Touches validator/executor (`neurons/miners/src/clients/miner_portal_api.py`) — read that file first.

**What changed**
- Test `test_wave_sees_node_added_after_a_recent_rental_refresh` replays the prod timeline (rental refresh at T, node added.

**How to verify**
- `cd neurons/miners && pdm run pytest -q tests/test_miner_portal_api.py` → green

**Verified as slice #1280 (at its head `1007b41`):** 7 Sep 2026 · Linux pod (py3.11) · validators 1939 passed · executor 128 passed · miners 27 passed · Result: PASS · Gate: not run

**Docs:** none changed in this PR — executor/validator internals; nothing a provider sees or sets changes.

<details><summary>#1280 details</summary>

[DAH-2957](https://app.notion.com/p/New-nodes-miss-their-first-validator-cycle-the-central-miner-s-5-min-portal-snapshot-is-served-as-f-3d3b8bfdbde981cb9267e1cd046c6f46).

## Problem
A node registered in the portal shortly after a rental refreshed the central miner's executor snapshot is invisible to the validator wave that starts inside the snapshot's 5-minute TTL, and waits a whole extra 15-minute cycle. Prod Loki, 4 Sep: node `b3e4ca69 (a superseded, rewritten head)` added 15:32:51 — snapshot refreshed 15:32:13 by a rental key-submit, wave at 15:33:54 served the 101-s-old snapshot, no pubkey went to the node, next wave 15:49:03 picked it up (+15 min). Same shape for `aeb904f6 (a superseded, rewritten head)` (refresh 18:31:20, add 18:33:13, wave 18:34:21 skipped, 18:49:38 picked up).

Population (read-only prod DB, 175 nodes added through the portal in the last 30 days): node add → first AVAILABLE p50 21.4 min, p90 63.5 min; the 25–45 min band (26 nodes, 15 %) is exactly one missed cycle. Adds in the 5 min before a wave are 1/3 of all adds, and rental/unrent key-submits (~5 per cycle) refresh the snapshot often enough that the window is usually live.

## Change
`neurons/miners/src/clients/miner_portal_api.py`: `SNAPSHOT_TTL_SECONDS` 300 → 30, with a comment saying why. Nothing else moves: the single-flight lock still collapses the 189-miner wave into one bulk `GET /miners/executors`; stale-on-error and the failed-refresh backoff are unchanged. Cost: at most one extra bulk request per 30 s of rental traffic (≈ 5 per 15-min cycle instead of ≈ 3), against the thin JOIN endpoint DAH-2469 added for exactly this call. Residual miss window 30 s ≈ 0.5 % of adds instead of ≈ 15 %.

Test `test_wave_sees_node_added_after_a_recent_rental_refresh` replays the prod timeline (rental refresh at T, node added, wave at T+101 s) with a mocked monotonic clock; it fails on the old constant.

## How to test
```
cd neurons/miners && pdm run pytest -q tests/test_miner_portal_api.py
```
Run on a Lium pod: 14 passed (13 existing + 1 new); whole miners suite 27 passed. With the constant set back to 300 the new test fails at `assert added in executors_a`.

## Verification

**Verified as slice #1280 on 7 Sep 2026:** PR head merged onto `main` (55be0e9e) on a Linux pod, the three CI suites (Python 3.11.11, pdm, sqlite, CI env vars): Validators 1939 passed, 15 skipped, 2 env artefacts, Executor 128 passed, Miners 27 passed (this PR adds one). The only validator failures are two root-on-a-pod artefacts `main` has too (`test_scrape_infiniband::…unreadable_sysfs…` — chmod 000 does not stop root; `test_sshd_bootstrap_script::…adopt_path…` — the pod runs a live sshd), both pass as a non-root user / in CI. This is the Miners suite CI never ran (no job on `main`); it passes here and under #1289's new job.

## Notes for reviewers
DAH-2469 chose 5 min to kill the per-hotkey fan-out; the fan-out protection is the single-flight lock, not the TTL, so shortening it does not reopen that incident. If you would rather keep 300 s for rentals and force a refresh only on the wave path, the same effect needs a `max_age` parameter threaded from `register_pubkey` (fleet-wide requests have `executor_id=None`); we chose the one-line version. Measurement report and the two other time-to-ready buckets (cycle boundary + slowest-miner wait, DAH-2958; VerifyX first-sample gate, DAH-2959) are on the Notion ticket.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-2957.

Docs: none changed in this PR — executor/validator internals; nothing a provider sees or sets changes.

</details>

## #1282 — DAH-2958 - [P1] validator express lane for never-validated executors (flag, off)

_head `fda52420` (`DAH-2958-express-lane`), was based on `DAH-2957-miner-snapshot-ttl`._

Implements [DAH-2958](https://app.notion.com/p/Provider-time-to-ready-a-new-node-waits-for-the-15-min-cycle-boundary-and-then-for-the-slowest-mine-3d3b8bfdbde9816f907ac5ec52096c92) · stacked on #1280 · reviewer: @jam6099 @pixel29913

**TL;DR** — A new node is published only by the fleet-wide scored cycle, so its first publish waits twice: for the cycle boundary (`BLOCKS_FOR_JOB = 75` blocks. Validator express lane for never-validated executors (flag, off). Touches validator/executor (`neurons/validators/.env.template`) — read that file first.

**What changed**
- An express lane for never-validated executors, behind `EXPRESS_LANE_ENABLED` (default False — flag off is byte-for-byte today's behaviour.
- `core/express_lane.py` (new): `ExpressLane` runs as a second asyncio task beside `Validator.sync()` in the same process, ticking every `EXPRESS_LANE_TICK_SECONDS` (30).
- Seeding: with the flag on, every cycle adds the uuids it published to the Redis set (one `SADD`).
- Caps: `EXPRESS_LANE_MAX_IN_FLIGHT` (4) express verifications at any moment (so ≤ 4 launched per tick), `EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER` (2); oldest registration first.
- Coordination (`MinerService.in_flight: {uuid: "cycle"|"express"}`): the wave claims the executors each miner returns and releases them when the miner's tasks finish…
- Instrumentation: one structured line per express verification, `[express] Executor verified and published ahead of the cycle`, with `executor_uuid`, `miner_hotkey`.

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_express_lane.py -q` → green

**Verified as slice #1282 (at its head `fda5242`):** 7 Sep 2026 · validators 1951 passed · Result: PASS · Gate: not run

**Docs:** neurons/validators/.env.template (EXPRESS_LANE_*) (this PR) · public: none changed in this PR — validator flag off by default; providers see the same statuses, sooner when it is on — troubleshooting.md needs no change

<details><summary>#1282 details</summary>

Merge after #1280 — this branch is stacked on it; GitHub retargets this PR to main when #1280 merges. Review/merge order per repo: https://github.com/Datura-ai/lium-loop/blob/main/improvements/CHANGES_FOR_REVIEW.md

[DAH-2958](https://app.notion.com/p/Provider-time-to-ready-a-new-node-waits-for-the-15-min-cycle-boundary-and-then-for-the-slowest-mine-3d3b8bfdbde9816f907ac5ec52096c92). Origin: prod measurement of 175 node onboardings over 30 days (`RECOVERY/reports/provider_time_to_ready.md`, 6 Sep) — node add → AVAILABLE p50 21.4 / p90 63.5 min, floor 8.2 min; owner decision 6 Sep 16:33Z "build the express lane".

## Problem
A new node is published only by the fleet-wide scored cycle, so its first publish waits twice: for the cycle boundary (`BLOCKS_FOR_JOB = 75` blocks, `core/validator.py` gate → uniform 0–15 min, mean 7.5) and then, after its own pipeline is done (p50 152 s / p90 208 s, fresh node 253 s), for the slowest miner in the fleet — `publish_machine_specs` runs only after `asyncio.wait(jobs)` over all ~189 miners and scoring (last miner +394–801 s after wave start; the node's own task ends at ~250 s → +2–9 min of pure waiting). Dogfood node, 6 Sep: add 04:53:05 → wave 05:01:48 → own task done 05:06:33 → published 05:08:56 = 15 m 52 s, of which ~11 min was waiting. p50 ≈ 10.5 of the 21.4 min is these two waits; sub-5-min time-to-ready is structurally impossible while publish is coupled to fleet-wide scoring.

## Change
An express lane for **never-validated** executors, behind `EXPRESS_LANE_ENABLED` (default **False** — flag off is byte-for-byte today's behaviour: `request_job_to_miner` still sends `executor_id=None`, the wave claims nothing, no task is started, no Redis write).

- `core/express_lane.py` (new): `ExpressLane` runs as a second asyncio task beside `Validator.sync()` in the same process, ticking every `EXPRESS_LANE_TICK_SECONDS` (30). Each tick: one `GET {MINER_PORTAL_REST_API_URL}/miners/executors` — the bulk snapshot the central miner already polls (DAH-2469) — signed with the validator hotkey over the same `AuthenticationPayload` blob `signature_auth_miner` verifies. Candidates = rows with `validator_hotkey == ours` that are not in the Redis set `express_lane_validated_executors` and not held by the wave. For each: `request_job_to_miner(..., executor_id=<uuid>)` → the miner installs the key on that one executor only (`register_pubkey(executor_id=…)`, the path the rental key-submit already uses) → `TaskService.create_task` runs the **same** pipeline with the **same** cycle inputs (the current cycle's encrypted job files, default-image digests and executor-image snapshot, reused via `CycleInputs`; nothing weaker, nothing skipped) → `publish_machine_specs([result])` as the pipeline produced it: no incentive, `scored_at=None`. The backend creates the executor row (score > 0 ⇒ AVAILABLE) and the `prod_executors` validation row, and writes **no** `incentive_per_validator_cycle` row (`is_provider_emission_cycle_eligible` needs `scored_at`). The next scored cycle overwrites the row exactly as today.
- Seeding: with the flag on, every cycle adds the uuids it published to the Redis set (one `SADD`); the lane runs only after the first completed cycle since start. That set holds what cycles published since the flag went on, so an executor whose miner failed or was offline in that first cycle is not in it; the lane therefore also skips every executor the portal registered before that first cycle began (`CycleInputs.fleet_known_since`) or without a `created_at`. A long-known executor stays the cycle's after a deploy or restart; only registrations after the first cycle since start are candidates.
- Caps: `EXPRESS_LANE_MAX_IN_FLIGHT` (4) express verifications at any moment (so ≤ 4 launched per tick), `EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER` (2); oldest registration first. An executor the miner does not return (its own portal snapshot not refreshed yet — lium-io#1280 shrinks that window to 30 s — or unreachable) is retried ≤ 3 times, ≥ 120 s apart, then left to the normal cycle. A registration flood costs the fleet ≤ 4 extra SSH sessions at a time and one portal GET per 30 s.
- Coordination (`MinerService.in_flight: {uuid: "cycle"|"express"}`): the wave claims the executors each miner returns and releases them when the miner's tasks finish (try/finally); the lane never touches a claimed uuid, and re-checks after its own awaits. If a miner's `AcceptSSHKeyRequest` lists an executor the lane is verifying right now, the wave skips that executor for this cycle (`"Executor left to the express lane this cycle"`), so a new node's VerifyX/matrix never run twice concurrently. Only an executor registered after the first cycle since start that no cycle has published can be in that state; scoring of every long-known executor is untouched.
- Instrumentation: one structured line per express verification, `[express] Executor verified and published ahead of the cycle`, with `executor_uuid`, `miner_hotkey`, `outcome`, `score`, `attempt`, `registered_at` (portal `created_at`), `published_at`, `registration_to_publish_s`, `first_seen_to_publish_s`, `verification_s`. The p50 of `registration_to_publish_s` in Loki is the deploy metric. Retries/give-ups log `[express] Executor not verified yet, will retry` / `[express] Executor left to the normal cycle`.
- `request_job_to_miner` / `_request_job_to_miner` gain `executor_id: str | None = None`, threaded into `SSHPubKeySubmitRequest` and the remove request on both the WebSocket and REST paths (the field already exists on the protocol; no datura/miner change), and `first_pass: bool = False`, handed to `TaskService.create_task` on both paths; `ExpressLane._verify` passes `first_pass=True` (DAH-3011), the cycle never does.
- Job files across a cycle boundary: `FileEncryptService.ecrypt_miner_job_files(keep_directories=…)` writes each cycle's files to a fresh `temp/cycle-*` directory and removes the earlier ones except those an express verification still reads (`ExpressLane.directories_in_use()`); an express verification that straddles the next cycle keeps reading the files it started with. With the flag off nothing is kept, so every earlier directory goes, as the rmtree did.

Expected effect: registration → publish ≈ portal poll ≤ 30 s + key install 1–5 s + own pipeline (p50 152 s / fresh 253 s) ≈ **3–4.5 min p50**, removing the ~10.5 min p50 of waiting. Rollback: flag off.

## How to test
```
cd neurons/validators && pdm run pytest tests/test_express_lane.py -q
```
17 tests (13 from the slice + 4 from the self-review round): flag off → the cycle asks for every executor (`executor_id=None`) and `in_flight` stays empty; flag on → `executor_id` is threaded to submit and remove; `first_pass` reaches `create_task` only when the caller passes it (the express request; the wave's is False); an executor registered before the first cycle since start, or without `created_at`, is left to the cycle even when it is not in the validated set; the next cycle's job-files prep keeps the directory a running express verification reads and removes it once no verification does (and, without `keep`, removes it mid-run — the negative control); a verification that raises releases its directory; the wave skips an executor the lane holds and releases its own claims even when a task raises; nothing runs before the first cycle has completed; a never-validated executor is verified alone with the cycle's inputs and published spec-only (no incentive, no `scored_at`), lands in the Redis set, and emits the metric line with `registration_to_publish_s`; validated / foreign-validator / wave-held executors are not touched; a 10-node flood across 3 miners is drained 4-then-4-then-2 with ≤ 2 per miner; an executor the miner never returns is retried 3× then left to the cycle, never published; a failed verification is still published so the provider sees the reason; Redis round-trip; the portal auth blob verifies with a real keypair; the bulk snapshot parses and a 503 fails soft.

Full validator suite as CI runs it (`pdm run pytest tests/ -v --tb=short --strict-markers`, Python 3.11, local macOS): **1941 passed, 15 skipped**; the 3 failures in `test_sshd_bootstrap_script.py` and 9 errors in `test_port_mapping_dao.py` are identical on `origin/main` in the same venv (Linux-only script tooling / DB fixture) — the Validators Tests check on this PR is the authoritative run.

## Verification

**Verified as slice #1282 on 7 Sep 2026:** Suite with the flag OFF (default): Validators 1951 passed (2 env artefacts), Executor 128, Miners 26. **With `EXPRESS_LANE_ENABLED=True` two existing tests failed** (`test_new_rentals_pause_filter.py`: the fixture builds `MinerService` with `__new__`, so `_claim_for_cycle` hit `AttributeError: 'MinerService' object has no attribute 'in_flight'`, swallowed by `request_job_to_miner`). Fixed on the branch (27f5bdc8, test fixture only) — re-run with the flag ON: only the 2 env artefacts remain. Not exercised against real executors (needs the validator ↔ miner path).

## Notes for reviewers
- `git diff -w` on `miner_service.py`: the only change inside the two task-list blocks is `msg.executors` → `executors` and the `try/finally` around the gather; the rest is the re-indent.
- Discovery reuses `GET /miners/executors` rather than a new portal endpoint, so this PR is self-contained in lium-io. `signature_auth_miner` verifies the signature only (the subnet-registration check is commented out since the central-miner deregistration); if that check comes back, the validator hotkey is a registered neuron and still passes. If you would rather have a `/validators/pending-executors` view, only `ValidatorPortalAPI.get_all_executors` changes.
- Job files across a cycle boundary: the next cycle writes to its own `temp/cycle-*` directory and keeps the ones the lane still reads (`ExpressLane.directories_in_use()`), so an express verification that straddles the boundary reads the files it started with (before the self-review round the shared directory was rmtree'd and such a verification failed as the node's).
- A miner whose only executor is on the express lane when the wave arrives gets an empty result list for that cycle (as if the node were not registered yet) — a never-validated node has never earned anything, so no existing incentive changes.
- The express `prod_executors` row carries an off-boundary `time` (the express start, `%Y-%m-%d %H:%M:%S`), not a cycle label; any per-cycle grouping sees one extra row for that executor. `incentive_source` on the published message is `"unknown"` (derived property when `incentive is None`); the `[express]` Loki line is the lane marker.
- Related, in flight: lium-io#1280 (central-miner snapshot TTL 300 → 30 s — shortens the "miner did not return the executor" retry window here), lium#163 (`lium mine` pre-pull). Sub-5 residuals after this PR: the first VerifyX sample failing the 100 Mbps EMA gate on a cold measurement (DAH-2959, 14 % of fresh nodes → failed first publish, next cycle), and nodes whose own pipeline runs > ~4.5 min (p99 360 s, max 477 s measured).
- No change to `BLOCKS_FOR_JOB`, `JOB_TIME_OUT`, scoring, weights or the ledger.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-2958.

Docs: neurons/validators/.env.template (EXPRESS_LANE_*) (this PR) · public: none changed in this PR — validator flag off by default; providers see the same statuses, sooner when it is on — troubleshooting.md needs no change

</details>

## #1291 — DAH-3011 - [P1] validator: a fast first pass for a never-validated executor

_head `0a890c35` (`DAH-3011-first-pass-fast-path`), was based on `DAH-2958-express-lane`._

Implements [DAH-3011](https://app.notion.com/p/Fast-first-pass-for-a-never-validated-executor-right-size-the-matmul-and-the-VerifyX-RAM-disk-probe-3d3b8bfdbde98150aed2da13af160eb5) · stacked on #1282 · reviewer: @jam6099 @pixel29913

**TL;DR** — The express lane (lium-io#1282, DAH-2958) verifies a never-validated executor between cycles and publishes it spec-only (no score, `scored_at=None`). `FIRST_PASS_FAST_PATH_ENABLED` (default False) plus a `first_pass: bool = False` argument threaded `TaskService.create_task` → `PipelineFactory.build_context` → `ContextConfig.first_pass`. Touches validator/executor (`neurons/validators/.env.template`) — read that file first.

**What changed**
- With both on, two checks change and only two.
- `CapabilityCheck` (matmul): `dim_k` is sized from `min(card VRAM, FIRST_PASS_MATMUL_VRAM_MB = 8192)` instead of the whole card.
- `VerifyXCheck` (RAM/disk/network probe): the challenge config uses `memory_max_test_gb = FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB` (16) and `storage_throughput_test_gb = FIRST_PASS_VERIFYX_STORAGE_TEST_GB` (1) instead of 128 /…
- What the fast first pass skips, explicitly: the VRAM-filling matmul (capacity proof — the matmul still runs.
- Expected first-pass pipeline for the fresh dogfood node (6 Sep, 1× A6000, measured 253 s): ≈ 150 s.

**How to verify**
- `cd neurons/validators && pdm run pytest -q tests/test_first_pass_fast_path.py tests/test_capability_check.py tests/test_verifyx_check.py tests/test_matrix_validation_service_precheck.py` → green

**Verified as slice #1291 (at its head `0a890c3`):** 7 Sep 2026 · Linux pod (py3.11) · validators 1956 passed · executor 128 passed · miners 26 passed · Result: PASS a387d9f9 · Gate: not run

**Docs:** neurons/validators/.env.template (FIRST_PASS_*) (this PR) · public: none changed in this PR — validator flag off by default; scored verifications unchanged

<details><summary>#1291 details</summary>

Merge after #1282 — this branch is stacked on it; GitHub retargets this PR to main when #1282 merges. Review/merge order per repo: https://github.com/Datura-ai/lium-loop/blob/main/improvements/CHANGES_FOR_REVIEW.md

[DAH-3011](https://app.notion.com/p/Fast-first-pass-for-a-never-validated-executor-right-size-the-matmul-and-the-VerifyX-RAM-disk-probe-3d3b8bfdbde98150aed2da13af160eb5). Origin: owner ask (6 Sep 21:54Z) to decrease time until a provider's GPUs are rentable; prod Loki per-step measurement 1–6 Sep (`provider-dogfood/VERIFICATION_PIPELINE.md`) — a non-filler idle node's pipeline is p50 256 s / p90 356 s, of which VerifyX p50 80 s and the matmul p50 26 s (74 s on the fresh dogfood node) prove capacity a spec-only first publish does not need.

## Problem
The express lane (lium-io#1282, DAH-2958) verifies a never-validated executor between cycles and publishes it spec-only (no score, `scored_at=None`), so a new node is listed ≈ 0.5 min + its own pipeline after `node add`. That pipeline is the full scored pipeline: p50 152 s / p90 208 s fleet-wide, 253 s for the fresh dogfood node (6 Sep). Measured per step on idle non-filler runs, 2–6 Sep (Loki `execution_time_ms`, 6-h windows): VerifyX p50 78 s / p90 120 s (RAM write/read of up to 128 GB, a 5 GB disk write/read, a 260–500 MB single-stream download, a 100 MB Cloudflare up/down); the capability matmul p50 26 s / p90 29 s (a `dim_n × dim_k` double matmul sized to fill the card's VRAM minus 2–4 GB); scrape 21 s; port connectivity 18 s; rental verification 24 s. For a first, unscored publish the pipeline proves far more than "this GPU exists, is the model claimed, and the host is reachable/rentable": the VRAM-filling matmul and the 128 GB RAM proof exist to make a scored cycle expensive to fake, and the next scored cycle runs them anyway.

The first pass also inherits the cold-bandwidth failure (DAH-2959): 14 % of fresh nodes fail their very first VerifyX sample and are published with score 0.

## Change
`FIRST_PASS_FAST_PATH_ENABLED` (default **False**) plus a `first_pass: bool = False` argument threaded `TaskService.create_task` → `PipelineFactory.build_context` → `ContextConfig.first_pass`. Nothing changes unless a caller passes `first_pass=True` **and** the flag is on; the wave never does, so every scored verification is byte-for-byte today's. The express lane (lium-io#1282) is the intended caller: one argument at its `request_job_to_miner(...)` → `create_task(...)` call once both PRs land.

With both on, two checks change and only two:
- `CapabilityCheck` (matmul): `dim_k` is sized from `min(card VRAM, FIRST_PASS_MATMUL_VRAM_MB = 8192)` instead of the whole card — the same challenge/response, seal and UUID check, so a wrong or absent GPU, a driver that cannot run CUDA, or a spoofed UUID still fails; only the "fill the card" part is deferred. Expected saving: the matmul's time is dominated by generating and copying `2 × dim_n × dim_k × 8` bytes (≈ 44 GB on a 48 GB card, ≈ 137 GB on an H200) — 8 GB is 5–17× less, so 26 s → ≈ 5–8 s on data-center cards, 74 s → ≈ 10 s on the dogfood A6000.
- `VerifyXCheck` (RAM/disk/network probe): the challenge config uses `memory_max_test_gb = FIRST_PASS_VERIFYX_MEMORY_MAX_TEST_GB` (16) and `storage_throughput_test_gb = FIRST_PASS_VERIFYX_STORAGE_TEST_GB` (1) instead of 128 / 5 — the same binary, the same challenge/response, the same download; the RAM/disk *measurements* are still taken and published. The download sample still seeds the EMA, but a **first-pass** sample below the gate does not fail the pass: the node is published spec-only with its measured `verifyx_download_speed`, the EMA is left unseeded so the first scored cycle bootstraps from a warm sample, and the event says so (`bandwidth_gate: deferred_to_first_scored_cycle`). Expected saving: 78 s → ≈ 45 s (the download is unchanged; RAM/disk work shrinks 8–100×).
What the fast first pass skips, explicitly: the VRAM-filling matmul (capacity proof — the matmul still runs, sized from 8 GB), the 128 GB / 5 GB RAM-and-disk write proof (16 GB / 1 GB are written; RAM/disk totals are still measured and published), and the bandwidth *gate* for a never-measured node (measured, published as `verifyx_download_speed`, not enforced; EMA left unseeded so the first scored cycle bootstraps from a warm sample and enforces it). What it does not skip: SSH + key install, scrape, GPU count/model/VRAM/driver/NVML/fingerprint/banned/duplicate/collateral checks, sysbox, port connectivity + port count, executor image, GPU usage, TDX, capability matmul (right-sized), VerifyX (right-sized), rental verification (backend rents a container on the node), scoring. The next scored cycle — the one that pays — runs the full pipeline as today and overwrites the row.

Expected first-pass pipeline for the fresh dogfood node (6 Sep, 1× A6000, measured 253 s): ≈ 150 s — matmul 74 s → ≈ 10 s, VerifyX 86 s → ≈ 45 s, the 31-s Redis queue wait gone with DAH-3006 (an express verification between waves never queues anyway). With lium-io#1282's ≤ 30-s poll and 1–5-s key install, `node add` → published ≈ 3 min for that node instead of ≈ 4.5 min.

## How to test
```
cd neurons/validators && pdm run pytest -q tests/test_first_pass_fast_path.py tests/test_capability_check.py tests/test_verifyx_check.py tests/test_matrix_validation_service_precheck.py
```
14 tests (13 from the slice + 1 from the self-review round; one parametrized over the 4 flag combinations): `build_context` resolves `ContextConfig.first_pass` only when the flag AND the caller's `first_pass` are both on (4 combinations); with the DAH-2959 retry on, the cold-sample retry carries the same smaller challenge config; `ContextConfig` default is False; the scored capability call passes no sizing keyword; the first-pass call sizes from `FIRST_PASS_MATMUL_VRAM_MB` and a failed matmul still fails; `ValidationService` `dim_k` follows `get_max_matrix_dimensions(min(card, budget))` — 20× less for an H200, unchanged for a card smaller than the budget; the scored VerifyX call passes no overrides and keeps the gate; the first pass sends `memory_max_test_gb=16, storage_throughput_test_gb=1` and a warm sample seeds the EMA as today; a cold sample passes with `bandwidth_gate: deferred_to_first_scored_cycle`, raw speed published, no EMA; a failed network probe is deferred too; a host with an EMA keeps the gate even on a first pass; RAM/disk failure still fails; flag off is today's behaviour; `VerifyXValidationService` applies the overrides to the challenge `config` only (min RAM, min disk, download timeout untouched). Existing capability / VerifyX / matrix tests unchanged (87).

## Verification
Unit tests above; full validator suite as CI runs it: 1937 passed, 15 skipped locally (Python 3.11; `test_sshd_bootstrap_script.py` / `test_port_mapping_dao.py` excluded — Linux-only tooling / DB fixture, identical on `origin/main`). Not staged: loop staging pipeline pending (STAGING.md). Staging test plan: deploy lium-io#1282 + this branch to the staging validator with both flags on, register one Shadeform node, and read the `[express]` line's `verification_s` against the previous express verification of a comparable node; confirm the following scored cycle's `gpu.validate.capability` `dim_k` (in the `Matrix Multiplication Python Script Command` line) is the full-card size again and the EMA is seeded by that cycle.

**Verified as slice #1291 on 7 Sep 2026:** PR head merged onto `main` (55be0e9e) on a Linux pod, the three CI suites (Python 3.11.11, pdm, sqlite, CI env vars): Validators 1956 passed, 15 skipped, 1 env artefact (head a387d9f9), Executor 128 passed, Miners 26 passed. The only validator failures are two root-on-a-pod artefacts `main` has too (`test_scrape_infiniband::…unreadable_sysfs…` — chmod 000 does not stop root; `test_sshd_bootstrap_script::…adopt_path…` — the pod runs a live sshd), both pass as a non-root user / in CI. Also run with `FIRST_PASS_FAST_PATH_ENABLED=True`: 1955 passed, only the env artefacts. Not exercised on hardware.

## Notes for reviewers
- Sizing knobs are settings so the owners can tune them on staging without a code redeploy; the 8 GB default means a card at or below 8 GB still runs a full-card matmul.
- The all-cards work-proof (`MATMUL_ALLCARDS_CHECK_ENABLED`, off in prod) is untouched: it is the count-lie detector and sizes from the registry, not from this budget.
- Not proposed: skipping VerifyX or the matmul entirely on the first pass — a GPU-less host would then be listed for up to 15 min.
- Wiring: `ExpressLane._verify` → `request_job_to_miner(first_pass=True)` → `create_task(first_pass=True)` on both the WebSocket and REST paths (`MinerService`); the wave passes nothing, so `ContextConfig.first_pass` is False on every scored verification. The `VerifyXCheck` here composes with DAH-2959 (lium-io#1288): with both on, a cold first-pass sample is re-measured once with the same smaller challenge config and deferred only if the retry is cold too.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-3011.

Docs: neurons/validators/.env.template (FIRST_PASS_*) (this PR) · public: none changed in this PR — validator flag off by default; scored verifications unchanged

</details>

## #1288 — DAH-2959 - [P1] validator re-measures a cold VerifyX sample once (flag, off)

_head `60e2fd0d` (`DAH-2959-verifyx-cold-sample-retry`), was based on `DAH-3011-first-pass-fast-path`._

Implements [DAH-2959](https://app.notion.com/p/First-VerifyX-sample-of-a-new-node-fails-the-100-Mbps-EMA-gate-on-a-cold-measurement-11-of-80-fres-3d3b8bfdbde9819e8732d6dc2620c3e7) · stacked on #1291 · reviewer: @jam6099 @pixel29913

**TL;DR** — A new node's first VerifyX network sample is often below the 100 Mbps EMA gate (`services/task/checks/verifyx.py`, `MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS`) and the node fails its first cycle. `VERIFYX_COLD_SAMPLE_RETRY_ENABLED` (default False — flag off is byte-for-byte today's single sample). Touches validator/executor (`neurons/validators/.env.template`) — read that file first.

**What changed**
- With the flag on, `VerifyXCheck` takes one more VerifyX sample inside the same task when, and only when, all of.
- the backend answered this cycle (`rented_data` present) and it has no EMA for this executor (never measured).
- the first probe otherwise passed (RAM + disk fine — a RAM/disk failure is judged as today).
- its download sample is below the gate (or the network probe failed, which would bootstrap the EMA to 0).
- The better of the two samples (by download speed.

**How to verify**
- `cd neurons/validators && pdm run pytest -q tests/test_verifyx_cold_sample_retry.py tests/test_verifyx_check.py` → green

**Verified as slice #1288 (at its head `60e2fd0`):** 7 Sep 2026 · Linux pod (py3.11) · validators 1949 passed · executor 128 passed · miners 26 passed · Result: PASS 2694a444 · Gate: not run

**Docs:** neurons/validators/.env.template (VERIFYX_COLD_SAMPLE_RETRY_ENABLED) (this PR) · public: none changed in this PR — validator flag off by default; gate, threshold and reason codes unchanged

<details><summary>#1288 details</summary>

Merge after #1291 — this branch is stacked on it; GitHub retargets this PR to main when #1291 merges. Review/merge order per repo: https://github.com/Datura-ai/lium-loop/blob/main/improvements/CHANGES_FOR_REVIEW.md

[DAH-2959](https://app.notion.com/p/First-VerifyX-sample-of-a-new-node-fails-the-100-Mbps-EMA-gate-on-a-cold-measurement-11-of-80-fres-3d3b8bfdbde9819e8732d6dc2620c3e7). Origin: prod Loki, 2–5 Sep — 11 of 80 fresh nodes failed their first cycle on the VerifyX 100 Mbps EMA gate with a cold first sample and passed the next cycle (`RECOVERY/reports/provider_time_to_ready.md` §3.3; three nodes traced end to end below).

## Problem
A new node's first VerifyX network sample is often below the 100 Mbps EMA gate (`services/task/checks/verifyx.py`, `MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS`) and the node fails its first cycle. The EMA bootstraps from the first sample (`checks/network_ema.py`: `prev is None → EMA = current`), so one cold measurement decides the cycle, and the next cycle then needs ≥ 100 + (100 − first) Mbps to recover. Each failure is +15 min for the provider (one cycle), sometimes +30–45 min.

Prod Loki, 2–5 Sep (`VerifyX validation failed (network speed too slow)`): **11 of 80 fresh central-mode nodes (14 %)** failed ≥ 1 cycle on this gate before their first AVAILABLE, 3 of them 2–3 cycles; first-sample EMAs 32.2–88.4 Mbps; all passed the following cycle. Three traced end to end:

| node | first cycle | next cycle | what the same task's scrape speedtest read |
|---|---|---|---|
| `b3e4ca69 (a superseded, rewritten head)` | VerifyX 59.9 Mbps, 164 s, fail (15:55) | ≈ 760 Mbps sample (EMA 59.9 → 410), pass (16:09) | 104 Mbps, then 368 Mbps — the link was busy; the recommended template image is present by 16:09 (executor on-boot pre-pull, `neurons/executor/src/services/cache_template_service.py`) |
| `aeb904f6 (a superseded, rewritten head)` | 32.2 Mbps, 158 s, fail (18:55) | 205 Mbps, 87 s, pass (19:09) | 1708 Mbps both times — the link was free; the one 260–500 MB single-stream CDN object (`verifyx/src/challenge/network.rs`: `seed % 134` of `pkg_verify/verified_pkg_list.json`, huggingface.co / files.pythonhosted.org) came in cold |
| `0187e017 (a superseded, rewritten head)` | 48.9 Mbps, 164 s, fail (23:56) | 501 Mbps, 105 s, pass (00:10) | 739 / 476 Mbps — same shape as `aeb904f6 (a superseded, rewritten head)` |

So the cold sample is one slow single-connection object fetch (a CDN edge miss or a link shared with the node's own first image pull), not the host's bandwidth; a second sample in the same task (a different object — the seed is per challenge) reads the real link. Fleet-wide the same message fired 338× / 64 executors in 4 days, 179 of them on two hosts: those are real slow hosts, and this change does not touch them (they have an EMA).

## Change
`VERIFYX_COLD_SAMPLE_RETRY_ENABLED` (default **False** — flag off is byte-for-byte today's single sample).

With the flag on, `VerifyXCheck` takes one more VerifyX sample inside the same task when, and only when, all of:
- the backend answered this cycle (`rented_data` present) and it has **no EMA** for this executor (never measured) — without the backend's answer every executor looks new, and a backend blip must not double VerifyX fleet-wide;
- the first probe otherwise **passed** (RAM + disk fine — a RAM/disk failure is judged as today);
- its download sample is below the gate (or the network probe failed, which would bootstrap the EMA to 0).

The better of the two samples (by download speed; the retry only when its probe succeeded) is the one the existing code then processes — same EMA bootstrap, same `MIN_VERIFYX_EMA_DOWNLOAD_SPEED_MBPS` gate, same specs. The event's `what_we_saw.cold_sample_retry` records `{first_download_speed_mbps, retry_download_speed_mbps, used}`, and one INFO line `VerifyX cold first sample below the gate, re-measured once` carries the same fields for Loki. Nothing changes for an executor with any prior EMA, so no known host is measured twice and the gate's purpose (real slow hosts) is intact.

Cost: at most one extra VerifyX run (p50 78 s, p90 120 s measured) for the ~14 % of fresh nodes whose first sample is cold, once in their life; today that node loses 15–45 min. With the express lane (lium-io#1282) the retry runs inside the express verification, so the node is still published ≈ 4–5 min after `node add` instead of failing and waiting for the next cycle.

## How to test
```
cd neurons/validators && pdm run pytest -q tests/test_verifyx_cold_sample_retry.py tests/test_verifyx_check.py
```
10 new tests: flag off → one sample, fails as today, no `cold_sample_retry` key; cold first sample then a good one (the `b3e4ca69 (a superseded, rewritten head)` numbers) → two calls, pass, EMA and raw speeds seeded from the retry, `used: retry`; two slow samples → still fail the unchanged gate, EMA seeded from the better; a failed network probe (None) on the first sample is retried; a worse retry keeps the first sample; a retry whose probe failed outright is not used; a known host below the gate → one call, fails as today (EMA decay unchanged); a fast first sample → one call; `rented_data` None → one call; RAM/disk failure on the first sample → one call, `VERIFYX_FAILED`. The 22 existing VerifyX check tests are unchanged and pass.

## Verification
Unit tests above (Python 3.11, local). Not staged: loop staging pipeline pending (STAGING.md). Staging test plan: deploy the validator branch with `VERIFYX_COLD_SAMPLE_RETRY_ENABLED=true`, register one fresh Shadeform node on a ≤ 300 Mbps link (or throttle egress with `tc` on a staging node) and force a cycle; expect in Loki one `VerifyX cold first sample below the gate, re-measured once` line for that executor with two speeds, the check's `execution_time_ms` ≈ 2× a single VerifyX run, and no second line for any executor that already has an EMA; then read `network.ema_verifyx_download_speed` on the executor row.

**Verified as slice #1288 on 7 Sep 2026:** PR head merged onto `main` (55be0e9e) on a Linux pod, the three CI suites (Python 3.11.11, pdm, sqlite, CI env vars): Validators 1949 passed, 15 skipped, 2 env artefacts (head 2694a444), Executor 128 passed, Miners 26 passed. The only validator failures are two root-on-a-pod artefacts `main` has too (`test_scrape_infiniband::…unreadable_sysfs…` — chmod 000 does not stop root; `test_sshd_bootstrap_script::…adopt_path…` — the pod runs a live sshd), both pass as a non-root user / in CI. Also run with `VERIFYX_COLD_SAMPLE_RETRY_ENABLED=True`: 1950 passed, only the env artefacts. Not exercised on hardware.

## Notes for reviewers
- This is the ticket's option A (re-measure inside the task). Option B (provisional first sample) was not taken here because it would pass a scored cycle on an unproven link; it is the right shape for the unscored express-lane first pass and is proposed there separately (DAH-3011, `first_pass`).
- Root-cause follow-ups outside this PR, both for validator owners: (1) the VerifyX object is 263–501 MB on one connection (`verifyx/src/challenge/network.rs`), so at the 100 Mbps gate the download alone is ≥ 30 s and its cold-start penalty is large — a 100 MB object with a minimum-duration floor would measure the same thing in a quarter of the time (that is the VerifyX step's p50 78 s / p90 120 s); (2) the executor's on-boot template pre-pull runs during the node's first validation on the same link — `lium mine` could pre-pull before `node add`, or the executor could wait for its first verification. DAH-1571 (team, Dec 2025: "fix bandwidth check once and for all … run the test every 12 hours and keep the number") is the same complaint from the other side.
- Composes with lium-io#1282: the express lane runs this same check with the same inputs; no code dependency between the two PRs.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-2959.

Docs: neurons/validators/.env.template (VERIFYX_COLD_SAMPLE_RETRY_ENABLED) (this PR) · public: none changed in this PR — validator flag off by default; gate, threshold and reason codes unchanged

</details>

### Self-review

Verdict `clean` at `0b5c576` · 15 checks · by subagent-r15b · 2026-09-08 07:38Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | CODE-QUALITY | `neurons/validators/src/core/validator.py:51` | Known nit carried from the b20979a review: `FAILED_MINER_EXECUTOR_UUID = "11111111-1111-1111-1111-111111111111"` re-declares the sentinel that miner_service.py:812 builds the failed-miner result with as a bare literal; the property is one definition read by both the writer and the cycle's published-ids filter (validator.py:625) so a change to one cannot silently unfilter the other (`rg -n 11111111-1111 neurons/validators/src/`). | Define the constant once in miner_service.py next to CYCLE_LANE/EXPRESS_LANE, use it at :812, import it in validator.py. |
| low | STALE-BODY | `body:15` | Known nit carried from the b20979a review: the fold's `How to verify` counts (49 / 1988), `Verified by the loop … PASS 284eb153`, `Ran it … at 284eb153` and `Self-review: clean at 284eb15` are from the earlier head; `0b5c576` changes `express_lane.py`, `verifyx.py` and `validator_portal_api.py` (annotations, `is not None` guards, docstring wording, ruff 0.5.1 re-wraps — read analytically as semantically identical, see dismissed). The property is that every count and sha in the fold comes from a run at the pushed head (PR_PROCESS §12); the author reports the EC2 suite is re-running at `0b5c576` and the body will cite it. | Once the run at `0b5c576` finishes, refresh the `Ran it` / `Verified by the loop` lines with that sha and `--record` this verdict at the pushed head. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/tests/test_express_lane.py:33` Unchanged since b20979a: `datura.requests.miner_requests` is `datura/datura/requests/miner_requests.py` at the repo root, installed as `datura @ file:///${PROJECT_ROOT}/../../datura` (neurons/validators/pyproject.toml:19); `ExecutorSSHInfo` :42, `AcceptSSHKeyRequest` :61; miner_service.py:15 and test_new_rentals_pause_filter.py:6 import it the same way. · `neurons/validators/src/core/express_lane.py:26` The three new imports create no cycle: `services.miner_service` (which express_lane already imported at b20979a) itself does `import bittensor` (:13), `from protocol.vc_protocol.compute_requests import RentedExecutorsResponse` (:63) and `from services.task_service import TaskService, JobResult` (:71), so all three modules are loaded before express_lane's own imports run; `services.task_service` re-exports `JobResult` from `services.task.models:29` via `services/task/__init__.py`; nothing under `src/services`, `src/protocol` or `src/clients` imports `core.express_lane` or `core.validator` (only `core/validator.py` and tests do). `bittensor.NeuronInfo` is the attribute `incentive/base.py:135` and `incentive/default.py:239` already annotate with; `subtensor_client.get_miners()` returns it, and `RentedExecutorsResponse` is what `backend_client.get_all_rented_executors()` returns and the test harness passes. · `neurons/validators/src/services/task/checks/verifyx.py:128` The ruff 0.5.1 re-wraps are semantically identical: `use_retry` was `A and B and (retry_speed or 0.0) > (first_speed or 0.0)` and `>` binds tighter than `and`, so the new explicit `(A and B and (...) > (...))` is the same expression; the `sizing` / `prev_ema` conditionals, the three-clause `if (... and ... and ...)` at :215, the `sizing["challenge_config_overrides"]` subscript split, the two `logger.*` one-liners in `_defer`, the `_m(...)` in `_launch`, the dict literal in validator_portal_api.py:205 and the `_verify`/`_publish` signature wraps change only whitespace/line breaks. `if cold_sample_retry is not None:` at :208 and :247 is truth-equivalent to the old `if cold_sample_retry:` because a `ColdSampleRetry` instance is always truthy. `git diff b20979a 0b5c576 --stat` touches only the three named files. · `neurons/validators/src/clients/validator_portal_api.py:176` The docstring now reads 'commented out today with a note to restore it', which matches lium-platform `apps/portal/backend/src/auth/signature_auth.py:50-59` @ fd738399e (commented-out `SubtensorClient.get_instance().get_miner(hotkey)` under a `TODO: re-enable` comment); the `get_miner` description (every neuron of the subnet, fallback on-chain lookup, a registered validator hotkey passes) was verified in the b20979a round and is unchanged. The working tree is clean (`git status --short` empty), so the pushed head can equal the reviewed sha.

### Ran it

aws_run `20260908T003721Z-7etq` (`fixD2-lium-io-1315-r3`, c6i.4xlarge, AL2023, Python 3.11.11; `tools/aws_run_jobs/reverify_io.sh` E2E=1 PAR=1) — `RECOVERY/aws_run/20260908T003721Z-7etq/out/results/1315/summary.txt`. Head = the pushed `284eb153` (uploaded as a git bundle before the push), merged onto `main` `07ec64cd`:

```
MERGE ok: pr/1315@284eb153 + main@07ec64cd
1315 validators pytest: 2 failed, 1988 passed, 15 skipped, 158 warnings in 114.26s (0:01:54)
INFO validators: no failure beyond main's own (2)
   FAILED tests/test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices
   FAILED tests/test_sshd_bootstrap_script.py::test_adopt_path_hardens_config_for_key_only_auth
1315 miners pytest: 27 passed, 21 warnings in 0.86s
UNIT done: PASS 120s
E2E start: e2e/ from pr/1312 on a clean worktree
PASS e2e-gate 194s
1315 e2e cycle: 5 passed, 0 failed, 0 skipped
1315 e2e protocol: 13 passed, 0 failed, 0 skipped
1315 e2e rental: 2 passed, 0 failed, 0 skipped
E2E done: PASS
main baseline (same box): validators 2 failed, 1939 passed · executor 128 passed · miners 26 passed · e2e PASS
```

Targeted, on this run's box (same venv, merged tree): negative control with `ff87f057`'s `express_lane.py` and the old `del` in `_release_cycle_claims` swapped back in → `pytest tests/test_express_lane.py`: `3 failed, 19 passed` (the two new tests and the re-worded wave test). Round 2, on the `20260907T232755Z-koo5` box: `20 passed`; with `2fbcdae3`'s `express_lane.py` → `3 failed, 17 passed` (that round's three new tests). Earlier round (aws_run `20260907T215853Z-cfbm`, the three changed test files + `test_scrape_source_delivery.py` + `test_incentive_flow.py`): `79 passed in 1.33s`. `ruff format --check` on `express_lane.py` / `file_encrypt_service.py` reports the same pre-existing diffs as before this round (CI's format check is report-only).

Not run: a live validator ↔ miner ↔ executor cycle with the flags on (the e2e stack runs the flag-off validator code path against a GPU-less executor); not run on macOS (server code).

### Claims

Claims: 12 · proven 12 · unproven 0 (tools/pr_quality_gate.py --claims)

| where | claim | proof | status |
|---|---|---|---|
| neurons/validators/src/core/config.py:202 | prose: it streams output | `datura/datura/consumers/base.py:4` | proven |
| neurons/validators/src/services/task/checks/verifyx.py:102 | prose: it retries | `neurons/executor/docker-compose.app.dev.yml:32` | proven |
| neurons/validators/tests/test_express_lane.py:9 | prose: it retries | `neurons/executor/docker-compose.app.dev.yml:32` | proven |
| neurons/validators/tests/test_first_pass_fast_path.py:295 | prose: it retries | `neurons/executor/docker-compose.app.dev.yml:32` | proven |
| neurons/validators/tests/test_verifyx_cold_sample_retry.py:183 | prose: it retries | `neurons/executor/docker-compose.app.dev.yml:32` | proven |
| body:40 | prose: it retries | `neurons/executor/docker-compose.app.dev.yml:32` | proven |
| body:170 | route `/miners/executors` | `neurons/miners/src/clients/miner_portal_api.py:152` | proven |
| body · What changed | `SNAPSHOT_TTL_SECONDS` 300 → 30 in the central miner's portal client (`miners/src/clients/miner_portal_api.py`) | `neurons/miners/src/clients/miner_portal_api.py` | proven |
| body · What changed | `EXPRESS_LANE_ENABLED` (off): verifies executors registered after the first cycle since start, alone; publishes spec-only (`core/express_lane.py`) | `neurons/validators/src/core/express_lane.py` | proven |
| body · What changed | `FIRST_PASS_FAST_PATH_ENABLED` (off): the express verification runs with `first_pass=True` → smaller probes (`services/miner_service.py`) | `neurons/validators/src/services/miner_service.py` | proven |
| body · What changed | `VERIFYX_COLD_SAMPLE_RETRY_ENABLED` (off): one more sample when a new node's first is under the gate (`checks/verifyx.py`) | `neurons/validators/src/services/task/checks/verifyx.py` | proven |
| body · What changed | job files in a fresh `temp/cycle-*` per cycle; ones the lane still reads survive the next cycle (`services/file_encrypt_service.py`) | `neurons/validators/src/services/file_encrypt_service.py` | proven |

### Cross-PR

Open loop PRs on the same files (`gh pr list --limit 500`, gate CROSS-PR at `2fbcdae3`):

| PR | file | same lines | order |
|---|---|---|---|
| #1281 (DAH-2962, delete the dead hashcat scoring path) | `services/file_encrypt_service.py` — deletes the commented-out `score_script` block right under `make_binary_file` | yes — this PR's docstring step 6 and the block it sits next to | #1281 first; this PR's `fresh_job_files_directory` / `keep_directories` hunk re-applies cleanly (the dead block is not touched here) |
| #1296 (DAH-3019, verification-start report per executor) | `services/task/service.py` — new code around `create_task`'s signature and the pipeline call | yes — `create_task(..., first_pass=…)` | #1296 first; this PR adds the `first_pass` keyword to the signature and the `build_context` call on the rebase |
| #1297 (DAH-3035, GPU fault probe) | `.env.template` — a new block after `REDIS_USERNAME` | yes — the same insertion point as the FIRST_PASS / COLD_SAMPLE blocks | either order; the second one rebases a comment block (no semantic overlap) |

Different lines, clean merge: #1276, #1278, #1285, #1290, #1298, #1302, #1303, #1307, #1309, #1316. Nothing here tightens a validation rule another PR's fixtures depend on; the flags all default off.

### Verified

Gate: PASS (0b5c576) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1315)

</details>
