### PR TITLE
scratch: DAH-3145 router proof — docs-only PR (close after the run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,5 @@ For more details, visit the [Validator Setup Guide](neurons/validators/README.md
 If you need assistance or have any questions, feel free to reach out:
 
 - **Discord Support**: [Dedicated Channel within the Bittensor Discord](https://discord.com/channels/799672011265015819/1291754566957928469)
+
+<!-- DAH-3145 router proof: a docs-only change selects no package (scratch PR, closed after the run) -->


### PR DESCRIPTION
Proof run for #1311 (PR_PROCESS L-127): a docs-only change against the router branch. Expected: the run summary's Route table shows validators/executor/miners `unchanged`, the three test jobs are skipped, `tests-ok` is green. Closed once the run is linked from #1311.

Made with [Cursor](https://cursor.com)