### PR TITLE
DAH-3200 - [P2] executor refuses /containers signatures with a stale or future timestamp

### DIFF
--- a/neurons/executor/.env.template
+++ b/neurons/executor/.env.template
@@ -33,3 +33,9 @@ MINER_HOTKEY_SS58_ADDRESS=
 # (optional) How often the executor re-checks the template digest, in seconds.
 # Defaults to 900 (15 minutes) when unset.
 # CACHE_TEMPLATE_REFRESH_SECONDS=900
+
+# (optional) Signed pod-metrics and pod-log requests from the platform carry a
+# timestamp; the executor refuses one more than this many seconds away from its
+# own clock, in either direction (a 401 that names the skew). Defaults to 300.
+# Keep the host clock NTP-synced rather than widening this.
+# CONTAINER_SIGNATURE_MAX_AGE_SECONDS=300

--- a/neurons/executor/src/core/config.py
+++ b/neurons/executor/src/core/config.py
@@ -60,6 +60,11 @@ class Settings(BaseSettings):
     # nonce. Leave off until the validator fleet mints nonces (migration order:
     # executors accept optional nonce first, then validators send, then this).
     REQUIRE_ATTESTATION_NONCE: bool = Field(env="REQUIRE_ATTESTATION_NONCE", default=False)
+    # DAH-3200: the backend signs `timestamp = int(time.time())` into every /containers/{name}
+    # request (utilization and logs). A signed request older or newer than this many seconds is
+    # refused, so a captured one cannot be replayed for the life of the container. Symmetric so a
+    # host clock that runs ahead is treated like one that runs behind; wide enough for NTP drift.
+    CONTAINER_SIGNATURE_MAX_AGE_SECONDS: int = Field(env="CONTAINER_SIGNATURE_MAX_AGE_SECONDS", default=300)
 
 
 settings = Settings()

--- a/neurons/executor/src/dependencies/auth.py
+++ b/neurons/executor/src/dependencies/auth.py
@@ -1,7 +1,8 @@
 from fastapi import HTTPException
 import bittensor
 import json
-from core.config import VALIDATOR_HOTKEY_SS58
+import time
+from core.config import VALIDATOR_HOTKEY_SS58, settings
 from core.logger import get_logger
 from payloads.backend import SignaturePayload, HardwareUtilizationPayload, PingPayload, ContainerUtilizationPayload
 
@@ -50,6 +51,29 @@ async def verify_signature(payload: SignaturePayload, message: str) -> None:
         )
 
 
+def require_fresh_timestamp(timestamp: int) -> None:
+    """The signed timestamp is within CONTAINER_SIGNATURE_MAX_AGE_SECONDS of this host's clock.
+
+    A valid signature proves who signed, not when the request was made: without this check a
+    captured /containers request stays accepted for as long as the container exists (DAH-3200).
+    The window is symmetric, so a host clock that runs ahead of the signer is refused the same way
+    as one that runs behind, and the 401 names the skew so a provider can see it is their clock.
+    """
+    max_age = settings.CONTAINER_SIGNATURE_MAX_AGE_SECONDS
+    # integer arithmetic: the signer's resolution is whole seconds, and a float subtraction would
+    # overflow (500) on an absurdly large int the header parser still admits
+    skew = int(time.time()) - timestamp
+    if abs(skew) > max_age:
+        detail = (
+            f"Signed timestamp is {abs(skew)}s "
+            f"{'behind' if skew > 0 else 'ahead of'} the executor clock; "
+            f"the accepted window is {max_age}s. Check that this host's clock is NTP-synced."
+        )
+        # the 401 body goes back to the platform; this line is what the provider sees in `docker logs`
+        logger.warning("Refusing a signed /containers request: %s", detail)
+        raise HTTPException(status_code=401, detail=detail)
+
+
 async def verify_allowed_hotkey_signature(payload: HardwareUtilizationPayload):
     FIXED_MESSAGE = "hardware_utilization_request"
     await verify_signature(payload, FIXED_MESSAGE)
