### PR TITLE
DAH-2967 - [P3] READMEs — repository layout and tests, executor set-up with lium mine

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Welcome to **Lium.io powered by Bittensor Subnet 51**! This project enables a de
   - [For Renters](#for-renters)
   - [For Miners](#for-miners)
   - [For Validators](#for-validators)
+- [Repository Layout](#repository-layout)
+- [Running the Tests](#running-the-tests)
 - [Contact and Support](#contact-and-support)
 
 ## Introduction
@@ -41,7 +43,7 @@ If you are looking to rent computational resources, you can easily do so through
 
 To start renting machines, visit [lium.io](https://lium.io) and access the resources you need.
 
-**Command-Line Alternative**: For renters who prefer working from the terminal, you can also use [lium-cli](https://github.com/Datura-ai/lium-cli) - a command-line interface that allows you to manage GPU pods, SSH into machines, transfer files, and execute commands directly from your terminal. Install it with `pip install lium-cli`.
+**Command-Line Alternative**: For renters who prefer working from the terminal, you can also use the [Lium CLI](https://github.com/Datura-ai/lium) - a command-line interface that allows you to manage GPU pods, SSH into machines, transfer files, and execute commands directly from your terminal. Install it with `pip install lium.io`.
 
 ### For Miners
 
@@ -60,6 +62,33 @@ Validators play a crucial role in maintaining the integrity of the Compute Subne
 
 For more details, visit the [Validator Setup Guide](neurons/validators/README.md).
 
+## Repository Layout
+
+Three deployable services, one shared package, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files:
+
+- `neurons/validators/` — the validator: scores miners, verifies executors over SSH, creates and manages rental containers on them (`src/services/docker_service.py`), sets weights. `src/miner_jobs/` holds the scripts the validator uploads to an executor and runs there (`machine_scrape.py` hardware scrape, `backup_storage.py` / `restore_storage.py`, `workspace_mount.py`); `machine_scrape.py` is obfuscated per job by `src/services/file_encrypt_service.py` before upload, so its key order is load-bearing (see the comment at the top of that file).
+- `neurons/miners/` — the miner: registers executors with the network and answers validator requests; its database schema is Alembic migrations under `migrations/`.
+- `neurons/executor/` — the agent installed on a GPU machine: exposes the machine to its miner's validators, runs the containers. `dstacktee/` runs it inside an Intel TDX confidential VM with attestation (its own README).
+- `datura/` — the protocol shared by the three: request/response models (`datura/requests`), consumers, errors.
+- `watchtower/` — pulls validator-signed image updates and restarts containers (its own README).
+- `scripts/` — the `install_*_on_ubuntu.sh` installers referenced by the setup guides; `docs/` — operator notes; `contrib/` — contribution and style guides.
+
+## Running the Tests
+
+Python 3.11 and [pdm](https://pdm-project.org). Each service is its own pdm project; the validator suite is the large one (~1,950 tests, about two minutes, SQLite — no Postgres needed):
+
+```bash
+cd neurons/validators && pdm install
+BITTENSOR_WALLET_NAME=test_wallet BITTENSOR_WALLET_HOTKEY_NAME=test_hotkey \
+SQLALCHEMY_DATABASE_URI=sqlite:///test.db ASYNC_SQLALCHEMY_DATABASE_URI=sqlite+aiosqlite:///test.db \
+ENABLE_TDX_ATTESTATION=True TDX_VERIFIER_URL=http://localhost:8000/verify \
+pdm run pytest tests/ -q
+
+cd neurons/executor && pdm install && mkdir -p tmp && pdm run pytest tests/ -q
+cd neurons/miners && pdm install && pdm run pytest tests/ -q
+```
+
+These are the exact commands `.github/workflows/test.yml` runs on every pull request. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
 
 ## Contact and Support
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more details, visit the [Validator Setup Guide](neurons/validators/README.md
 
 ## Repository Layout
 
-Three deployable services, one shared package, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files:
+Three deployable services, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files, and one shared pdm package (`datura/`, a `pyproject.toml` only):
 
 - `neurons/validators/` — the validator: scores miners, verifies executors over SSH, creates and manages rental containers on them (`src/services/docker_service.py`), sets weights. `src/miner_jobs/` holds the scripts the validator uploads to an executor and runs there (`machine_scrape.py` hardware scrape, `backup_storage.py` / `restore_storage.py`, `workspace_mount.py`); `machine_scrape.py` is obfuscated per job by `src/services/file_encrypt_service.py` before upload, so its key order is load-bearing (see the comment at the top of that file).
 - `neurons/miners/` — the miner: registers executors with the network and answers validator requests; its database schema is Alembic migrations under `migrations/`.
@@ -82,13 +82,13 @@ cd neurons/validators && pdm install
 BITTENSOR_WALLET_NAME=test_wallet BITTENSOR_WALLET_HOTKEY_NAME=test_hotkey \
 SQLALCHEMY_DATABASE_URI=sqlite:///test.db ASYNC_SQLALCHEMY_DATABASE_URI=sqlite+aiosqlite:///test.db \
 ENABLE_TDX_ATTESTATION=True TDX_VERIFIER_URL=http://localhost:8000/verify \
-pdm run pytest tests/ -q
+pdm run pytest tests/ -v --tb=short --strict-markers
 
-cd neurons/executor && pdm install && mkdir -p tmp && pdm run pytest tests/ -q
-cd neurons/miners && pdm install && pdm run pytest tests/ -q
+cd neurons/executor && pdm install && mkdir -p tmp && pdm run pytest tests/ -v --tb=short
+cd neurons/miners && pdm install && pdm run pytest tests/ -v --tb=short
 ```
 
-These are the exact commands `.github/workflows/test.yml` runs on every pull request. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
+These are the commands `.github/workflows/test.yml` runs on every pull request against `main` or `dev`. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
 
 ## Contact and Support
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For more details, visit the [Validator Setup Guide](neurons/validators/README.md
 
 ## Repository Layout
 
-Three deployable services, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files, and one shared pdm package (`datura/`, a `pyproject.toml` only):
+Three neurons, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files; `watchtower/`, its own pdm project with a Dockerfile; and one shared pdm package (`datura/`, a `pyproject.toml` only):
 
 - `neurons/validators/` — the validator: scores miners, verifies executors over SSH, creates and manages rental containers on them (`src/services/docker_service.py`), sets weights. `src/miner_jobs/` holds the scripts the validator uploads to an executor and runs there (`machine_scrape.py` hardware scrape, `backup_storage.py` / `restore_storage.py`, `workspace_mount.py`); `machine_scrape.py` is obfuscated per job by `src/services/file_encrypt_service.py` before upload, so its key order is load-bearing (see the comment at the top of that file).
 - `neurons/miners/` — the miner: registers executors with the network and answers validator requests; its database schema is Alembic migrations under `migrations/`.
@@ -75,17 +75,17 @@ Three deployable services, each with its own `pyproject.toml` / `pdm.lock`, Dock
 
 ## Running the Tests
 
-Python 3.11 and [pdm](https://pdm-project.org). Each service is its own pdm project; the validator suite is the large one (~1,950 tests, about two minutes, SQLite — no Postgres needed):
+Python 3.11 and [pdm](https://pdm-project.org). Each service is its own pdm project; the validator suite is the large one (~1,950 tests, about two minutes, SQLite — no Postgres needed). From the repository root, each service in its own subshell so the block runs top to bottom:
 
 ```bash
-cd neurons/validators && pdm install
-BITTENSOR_WALLET_NAME=test_wallet BITTENSOR_WALLET_HOTKEY_NAME=test_hotkey \
-SQLALCHEMY_DATABASE_URI=sqlite:///test.db ASYNC_SQLALCHEMY_DATABASE_URI=sqlite+aiosqlite:///test.db \
-ENABLE_TDX_ATTESTATION=True TDX_VERIFIER_URL=http://localhost:8000/verify \
-pdm run pytest tests/ -v --tb=short --strict-markers
+(cd neurons/validators && pdm install && \
+ BITTENSOR_WALLET_NAME=test_wallet BITTENSOR_WALLET_HOTKEY_NAME=test_hotkey \
+ SQLALCHEMY_DATABASE_URI=sqlite:///test.db ASYNC_SQLALCHEMY_DATABASE_URI=sqlite+aiosqlite:///test.db \
+ ENABLE_TDX_ATTESTATION=True TDX_VERIFIER_URL=http://localhost:8000/verify \
+ pdm run pytest tests/ -v --tb=short --strict-markers)
 
-cd neurons/executor && pdm install && mkdir -p tmp && pdm run pytest tests/ -v --tb=short
-cd neurons/miners && pdm install && pdm run pytest tests/ -v --tb=short
+(cd neurons/executor && pdm install && mkdir -p tmp && pdm run pytest tests/ -v --tb=short)
+(cd neurons/miners && pdm install && pdm run pytest tests/ -v --tb=short)
 ```
 
 These are the commands `.github/workflows/test.yml` runs on every pull request against `main` or `dev`. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.

--- a/contrib/CONTRIBUTING.md
+++ b/contrib/CONTRIBUTING.md
@@ -16,10 +16,10 @@ The following is a set of guidelines for contributing to `lium-io`, the Subnet 5
 
 
 ## How Can I Contribute?
-Open an issue on [Datura-ai/lium-io](https://github.com/Datura-ai/lium-io/issues) describing the bug or the change you want, or pick one that is open. Fork the repository, branch from `main`, and open a pull request against `main` — the [README](../README.md) lists the layout and the exact test command for each neuron. Every pull request needs one approving review before it merges; the **Tests** workflow (validator and executor suites) runs on pull requests that touch `neurons/validators`, `neurons/executor` or `datura` — keep it green.
+Open an issue on [Datura-ai/lium-io](https://github.com/Datura-ai/lium-io/issues) describing the bug or the change you want, or pick one that is open. Fork the repository, branch from `main`, and open a pull request against `main` — the [README](../README.md) lists the layout and the exact test command for each neuron. Every pull request needs one approving review before it merges; the **Tests** workflow (validator, executor and miner suites) runs on every pull request against `main` or `dev` — keep it green.
 
 ## Communication Channels
-GitHub issues and pull requests on this repository. Providers running a node reach the team in the Lium Discord (linked from [docs.lium.io](https://docs.lium.io/providers/)); questions about the code belong in an issue so the answer stays findable.
+GitHub issues and pull requests on this repository. Providers running a node reach the team in the Lium Discord (linked from [docs.lium.io](https://docs.lium.io/providers)); questions about the code belong in an issue so the answer stays findable.
 
 > Please follow the Bittensor Subnet [style guide](./STYLE.md) regardless of your contribution type. 
 

--- a/contrib/CONTRIBUTING.md
+++ b/contrib/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Bittensor Subnet Development
+# Contributing to lium-io
 
-The following is a set of guidelines for contributing to the Bittensor ecosystem. These are **HIGHLY RECOMMENDED** guidelines, but not hard-and-fast rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to `lium-io`, the Subnet 51 validator, executor and miner. These are **HIGHLY RECOMMENDED** guidelines, but not hard-and-fast rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
 ## Table Of Contents
 1. [How Can I Contribute?](#how-can-i-contribute)
@@ -16,10 +16,10 @@ The following is a set of guidelines for contributing to the Bittensor ecosystem
 
 
 ## How Can I Contribute?
-TODO(developer): Define your desired contribution procedure.
+Open an issue on [Datura-ai/lium-io](https://github.com/Datura-ai/lium-io/issues) describing the bug or the change you want, or pick one that is open. Fork the repository, branch from `main`, and open a pull request against `main` — the [README](../README.md) lists the layout and the exact test command for each neuron. Every pull request needs one approving review before it merges; the **Tests** workflow (validator and executor suites) runs on pull requests that touch `neurons/validators`, `neurons/executor` or `datura` — keep it green.
 
 ## Communication Channels
-TODO(developer): Place your communication channels here
+GitHub issues and pull requests on this repository. Providers running a node reach the team in the Lium Discord (linked from [docs.lium.io](https://docs.lium.io/providers/)); questions about the code belong in an issue so the answer stays findable.
 
 > Please follow the Bittensor Subnet [style guide](./STYLE.md) regardless of your contribution type. 
 
@@ -99,7 +99,7 @@ After you submit a pull request, it will be reviewed by the maintainers. They ma
 > Note: Be sure to merge the latest from "upstream" before making a pull request:
 
 ```bash
-git remote add upstream https://github.com/opentensor/bittensor.git # TODO(developer): replace with your repo URL
+git remote add upstream https://github.com/Datura-ai/lium-io.git
 git fetch upstream
 git merge upstream/<your-branch-name>
 git push origin <your-branch-name>

--- a/datura/README.md
+++ b/datura/README.md
@@ -1,1 +1,23 @@
 # datura
+
+The protocol package shared by the three neurons in this repository. It has no
+dependencies of its own and is installed from the working tree by
+`neurons/validators`, `neurons/executor` and `neurons/miners`
+(`datura @ file:///…/datura` in each `pyproject.toml`), so a change here is
+picked up by all three on their next `pdm install`.
+
+What lives here:
+
+- `datura/requests/` — the WebSocket message types the validator and the miner
+  exchange, as pydantic models: `validator_requests.py` (what the validator
+  sends: authentication, SSH-key submit/remove, pod-log requests) and
+  `miner_requests.py` (what the miner answers: accept/decline job, executor SSH
+  info, generic error). `base.py` holds `BaseRequest`, which parses an incoming
+  JSON frame into the right subclass by its `message_type`.
+- `datura/consumers/base.py` — `BaseConsumer`, the FastAPI WebSocket
+  receive/send loop both sides build their consumers on.
+- `datura/errors/protocol.py` — the protocol-level exceptions.
+
+Adding a message type means adding a model in the right `*_requests.py` and a
+member to its `RequestType` enum; the validator and the miner must ship the
+change together, since neither side tolerates an unknown type.

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -1,8 +1,35 @@
 # Executor
 
-**[Executor Documentation](https://docs.lium.io/bittensor-subnet/executor)**
+**[Node Quickstart on docs.lium.io](https://docs.lium.io/providers/nodes/quickstart)**
 
-## Setup project
+## Quick setup with `lium mine` (recommended)
+
+Install [Sysbox](https://docs.lium.io/providers/nodes/sysbox) first — validators reject a node without the `sysbox-runc` runtime. The installer below also sets up the NVIDIA Container Toolkit:
+
+```shell
+curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash
+```
+
+Then run the node in one command, with your miner hotkey:
+
+```shell
+curl -fsSL https://lium.io/mine.sh | bash -s -- -k <your_miner_hotkey_ss58>
+```
+
+The script installs the [`lium`](https://github.com/Datura-ai/lium) CLI and runs `lium mine`, which:
+
+1. clones this repository into `./compute-subnet` (or pulls the branch if the directory already exists),
+2. runs `scripts/install_executor_on_ubuntu.sh` (Docker, NVIDIA Container Toolkit and GPU checks),
+3. renders `neurons/executor/.env` from `.env.template` with the hotkey and the ports — you are prompted for the service port (`8080`), the node SSH port (`2200`), an optional public SSH port and an optional renting port range; pass `--auto` to accept the defaults without prompts,
+4. starts the executor with `docker compose up -d` and waits for the container to report `healthy`,
+5. runs the validator's own check against the node (`daturaai/lium-validator:latest`).
+
+At the end it prints the node's endpoint, GPU type and count, and a `provider.lium.io/nodes?action=add&…` link that pre-fills the **Add Node** form in the [Provider Portal](https://provider.lium.io) with those values. Other options: `-d/--dir` (checkout directory, default `compute-subnet`) and `-b/--branch` (default `main`); `lium mine --help` lists them.
+
+## Manual setup
+
+Use this path if you want to set every value yourself instead of running `lium mine`.
+
 ### Requirements
 * Ubuntu machine
 * install [docker](https://docs.docker.com/engine/install/ubuntu/)
@@ -11,14 +38,14 @@
 ### Step 1: Clone project
 
 ```
-git clone https://github.com/Datura-ai/compute-subnet.git
+git clone https://github.com/Datura-ai/lium-io.git
 ```
 
 ### Step 2: Install Required Tools
 
 Run following command to install required tools: 
 ```shell
-cd compute-subnet && chmod +x scripts/install_executor_on_ubuntu.sh && scripts/install_executor_on_ubuntu.sh
+cd lium-io && chmod +x scripts/install_executor_on_ubuntu.sh && scripts/install_executor_on_ubuntu.sh
 ```
 
 if you don't have sudo on your machine, run

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -4,6 +4,15 @@
 
 ## Quick setup with `lium mine` (recommended)
 
+Before the first command, the machine needs:
+
+- **Ubuntu 22.04 on x86_64**, kernel 5.19 or newer (6.x recommended; `hostnamectl` shows both), and root or passwordless `sudo`;
+- **the NVIDIA driver loaded** — `nvidia-smi` lists the GPUs;
+- **Docker Engine installed and running** — `docker ps` works. The Sysbox installer below refuses to run without it (`lium mine` runs the Docker install script too, but only after this step, and it is a no-op on a machine that already has Docker);
+- **a public IP** with the service port (`8080`) and the node SSH port (`2200`) reachable, and the SS58 hotkey of a provider registered on subnet 51.
+
+RAM, disk (including the 1.5× VRAM rule for the idle incentive) and the recommended XFS storage setup are in the [Node Quickstart requirements](https://docs.lium.io/providers/nodes/quickstart#requirements).
+
 Install [Sysbox](https://docs.lium.io/providers/nodes/sysbox) first — validators reject a node without the `sysbox-runc` runtime. The installer below also sets up the NVIDIA Container Toolkit:
 
 ```shell

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://lium.io/mine.sh | bash -s -- -k <your_miner_hotkey_ss58>
 The script installs the [`lium`](https://github.com/Datura-ai/lium) CLI and runs `lium mine`, which:
 
 1. clones this repository into `./compute-subnet` (or pulls the branch if the directory already exists),
-2. runs `scripts/install_executor_on_ubuntu.sh` (Docker, NVIDIA Container Toolkit and GPU checks),
+2. runs `scripts/install_executor_on_ubuntu.sh` (Docker Engine and the compose plugin), then checks prerequisites — `nvidia-smi`, `nvidia-container-cli`, `docker info`,
 3. renders `neurons/executor/.env` from `.env.template` with the hotkey and the ports — you are prompted for the service port (`8080`), the node SSH port (`2200`), an optional public SSH port and an optional renting port range; pass `--auto` to accept the defaults without prompts,
 4. starts the executor with `docker compose up -d` and waits for the container to report `healthy`,
 5. runs the validator's own check against the node (`daturaai/lium-validator:latest`).

--- a/neurons/miners/README.md
+++ b/neurons/miners/README.md
@@ -1,6 +1,11 @@
 # Miner
 
-**[Miner Documentation](https://docs.lium.io/bittensor-subnet/miner/overview)**
+**[Provider Documentation](https://docs.lium.io/providers)** — docs.lium.io calls a miner a *provider*, the
+central miner the *self-hosted provider* ([setup guide](https://docs.lium.io/providers/self-hosted-provider)),
+and an executor a *node*. Most providers do not run this service themselves: opting into the
+[Lium.io Central Provider Server](https://docs.lium.io/providers/provider-configuration) from the
+[Provider Portal](https://provider.lium.io) lets Lium run it for you, and nodes are then set up with
+`lium mine` ([Node Quickstart](https://docs.lium.io/providers/nodes/quickstart)).
 
 ## Overview
 
@@ -19,7 +24,7 @@ To run the central miner, you only need a CPU server with the following specific
 
 Executors are GPU-equipped machines that perform the computational tasks. The central miner manages these executors, which can be easily added or removed from the network.
 
-To see the compatible GPUs to mine with and their relative rewards, see this dict [here](https://github.com/Datura-ai/compute-subnet/blob/main/neurons/validators/src/services/const.py#L3).
+To see the compatible GPUs to mine with and their relative rewards, see this dict [here](https://github.com/Datura-ai/lium-io/blob/main/neurons/validators/src/services/const.py).
 
 ## Installation
 
@@ -28,13 +33,13 @@ To see the compatible GPUs to mine with and their relative rewards, see this dic
 #### Step 1: Clone the Git Repository
 
 ```
-git clone https://github.com/Datura-ai/compute-subnet.git
+git clone https://github.com/Datura-ai/lium-io.git
 ```
 
 #### Step 2: Install Required Tools
 
 ```
-cd compute-subnet && chmod +x scripts/install_miner_on_ubuntu.sh && ./scripts/install_miner_on_ubuntu.sh
+cd lium-io && chmod +x scripts/install_miner_on_ubuntu.sh && ./scripts/install_miner_on_ubuntu.sh
 ```
 
 Verify if bittensor and docker installed: 

--- a/neurons/validators/README.md
+++ b/neurons/validators/README.md
@@ -1,6 +1,11 @@
 # Validator
 
-**[Validator Documentation](https://docs.lium.io/bittensor-subnet/validator)**
+**[Validator Documentation](https://docs.lium.io/validators)**
+
+Subnet 51 has one validator, operated by the Lium team (hotkey `5F7X5UpKSr26KU3jKfpLmT8kuKtBNyHhEnfS8xtxPCqCb13p`).
+This directory is its source. If you want to verify what the validator does, use the community
+[sn51-auditor](https://github.com/Datura-ai/sn51-auditor) instead of running a second validator.
+The steps below are for the Lium team's own deployments and for testnet.
 
 ## System Requirements
 
@@ -33,13 +38,13 @@ btcli w regen_hotkey
 #### Step 1: Clone Git repo
 
 ```
-git clone https://github.com/Datura-ai/compute-subnet.git
+git clone https://github.com/Datura-ai/lium-io.git
 ```
 
 #### Step 2: Install Required Tools
 
 ```
-cd compute-subnet && chmod +x scripts/install_validator_on_ubuntu.sh && ./scripts/install_validator_on_ubuntu.sh
+cd lium-io && chmod +x scripts/install_validator_on_ubuntu.sh && ./scripts/install_validator_on_ubuntu.sh
 ```
 
 Verify docker installation


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-2967](https://app.notion.com/p/Write-the-READMEs-that-do-not-describe-their-repo-computenet-docker-images-4-lines-lium-infra-1-3d3b8bfdbde981aebeb3e46a1c5668d4) · reviewer: @taiberium

**TL;DR** — The lium-io READMEs were stale: the root one last changed 888 commits ago and pointed at a dead package, the executor one never mentioned `lium mine`, `datura/README.md` was one line, and nobody could tell who runs the SN51 validator. Four README-only PRs, one read. Risk: docs only.

**What changed**
- root README: repository layout (three neurons, `watchtower/`, `datura/`), the test commands `test.yml` runs as one block from the root, `pip install lium.io` (`README.md`)
- executor README: *Quick setup with lium mine* first, manual setup kept (`neurons/executor/README.md`)
- validator and miner READMEs: who runs the SN51 validator, the provider glossary (`neurons/validators/README.md`, `neurons/miners/README.md`)
- `datura/README.md` describes the protocol package; `contrib/CONTRIBUTING.md` says what the Tests workflow runs and drops the template placeholders

**How to verify**
- run the `README.md` § Running the Tests block as one script from the repository root → validators 1939 passed (+ main's own 2 failures), executor 128, miners 26
- `grep -n 'branches:\|paths:' .github/workflows/test.yml` → `branches: [main, dev]`, no `paths:` — what CONTRIBUTING now says
- `curl -sI https://docs.lium.io/providers/nodes/quickstart` → 200 (the executor README's link target)

**Verified by the loop:** 8 Sep 2026 · sandbox EC2 · validators 1939 passed · executor 128 passed · miners 26 passed · Gate: PASS 61d14b6c

**Ran it:** `bash` the README § Running the Tests block, top to bottom from the repository root at 61d14b6c → validators 1939 passed (+ main's own 2 failures), executor 128, miners 26 in 201 s · sandbox EC2 aws_run 20260907T235743Z-1uqv (Linux) · links checked from a Mac: all 200 but one pre-existing 404

**Self-review:** clean at 61d14b6 (15 checks, 13 mechanical notes dismissed; subagent-batchD4)

**Parts:** backend n/a — README-only · migration n/a — no schema change · frontend n/a — no UI in this repo · CLI/SDK n/a — no client change · docs ✓ five READMEs + CONTRIBUTING · tests n/a — README-only; the README's own test block ran · dashboards n/a — no new metric

**Docs:** this PR is the docs change (in-repo READMEs).

<details><summary>Details</summary>

**Consolidates** #1277, #1293, #1299, #1306 — one PR per feature (owner, daily call 7 Sep 2026; SO §40). Why one feature: four README-only PRs (DAH-2967/1515/3095/3131). Base: `main`. Every slice's branch is merged with `--no-ff`, so its commits, authorship and history are intact; the slices are closed with a pointer here. The reviewer is the one named on line 1.

## Self-review round (7 Sep 2026, subagent-batchD) — 3 findings, fixed in `6f2a96d3`

| finding | fix | proof |
|---|---|---|
| `contrib/CONTRIBUTING.md`: "the Tests workflow (validator and executor suites) runs on pull requests that touch neurons/validators, neurons/executor or datura" — `test.yml` on main has no `paths:` filter and runs the miner suite too | "the **Tests** workflow (validator, executor and miner suites) runs on every pull request against `main` or `dev`" | `test.yml` lines 7–8: `pull_request: branches: [main, dev]`, jobs `validators`, `executor`, `miners` |
| `README.md`: "These are the exact commands `.github/workflows/test.yml` runs" while the README used `pytest tests/ -q` and CI `-v --tb=short` (+ `--strict-markers` for validators) | the README block carries CI's flags; "the commands `test.yml` runs on every pull request against `main` or `dev`" | the block ran verbatim on EC2 (Ran it) |
| `README.md`: "Three deployable services, one shared package, each with its own pyproject.toml / pdm.lock, Dockerfile and compose files" — `datura/` has a `pyproject.toml` only | "Three deployable services, each with its own … and one shared pdm package (`datura/`, a `pyproject.toml` only)" | `ls datura/` → `datura pyproject.toml` |

Also fixed while running the links: CONTRIBUTING's `https://docs.lium.io/providers/` answers 404 with the trailing slash and 200 without, so the slash goes. Pre-existing and left alone: `https://github.com/GNOME/byzanz` (bittensor-template text on `main`, lines 173/208) answers 404.

**Verified by the loop on 8 Sep 2026** (sandbox EC2 c6i.2xlarge, Python 3.11.11; aws_run `20260907T235743Z-1uqv`): head `61d14b6c` (uploaded as a bundle before the push) — the README § *Running the Tests* fenced block extracted with `awk` and run with `bash` as one script from the repository root — Validators 1939 passed, 15 skipped, 2 pre-existing failures = main (`test_scrape_infiniband::…unreadable_sysfs…`, `test_sshd_bootstrap_script::…adopt_path…`, root-on-the-box artefacts); Executor 128 passed; Miners 26 passed; the block ran to its end (rc 0) because each service is its own subshell. Every other README/CONTRIBUTING link answered 200 on 7 Sep (unchanged in this round). Result: PASS 61d14b6c.
Gate: PASS (61d14b6) on EC2 sandbox Linux x86_64 (aws_run fixD2-gate3)

## Self-review round 3 (8 Sep 2026, subagent-batchD3) — 2 findings, fixed in `61d14b6c`

| finding | fix | proof |
|---|---|---|
| the README test block chained `cd neurons/validators` then `cd neurons/executor`, so pasted from the root the second and third commands failed | each service runs in its own subshell; the sentence above the block says "from the repository root" | the run above: the block as one `bash` script, three suites in order |
| the layout sentence counted three pdm projects; `watchtower/` has `pyproject.toml`, `pdm.lock` and a Dockerfile too | the sentence names it | `ls watchtower/` on the head |

Earlier run at `6f2a96d3`'s README (aws_run `20260907T221507Z-9msk`): the same three results, each `cd … && …` line evaluated from the root by hand.

## Verification of the consolidated branch (at `0e73284`, before the self-review round)

Sandbox EC2 run `consol-lium-io-20260907T174547Z` (`tools/aws_run_jobs/reverify_io.sh`, E2E=0, CI env: sqlite, wallet/TDX vars, --strict-markers): head at run time (its message was since amended to add and then drop `[skip ci]`; tree unchanged) merged onto `main` `07ec64cd` cleanly; UNIT PASS (failures compared with main's own two). The #1312 e2e stack is not merged on main, so it did not run here.

CI on GitHub at `0e73284` (7 Sep 2026): every check green — https://github.com/Datura-ai/lium-io/actions/runs/34158235687, https://github.com/Datura-ai/lium-io/actions/runs/34158238331. The tip was re-committed without `[skip ci]` on 7 Sep 20:00Z (same tree) so CI would run.

## #1277 — DAH-1515 - [P2] Executor README: set a node up with lium mine

_head `0c25220f` (`DAH-1515-executor-readme-lium-mine`), was based on `main`._

Implements [DAH-1515](https://app.notion.com/p/Subnet-Update-executor-neuron-README-md-to-use-the-new-lium-mine-CLI-to-add-an-executor-28eb8bfdbde9800ea61beab45a3eac52) · reviewer: @arhangel66

**TL;DR** — `neurons/executor/README.md` still documents only the hand-rolled setup — clone, run the install script, copy `.env.template`, fill the keys in, `docker compose up -d` — and never mentions `lium mine`. Executor README: set a node up with lium mine. Touches validator/executor (`neurons/executor/README.md`) — read that file first.

**What changed**
- `neurons/executor/README.md` only.
- Header link → `https://docs.lium.io/providers/nodes/quickstart` (the redirect's target).
- New first section Quick setup with `lium mine` (recommended).
- The old section is kept as Manual setup with one sentence on when to use it.

**How to verify**
- `gh pr checks 1277 -R Datura-ai/lium-io` → all green
- re-run the loop's suites (Details → Verification) → validators 1940 passed, executor 128 passed, miners 26 passed

**Verified as slice #1277 (at its head `0c25220`):** 7 Sep 2026 · Linux pod (py3.11) · validators 1940 passed · executor 128 passed · miners 26 passed · Result: PASS · Gate: not run

**Docs:** this PR is the docs change.

<details><summary>#1277 details</summary>

[DAH-1515](https://app.notion.com/p/Subnet-Update-executor-neuron-README-md-to-use-the-new-lium-mine-CLI-to-add-an-executor-28eb8bfdbde9800ea61beab45a3eac52).

## Problem

`neurons/executor/README.md` still documents only the hand-rolled setup — clone, run the install script, copy `.env.template`, fill the keys in, `docker compose up -d` — and never mentions `lium mine`, which is the path docs.lium.io gives providers (Node Quickstart → Step 2: `curl -fsSL https://lium.io/mine.sh | bash -s -- -k <hotkey>`). A provider who lands on the repo instead of the docs does everything by hand and misses the validator self-check the CLI runs for them.

Two stale details on top: the header links `docs.lium.io/bittensor-subnet/executor`, which is a redirect to `/providers/nodes/quickstart`, and the clone command names `Datura-ai/compute-subnet.git`, the repository's old name (GitHub redirects it; the next step's `cd compute-subnet` then points at a directory the current clone does not create).

## Change

`neurons/executor/README.md` only:

- Header link → `https://docs.lium.io/providers/nodes/quickstart` (the redirect's target).
- New first section **Quick setup with `lium mine` (recommended)**: install Sysbox first with `nvidia_docker_sysbox_setup.sh` (the CLI's install script does not install it, and validators reject a node without `sysbox-runc`), then the one-line `mine.sh` command. The five steps listed are what `lium/cli/commands/mine.py` does on `Datura-ai/lium@main`: `_clone_or_update_repo` (clone into `./compute-subnet`, or `git pull` the branch when it exists), `_install_executor_tools` (`scripts/install_executor_on_ubuntu.sh`), `_setup_executor_env` (renders `.env` from `.env.template`; `_gather_inputs` prompts for service port 8080, SSH port 2200, optional public SSH port and renting port range, `--auto` takes the defaults), `_start_executor` (`docker compose up -d`, waits for `healthy`), `_validate_executor` (`daturaai/lium-validator:latest`). The closing paragraph describes the summary the command prints (endpoint, GPU count×type, and the `provider.lium.io/nodes?action=add&…` link that pre-fills Add Node) and names the `-d/--dir` and `-b/--branch` options.
- The old section is kept as **Manual setup** with one sentence on when to use it; its clone URL becomes `Datura-ai/lium-io.git` and the following `cd` becomes `cd lium-io`. The environment-variable reference and the GPU/Docker/Sysbox sections below it are unchanged.

## How to test

Read the page on the branch. Every command in the new section is copied from the docs Node Quickstart and from `mine.py`; `lium mine --help` on lium 0.0.33 shows the `-k/-d/-b/-a/-v` options named. `https://docs.lium.io/providers/nodes/quickstart` answers 200; the old header link answers 308 to it.

## Verification

**Verified as slice #1277 on 7 Sep 2026:** PR head merged onto `main` (55be0e9e) on a Linux pod, the three CI suites (Python 3.11.11, pdm, sqlite, CI env vars): Validators 1940 passed, 15 skipped, 1 env artefact, Executor 128 passed, Miners 26 passed. The only validator failures are two root-on-a-pod artefacts `main` has too (`test_scrape_infiniband::…unreadable_sysfs…` — chmod 000 does not stop root; `test_sshd_bootstrap_script::…adopt_path…` — the pod runs a live sshd), both pass as a non-root user / in CI. README-only; the `lium mine` one-liner it documents was not run (it would register the pod as a provider node).

## Notes for reviewers

- The ticket has no body; the title asks for the README to use `lium mine`. Nothing in the executor code or compose files changes.
- Kept the manual path rather than deleting it: `.env.template` keys (`RENTING_PORT_RANGE`, `RENTING_PORT_MAPPINGS`, `SSH_PUBLIC_PORT`) are documented nowhere else, and `lium mine` writes the same file, so the reference still serves both paths.
- `lium mine` clones into `./compute-subnet` by default while a manual clone of `lium-io.git` lands in `./lium-io`; the README states each where it applies.


---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-1515.

Docs: this PR is the docs change.

</details>

## #1293 — DAH-2967 - [P3] repository layout, how to run the tests

_head `636d7be3` (`DAH-2967-io-readme-layout-tests`), was based on `main`._

Implements [DAH-2967](https://app.notion.com/p/Write-the-READMEs-that-do-not-describe-their-repo-computenet-docker-images-4-lines-lium-infra-1-3d3b8bfdbde981aebeb3e46a1c5668d4) · reviewer: @jam6099

**TL;DR** — The 6 Sep audit: the lium-io README last changed 293 days / 888 code commits ago. `README.md` only, +30 / −1: - Fix the dead reference (DAH-2968): `pip install lium-cli` → `pip install lium.io` (the package name in the CLI's `pyproject.toml`, PyPI 200), link → `github.com/Datura-ai/lium`. Biggest change: `README.md` (+30 −1).

**What changed**
- `README.md` only, +30 / −1.
- **Fix the dead reference** (DAH-2968): `pip install lium-cli` → `pip install lium.io` (the package name in the CLI's `pyproject.toml`.
- **Repository Layout** (8 lines): `neurons/validators` / `miners` / `executor` (+ `dstacktee` TDX variant), `datura` shared protocol, `watchtower`.
- **Running the Tests** (12 lines): the exact `pdm install` + `pytest` commands and env vars that `.github/workflows/test.yml` runs for validators (SQLite…
- Table of contents updated.

**How to verify**
- `curl https://pypi.org/pypi/lium-cli/json` → → 404; `/lium-io/json` → 200, name `lium.io`, homepage `github.com/Datura-ai/lium`

**Verified as slice #1293 (at its head `636d7be`):** 7 Sep 2026 · Linux pod (py3.11) · validators 1939 passed · executor 128 passed · miners 26 passed · Result: PASS · Gate: not run

**Docs:** this PR is the docs change.

<details><summary>#1293 details</summary>

[DAH-2967](https://app.notion.com/p/Write-the-READMEs-that-do-not-describe-their-repo-computenet-docker-images-4-lines-lium-infra-1-3d3b8bfdbde981aebeb3e46a1c5668d4) · [DAH-2968](https://app.notion.com/p/Delete-or-fix-README-lines-that-name-files-scripts-and-commands-that-no-longer-exist-12-repos-35--3d3b8bfdbde9814abc0fc46ca5f4add0).

## Origin
The 6 Sep audit: the lium-io README last changed **293 days / 888 code commits ago**; it explains the marketplace to renters and points miners and validators at their setup guides, but says nothing about how the repository itself is laid out or how to run its ~1,950 tests (Newcomer axis: "usage ✗", "AGENTS.md ✗"). Its one developer-facing pointer is wrong: `pip install lium-cli` is a 404 on PyPI and `github.com/Datura-ai/lium-cli` is a renamed repo (redirects to `Datura-ai/lium`).

## Change
`README.md` only, +30 / −1:
- **Fix the dead reference** (DAH-2968): `pip install lium-cli` → `pip install lium.io` (the package name in the CLI's `pyproject.toml`, PyPI 200), link → `github.com/Datura-ai/lium`.
- **Repository Layout** (8 lines): `neurons/validators` / `miners` / `executor` (+ `dstacktee` TDX variant), `datura` shared protocol, `watchtower`, `scripts` / `docs` / `contrib` — one line each on what it is; where the uploaded job scripts live (`validators/src/miner_jobs/`) and that `machine_scrape.py` is obfuscated per job by `file_encrypt_service.py` with a load-bearing key order (the thing a newcomer breaks first).
- **Running the Tests** (12 lines): the exact `pdm install` + `pytest` commands and env vars that `.github/workflows/test.yml` runs for validators (SQLite, no Postgres), executor and miners; AAA convention and the ruff pre-commit hook.
- Table of contents updated.

## Verification
- Every path named in the new sections exists on `main` (`neurons/validators/src/miner_jobs/{machine_scrape,backup_storage,restore_storage,workspace_mount}.py`, `src/services/file_encrypt_service.py`, `neurons/miners/migrations`, `neurons/executor/dstacktee/README.md`, `datura/datura/requests`, `watchtower/README.md`, `scripts/install_*_on_ubuntu.sh`, `contrib/`, `.pre-commit-config.yaml`).
- The test commands are copied from `test.yml` (validators env block included) — the same ones that ran green on #1286 (1941 passed / 128 passed).
- `curl https://pypi.org/pypi/lium-cli/json` → 404; `/lium-io/json` → 200, name `lium.io`, homepage `github.com/Datura-ai/lium`.
- Docs only; not staged: no runtime change.

**Verified as slice #1293 on 7 Sep 2026:** PR head merged onto `main` (55be0e9e) on a Linux pod, the three CI suites (Python 3.11.11, pdm, sqlite, CI env vars): Validators 1939 passed, 15 skipped, 2 env artefacts, Executor 128 passed (one flaky digest test under parallel load; 128/128 serially), Miners 26 passed. The only validator failures are two root-on-a-pod artefacts `main` has too (`test_scrape_infiniband::…unreadable_sysfs…` — chmod 000 does not stop root; `test_sshd_bootstrap_script::…adopt_path…` — the pod runs a live sshd), both pass as a non-root user / in CI. README-only.

## Notes for reviewers
- Kept to what a newcomer needs to find code and run tests; the validator/miner/executor setup guides stay where they are.
- The miners tests command is listed although `test.yml` does not run it yet — #1289 (DAH-3001) adds that job.
- The audit's "888 code commits since the README changed" count resets with this PR; the layout section is deliberately short so it does not rot.


---
Opened by the Lium automation account; commits are anonymous by policy. Tickets: DAH-2967, DAH-2968.

Docs: this PR is the docs change.

</details>

## #1299 — DAH-3095 - [P3] validators/README says who runs the SN51 validator (Lium

_head `6cf71aa1` (`DAH-3095-neuron-readmes`), was based on `main`._

Implements [DAH-3095](https://app.notion.com/p/lium-io-validators-README-tells-anyone-to-run-a-validator-Lium-runs-the-only-one-miner-validator-3d4b8bfdbde9813e86bde42a36dbffb0) · reviewer: @jam6099

**TL;DR** — Docs review, 7 Sep 2026 (`docs-review/DOCS_REVIEW.md`): the neuron READMEs read against docs.lium.io and the repository. Validators/README says who runs the SN51 validator (Lium; audit with sn51-auditor); miner + validator READMEs use the lium-io repo name, live docs URLs and the provider vocabulary. Touches validator/executor (`neurons/miners/README.md`) — read that file first.

**What changed**
- `validators/README.md`: three sentences under the title — one validator, its hotkey, use sn51-auditor to audit.
- `miners/README.md`: the docs link becomes a short glossary paragraph (miner = provider, central miner = self-hosted provider.
- No setup step changed.

**How to verify**
- `curl -sI` → on 7 Sep: `docs.lium.io/bittensor-subnet/validator` → 308 → `/validators`; `/bittensor-subnet/miner/overview` → 308 → `/providers/architecture`.

**Verified as slice #1299 (at its head `6cf71aa`):** not yet run for this head.

**Docs:** this PR is the docs change.

<details><summary>#1299 details</summary>

[DAH-3095](https://app.notion.com/p/lium-io-validators-README-tells-anyone-to-run-a-validator-Lium-runs-the-only-one-miner-validator-3d4b8bfdbde9813e86bde42a36dbffb0) · DAH-2968.
## Origin

Docs review, 7 Sep 2026 (`docs-review/DOCS_REVIEW.md`): the neuron READMEs read against docs.lium.io and the repository. #1293 (root README) and #1277 (executor README) are already open; this is the two remaining neuron READMEs.

## Problem

1. `neurons/validators/README.md` is a public "register a hotkey on netuid 51 and run the validator" guide. docs.lium.io/validators says Subnet 51 has one validator, run by the Lium team, and sends other neurons to `Datura-ai/sn51-auditor`; the README never says so, so an outsider following it burns a registration for a neuron that will not set weights.
2. Both `neurons/validators/README.md` and `neurons/miners/README.md` clone `github.com/Datura-ai/compute-subnet` and `cd compute-subnet` (the repository is `lium-io`; the old URL only redirects), link `docs.lium.io/bittensor-subnet/validator` and `/bittensor-subnet/miner/overview` (redirects), and the miner README links the GPU rate table inside the old repo name.
3. `neurons/miners/README.md` never says that a "miner" is what docs.lium.io calls a *provider*, that the central miner is the *self-hosted provider*, or that most providers do not run it at all (the Lium.io Central Provider Server + `lium mine` path) — a provider arriving from the docs cannot map the words.

## Change

- `validators/README.md`: three sentences under the title — one validator, its hotkey, use sn51-auditor to audit, the steps below are for the team's deployments and testnet; docs link → `/validators`; clone URL and `cd` → `lium-io`. (+8 / −3)
- `miners/README.md`: the docs link becomes a short glossary paragraph (miner = provider, central miner = self-hosted provider, executor = node) with the Central Provider Server and `lium mine` alternative; clone URL, `cd`, and the `const.py` link → `lium-io`. (+9 / −4)

No setup step changed.

## Verification

- `curl -sI` on 7 Sep: `docs.lium.io/bittensor-subnet/validator` → 308 → `/validators`; `/bittensor-subnet/miner/overview` → 308 → `/providers/architecture`; `github.com/Datura-ai/compute-subnet` → 301 → `lium-io`; `github.com/Datura-ai/sn51-auditor` → 200; all new targets → 200.
- Validator hotkey and the one-validator statement copied from `lium-docs` `docs/validators/index.md` on `main`.
- Docs only; not staged: no runtime change.

## Notes for reviewers

- `neurons/miners/assigning_validator_hotkeys.md` (assign executors across validators by stake) reads as moot with a single validator; left untouched pending your call — delete or mark historical.
- `datura/README.md` is two words; not touched here.

---
Opened by the Lium automation account; commits are anonymous by policy. Ticket: DAH-3095.

Docs: this PR is the docs change.

</details>

## #1306 — DAH-3131 - [P3] describe the datura package; drop the bittensor placeholders

_head `d4043b20` (`DAH-3131-contrib-docs`), was based on `main`._

Implements [DAH-3131](https://app.notion.com/p/lium-io-contributor-docs-datura-README-md-is-two-words-CONTRIBUTING-md-still-carries-the-bittensor-3d4b8bfdbde98129ba88db09f6916ef6) · reviewer: @jam6099

**TL;DR** — `datura/README.md` is `# datura` and nothing else, although the package is the protocol layer all three neurons install from the tree (`datura @ file:///…/datura` in each `pyproject.toml`). Describe the datura package; drop the bittensor-template placeholders from CONTRIBUTING. Biggest change: `datura/README.md` (+22 −0).

**What changed**
- `datura/README.md`: what lives where (`requests/validator_requests.py`, `requests/miner_requests.py`, `requests/base.py` → `BaseRequest.parse` dispatches on `message_type`; `consumers/base.py` → `BaseConsumer`; `errors/protocol.py`), who installs it.
- `contrib/CONTRIBUTING.md`: title, "How Can I Contribute?"

**How to verify**
- `rg 'TODO\(developer\)|opentensor' contrib/` → → nothing. Claims checked against `datura/datura/requests/base.py`, the three `pyproject.toml` files and `.github/workflows/test.yml`. No code change.

**Verified as slice #1306 (at its head `d4043b2`):** not yet run for this head.

**Docs:** this PR is the docs change.

<details><summary>#1306 details</summary>

[DAH-3131](https://app.notion.com/p/lium-io-contributor-docs-datura-README-md-is-two-words-CONTRIBUTING-md-still-carries-the-bittensor-3d4b8bfdbde98129ba88db09f6916ef6) — docs only, from the 7 Sep docs review.

## Problem
- `datura/README.md` is `# datura` and nothing else, although the package is the protocol layer all three neurons install from the tree (`datura @ file:///…/datura` in each `pyproject.toml`).
- `contrib/CONTRIBUTING.md` is still the bittensor subnet template: titled "Contributing to Bittensor Subnet Development", two `TODO(developer)` placeholders (contribution procedure, communication channels), and `git remote add upstream https://github.com/opentensor/bittensor.git # TODO(developer): replace with your repo URL`.

## Change
- `datura/README.md`: what lives where (`requests/validator_requests.py`, `requests/miner_requests.py`, `requests/base.py` → `BaseRequest.parse` dispatches on `message_type`; `consumers/base.py` → `BaseConsumer`; `errors/protocol.py`), who installs it, and that adding a message type means a model + a `RequestType` member shipped to validator and miner together (an unknown type fails `parse`).
- `contrib/CONTRIBUTING.md`: title, "How Can I Contribute?" (issues/PRs against `main`, one approving review, the Tests workflow and what triggers it), "Communication Channels" (issues; Lium Discord via docs.lium.io for providers), and the upstream remote → `Datura-ai/lium-io`. Nothing else on the page touched.

## Verification
`rg 'TODO\(developer\)|opentensor' contrib/` → nothing. Claims checked against `datura/datura/requests/base.py`, the three `pyproject.toml` files and `.github/workflows/test.yml`. No code change; lium-io#1293 (root README) is untouched.

Docs: this PR is the docs change.

</details>

### Self-review

Verdict `clean` at `61d14b6` · 15 checks · by subagent-batchD4 · 2026-09-08 00:21Z (tools/pr_self_review.py)

Mechanical notes dismissed: `README.md:81` D3 finding 1 (the § Running the Tests block did not run top to bottom) is fixed: at 61d14b6c the block is three subshells `(cd neurons/validators && …)`, `(cd neurons/executor && …)`, `(cd neurons/miners && …)` and the sentence above it reads 'From the repository root, each service in its own subshell so the block runs top to bottom'; RECOVERY/aws_run/20260907T235743Z-1uqv/out/readme-block.sh is byte-equal to the README block and job.log shows `head 61d14b6c · main 07ec64cd`, `running the block as one script from /job/work/lium-io`, `block rc=0 in 201s`, summaries `2 failed, 1939 passed, 15 skipped … 113.65s` / `128 passed … 3.47s` / `26 passed … 2.02s`, the same two FAILED ids as main — exactly what the fold line, Verified-by-the-loop and `### Ran it` quote. · `README.md:67` D3 finding 2 (layout sentence missed watchtower) is fixed: `ls /tmp/fixD2/1317/watchtower` → Dockerfile README.md docker_build.sh pdm.lock pyproject.toml src tests (a pdm project with a Dockerfile, no compose file — as the sentence says); `ls datura` → README.md datura pyproject.toml tests (no pdm.lock — 'a `pyproject.toml` only'); validators/executor/miners each have pyproject.toml, pdm.lock, Dockerfile(s) and docker-compose*.yml. · `README.md:1` The new commit's scope matches the body: `git show --stat 61d14b6c` → README.md only, +10 −10, on top of 6f2a96d3; the five other files in the diff are unchanged since D3 read them. · `body:29` The `**Consolidates**` paragraph names no reviewer beyond 'the one named on line 1' — a deliberate decision (line 1 / the ledger is the single source of truth), not to be flagged. · `neurons/executor/README.md:19` Mechanical curl|sudo bash: this repository's own `neurons/executor/nvidia_docker_sysbox_setup.sh` fetched over TLS from GitHub main, the same installer the Manual path runs from the clone and the docs.lium.io Sysbox flow (pass D read the script); unchanged since D3. · `neurons/executor/README.md:25` Mechanical curl|bash: `curl -fsSL https://lium.io/mine.sh | bash -s -- -k <hotkey>` is docs.lium.io Node Quickstart step 2 verbatim from the product's own domain (pass D matched every `lium mine` step to mine.py); unchanged since D3. · `body:22` Mechanical 'tests were added, no test file': Parts says `tests n/a — README-only; the README's own test block ran`; the scanner keyed on the word 'test' in the Ran-it line. · `body:92` 'the block ran to its end (rc 0) because each service is its own subshell': rc 0 is the last subshell's (miners) status — job.log says so in the same line ('validators' 2 pre-existing failures do not stop the block') — and the body sentence names the two failures in the same breath, so no reader takes rc 0 for three green suites; the subshells are what makes the `cd`s resolve from the root, which is the claim.

### Ran it

aws_run `20260907T235743Z-1uqv` (c6i.2xlarge, AL2023, Python 3.11.11 via uv, pdm; `pdm use` pointed each project at that interpreter — the README's one assumption) — `RECOVERY/aws_run/20260907T235743Z-1uqv/job.log`. The README § *Running the Tests* fenced block was extracted with `awk` and run with `bash` as one script from the repository root:

```
head 61d14b6c · main 07ec64cd
running the block as one script from /job/work/lium-io:
block rc=0 in 201s
suite summaries, in order:
   2 failed, 1939 passed, 15 skipped, 149 warnings in 113.65s (0:01:53)
   128 passed, 18 warnings in 3.47s
   26 passed, 21 warnings in 2.02s
FAILED tests/test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices
FAILED tests/test_sshd_bootstrap_script.py::test_adopt_path_hardens_config_for_key_only_auth
```

The earlier run (aws_run `20260907T221507Z-9msk`, `6f2a96d3`'s README, each `cd … && …` line evaluated from the root by hand): the same three results.

```
CONTRIBUTING claim vs test.yml:
7:  pull_request:
8:    branches: [main, dev]        # no paths:
21:  validators:   58:  executor:   88:  miners:   120:  lint:   142:  tests-ok:
```

The two validator failures are `main`'s own on a root shell (chmod 000 does not stop root; a live sshd on the box). Links (Mac, `curl -sIL`): every README/CONTRIBUTING URL 200 except `https://github.com/GNOME/byzanz` (pre-existing template text) and the trailing-slash `…/providers/`, fixed in `6f2a96d3`. README-only change; nothing to run on macOS beyond the link check.

### Claims

Claims: 11 · proven 11 · unproven 0 (tools/pr_quality_gate.py --claims)

| where | claim | proof | status |
|---|---|---|---|
| README.md:82 | env/setting `BITTENSOR_WALLET_NAME` | `.github/workflows/test.yml:50` | proven |
| README.md:82 | env/setting `BITTENSOR_WALLET_HOTKEY_NAME` | `.github/workflows/test.yml:51` | proven |
| README.md:83 | env/setting `SQLALCHEMY_DATABASE_URI` | `.github/workflows/test.yml:52` | proven |
| README.md:83 | env/setting `ASYNC_SQLALCHEMY_DATABASE_URI` | `.github/workflows/test.yml:53` | proven |
| README.md:84 | env/setting `ENABLE_TDX_ATTESTATION` | `.github/workflows/test.yml:54` | proven |
| README.md:84 | env/setting `TDX_VERIFIER_URL` | `.github/workflows/test.yml:55` | proven |
| body · What changed | root README: repository layout, the test commands `test.yml` runs (with its flags), `pip install lium.io` (`README.md`) | `README.md` | proven |
| body · What changed | executor README: *Quick setup with lium mine* first, manual setup kept (`neurons/executor/README.md`) | `neurons/executor/README.md` | proven |
| body · What changed | validator and miner READMEs: who runs the SN51 validator, the provider glossary (`neurons/validators/README.md`, `neurons/miners/README.md`) | `neurons/validators/README.md` | proven |
| body · What changed | `datura/README.md` describes the protocol package; `contrib/CONTRIBUTING.md` says what the Tests workflow runs and drops the template placeholders | `datura/README.md` | proven |
| body · TL;DR | The lium-io READMEs were stale: the root one last changed 888 commits ago and pointed at a dead package, the executor one never mentioned `lium mine`, `datura/R | `datura/README.md` | proven |

### Cross-PR

`gh pr list --state open --limit 500` (loop PRs, 7 Sep 22:44Z): no other open loop PR touches `README.md`, `contrib/CONTRIBUTING.md`, `datura/README.md` or the three neuron READMEs; the gate's CROSS-PR check at `6f2a96d3` lists no overlapping file. Two open PRs change what the README describes and stay true under it: #1316 (DAH-2971) adds a `ruff check` job to the Tests workflow — the README's "the commands `test.yml` runs" are the three pytest lines, still exact; #1311 (DAH-3145) drops the `branches: [main, dev]` filter and routes jobs by changed package — if it lands first, CONTRIBUTING's "on every pull request against `main` or `dev`" becomes "on every pull request" (one phrase, this PR rebases). Neither blocks the other.

</details>
