### PR TITLE
DAH-3199 - [P1] rental pods join an ICC-off bridge; co-tenants cannot reach each other

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -98,6 +98,7 @@ from services.rental_docker_sdk import (
     ContainerUlimit,
     DeviceMount,
     PortBinding,
+    RENTAL_NETWORK_NAME,
     RentalDockerConnectionError,
     RentalDockerOperationError,
     RentalDockerSdkClient,
@@ -1061,6 +1062,7 @@ class DockerService:
             storage_limit_gb=effective_storage_limit_gb,
             shm_size=custom_options.shm_size,
             entrypoint=custom_options.entrypoint,
+            network=RENTAL_NETWORK_NAME,
         )
 
     async def _ensure_pod_quote_socket(

--- a/neurons/validators/src/services/rental_docker_observability.py
+++ b/neurons/validators/src/services/rental_docker_observability.py
@@ -188,6 +188,7 @@ def rental_run_spec_log_fields(run_spec: ContainerRunSpec) -> dict:
         ],
         "restart_policy": run_spec.restart_policy,
         "runtime": run_spec.runtime,
+        "network": run_spec.network,
         "cap_add": list(run_spec.cap_add),
         "sysctls": run_spec.sysctls,
         "device_mounts": [

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -30,6 +30,15 @@ _DOCKER_EXECUTOR_MAX_WORKERS = 32
 _DOCKER_EXECUTOR = ThreadPoolExecutor(
     max_workers=_DOCKER_EXECUTOR_MAX_WORKERS, thread_name_prefix="docker-sdk"
 )
+# DAH-3199: every rental on a host shares this user-defined bridge instead of docker0. The daemon's
+# default bridge allows inter-container traffic, and a pod holds NET_ADMIN, so two rentals on a split
+# host could otherwise reach each other's unpublished ports. Docker enforces ICC=false with a FORWARD
+# drop between ports of this bridge; published ports still arrive through the host and NAT egress is
+# untouched. One network per host — nothing to remove at teardown.
+RENTAL_NETWORK_NAME = "lium-rentals"
+RENTAL_NETWORK_ICC_OPTION = "com.docker.network.bridge.enable_icc"
+RENTAL_NETWORK_OPTIONS = {RENTAL_NETWORK_ICC_OPTION: "false"}
+RENTAL_NETWORK_LABELS = {"io.lium.purpose": "rental-isolation"}
 logger = logging.getLogger(__name__)
 
 
@@ -120,6 +129,8 @@ class ContainerRunSpec:
     storage_limit_gb: int | None = None
     shm_size: str | None = None
     entrypoint: str | None = None
+    # None keeps the daemon's default bridge (the CVM quote broker talks over unix sockets only)
+    network: str | None = None
 
 
 @dataclass(slots=True)
@@ -445,6 +456,8 @@ class RentalDockerSdkClient:
         return None
 
     def _run_container_sync(self, spec: ContainerRunSpec) -> None:
+        if spec.network:
+            self._ensure_rental_network_sync(spec.network)
         host_config = self._api_client.create_host_config(
             **_build_host_config_kwargs(spec)
         )
@@ -460,6 +473,46 @@ class RentalDockerSdkClient:
             host_config=host_config,
         )
         self._api_client.start(spec.name)