@@ -61,6 +85,7 @@ async def verify_ping_signature(payload: PingPayload):
 
 
 async def verify_container_signature(payload: ContainerUtilizationPayload):
+    require_fresh_timestamp(payload.timestamp)
     signing_data  = {
         "gpu_uuids": payload.gpu_uuids,
         "timestamp": payload.timestamp,
@@ -78,6 +103,7 @@ async def verify_container_logs_signature(container_name: str, timestamp: int, s
         timestamp: Unix timestamp (part of signed message)
         signature: The signature from header
     """
+    require_fresh_timestamp(timestamp)
     signing_data = {
         "container_name": container_name,
         "timestamp": timestamp,

--- a/neurons/executor/tests/test_container_signature_freshness.py
+++ b/neurons/executor/tests/test_container_signature_freshness.py
@@ -1,0 +1,194 @@
+"""DAH-3200: a signed /containers request is accepted only while its timestamp is fresh.
+
+The backend signs `{"container_name"|"gpu_uuids", "timestamp": int(time.time())}` with the validator
+hotkey and the executor verified the signature but never read the clock, so a captured request stayed
+valid for the life of the container. Both verifiers now refuse a timestamp more than
+CONTAINER_SIGNATURE_MAX_AGE_SECONDS away from the executor clock, in either direction, before the
+signature is even checked. Signatures below are real (ephemeral keypair), as the backend produces them.
+"""
+
+import json
+import time
+from unittest.mock import MagicMock
+
+import bittensor
+import pytest
+import routes.apis as apis
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+from payloads.backend import ContainerUtilizationPayload
+from routes.apis import apis_router
+
+import dependencies.auth as auth
+from core.config import settings
+
+WINDOW = 5  # seconds; a stale request only gets staler on a slow runner, so the refused cases hold
+
+
+@pytest.fixture(scope="module")
+def validator_keypair():
+    return bittensor.Keypair.create_from_uri("//LiumTestValidatorFreshness")
+
+
+@pytest.fixture(autouse=True)
+def trust_the_test_validator(validator_keypair, monkeypatch):
+    monkeypatch.setattr(auth, "VALIDATOR_HOTKEY_SS58", validator_keypair.ss58_address)
+    monkeypatch.setattr(settings, "CONTAINER_SIGNATURE_MAX_AGE_SECONDS", WINDOW)
+
+
+def _sign(keypair, signing_data: dict) -> str:
+    # lium-platform pod.py: json.dumps(payload, sort_keys=True) then wallet.hotkey.sign(...).hex()
+    return keypair.sign(json.dumps(signing_data, sort_keys=True).encode()).hex()
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.run(coro)
+
+
+# --- the verifiers -----------------------------------------------------------------------------
+
+
+def test_a_fresh_container_logs_signature_is_accepted(validator_keypair):
+    timestamp = int(time.time())
+    signature = _sign(validator_keypair, {"container_name": "container_x", "timestamp": timestamp})
+
+    _run(auth.verify_container_logs_signature("container_x", timestamp, signature))
+
+
+@pytest.mark.parametrize("offset", [-(WINDOW + 2), WINDOW + 60], ids=["stale", "future"])
+def test_a_container_logs_signature_outside_the_window_is_refused_even_though_it_verifies(
+    validator_keypair, offset
+):
+    timestamp = int(time.time()) + offset
+    signature = _sign(validator_keypair, {"container_name": "container_x", "timestamp": timestamp})
+
+    with pytest.raises(HTTPException) as refused:
+        _run(auth.verify_container_logs_signature("container_x", timestamp, signature))
+
+    assert refused.value.status_code == 401
+    assert f"the accepted window is {WINDOW}s" in refused.value.detail
+    assert ("behind" if offset < 0 else "ahead of") in refused.value.detail
+
+
+def test_a_fresh_container_utilization_signature_is_accepted(validator_keypair):
+    timestamp = int(time.time())
+    payload = ContainerUtilizationPayload(
+        gpu_uuids=["GPU-1"],
+        timestamp=timestamp,
+        signature=_sign(validator_keypair, {"gpu_uuids": ["GPU-1"], "timestamp": timestamp}),
+    )
+
+    _run(auth.verify_container_signature(payload))
+
+
+@pytest.mark.parametrize("offset", [-(WINDOW + 2), WINDOW + 60], ids=["stale", "future"])
+def test_a_container_utilization_signature_outside_the_window_is_refused(validator_keypair, offset):
+    timestamp = int(time.time()) + offset
+    payload = ContainerUtilizationPayload(
+        gpu_uuids=["GPU-1"],
+        timestamp=timestamp,
+        signature=_sign(validator_keypair, {"gpu_uuids": ["GPU-1"], "timestamp": timestamp}),
+    )
+
+    with pytest.raises(HTTPException) as refused:
+        _run(auth.verify_container_signature(payload))
+
+    assert refused.value.status_code == 401
+
+
+def test_the_window_comes_from_settings(validator_keypair, monkeypatch):
+    monkeypatch.setattr(settings, "CONTAINER_SIGNATURE_MAX_AGE_SECONDS", 3 * WINDOW)
+    timestamp = int(time.time()) - (WINDOW + 2)  # refused under WINDOW, accepted under 3 * WINDOW
+    signature = _sign(validator_keypair, {"container_name": "container_x", "timestamp": timestamp})
+
+    _run(auth.verify_container_logs_signature("container_x", timestamp, signature))
+
+
+def test_a_bad_signature_with_a_fresh_timestamp_is_still_refused(validator_keypair):
+    # freshness is added in front of the signature check, not instead of it
+    stranger = bittensor.Keypair.create_from_uri("//LiumTestStrangerFreshness")
+    timestamp = int(time.time())
+    signature = _sign(stranger, {"container_name": "container_x", "timestamp": timestamp})
+
+    with pytest.raises(HTTPException) as refused:
+        _run(auth.verify_container_logs_signature("container_x", timestamp, signature))
+
+    assert refused.value.status_code == 401
+    assert "Invalid signature" in refused.value.detail
+
+
+# --- the route: refused before any docker call ---------------------------------------------------
+
+
+def test_stale_logs_request_is_refused_before_the_container_is_looked_up(
+    validator_keypair, monkeypatch
+):
+    def no_docker():
+        raise AssertionError(
+            "docker.from_env() was called for a request that should have been refused"
+        )
+
+    monkeypatch.setattr(apis.docker, "from_env", no_docker)
+    monkeypatch.setattr(apis, "_active_follow_log_streams", 0)
+    app = FastAPI()
+    app.include_router(apis_router)
+    client = TestClient(app)
+
+    timestamp = int(time.time()) - (WINDOW + 2)
+    signature = _sign(validator_keypair, {"container_name": "container_x", "timestamp": timestamp})
+
+    response = client.get(
+        "/containers/container_x/logs",
+        headers={"X-Signature": signature, "X-Timestamp": str(timestamp)},
+    )
+
+    assert response.status_code == 401
+    assert f"the accepted window is {WINDOW}s" in response.json()["detail"]
+
+
+def test_an_absurdly_large_timestamp_is_refused_not_a_500(monkeypatch):
+    # the header parser admits any int; the skew must stay integer arithmetic so this answers 401
+    def no_docker():
+        raise AssertionError(
+            "docker.from_env() was called for a request that should have been refused"
+        )
+
+    monkeypatch.setattr(apis.docker, "from_env", no_docker)
+    app = FastAPI()
+    app.include_router(apis_router)
+    client = TestClient(app)
+    huge = "1" + "0" * 400
+
+    response = client.get(
+        "/containers/container_x/logs",
+        headers={"X-Signature": "00" * 64, "X-Timestamp": huge},
+    )
+
+    assert response.status_code == 401
+    assert "ahead of the executor clock" in response.json()["detail"]
+
+
+def test_fresh_logs_request_reaches_the_container_lookup(validator_keypair, monkeypatch):
+    fake_container = MagicMock()
+    fake_container.logs.return_value = iter([b"log line\n"])
+    fake_client = MagicMock()
+    fake_client.containers.get.return_value = fake_container
+    monkeypatch.setattr(apis.docker, "from_env", lambda: fake_client)
+    monkeypatch.setattr(apis, "_active_follow_log_streams", 0)
+    app = FastAPI()
+    app.include_router(apis_router)
+    client = TestClient(app)
+
+    timestamp = int(time.time())
+    signature = _sign(validator_keypair, {"container_name": "container_x", "timestamp": timestamp})
+
+    response = client.get(
+        "/containers/container_x/logs",
+        headers={"X-Signature": signature, "X-Timestamp": str(timestamp)},
+    )
+
+    assert response.status_code == 200
+    assert response.content == b"log line\n"
+    fake_client.containers.get.assert_called_once_with("container_x")


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Fixes [DAH-3200](https://app.notion.com/p/lium-io-executor-reject-container-endpoint-signatures-whose-timestamp-is-outside-a-freshness-window-3d5b8bfdbde981b0bedbf701b47b3842) · reviewer: @jam6099

**TL;DR** — `POST /containers/{name}` and `GET /containers/{name}/logs` verified the signature over `{…, timestamp}` but never read the clock, so a captured signed request stayed valid for the container's life. Both now refuse a timestamp more than `CONTAINER_SIGNATURE_MAX_AGE_SECONDS` (300) off the executor clock, either way, before the signature check. Risk: a host clock over 5 minutes off gets a 401 naming the skew.

**What changed**
- `require_fresh_timestamp` before both container verifiers (`neurons/executor/src/dependencies/auth.py`)
- `CONTAINER_SIGNATURE_MAX_AGE_SECONDS` setting, default 300 (`neurons/executor/src/core/config.py`, `neurons/executor/.env.template`)
- 9 tests (11 items) with real signatures: fresh accepted, stale/future refused, window from settings, oversized timestamp → 401 not 500, route refuses before any docker call (`neurons/executor/tests/test_container_signature_freshness.py`)

**How to verify**
- `cd neurons/executor && pdm run pytest tests/test_container_signature_freshness.py -q` → 11 passed; on main the file errors in its fixture (the setting does not exist)
- e2e stack (lium-io#1312): `GET /containers/<name>/logs` signed with `timestamp = now-3600` → 401 `…3600s behind the executor clock; the accepted window is 300s` (main: 200)
- `pdm run pytest tests/ -q` → whole executor suite green

**Verified by the loop:** 8 Sep 2026 · sandbox EC2 · executor 139 passed · e2e freshness probe 200 → 401 · targeted 15/15 · Result: PASS d15c464c · Gate: not run

**Ran it:** e2e stack, `GET /containers/<pod>/logs` signed by the stack's validator: fresh → 200, `now-3600` → 401 naming the skew (main: 200) · EC2 20260908T014451Z-k4eg

**Self-review:** clean at d15c464 (15 checks, 11 mechanical notes dismissed; subagent-sec0253c)

**Parts:** backend ✓ (executor) · migration n/a — no schema change · frontend n/a — no user-visible surface · CLI/SDK n/a — executor API only · docs ✓ `.env.template` + lium-docs#234 · tests ✓ 9 (11 items) · dashboards n/a — the refusal is a WARNING in the executor log

**Docs:** `neurons/executor/.env.template` (the new setting) + [lium-docs#234](https://github.com/Datura-ai/lium-docs/pull/234) (providers troubleshooting: the log line and the NTP fix)

<details><summary>Details</summary>

## Origin

External security report, Discord ticket-0253 report 02 (`richardeyyy`, 8 Sep 2026); the same gap was recorded as ticket-0249 #6b ("the two container endpoints already sign a backend-supplied timestamp but the executor never checks its age"). Verified against `main` `07ec64cd`. The signer is lium-platform `services/pod.py` (`timestamp = int(time.time())`, `json.dumps(payload, sort_keys=True)`, `wallet.hotkey.sign(...).hex()`), so the executor can enforce a window without a backend change — unlike `/ping` and `/hardware_utilization`, which sign fixed strings and still need the backend to send a timestamp first.

Cross-PR: #1283 (DAH-2977) appends its pre-pull flag to the same tail of `neurons/executor/.env.template`. Order, as in MERGE_ORDER.md: **this PR lands first; #1283 rebases its block after it** (the file now ends with a newline so the next append does not rewrite the previous last line). #1301 and #1316 touch `core/config.py` in the file header, a different hunk. Nothing here is only true once another PR merges.

## Design

- Integer skew (`int(time.time()) - timestamp`): the header parser admits any int; a float subtraction would raise on an oversized value and answer 500 where a 401 is due. Pinned by `test_an_absurdly_large_timestamp_is_refused_not_a_500`.
- Symmetric window: a host clock that runs ahead of the backend is refused the same way as one that runs behind; the detail says which and by how much, so a provider can read it as "my clock" and not "Lium is down".
- 300 s: the miner's REST/WebSocket auth (`neurons/miners/src/dependencies/auth.py`, `AUTH_MESSAGE_MAX_AGE = 10`) already requires provider clocks within 10 s of Lium's for `lium mine`; the executor's two routes serve one-shot user reads (pod logs, pod metrics), where a false refusal is a support ticket, so the window is wider. Configurable per host through `CONTAINER_SIGNATURE_MAX_AGE_SECONDS`.
- The freshness check runs before the signature check: a stale request costs no sr25519 verification, and the test `test_stale_logs_request_is_refused_before_the_container_is_looked_up` pins that no docker call happens for it.
- Not changed here (design, needs the backend to sign it): `POST /containers/{name}` signs `{gpu_uuids, timestamp}` without the container name, so within the window a signed request can name another container; and `/ping` / `/hardware_utilization` sign fixed strings (ticket-0249 #6b). Both are on DAH-2868 as follow-ups.

## Ran it

Sandbox EC2 `20260908T014451Z-k4eg` (c6i.4xlarge, Linux), the lium-io#1312 e2e stack (real executor built from this tree, trust anchor = the stack's validator key) built twice: from the #1312 branch as-is ("before") and with this branch merged ("after"). The probe (kept in the loop's tree until #1312 lands) rents a pod, then signs `{"container_name": <pod>, "timestamp": T}` exactly as lium-platform `pod.py` does and calls `GET /containers/<pod>/logs?tail=5` three times.

```
# before (main)
freshness.json: fresh 200 · stale (T = now-3600) 200 · stranger key 401 "Invalid signature from allowed hotkey 5EPC…"
e2e before freshness rc=2 :: FAILED test_a_stale_container_logs_signature_is_refused
  an hour-old signed request was accepted: 200

# after (this branch)
freshness.json: fresh 200 · stale 401 {"detail":"Signed timestamp is 3601s behind the executor clock; the accepted window is 300s. Check that this host's clock is NTP-synced."} · stranger 401
e2e after freshness rc=0 :: 1 passed
```

Unit suites (executor, python 3.11.11, `pdm install` from the lock, EC2 `20260908T025940Z-n764`, head `d15c464c`):

```
main + tests/test_container_signature_freshness.py   → 11 errors: the fixture sets settings.CONTAINER_SIGNATURE_MAX_AGE_SECONDS, which does not exist on main (fail-before)
branch: tests/test_container_signature_freshness.py tests/test_executor_container_logs.py -v → 15 passed
branch: tests/ -q                                     → 139 passed   (main: 128)
```

The e2e probe above ran on the previous head of this branch (amended into `d15c464c`; only the test file changed since — offsets, formatting, an unused fixture parameter — `auth.py` is identical), so the 401 text is the same to the second.

The probe lives in the loop's tree (`security/ticket-0253/e2e/`) until #1312 is on `main`; it then joins that stack's suites.

## Claims

pending — `tools/pr_quality_gate.py lium-io <n> --claims`

## Self-review

pending

### Self-review

Verdict `clean` at `d15c464` · 15 checks · by subagent-sec0253c · 2026-09-08 03:24Z (tools/pr_self_review.py)

Mechanical notes dismissed: `PR body (Details > Origin, Cross-PR paragraph):1` Earlier finding 1 (CROSS-PR order) is fixed: the body says `this PR lands first; #1283 rebases its block after it`, MERGE_ORDER.md lines 239 and 385 say `#1283 after #1322 (.env.template)`, and #1283's body (line 64) carries the same one-liner naming #1322/DAH-3200; #1283, #1301 and #1316 are all still OPEN, so nothing here depends on another merge. · `PR body (Details > Ran it, last paragraph):1` Earlier finding 2 (STALE-BODY sha) is fixed: `ran at the earlier head the previous head (amended into d15c464c; … auth.py is identical)` carries the word `earlier` within the window pr_quality_gate.py:1318 skips, `git diff the previous head d15c464c` touches only the test file (offsets, formatting, the dropped parameter), and the unit numbers and Verified line now cite the d15c464c run `20260908T025940Z-n764` (11 errors on main, 15 targeted, 139 vs 128). · `PR body (fold line Verified by the loop):1` The fold still lists `e2e freshness probe 200 → 401` under `PASS d15c464c` while the probe ran at the previous head; accepted because the line is tool-computed, the gate skips it (pr_quality_gate.py:1308), the Details say which head the probe ran on and why, and the code the probe exercises (`auth.py`) is byte-identical between the two heads. · `neurons/executor/tests/test_container_signature_freshness.py:60` Earlier finding 3 (future-case margin) is fixed: both `future` parametrizations (lines 60 and 86) use `WINDOW + 60`, so the case stays refused under any stall shorter than 60 s; the stale cases only get staler; the fresh cases keep 5 s and `test_the_window_comes_from_settings` 8 s of margin; the `WINDOW` comment (line 25) now states exactly the stale-direction property. · `neurons/executor/tests/test_container_signature_freshness.py:151` Earlier finding 4 (dead parameter) is fixed: `test_an_absurdly_large_timestamp_is_refused_not_a_500(monkeypatch)`; the autouse fixture still installs the trusted keypair and the WINDOW. · `neurons/executor/tests/test_container_signature_freshness.py:77` Earlier finding 5 (format) is fixed: `ruff format --check` at the root config reports the file already formatted, and `ruff check --select F,ASYNC210,ASYNC251 --ignore F541` (the gate #1316 adds) passes on the test file and auth.py. · `neurons/executor/src/dependencies/auth.py:65` CORRECTNESS/SECURITY/TEST-GAP unchanged from the the previous head review: `auth.py`, `config.py` and `.env.template` are byte-identical to that head (the incremental diff is the test file only); integer skew is exact for the 401-digit header pydantic-core 2.27.2 admits as BigInt (422 only above 4300 chars), the 401 and WARNING carry a number capped by that parser, fail-closed on a zero/negative window, the freshness check precedes the sr25519 verify in both verifiers, and the platform signer (lium-platform pod.py:1265/1345) signs a fresh `int(time.time())` per call with no signature reuse. · `PR body (What changed, How to verify, Parts, Details > Unit suites):1` Counts consistent: 9 `def test_` + two `parametrize(ids=[stale, future])` = 11 items; 11 + 4 in test_executor_container_logs.py = 15 targeted; 139 − 128 = 11; every behaviour sentence maps to auth.py:65-74/88/106, config.py:67, .env.template:37-41 or a test name; lium-docs#234 (open draft) carries the log line and the NTP fix, so `docs ✓` holds and brief §6 `docs: NOT in diff` is wrong.

### Verification
Gate: PASS (d15c464) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1322)

</details>

