### PR TITLE
DAH-3207 - [P2] executor /pod_logs: the signed string must be the container name

### DIFF
--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -261,10 +261,32 @@ async def remove_ssh_key(
     return response
 
 
+def _validate_pod_logs_consistency(payload: GetPodLogsPaylod) -> None:
+    """Require the signed string to be the container name the request reads.
+
+    MinerMiddleware verifies the miner's signature over `data_to_sign` and nothing
+    else, so without this check any string the miner ever signed (an SSH public key
+    sent to /upload_ssh_key, another container's name) authenticates a read of any
+    container's events. The miner signs the container name itself
+    (ExecutorService.get_pod_logs), same shape as `_validate_ssh_key_consistency`.
+
+    Raises:
+        HTTPException: 400 when data_to_sign is not the requested container name
+    """
+    if payload.container_name.strip() != payload.data_to_sign.strip():
+        logger.warning(
+            "pod_logs request signed over a different string: "
+            f"container_name length={len(payload.container_name.strip())}, "
+            f"data_to_sign length={len(payload.data_to_sign.strip())}"
+        )
+        raise HTTPException(status_code=400, detail="Container name mismatch")
+
+
 @apis_router.post("/pod_logs")
 async def get_pod_logs(
     payload: GetPodLogsPaylod, pod_log_service: Annotated[PodLogService, Depends(PodLogService)]
 ):
+    _validate_pod_logs_consistency(payload)
     return await pod_log_service.find_by_continer_name(payload.container_name)
 
 

--- a/neurons/executor/tests/test_pod_logs_signed_name.py
+++ b/neurons/executor/tests/test_pod_logs_signed_name.py
@@ -1,0 +1,121 @@
+"""
+POST /pod_logs answers only a request whose miner signature was made over the container name it reads.
+
+MinerMiddleware verifies the signature over `data_to_sign`; the route reads `container_name`. Both must be the
+same string (the miner signs exactly the container name, ExecutorService.get_pod_logs), the way
+/upload_ssh_key and /remove_ssh_key already require `public_key == data_to_sign` (issue #744).
+
+Ephemeral keypairs, the real middleware and the real route; only the log store is replaced.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import bittensor
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from middlewares.miner import MinerMiddleware
+from routes.apis import apis_router
+from services.pod_log_service import PodLogService
+
+# conftest.py already inserted src/ into sys.path and set required env vars.
+from core.config import settings
+
+_SSH_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey123456789abcdef user@host"
+_CONTAINER = "pod_0b2a6d1e-9e2e-4e2e-8e2e-000000000e2e"
+_OTHER_CONTAINER = "pod_0b2a6d1e-9e2e-4e2e-8e2e-00000000beef"
+
+
+@pytest.fixture(scope="module")
+def miner_keypair():
+    return bittensor.Keypair.create_from_uri("//LiumTestMinerPodLogs")
+
+
+@pytest.fixture(scope="module")
+def portal_keypair():
+    """The fixed portal hotkey every executor also trusts (settings.DEFAULT_MINER_HOTKEY)."""
+    return bittensor.Keypair.create_from_uri("//LiumTestPortalPodLogs")
+
+
+@pytest.fixture()
+def store():
+    service = MagicMock(spec=PodLogService)
+    service.find_by_continer_name = AsyncMock(
+        return_value=[{"event": "start", "container_name": _CONTAINER}]
+    )
+    return service
+
+
+@pytest.fixture()
+def client(miner_keypair, portal_keypair, store, monkeypatch):
+    monkeypatch.setattr(settings, "MINER_HOTKEY_SS58_ADDRESS", miner_keypair.ss58_address)
+    monkeypatch.setattr(settings, "DEFAULT_MINER_HOTKEY", portal_keypair.ss58_address)
+
+    app = FastAPI()
+    app.add_middleware(MinerMiddleware)
+    app.include_router(apis_router)
+    app.dependency_overrides[PodLogService] = lambda: store
+    return TestClient(app)
+
+
+def _signed(keypair, data_to_sign: str, container_name: str) -> dict:
+    return {
+        "container_name": container_name,
+        "data_to_sign": data_to_sign,
+        "signature": "0x" + keypair.sign(data_to_sign).hex(),
+    }
+
+
+def test_the_miners_own_request_is_answered(client, miner_keypair, store):
+    """What ExecutorService.get_pod_logs sends: data_to_sign is the container name."""
+    response = client.post("/pod_logs", json=_signed(miner_keypair, _CONTAINER, _CONTAINER))
+
+    assert response.status_code == 200, response.text
+    assert response.json() == [{"event": "start", "container_name": _CONTAINER}]
+    store.find_by_continer_name.assert_awaited_once_with(_CONTAINER)
+
+
+def test_a_signature_over_another_string_does_not_read_a_container(client, miner_keypair, store):
+    """A blob the miner signed for /upload_ssh_key is a valid miner signature, but not over this container name."""
+    response = client.post("/pod_logs", json=_signed(miner_keypair, _SSH_KEY, _CONTAINER))
+
+    assert response.status_code == 400, response.text
+    assert response.json() == {"detail": "Container name mismatch"}
+    store.find_by_continer_name.assert_not_awaited()
+
+
+def test_a_signature_over_one_container_does_not_read_another(client, miner_keypair, store):
+    response = client.post("/pod_logs", json=_signed(miner_keypair, _OTHER_CONTAINER, _CONTAINER))
+
+    assert response.status_code == 400, response.text
+    store.find_by_continer_name.assert_not_awaited()
+
+
+def test_the_portal_hotkey_is_held_to_the_same_binding(client, portal_keypair, store):
+    """The portal hotkey is trusted by every executor; its signatures must bind the name too."""
+    accepted = client.post("/pod_logs", json=_signed(portal_keypair, _CONTAINER, _CONTAINER))
+    assert accepted.status_code == 200, accepted.text
+
+    refused = client.post("/pod_logs", json=_signed(portal_keypair, _SSH_KEY, _CONTAINER))
+    assert refused.status_code == 400, refused.text
+    store.find_by_continer_name.assert_awaited_once_with(_CONTAINER)
+
+
+def test_surrounding_whitespace_is_not_a_mismatch(client, miner_keypair, store):
+    """Same normalisation as the SSH-key routes: the signed string is compared stripped."""
+    body = _signed(miner_keypair, f" {_CONTAINER}\n", _CONTAINER)
+
+    response = client.post("/pod_logs", json=body)
+
+    assert response.status_code == 200, response.text
+    store.find_by_continer_name.assert_awaited_once_with(_CONTAINER)
+
+
+def test_a_stranger_is_still_refused_before_the_binding_is_checked(client, store):
+    """The middleware's 401 comes first: a matching name with a foreign signature reads nothing."""
+    stranger = bittensor.Keypair.create_from_uri("//LiumTestStrangerPodLogs")
+
+    response = client.post("/pod_logs", json=_signed(stranger, _CONTAINER, _CONTAINER))
+
+    assert response.status_code == 401, response.text
+    store.find_by_continer_name.assert_not_awaited()


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Fixes [DAH-3207](https://app.notion.com/p/lium-io-executor-POST-pod_logs-accepts-only-a-miner-signature-made-over-the-requested-container-na-3d5b8bfdbde981fb9cc8f9558cf75c36) · reviewer: @jam6099

**TL;DR** — `POST /pod_logs` let `MinerMiddleware` verify the miner's signature over `data_to_sign` and then read `container_name` without comparing the two, so any string the executor was ever sent a valid signature for read any container's lifecycle events. The route now requires `data_to_sign` to be the requested container name, as `/upload_ssh_key` and `/remove_ssh_key` require `public_key == data_to_sign` (issue #744). Risk: none for the miner — it already signs exactly the container name.

**What changed**
- `_validate_pod_logs_consistency`: 400 `Container name mismatch` unless `data_to_sign.strip() == container_name.strip()`, before the store is read (`neurons/executor/src/routes/apis.py`)
- 6 tests through the real middleware and route: own request 200, SSH key or other name 400, stranger 401 (`neurons/executor/tests/test_pod_logs_signed_name.py`)

**How to verify**
- `cd neurons/executor && pdm run pytest tests/test_pod_logs_signed_name.py -v` → 6 passed; on `main` the three that expect 400 get 200
- e2e stack (lium-io#1312): `POST /pod_logs` signed by the stack's miner over an SSH public key, naming a pod → 400 (main: 200 `[]`); signed over the name → 200
- `pdm run pytest tests/ -q` → 134 passed

**Verified by the loop:** 8 Sep 2026 · sandbox EC2 · e2e podlogs probe 200 → 400 · targeted 19/19 · Result: PASS 0b54a451 · Gate: not run

**Ran it:** e2e stack, `POST /pod_logs` with the miner's signature over an SSH key naming a pod container: 200 `[]` → 400 `{"detail":"Container name mismatch"}`; signed over the name: 200 both times · EC2 20260908T050308Z-sdnk

**Self-review:** clean at 0b54a45 (15 checks, 3 low item(s) listed; subagent-r3b)

**Parts:** backend ✓ (executor) · migration n/a — no schema change · frontend n/a — no user surface · CLI/SDK n/a — executor API only · docs n/a — see Docs · tests ✓ 6 · dashboards n/a — a WARNING in the executor log

**Docs:** none needed because the only caller (the miner, `ExecutorService.get_pod_logs`) already sends what the check requires; nothing provider- or renter-facing changes and the executor API is not on docs.lium.io

<details><summary>Details</summary>

## Origin

External security report, Discord ticket-0253 report 3 (`richardeyyy`, 8 Sep 2026), finding LIUM-001 — the part of it that is new: "in `MinerMiddleware`, `payload.data_to_sign` is user-provided and unverified". Verified against `main` `75298589`: `middlewares/miner.py:47-89` verifies the signature over `data_to_sign` against `MINER_HOTKEY_SS58_ADDRESS` or `DEFAULT_MINER_HOTKEY` (the fixed portal hotkey, trusted by every executor); `routes/apis.py:264-268` read `payload.container_name` with no comparison. The two SSH-key routes on the same middleware have `_validate_ssh_key_consistency` for exactly this (issue #744). What the route returns is the executor's Docker lifecycle events for the container (`pod_log_store.find_by_container_name`: start/stop/die/oom, exit code, container id), not the renter's stdout. The other parts of LIUM-001 are ticket-0249 #6b (`/ping`, `/hardware_utilization`: the backend must sign a timestamp first) and report 02 (`/containers/*` freshness, lium-io#1322).

Cross-PR: #1322 (DAH-3200) edits `dependencies/auth.py` and `core/config.py`; #1301 (DAH-3114) edits `middlewares/miner.py`; #1216 (DAH-2501, vast_api) also edits `middlewares/miner.py` (per-path trusted hotkeys) — for `/pod_logs` it keeps the same two hotkeys and does not touch `routes/apis.py`. None of them touches the `/pod_logs` route. No ordering needed; nothing here is only true once another PR merges.

## Design

- Same normalisation as the SSH-key check (`strip()` on both sides), same status (400), same place (before any work): a request the miner did not sign for this name costs one string comparison.
- The check is route-level, not middleware-level, on purpose: the middleware knows only `data_to_sign`; which body field it must equal is the route's contract (`public_key` on the SSH-key routes, `container_name` here).
- The portal hotkey (`settings.DEFAULT_MINER_HOTKEY`) is held to the same rule; the test pins it because its signatures are valid on every executor.
- Not changed here (design, the signer must add it first): the miner's `data_to_sign` carries no timestamp, so a signature over a container name stays valid for that container — the same class as ticket-0249 #6b, already on DAH-2868.

## Ran it

Sandbox EC2 `20260908T050308Z-sdnk` (c6i.4xlarge, Linux), the lium-io#1312 e2e stack (real executor built from this tree, the stack's miner key as `MINER_HOTKEY_SS58_ADDRESS`) built twice: from the #1312 branch as-is ("before") and with this branch merged ("after"). The probe (kept in the loop's tree until #1312 lands) signs as the miner does and calls `POST /pod_logs` four ways.

```
# before (main)
podlogs.json: over_the_name 200 [] · over_an_ssh_key 200 [] · over_another_name 200 [] · stranger 401
e2e before podlogs rc=2 :: FAILED test_pod_logs_answers_only_a_signature_over_the_requested_container_name
  a signature over an SSH key read a container's events: 200 []

# after (this branch)
podlogs.json: over_the_name 200 [] · over_an_ssh_key 400 {"detail":"Container name mismatch"} · over_another_name 400 · stranger 401
e2e after podlogs rc=0 :: 1 passed
e2e after protocol rc=0 :: 14 passed   (the stack's own suite, unchanged)
```

Unit suites (executor, python 3.11.11, `pdm install` from the lock):

```
main + tests/test_pod_logs_signed_name.py   → 3 failed, 3 passed  (fail-before: the three tests that expect 400 get 200)
branch: tests/test_pod_logs_signed_name.py tests/test_upload_ssh_key_auth.py -v → 19 passed
branch: tests/ -q                            → 134 passed   (main: 128)
```

The e2e probe ran at the earlier head of this branch; the current head `0b54a451` differs from it only by `ruff format` / import order in the test file — `routes/apis.py` is byte-identical.

The probe lives in the loop's tree (`security/ticket-0253/e2e/podlogs/`) until #1312 is on `main`; it then joins that stack's suites.

## Claims

pending — `tools/pr_quality_gate.py lium-io <n> --claims`

## Self-review

pending

### Self-review

Verdict `findings` at `0b54a45` · 15 checks · by subagent-r3b · 2026-09-08 05:34Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | CROSS-PR | `neurons/executor/src/middlewares/miner.py:52` | The body's Cross-PR paragraph lists #1322 and #1301 but not open #1216 (DAH-2501), which rewrites the hotkey list these tests drive (`hotkeys_to_verify` -> `trusted_hotkeys(request.url.path)`); for `/pod_logs` that function returns the same two hotkeys and #1216 does not touch `routes/apis.py`, so the body's conclusion 'no ordering needed' still holds. | Add one clause to the Cross-PR paragraph: '#1216 (DAH-2501) edits middlewares/miner.py (per-path trusted hotkeys); /pod_logs keeps the same two hotkeys, no ordering needed'. |
| low | CODE-QUALITY | `neurons/executor/tests/test_pod_logs_signed_name.py:21` | The comment 'conftest.py already inserted src/ into sys.path' explains why `middlewares`, `routes`, `services` and `core.config` resolve, but after the ruff-format amend it sits below three of the four imports it explains (the sibling test_upload_ssh_key_auth.py:20 keeps it above all of them). | Move the comment above `from middlewares.miner import MinerMiddleware` (line 17) or drop it; ruff's isort passes either way. |
| low | CODE-QUALITY | `neurons/executor/tests/test_pod_logs_signed_name.py:41` | The fixture is named `store` and the module docstring (line 8) says 'only the log store is replaced', but what is replaced is the `PodLogService` dependency (`MagicMock(spec=PodLogService)`, overridden at line 57); `services/pod_log_store.py` itself is untouched. | Rename the fixture to `pod_log_service` and say 'only PodLogService is replaced' in the docstring, or leave as-is (a human reviewer can accept it). |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

### Verification
Gate: PASS (0b54a45) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1323)

</details>