+
+    def _ensure_rental_network_sync(self, name: str) -> None:
+        """The container's network exists on the host and has inter-container traffic off.
+
+        Runs before every rental `create_container`, so the isolation holds on a host that has never
+        seen a rental, on one whose network was removed by hand, and for two creates racing on the
+        same host (the loser's `create_network` conflicts and the network is inspected again). A
+        network of that name whose options do not turn ICC off is refused rather than used: running
+        the pod on it would silently restore the docker0 behaviour this network exists to end.
+        """
+        network = self._inspect_network_or_none(name)
+        if network is None:
+            try:
+                self._api_client.create_network(
+                    name,
+                    driver="bridge",
+                    options=dict(RENTAL_NETWORK_OPTIONS),
+                    labels=dict(RENTAL_NETWORK_LABELS),
+                )
+            except Exception as exc:
+                network = self._inspect_network_or_none(name)
+                if network is None:
+                    raise RentalDockerOperationError(
+                        _wrap_error_message(f"Docker SDK create network {name} failed", exc)
+                    ) from exc
+            else:
+                network = self._inspect_network_or_none(name)
+                if network is None:
+                    raise RentalDockerOperationError(
+                        f"Docker network {name} was created but cannot be inspected"
+                    )
+        _require_icc_off(name, network)
+
+    def _inspect_network_or_none(self, name: str) -> dict | None:
+        try:
+            return self._api_client.inspect_network(name)
+        except Exception as exc:
+            if _is_docker_not_found_error(exc):
+                return None
+            raise
 
     def _create_volume_sync(
         self,
@@ -818,8 +871,21 @@ def _build_host_config_kwargs(spec: ContainerRunSpec) -> dict:
             else None
         ),
         "shm_size": spec.shm_size,
+        "network_mode": spec.network,
     }
     return {key: value for key, value in kwargs.items() if value is not None}
+
+
+def _require_icc_off(name: str, network: dict) -> None:
+    options = network.get("Options") or {}
+    if network.get("Driver") == "bridge" and options.get(RENTAL_NETWORK_ICC_OPTION) == "false":
+        return
+    raise RentalDockerOperationError(
+        f"Docker network {name} exists on the executor but is not a bridge with "
+        f"{RENTAL_NETWORK_ICC_OPTION}=false (driver={network.get('Driver')!r}, options={options!r}); "
+        "refusing to run the rental on it. Remove the network once it is empty so the validator "
+        "recreates it with inter-container traffic off."
+    )
 
 
 def _ulimits(ulimits: tuple[ContainerUlimit, ...]) -> list | None:

--- a/neurons/validators/tests/test_rental_docker_sdk.py
+++ b/neurons/validators/tests/test_rental_docker_sdk.py
@@ -9,12 +9,15 @@ from unittest.mock import Mock
 
 import pytest
 from docker import auth as docker_auth
