### PR TITLE
scratch: DAH-3147 red proof — e2e-gate must fail on an inverted signature check (close after the run)

### DIFF
--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -219,7 +219,7 @@ def _validate_validator_signature(payload: UploadSShKeyPayload, require_nonce: b
     try:
         keypair = bittensor.Keypair(ss58_address=VALIDATOR_HOTKEY_SS58)
         signed_blob = ssh_pubkey_signing_blob(payload.public_key, payload.nonce)
-        if not keypair.verify(signed_blob, payload.validator_signature):
+        if keypair.verify(signed_blob, payload.validator_signature):  # PLANT (scratch red proof): inverted on purpose
             raise HTTPException(status_code=401, detail="Invalid validator signature")
         logger.info("Validator signature verification successful")
     except HTTPException:


### PR DESCRIPTION
Proof run for #1312 (PR_PROCESS L-127): `_validate_validator_signature` in `neurons/executor/src/routes/apis.py` is inverted on purpose (the executor refuses every real validator and accepts every spoofer). Expected: `e2e-gate` red, the sticky comment says **e2e gate: FAIL** with the failing suites, the artifact is uploaded, `tests-ok` red. Closed once the run is linked from #1312. Never merge.

Made with [Cursor](https://cursor.com)