-from docker.errors import APIError
+from docker.errors import APIError, NotFound
 from docker.types import ContainerConfig
 
 import services.rental_docker_sdk as rental_docker_sdk
 from datura.requests.miner_requests import ExecutorSSHInfo
 from services.rental_docker_sdk import (
+    RENTAL_NETWORK_ICC_OPTION,
+    RENTAL_NETWORK_LABELS,
+    RENTAL_NETWORK_NAME,
     ContainerExecSpec,
     ContainerRunSpec,
     DeviceMount,
@@ -49,6 +52,11 @@ CGROUP_OCI_EXEC_ERROR = (
     "to cgroups caused: failed to write 123: openat2 "
     "/sys/fs/cgroup/init.scope (deleted)/cgroup.procs: no such file or directory\r\n"
 )
+
+
+def _bridge_network(options: dict | None) -> dict:
+    """The part of `docker network inspect` the SDK reads: driver and the options it was created with."""
+    return {"Name": RENTAL_NETWORK_NAME, "Driver": "bridge", "Options": dict(options or {})}
 
 
 def _container_state(
@@ -93,12 +101,35 @@ class FakeApiClient:
         self.pruned_images = False
         self.created_volumes = []
         self.removed_volumes = []
+        self.networks = {}  # name -> what inspect_network returns
+        self.created_networks = []
+        self.inspect_network_error = None  # raised by inspect_network instead of answering
+        self.create_network_error = None  # raised by create_network
+        self.lose_create_race = False  # with create_network_error: the network exists anyway (another create won)
         self.timeout = 60
         self.closed = False
 
     def create_host_config(self, **kwargs):
         self.host_config_kwargs = kwargs
         return {"host_config": True}
+
+    def inspect_network(self, net_id, **_kwargs):
+        self.events.append("inspect_network")
+        if self.inspect_network_error is not None:
+            raise self.inspect_network_error
+        if net_id not in self.networks:
+            raise NotFound(f"network {net_id} not found")
+        return self.networks[net_id]
+
+    def create_network(self, name, **kwargs):
+        self.events.append("create_network")
+        self.created_networks.append({"name": name, **kwargs})
+        if self.create_network_error is not None:
+            if self.lose_create_race:
+                self.networks[name] = _bridge_network(kwargs.get("options"))
+            raise self.create_network_error
+        self.networks[name] = _bridge_network(kwargs.get("options"))
+        return {"Id": "network-id"}
 
     def login(self, **kwargs):
         self.login_calls.append(kwargs)
@@ -112,10 +143,12 @@ class FakeApiClient:
         return {"Id": "image-id"}
 
     def create_container(self, **kwargs):
+        self.events.append("create_container")
         self.created_container = kwargs
         return {"Id": "container-id"}
 
     def start(self, container_name):
+        self.events.append("start")
         self.started.append(container_name)
 
     def stop(self, container_name, timeout=None):
@@ -546,6 +579,134 @@ async def test_run_container_maps_spec_to_docker_sdk_api():
     assert api_client.host_config_kwargs["mem_limit"] == "8g"
     assert api_client.host_config_kwargs["storage_opt"] == {"size": "20g"}
     assert api_client.started == ["pod_test"]
+
+
+# --- DAH-3199: a rental joins the ICC-off bridge, never docker0 ---
+
+
+def _rental_spec(network: str | None = RENTAL_NETWORK_NAME) -> ContainerRunSpec:
+    return ContainerRunSpec(image="registry.example/app:tag", name="pod_test", network=network)
+
+
+@pytest.mark.asyncio
+async def test_run_container_creates_the_icc_off_network_before_the_container():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    await client.run_container(_rental_spec())
+
+    # on a host that has never seen a rental the network is created first, then the container joins it
+    assert api_client.events == ["inspect_network", "create_network", "inspect_network", "create_container", "start"]
+    assert api_client.created_networks == [
+        {
+            "name": RENTAL_NETWORK_NAME,
+            "driver": "bridge",
+            "options": {RENTAL_NETWORK_ICC_OPTION: "false"},
+            "labels": RENTAL_NETWORK_LABELS,
+        }
+    ]
+    assert api_client.host_config_kwargs["network_mode"] == RENTAL_NETWORK_NAME
+
+
+@pytest.mark.asyncio
+async def test_run_container_reuses_the_existing_icc_off_network():
+    api_client = FakeApiClient()
+    api_client.networks[RENTAL_NETWORK_NAME] = _bridge_network({RENTAL_NETWORK_ICC_OPTION: "false"})
+    client = RentalDockerSdkClient(api_client)
+
+    await client.run_container(_rental_spec())
+
+    assert api_client.events == ["inspect_network", "create_container", "start"]
+    assert api_client.created_networks == []
+    assert api_client.host_config_kwargs["network_mode"] == RENTAL_NETWORK_NAME
+
+
+@pytest.mark.asyncio
+async def test_run_container_tolerates_losing_the_create_race_for_the_network():
+    api_client = FakeApiClient()
+    api_client.create_network_error = APIError(
+        f'409 Client Error: Conflict ("network with name {RENTAL_NETWORK_NAME} already exists")'
+    )
+    api_client.lose_create_race = True
+    client = RentalDockerSdkClient(api_client)
+
+    await client.run_container(_rental_spec())
+
+    # the second inspect finds the network the other create made, and the rental goes ahead on it
+    assert api_client.events == ["inspect_network", "create_network", "inspect_network", "create_container", "start"]
+    assert api_client.host_config_kwargs["network_mode"] == RENTAL_NETWORK_NAME
+
+
+@pytest.mark.asyncio
+async def test_run_container_surfaces_a_real_create_network_failure_and_starts_nothing():
+    api_client = FakeApiClient()
+    api_client.create_network_error = APIError(
+        '500 Server Error: Internal Server Error ("could not find an available, non-overlapping IPv4 address pool")'
+    )
+    client = RentalDockerSdkClient(api_client)
+
+    with pytest.raises(RentalDockerOperationError, match=f"create network {RENTAL_NETWORK_NAME} failed.*address pool"):
+        await client.run_container(_rental_spec())
+
+    # not a lost race: the second inspect still finds nothing, so the daemon's error is the answer
+    assert api_client.events == ["inspect_network", "create_network", "inspect_network"]
+    assert api_client.created_container is None
+    assert api_client.started == []
+
+
+@pytest.mark.asyncio
+async def test_run_container_propagates_an_inspect_network_error_instead_of_creating():
+    api_client = FakeApiClient()
+    api_client.inspect_network_error = APIError("500 Server Error: Internal Server Error (\"daemon busy\")")
+    client = RentalDockerSdkClient(api_client)
+
+    with pytest.raises(RentalDockerOperationError, match="daemon busy"):
+        await client.run_container(_rental_spec())
+
+    # only a 404 means "absent"; any other answer is not a reason to create or to run
+    assert api_client.events == ["inspect_network"]
+    assert api_client.created_networks == []
+    assert api_client.created_container is None
+
+
+@pytest.mark.parametrize(
+    "existing",
+    [
+        pytest.param({"Name": RENTAL_NETWORK_NAME, "Driver": "bridge", "Options": {}}, id="icc-left-on"),
+        pytest.param(
+            {"Name": RENTAL_NETWORK_NAME, "Driver": "bridge", "Options": {RENTAL_NETWORK_ICC_OPTION: "true"}},
+            id="icc-explicitly-on",
+        ),
+        pytest.param(
+            {"Name": RENTAL_NETWORK_NAME, "Driver": "macvlan", "Options": {RENTAL_NETWORK_ICC_OPTION: "false"}},
+            id="not-a-bridge",
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_run_container_refuses_a_same_named_network_that_does_not_isolate(existing):
+    api_client = FakeApiClient()
+    api_client.networks[RENTAL_NETWORK_NAME] = existing
+    client = RentalDockerSdkClient(api_client)
+
+    with pytest.raises(RentalDockerOperationError, match=f"{RENTAL_NETWORK_ICC_OPTION}=false"):
+        await client.run_container(_rental_spec())
+
+    # fail closed: no container is created on a network that would let co-tenants talk
+    assert api_client.created_container is None
+    assert api_client.started == []
+
+
+@pytest.mark.asyncio
+async def test_run_container_without_a_network_stays_on_the_default_bridge():
+    api_client = FakeApiClient()
+    client = RentalDockerSdkClient(api_client)
+
+    await client.run_container(_rental_spec(network=None))
+
+    # the CVM quote broker and other helper containers keep the daemon default; no network calls at all
+    assert api_client.events == ["create_container", "start"]
+    assert "network_mode" not in api_client.host_config_kwargs
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_rental_network_isolation.py
+++ b/neurons/validators/tests/test_rental_network_isolation.py
@@ -1,0 +1,89 @@
+"""DAH-3199: every rental container runs on the ICC-off bridge `lium-rentals`, not on docker0.
+
+The daemon's default bridge lets every container on it reach every other one, and a pod holds
+NET_ADMIN, so two rentals on a split host could otherwise open connections to each other's
+unpublished ports. The validator builds the run spec, so the property is pinned here:
+`_build_rental_container_run_spec` names the network for an ordinary rental, a sysbox rental and a
+cluster node alike; the CVM quote broker, which talks over unix sockets only, stays where it was.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+from payload_models.payloads import ClusterMembership, ContainerCreateRequest, CustomOptions
+from services.cluster_fabric import WIREGUARD_LISTEN_PORT
+from services.cvm_quote_broker import quote_broker_run_spec
+from services.docker_service import DockerService
+from services.rental_docker_observability import rental_run_spec_log_fields
+from services.rental_docker_sdk import RENTAL_NETWORK_NAME, GpuDockerConfig
+
+
+@pytest.fixture
+def docker_service() -> DockerService:
+    # _build_rental_container_run_spec is pure (no I/O), so mocked dependencies suffice.
+    return DockerService(
+        ssh_service=Mock(),
+        redis_service=Mock(),
+        attestation_service=Mock(),
+        rental_docker_client_factory=Mock(),
+    )
+
+
+def _payload(*, is_sysbox: bool = False, cluster_membership: ClusterMembership | None = None) -> ContainerCreateRequest:
+    return ContainerCreateRequest(
+        miner_hotkey="hk",
+        executor_id="ex",
+        pod_id="pod",
+        docker_image="img:tag",
+        gpu_uuids=["g0"],
+        is_sysbox=is_sysbox,
+        cluster_membership=cluster_membership,
+    )
+
+
+def _run_spec(docker_service: DockerService, payload: ContainerCreateRequest):
+    return docker_service._build_rental_container_run_spec(
+        payload=payload,
+        container_name="pod_test",
+        custom_options=CustomOptions(),
+        # (docker_port, internal_port, external_port) as the backend sends them; the host publishes internal_port
+        port_maps=[(22, 30022, 40022)],
+        local_volume="volume_pod",
+        local_volume_path="/root",
+        encrypted_local_volume=False,
+        external_volume_name=None,
+        gpu_devices=GpuDockerConfig(),
+        effective_storage_limit_gb=None,
+        cpu_count=None,
+    )
+
+
+@pytest.mark.parametrize("is_sysbox", [False, True], ids=["runc", "sysbox"])
+def test_a_rental_joins_the_isolated_network(docker_service, is_sysbox) -> None:
+    run_spec = _run_spec(docker_service, _payload(is_sysbox=is_sysbox))
+
+    assert run_spec.network == RENTAL_NETWORK_NAME
+    # what the pod needs from docker0 it keeps on the new bridge: its published ports and NET_ADMIN
+    assert [(port.container_port, port.host_port) for port in run_spec.ports] == [(22, 30022)]
+    assert "NET_ADMIN" in run_spec.cap_add
+
+
+def test_a_cluster_node_joins_the_isolated_network_and_keeps_its_wireguard_port(docker_service) -> None:
+    membership = ClusterMembership(node_index=0, wireguard_conf="[Interface]\nPrivateKey = x\n")
+
+    run_spec = _run_spec(docker_service, _payload(cluster_membership=membership))
+
+    # the overlay peers reach this node through the host-published UDP port, not through docker0
+    assert run_spec.network == RENTAL_NETWORK_NAME
+    assert any(port.protocol == "udp" and port.host_port == WIREGUARD_LISTEN_PORT for port in run_spec.ports)
+
+
+def test_the_network_is_in_the_run_log_fields(docker_service) -> None:
+    fields = rental_run_spec_log_fields(_run_spec(docker_service, _payload()))
+
+    assert fields["network"] == RENTAL_NETWORK_NAME
+
+
+def test_the_quote_broker_stays_on_the_default_bridge() -> None:
+    # it serves the pod over a unix socket bind mount and never opens a TCP port to another container
+    assert quote_broker_run_spec().network is None


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Fixes [DAH-3199](https://app.notion.com/p/lium-io-validator-rental-containers-on-one-ICC-off-bridge-network-so-pods-on-a-shared-host-cannot-r-3d5b8bfdbde98151944ce7eb8cc71ad0) · reviewer: @jam6099

**TL;DR** — Every rental ran on the host's default `docker0` bridge, where containers reach each other, and each pod holds `NET_ADMIN`; on a split host a pod could connect to a neighbour's unpublished ports. Now every rental runs on one bridge `lium-rentals` per host with `enable_icc=false`; `_ensure_rental_network_sync` runs on every create and refuses a same-named network that does not isolate. Deploy after lium-platform#231 (DAH-3203): neighbours can now learn pod ids, and that route turned an id into a shell.

**What changed**
- `ContainerRunSpec.network` → `network_mode` in the host config (`neurons/validators/src/services/rental_docker_sdk.py`)
- `_ensure_rental_network_sync` before `create_container`: inspect, create ICC-off, survive a lost race, refuse a non-isolating network (`rental_docker_sdk.py`)
- every rental spec gets `network=RENTAL_NETWORK_NAME`; the CVM quote broker keeps the default bridge (`services/docker_service.py`)
- run log gains `network` (`services/rental_docker_observability.py`)
- 14 tests: ordering, reuse, lost race, create failure, inspect error, refused shapes, default bridge, spec cases (`tests/test_rental_docker_sdk.py`, `tests/test_rental_network_isolation.py`)

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_rental_network_isolation.py tests/test_rental_docker_sdk.py -q` → 52 passed (main: import errors)
- e2e stack (lium-io#1312): two pods on one executor, from pod A `bash -c 'exec 3<>/dev/tcp/<pod B ip>/22'` → `CLOSED` (main: `OPEN`)

**Verified by the loop:** 8 Sep 2026 · sandbox EC2 · validators 1954 passed · e2e probe OPEN → CLOSED · targeted 52/52 · Result: PASS 425d8f75 · Gate: not run

**Ran it:** e2e stack, two pods on one executor; from pod A `exec 3<>/dev/tcp/<pod B>/22` → `CLOSED` (main: `OPEN`) · EC2 20260908T025702Z-d3c3

**Self-review:** clean at 425d8f7 (16 checks, 3 mechanical notes dismissed; subagent-sec0253d)

**Parts:** backend ✓ (validator) · migration n/a — no schema change · frontend n/a — no UI surface · CLI/SDK n/a — host behaviour · docs ✓ lium-docs#233 · tests ✓ 14 · dashboards n/a — a log field only

**Docs:** [lium-docs#233](https://github.com/Datura-ai/lium-docs/pull/233) — gpu-splitting, pod-users/security, nodes hub

<details><summary>Details</summary>

## Origin

External security report, Discord ticket-0253 report 01 (`richardeyyy`, 8 Sep 2026), verified against `main` `07ec64cd`: `ContainerRunSpec` had no network field, `_build_host_config_kwargs` set no `network_mode`, `neurons/executor/daemon.json` and `nvidia_docker_sysbox_setup.sh` set no `icc` option. Docker's default bridge allows inter-container communication; `_capabilities_for` gives every pod `NET_ADMIN`. Co-tenancy on a host is a real placement: `ContainerCreateRequest.active_container_names` is the list of neighbour pods a create must leave alone, and lium-platform refuses whole-host-only features on a host with co-tenants.

## Design

- One network per host, not one per pod: nothing to remove at teardown, no address-pool churn, and the property is the same — Docker installs a FORWARD drop between two ports of an ICC-off bridge, so two pods cannot exchange IP packets whatever their addresses. The pod keeps `NET_ADMIN` for WireGuard; an address it gives itself on the bridge is still behind the same drop rule.
- Published ports arrive through the host (`-p` DNAT) as before; a pod reaching a neighbour's published port through the host address goes through docker-proxy, which is the public path anyway.
- A cluster node's WireGuard port is published to the host; peers are whole-host rentals on other machines — lium-platform `apps/lium/backend/apps/server/src/services/cluster_rental.py`, `_reject_nodes_open_for_gpu_splitting`: a host a co-tenant can slice cannot be a cluster member. Unchanged.
- The CVM quote broker talks to pods over a unix-socket bind mount and stays on the default bridge (`quote_broker_run_spec().network is None`).
- Pods already running on `docker0` are not moved; Docker isolates user-defined bridges from `docker0`, so an old pod and a new pod cannot reach each other either. Two old pods on one host can until they are recycled.
- Fail closed: if `lium-rentals` exists but is not a bridge with `enable_icc=false`, the create fails with a message naming the network and the fix; the pod is not started on it.
- Inside a pod, `/etc/resolv.conf` now points at Docker's embedded DNS (`127.0.0.11`), as on every user-defined network — the executor's own compose stack already runs that way on every provider host.
- Not covered: a daemon started with `--iptables=false` enforces nothing (nor does it publish ports the way Lium needs); a pod can still reach services the host binds on its bridge address, as before.
- New with the move, stated rather than hidden: Docker's embedded DNS on a user-defined network answers a reverse lookup of a neighbour's address with its container name (`pod_<pod_id>.lium-rentals`), which docker0 (no resolver) did not — measured in the two-pod probe (`ptr_of_pod_b_from_pod_a` in `isolation.json`: `NO-PTR` before, the name after). So a pod id must not open anything by itself. On lium-platform `main` two routes take a pod id without an owner check: the web terminal websocket `/pods/terminal/{id}` (a shell into the pod — DAH-3203, fix open as lium-platform#231, P0) and `GET /pods/{pod_id}/gpu-utilization` (DAH-3202 / LIUM_ISSUES B-120, metrics only). Every other pod route calls `validate_owner`. **Deploy order: the DAH-3203 fix lands and deploys before this PR does.** Per-pod networks would hide the names too; not done here because a network per pod needs create/remove/orphan handling on a path five open PRs already edit, and a name is all the shared network shows.

## Ran it

Sandbox EC2 `20260908T025702Z-d3c3` (c6i.4xlarge, Linux; first run `20260908T014451Z-k4eg` at an earlier head, same result), the lium-io#1312 e2e stack (real executor on its own dockerd, real miner, the validator's `MinerService.handle_container`) built twice: from the #1312 branch as-is ("before") and with this branch merged ("after"). The two-pod probe (kept in the loop's tree until #1312 lands) rents pod A (ports 40000-40009) and pod B (40010-40019, `active_container_names=[A]`), reads both bridge addresses over SSH through the published ports, then from A tries B's sshd on the bridge.

```
# before (main): both pods on docker0 (.2 and .3 of the daemon's default subnet)     run 20260908T025702Z-d3c3
e2e before rental    rc=0 :: 2 passed
e2e before isolation rc=2 :: FAILED test_a_pod_cannot_reach_a_neighbour_pods_unpublished_port
  AssertionError: pod A opened a TCP connection to pod B's sshd at <pod B>:22 (OPEN)
  getent hosts <pod B> from pod A → NO-PTR   (resolv.conf: the host's nameservers)
docker network ls: bridge, host, none

# after (this branch merged): both pods on lium-rentals (.2 and .3 of the new network's subnet)
e2e after rental     rc=0 :: 2 passed                      (published SSH port still opens both pods)
e2e after isolation  rc=0 :: 1 passed
  probe "timeout 5 bash -c 'exec 3<>/dev/tcp/<pod B>/22'" · result CLOSED
  getent hosts <pod B> from pod A → "<pod B>  pod_<pod B id>.lium-rentals"   (resolv.conf: nameserver 127.0.0.11)
docker network inspect lium-rentals: Driver bridge · Options {com.docker.network.bridge.enable_icc: false}
  · Labels {io.lium.purpose: rental-isolation} · IPAM one /16 from the daemon's default pool
```

Unit suites (validators, python 3.11, `pdm install` from the lock, CI env, EC2 `20260908T025702Z-d3c3`, head `425d8f75`):

```
main + the two test files   → 2 errors at collection: `from services.rental_docker_sdk import RENTAL_NETWORK_NAME…` — the names do not exist on main (fail-before)
branch: tests/test_rental_network_isolation.py tests/test_rental_docker_sdk.py -v → 52 passed
branch: tests/ -q --strict-markers → 1 failed, 1954 passed, 15 skipped in 106 s   (the one failure, tests/test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices, fails the same way on main: root reads a chmod-000 tree — the 7 Sep security-harden run saw it too)
```

Cross-PR (`gh pr list --limit 500`): #1265 (arhangel66, DAH-2780) edits the same `ContainerRunSpec(...)` call in `_build_rental_container_run_spec` that this PR adds `network=` to — no line overlap, whichever lands second rebases that function; #1279, #1295, #1300, #1302, #1316 touch `docker_service.py` on other lines; #1316 touches `tests/test_rental_docker_sdk.py` on other lines; #1099 and #919 (July) touch `rental_docker_sdk.py` but are stale. Nothing here is only true once another PR merges.

The probe lives in the loop's tree (`security/ticket-0253/e2e/`) until #1312 is on `main`; it then joins that stack's suites.

## Claims

pending — `tools/pr_quality_gate.py lium-io <n> --claims`

## Self-review

pending

### Self-review

Verdict `clean` at `425d8f7` · 16 checks · by subagent-sec0253d · 2026-09-08 03:46Z (tools/pr_self_review.py)

Mechanical notes dismissed: `PR body (TL;DR and Details > Design, the DNS bullet):0` Property: the bullet states only what was measured and what is open, does not contradict itself, and the deploy order is stated where a merger reads it. It now says: embedded DNS answers a reverse lookup with `pod_<pod_id>.lium-rentals` where docker0 did not (matches e2e-before `NO-PTR` and e2e-after `<ip> pod_<id>.lium-rentals` in isolation.json, run 20260908T025702Z-d3c3); on lium-platform main two routes take a pod id without an owner check — `/pods/terminal/{id}` (DAH-3203, lium-platform#231, P0) and `GET /pods/{pod_id}/gpu-utilization` (DAH-3202 / B-120) — re-checked on main lium-platform main (unchanged since the last read): both still unguarded, #231 is OPEN (draft) against main with the described change; the deploy order 'DAH-3203 fix lands and deploys before this PR' is in the TL;DR ('Deploy after lium-platform DAH-3203') and bolded in the bullet; per-pod networks are named as the alternative with a reason. 'Every other pod route calls `validate_owner`' is true in substance (restore, restore-logs and feedback do their own `pod.user_id` compare / user-scoped query rather than calling `validate_owner`; none opens a pod without the owner) — a wording nit at most, not raised. · `PR body (Details > Cross-PR):0` Property: the list covers every open PR on the touched files and says which are live. #1265 is arhangel66, OPEN, updated 7 Sep, body cites DAH-2780 (and DAH-2306); its `docker_service.py` hunk `@@ -1049,7 +1049,14 @@ def _build_rental_container_run_spec` changes `restart_policy=` inside the same `ContainerRunSpec(...)` kwargs block this PR adds `network=RENTAL_NETWORK_NAME` to (`@@ -1061,6 +1062,7 @@`); no line overlap — as the body says. #1099 (OPEN, last touched 2 Jul) and #919 (OPEN draft, last touched 12 Apr) are named stale — matches their dates. The rest of the list (#1279, #1295, #1300, #1302, #1316) is as verified in sec0253c. · `neurons/validators/src/services/rental_docker_sdk.py:478` Head is still 425d8f75 (`git rev-parse HEAD` in the checkout); the diff is byte-identical to the one reviewed in sec0253c, so the code findings (none) and the scanner dismissals (`"/root"` is the volume target in a unit test; the f-prefix is present at test_rental_docker_sdk.py:627) stand. Ran-it block still matches run 20260908T025702Z-d3c3 (summary.txt: fail-before 2 collection errors, targeted 52 passed, full 1 failed / 1954 passed / 15 skipped, the one failure pre-existing on main).

### Verification
Gate: PASS (425d8f7) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1321)

</details>

