### PR TITLE
DAH-3206 - [P2] miner accepts a validator sign-in only when it names this miner

### DIFF
--- a/neurons/miners/src/consumers/validator_consumer.py
+++ b/neurons/miners/src/consumers/validator_consumer.py
@@ -52,6 +52,8 @@ class ValidatorConsumer(BaseConsumer):
         self.validator_key = validator_key
         self.my_hotkey = settings.get_bittensor_wallet().get_hotkey().ss58_address
         self.validator_authenticated = False
+        # the miner hotkey the validator's signed sign-in named; every later message must name it too
+        self.authenticated_miner_hotkey: str | None = None
         self.msg_queue = []
 
     def accepted_request_type(self):
@@ -60,8 +62,11 @@ class ValidatorConsumer(BaseConsumer):
     def verify_auth_msg(self, msg: AuthenticateRequest) -> tuple[bool, str]:
         if msg.payload.timestamp < time.time() - AUTH_MESSAGE_MAX_AGE:
             return False, "msg too old"
-        # if msg.payload.miner_hotkey != self.my_hotkey:
-        #     return False, f"wrong miner hotkey ({self.my_hotkey}!={msg.payload.miner_hotkey})"
+        # The signed payload names the miner it is for. A standard miner serves one hotkey and
+        # refuses a sign-in made for another; the central miner serves many portal hotkeys and
+        # cannot compare here — its later messages are bound to this name instead (handle_message).
+        if not settings.CENTRAL_MODE and msg.payload.miner_hotkey != self.my_hotkey:
+            return False, f"wrong miner hotkey ({self.my_hotkey}!={msg.payload.miner_hotkey})"
         if msg.payload.validator_hotkey != self.validator_key:
             return (
                 False,
@@ -71,6 +76,7 @@ class ValidatorConsumer(BaseConsumer):
         keypair = bittensor.Keypair(ss58_address=self.validator_key)
         if keypair.verify(msg.blob_for_signing(), msg.signature):
             return True, ""
+        return False, "invalid signature"
 
     async def handle_authentication(self, msg: AuthenticateRequest):
         # check if validator is registered
@@ -88,8 +94,12 @@ class ValidatorConsumer(BaseConsumer):
             return
 
         self.validator_authenticated = True
-        for msg in self.msg_queue:
-            await self.handle_message(msg)
+        self.authenticated_miner_hotkey = msg.payload.miner_hotkey
+        for queued in list(self.msg_queue):
+            await self.handle_message(queued)
+            if not self.validator_authenticated:
+                # a queued message named another miner: the session is over, stop replaying
+                break
 
     async def check_validator_allowance(self, msg: AuthenticateRequest):
         """Check if there's any executors opened for current validator.
@@ -145,6 +155,20 @@ class ValidatorConsumer(BaseConsumer):
         if not self.validator_authenticated:
             if len(self.msg_queue) <= MAX_MESSAGE_COUNT:
                 self.msg_queue.append(msg)
+            return
+
+        # every request after the sign-in carries a miner_hotkey; it must be the one the sign-in named
+        named_miner = getattr(msg, "miner_hotkey", None)
+        if named_miner != self.authenticated_miner_hotkey:
+            details = (
+                f"message names miner {named_miner}, but this session was authenticated "
+                f"for {self.authenticated_miner_hotkey}"
+            )
+            logger.info("Validator %s: %s", self.validator_key, details)
+            # the session is over: nothing queued behind this message is served either
+            self.validator_authenticated = False
+            await self.send_message(UnAuthorizedRequest(details=details))
+            await self.disconnect()
             return
 
         if isinstance(msg, SSHPubKeySubmitRequest):

--- a/neurons/miners/src/dependencies/auth.py
+++ b/neurons/miners/src/dependencies/auth.py
@@ -8,6 +8,7 @@ import bittensor
 from datura.requests.validator_requests import SimpleValidatorRequest
 from fastapi import Depends, Header, HTTPException, status
 
+from core import config as core_config
 from services.validator_service import ValidatorService
 
 logger = logging.getLogger(__name__)
@@ -72,10 +73,15 @@ async def verify_validator_auth_from_headers(
     must be within AUTH_MESSAGE_MAX_AGE seconds of the current time (symmetric window
     to handle small clock differences between servers). Each request must send a fresh
     timestamp to prevent replay attacks.
+
+    X-Miner-Hotkey is part of the signed blob and names the miner the validator signed in
+    to. Outside CENTRAL_MODE this miner serves one hotkey and answers 403 when the header
+    names another one; the central miner serves many portal hotkeys and accepts any, with
+    `authenticated_miner_hotkey` binding the request body to the same name.
     
     Args:
         x_validator_hotkey: Validator hotkey from header
-        x_miner_hotkey: Miner hotkey from header (must match this miner's hotkey)
+        x_miner_hotkey: Miner hotkey from header (must be this miner's hotkey outside CENTRAL_MODE)
         x_timestamp: Unix timestamp from header (in seconds, or milliseconds if > 1e12)
         x_signature: Signature from header
         validator_service: Service to check validator registration
@@ -128,6 +134,22 @@ async def verify_validator_auth_from_headers(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Validator is not registered",
         )
+
+    # A standard miner serves one hotkey: a sign-in made for another miner is not for us.
+    # settings is read through its module so a test can replace it for one request.
+    if not core_config.settings.CENTRAL_MODE:
+        own_hotkey = core_config.settings.get_bittensor_wallet().get_hotkey().ss58_address
+        if x_miner_hotkey != own_hotkey:
+            logger.warning(
+                "Validator %s signed in for miner %s; this miner is %s",
+                validator_hotkey,
+                x_miner_hotkey,
+                own_hotkey,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Authentication names another miner",
+            )
     
     # Create authentication payload and verify signature
     # Use normalized timestamp in seconds
@@ -161,6 +183,37 @@ async def verify_validator_auth_from_headers(
         )
     
     return validator_hotkey
+
+
+async def authenticated_miner_hotkey(
+    x_miner_hotkey: Annotated[str, Header(alias="X-Miner-Hotkey")],
+    _validator_hotkey: Annotated[str, Depends(verify_validator_auth_from_headers)],
+) -> str:
+    """The miner hotkey the validator's signed headers named (verified by the dependency above)."""
+    return x_miner_hotkey
+
+
+def require_request_names_authenticated_miner(request_miner_hotkey: str, authenticated: str) -> None:
+    """A request body's miner_hotkey must be the one the signed headers named.
+
+    The validator sends the same hotkey in both places (MinerService._generate_auth_headers and
+    every request it builds); a body naming another miner would let signed-in headers act for a
+    miner the signature never named.
+
+    Raises:
+        HTTPException: 403 when the body names another miner
+    """
+    if request_miner_hotkey != authenticated:
+        logger.warning(
+            "Request names miner %s but the signed headers named %s",
+            request_miner_hotkey,
+            authenticated,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Request names a miner the authentication did not",
+        )
+
 
 async def verify_simple_validator_signature(
     request: SimpleValidatorRequest,

--- a/neurons/miners/src/routes/validator_interface.py
+++ b/neurons/miners/src/routes/validator_interface.py
@@ -19,7 +19,12 @@ from datura.requests.miner_requests import (
 from fastapi import APIRouter, Depends, HTTPException, status
 
 from consumers.validator_consumer import ValidatorConsumer
-from dependencies.auth import verify_simple_validator_signature, verify_validator_auth_from_headers
+from dependencies.auth import (
+    authenticated_miner_hotkey,
+    require_request_names_authenticated_miner,
+    verify_simple_validator_signature,
+    verify_validator_auth_from_headers,
+)
 from services.executor_service import ExecutorService
 from services.ssh_service import MinerSSHService
 
@@ -87,6 +92,7 @@ async def get_executors_for_validator(
 async def submit_ssh_pubkey(
     request: SSHPubKeySubmitRequest,
     authenticated_validator: Annotated[str, Depends(verify_validator_auth_from_headers)],
+    authenticated_miner: Annotated[str, Depends(authenticated_miner_hotkey)],
     executor_service: Annotated[ExecutorService, Depends(ExecutorService)],
     ssh_service: Annotated[MinerSSHService, Depends(MinerSSHService)],
 ) -> AcceptSSHKeyRequest | FailedRequest:
@@ -104,6 +110,7 @@ async def submit_ssh_pubkey(
     Returns:
         AcceptSSHKeyRequest with executors or FailedRequest on error
     """
+    require_request_names_authenticated_miner(request.miner_hotkey, authenticated_miner)
     try:
         logger.info("Validator %s sent SSH Pubkey via REST API.", authenticated_validator)
         
@@ -151,6 +158,7 @@ async def submit_ssh_pubkey(
 async def remove_ssh_pubkey(
     request: SSHPubKeyRemoveRequest,
     authenticated_validator: Annotated[str, Depends(verify_validator_auth_from_headers)],
+    authenticated_miner: Annotated[str, Depends(authenticated_miner_hotkey)],
     executor_service: Annotated[ExecutorService, Depends(ExecutorService)],
 ) -> SSHKeyRemoved | FailedRequest:
     """Remove SSH public key from miner (REST API version).
@@ -166,6 +174,7 @@ async def remove_ssh_pubkey(
     Returns:
         SSHKeyRemoved on success or FailedRequest on error
     """
+    require_request_names_authenticated_miner(request.miner_hotkey, authenticated_miner)
     try:
         logger.info("Validator %s sent remove SSH Pubkey via REST API.", authenticated_validator)
         
@@ -187,6 +196,7 @@ async def remove_ssh_pubkey(
 async def get_pod_logs(
     request: GetPodLogsRequest,
     authenticated_validator: Annotated[str, Depends(verify_validator_auth_from_headers)],
+    authenticated_miner: Annotated[str, Depends(authenticated_miner_hotkey)],
     executor_service: Annotated[ExecutorService, Depends(ExecutorService)],
 ) -> PodLogsResponse | FailedRequest:
     """Get pod logs from miner (REST API version).
@@ -202,6 +212,7 @@ async def get_pod_logs(
     Returns:
         PodLogsResponse with logs or FailedRequest on error
     """
+    require_request_names_authenticated_miner(request.miner_hotkey, authenticated_miner)
     try:
         logger.info("Validator %s get pod logs for container %s via REST API.", authenticated_validator, request.container_name)
         

--- a/neurons/miners/tests/test_validator_auth_names_this_miner.py
+++ b/neurons/miners/tests/test_validator_auth_names_this_miner.py
@@ -1,0 +1,451 @@
+"""
+A validator sign-in is accepted only when its signed payload names this miner, and every message after it
+names the same miner (WebSocket consumer and REST routes).
+
+Ephemeral keypairs sign the real payload shape (AuthenticationPayload.blob_for_signing); the consumer's socket
+and the services are the only things replaced. The REST dependency and the route functions are called directly
+(the miners lock has no httpx, so no TestClient); lium-io#1312's e2e stack exercises the same routes over HTTP.
+"""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import UUID
+
+import bittensor
+import pytest
+from datura.requests.miner_requests import AcceptJobRequest, UnAuthorizedRequest
+from datura.requests.validator_requests import (
+    AuthenticateRequest,
+    AuthenticationPayload,
+    GetPodLogsRequest,
+    SSHPubKeyRemoveRequest,
+    SSHPubKeySubmitRequest,
+)
+from fastapi import HTTPException
+
+import consumers.validator_consumer as consumer_module
+import dependencies.auth as auth_module
+import routes.validator_interface as routes
+from consumers.validator_consumer import ValidatorConsumer
+from services.executor_service import ExecutorService
+from services.ssh_service import MinerSSHService
+from services.validator_service import ValidatorService
+
+_CONTAINER = "pod_0b2a6d1e-9e2e-4e2e-8e2e-000000000e2e"
+_EXECUTOR_ID = "0b2a6d1e-9e2e-4e2e-8e2e-000000000e2e"
+
+
+@pytest.fixture(scope="module")
+def validator_keypair():
+    return bittensor.Keypair.create_from_uri("//LiumTestValidatorNames")
+
+
+@pytest.fixture(scope="module")
+def miner_keypair():
+    return bittensor.Keypair.create_from_uri("//LiumTestMinerNames")
+
+
+@pytest.fixture(scope="module")
+def other_miner_keypair():
+    return bittensor.Keypair.create_from_uri("//LiumTestOtherMinerNames")
+
+
+def _settings(miner_keypair, central_mode: bool) -> MagicMock:
+    # Pydantic Settings refuses setattr of non-fields, so the module's settings object is replaced whole
+    wallet = MagicMock()
+    wallet.get_hotkey.return_value = miner_keypair
+    settings = MagicMock()
+    settings.get_bittensor_wallet.return_value = wallet
+    settings.CENTRAL_MODE = central_mode
+    settings.RENTAL_REQUEST_HOOK = None
+    return settings
+
+
+def _auth_request(validator_keypair, miner_hotkey: str, *, signer=None):
+    payload = AuthenticationPayload(
+        validator_hotkey=validator_keypair.ss58_address,
+        miner_hotkey=miner_hotkey,
+        timestamp=int(time.time()),
+    )
+    signer = signer or validator_keypair
+    return AuthenticateRequest(
+        payload=payload, signature=f"0x{signer.sign(payload.blob_for_signing()).hex()}"
+    )
+
+
+# ---------------------------------------------------------------- WebSocket consumer ----------------------------------
+
+
+@pytest.fixture()
+def consumer(validator_keypair, miner_keypair, monkeypatch):
+    def make(central_mode: bool = False) -> ValidatorConsumer:
+        monkeypatch.setattr(consumer_module, "settings", _settings(miner_keypair, central_mode))
+        validator_service = MagicMock(spec=ValidatorService)
+        validator_service.is_valid_validator.return_value = True
+        executor_service = MagicMock(spec=ExecutorService)
+        # one executor, so an accepted sign-in is answered with AcceptJobRequest and the session stays open
+        executor_service.get_executors_for_validator = AsyncMock(
+            return_value=[
+                SimpleNamespace(uuid=UUID(_EXECUTOR_ID), address="203.0.113.10", port=8001)
+            ]
+        )
+        executor_service.get_pod_logs = AsyncMock(return_value=[])
+        executor_service.register_pubkey = AsyncMock(return_value=[])
+        executor_service.deregister_pubkey = AsyncMock(return_value=None)
+        c = ValidatorConsumer(
+            websocket=MagicMock(),
+            validator_key=validator_keypair.ss58_address,
+            ssh_service=MagicMock(spec=MinerSSHService),
+            validator_service=validator_service,
+            executor_service=executor_service,
+        )
+        c.send_message = AsyncMock()
+        c.disconnect = AsyncMock()
+        return c
+
+    return make
+
+
+def test_a_sign_in_naming_this_miner_verifies(consumer, validator_keypair, miner_keypair):
+    c = consumer()
+    assert c.verify_auth_msg(_auth_request(validator_keypair, miner_keypair.ss58_address)) == (
+        True,
+        "",
+    )
+
+
+def test_a_sign_in_naming_another_miner_is_refused(
+    consumer, validator_keypair, other_miner_keypair
+):
+    """The validator signed this payload for another miner; a standard miner is not that miner."""
+    c = consumer()
+    ok, reason = c.verify_auth_msg(
+        _auth_request(validator_keypair, other_miner_keypair.ss58_address)
+    )
+    assert ok is False
+    assert reason.startswith("wrong miner hotkey"), reason
+
+
+def test_a_bad_signature_is_a_refusal_not_none(consumer, validator_keypair, miner_keypair):
+    stranger = bittensor.Keypair.create_from_uri("//LiumTestStrangerNames")
+    c = consumer()
+    assert c.verify_auth_msg(
+        _auth_request(validator_keypair, miner_keypair.ss58_address, signer=stranger)
+    ) == (
+        False,
+        "invalid signature",
+    )
+
+
+def test_the_central_miner_accepts_a_sign_in_for_any_portal_miner(
+    consumer, validator_keypair, other_miner_keypair
+):
+    """CENTRAL_MODE serves many hotkeys; the name is bound to the session instead (tests below)."""
+    c = consumer(central_mode=True)
+    assert c.verify_auth_msg(
+        _auth_request(validator_keypair, other_miner_keypair.ss58_address)
+    ) == (True, "")
+
+
+@pytest.mark.asyncio
+async def test_a_refused_sign_in_closes_the_socket_before_anything_runs(
+    consumer, validator_keypair, other_miner_keypair
+):
+    c = consumer()
+    await c.handle_message(_auth_request(validator_keypair, other_miner_keypair.ss58_address))
+
+    assert c.validator_authenticated is False
+    sent = c.send_message.await_args.args[0]
+    assert isinstance(sent, UnAuthorizedRequest) and "wrong miner hotkey" in sent.details
+    c.disconnect.assert_awaited_once()
+    c.executor_service.get_executors_for_validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_after_sign_in_a_request_naming_another_miner_is_refused(
+    consumer, validator_keypair, miner_keypair, other_miner_keypair
+):
+    c = consumer(central_mode=True)
+    await c.handle_message(_auth_request(validator_keypair, miner_keypair.ss58_address))
+    assert (
+        c.validator_authenticated is True
+        and c.authenticated_miner_hotkey == miner_keypair.ss58_address
+    )
+    c.send_message.reset_mock()
+
+    await c.handle_message(
+        GetPodLogsRequest(
+            executor_id=_EXECUTOR_ID,
+            container_name=_CONTAINER,
+            miner_hotkey=other_miner_keypair.ss58_address,
+        )
+    )
+
+    c.executor_service.get_pod_logs.assert_not_awaited()
+    sent = c.send_message.await_args.args[0]
+    assert (
+        isinstance(sent, UnAuthorizedRequest) and other_miner_keypair.ss58_address in sent.details
+    )
+    c.disconnect.assert_awaited_once()
+    assert c.validator_authenticated is False, "a refused message ends the session"
+
+
+@pytest.mark.asyncio
+async def test_a_request_queued_before_sign_in_is_held_to_the_same_name(
+    consumer, validator_keypair, miner_keypair, other_miner_keypair
+):
+    """Queued messages run right after authentication; they get the same binding, not a free pass."""
+    c = consumer(central_mode=True)
+    await c.handle_message(
+        SSHPubKeySubmitRequest(
+            public_key=b"ssh-ed25519 AAAA test",
+            validator_signature="0x00",
+            miner_hotkey=other_miner_keypair.ss58_address,
+        )
+    )
+    assert c.msg_queue and c.validator_authenticated is False
+
+    await c.handle_message(_auth_request(validator_keypair, miner_keypair.ss58_address))
+
+    c.executor_service.register_pubkey.assert_not_awaited()
+    assert any(
+        isinstance(call.args[0], UnAuthorizedRequest) for call in c.send_message.await_args_list
+    )
+    c.disconnect.assert_awaited_once()
+    # the refusal ended the session before the executor list was offered
+    c.executor_service.get_executors_for_validator.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_requests_naming_the_signed_in_miner_are_served(
+    consumer, validator_keypair, miner_keypair
+):
+    c = consumer()
+    await c.handle_message(_auth_request(validator_keypair, miner_keypair.ss58_address))
+    assert isinstance(c.send_message.await_args.args[0], AcceptJobRequest)
+
+    await c.handle_message(
+        GetPodLogsRequest(
+            executor_id=_EXECUTOR_ID,
+            container_name=_CONTAINER,
+            miner_hotkey=miner_keypair.ss58_address,
+        )
+    )
+    await c.handle_message(
+        SSHPubKeyRemoveRequest(
+            public_key=b"ssh-ed25519 AAAA test",
+            validator_signature="0x00",
+            miner_hotkey=miner_keypair.ss58_address,
+        )
+    )
+
+    c.executor_service.get_pod_logs.assert_awaited_once_with(
+        validator_keypair.ss58_address, miner_keypair.ss58_address, _EXECUTOR_ID, _CONTAINER
+    )
+    c.executor_service.deregister_pubkey.assert_awaited_once()
+    c.disconnect.assert_not_awaited()
+
+
+# ---------------------------------------------------------------- REST dependency and routes -------------------------
+
+
+def _headers(validator_keypair, miner_hotkey: str, *, signer=None) -> dict:
+    """The four headers MinerService._generate_auth_headers sends, as the dependency receives them."""
+    payload = AuthenticationPayload(
+        validator_hotkey=validator_keypair.ss58_address,
+        miner_hotkey=miner_hotkey,
+        timestamp=int(time.time()),
+    )
+    signer = signer or validator_keypair
+    return {
+        "x_validator_hotkey": validator_keypair.ss58_address,
+        "x_miner_hotkey": miner_hotkey,
+        "x_timestamp": payload.timestamp,
+        "x_signature": f"0x{signer.sign(payload.blob_for_signing()).hex()}",
+    }
+
+
+@pytest.fixture()
+def rest(miner_keypair, monkeypatch):
+    def make(central_mode: bool = False) -> tuple[MagicMock, MagicMock]:
+        monkeypatch.setattr(
+            auth_module.core_config, "settings", _settings(miner_keypair, central_mode)
+        )
+        validator_service = MagicMock(spec=ValidatorService)
+        validator_service.is_valid_validator.return_value = True
+        executor_service = MagicMock(spec=ExecutorService)
+        executor_service.get_pod_logs = AsyncMock(return_value=[])
+        executor_service.register_pubkey = AsyncMock(return_value=[])
+        executor_service.deregister_pubkey = AsyncMock(return_value=None)
+        return validator_service, executor_service
+
+    return make
+
+
+async def test_rest_headers_naming_this_miner_authenticate(rest, validator_keypair, miner_keypair):
+    validator_service, _ = rest()
+    headers = _headers(validator_keypair, miner_keypair.ss58_address)
+
+    assert (
+        await auth_module.verify_validator_auth_from_headers(
+            **headers, validator_service=validator_service
+        )
+        == validator_keypair.ss58_address
+    )
+    assert (
+        await auth_module.authenticated_miner_hotkey(
+            headers["x_miner_hotkey"], validator_keypair.ss58_address
+        )
+        == miner_keypair.ss58_address
+    )
+
+
+async def test_rest_headers_naming_another_miner_are_refused_403(
+    rest, validator_keypair, other_miner_keypair
+):
+    """The docstring always promised this 403; the signature is valid, the miner is not us."""
+    validator_service, _ = rest()
+
+    with pytest.raises(HTTPException) as refused:
+        await auth_module.verify_validator_auth_from_headers(
+            **_headers(validator_keypair, other_miner_keypair.ss58_address),
+            validator_service=validator_service,
+        )
+
+    assert refused.value.status_code == 403
+    assert refused.value.detail == "Authentication names another miner"
+
+
+async def test_rest_central_miner_accepts_headers_for_any_portal_miner(
+    rest, validator_keypair, other_miner_keypair
+):
+    validator_service, _ = rest(central_mode=True)
+    headers = _headers(validator_keypair, other_miner_keypair.ss58_address)
+
+    assert (
+        await auth_module.verify_validator_auth_from_headers(
+            **headers, validator_service=validator_service
+        )
+        == validator_keypair.ss58_address
+    )
+
+
+async def test_rest_a_stranger_signature_is_still_401_for_this_miner(
+    rest, validator_keypair, miner_keypair
+):
+    validator_service, _ = rest()
+    stranger = bittensor.Keypair.create_from_uri("//LiumTestStrangerNames")
+
+    with pytest.raises(HTTPException) as refused:
+        await auth_module.verify_validator_auth_from_headers(
+            **_headers(validator_keypair, miner_keypair.ss58_address, signer=stranger),
+            validator_service=validator_service,
+        )
+
+    assert refused.value.status_code == 401
+
+
+def _pod_logs_request(miner_hotkey: str) -> GetPodLogsRequest:
+    return GetPodLogsRequest(
+        executor_id=_EXECUTOR_ID, container_name=_CONTAINER, miner_hotkey=miner_hotkey
+    )
+
+
+async def test_rest_pod_logs_names_the_signed_in_miner_and_is_served(
+    rest, validator_keypair, miner_keypair
+):
+    _, executor_service = rest()
+    me = miner_keypair.ss58_address
+
+    response = await routes.get_pod_logs(
+        _pod_logs_request(me),
+        authenticated_validator=validator_keypair.ss58_address,
+        authenticated_miner=me,
+        executor_service=executor_service,
+    )
+
+    assert response.message_type.value == "PodLogsResponse"
+    executor_service.get_pod_logs.assert_awaited_once_with(
+        validator_keypair.ss58_address, me, _EXECUTOR_ID, _CONTAINER
+    )
+
+
+async def test_rest_body_naming_a_miner_the_headers_did_not_is_refused_403(
+    rest, validator_keypair, miner_keypair, other_miner_keypair
+):
+    """CENTRAL_MODE: the headers may name any portal miner, the body must name that same one — on all three routes,
+    and as a 403, not as a FailedRequest body the route's except would otherwise turn it into."""
+    _, executor_service = rest(central_mode=True)
+    me, other = miner_keypair.ss58_address, other_miner_keypair.ss58_address
+    vk = validator_keypair.ss58_address
+    submit = SSHPubKeySubmitRequest(
+        public_key=b"ssh-ed25519 AAAA test", validator_signature="0x00", miner_hotkey=other
+    )
+    remove = SSHPubKeyRemoveRequest(
+        public_key=b"ssh-ed25519 AAAA test", validator_signature="0x00", miner_hotkey=other
+    )
+
+    for call in (
+        routes.get_pod_logs(
+            _pod_logs_request(other),
+            authenticated_validator=vk,
+            authenticated_miner=me,
+            executor_service=executor_service,
+        ),
+        routes.submit_ssh_pubkey(
+            submit,
+            authenticated_validator=vk,
+            authenticated_miner=me,
+            executor_service=executor_service,
+            ssh_service=MagicMock(),
+        ),
+        routes.remove_ssh_pubkey(
+            remove,
+            authenticated_validator=vk,
+            authenticated_miner=me,
+            executor_service=executor_service,
+        ),
+    ):
+        with pytest.raises(HTTPException) as refused:
+            await call
+        assert refused.value.status_code == 403
+        assert refused.value.detail == "Request names a miner the authentication did not"
+
+    executor_service.get_pod_logs.assert_not_awaited()
+    executor_service.register_pubkey.assert_not_awaited()
+    executor_service.deregister_pubkey.assert_not_awaited()
+
+
+def test_require_request_names_authenticated_miner_accepts_the_same_name(miner_keypair):
+    auth_module.require_request_names_authenticated_miner(
+        miner_keypair.ss58_address, miner_keypair.ss58_address
+    )
+
+
+def _dependency_names(dependant) -> set[str]:
+    names = {dependant.call.__name__} if dependant.call is not None else set()
+    for sub in dependant.dependencies:
+        names |= _dependency_names(sub)
+    return names
+
+
+def test_the_three_rest_routes_are_wired_to_the_miner_binding():
+    """FastAPI resolves both dependencies on each route: the signed headers and the miner hotkey they named."""
+    from fastapi.routing import APIRoute
+
+    wanted = {
+        "/api/validator/ssh-pubkey-submit",
+        "/api/validator/ssh-pubkey-remove",
+        "/api/validator/pod-logs",
+    }
+    seen = set()
+    for route in routes.validator_router.routes:
+        if isinstance(route, APIRoute) and route.path in wanted:
+            names = _dependency_names(route.dependant)
+            assert {"verify_validator_auth_from_headers", "authenticated_miner_hotkey"} <= names, (
+                route.path,
+                names,
+            )
+            seen.add(route.path)
+    assert seen == wanted


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Fixes [DAH-3206](https://app.notion.com/p/lium-io-miner-accept-a-validator-sign-in-only-when-it-names-this-miner-and-bind-later-messages-to--3d5b8bfdbde98106a188e9fb66cd4191) · reviewer: @jam6099

**TL;DR** — The validator's signed sign-in names the miner it is for and the miner never checked it, so a sign-in made for miner A authenticated on miner B for 10 seconds. A standard miner now refuses a sign-in for another hotkey on both transports; the session and REST bodies are bound to the miner the signature named. Risk: a validator whose later messages name another miner is refused (its next signed sign-in re-binds the session); ours never does.

**What changed**
- `verify_auth_msg`: outside `CENTRAL_MODE` a payload naming another miner is refused; a bad signature is an explicit `False` (`neurons/miners/src/consumers/validator_consumer.py`)
- the socket keeps `authenticated_miner_hotkey`; a later message naming another miner gets `UnAuthorizedRequest` and ends the session (`validator_consumer.py`)
- REST: `X-Miner-Hotkey` must be this miner's hotkey outside `CENTRAL_MODE`, else 403 (`neurons/miners/src/dependencies/auth.py`)
- REST: a body `miner_hotkey` unlike the signed header → 403 (`neurons/miners/src/routes/validator_interface.py`)
- 16 tests: real signatures, socket and REST, both modes (`neurons/miners/tests/test_validator_auth_names_this_miner.py`)

**How to verify**
- `cd neurons/miners && pdm run pytest tests/test_validator_auth_names_this_miner.py -v` → 16 passed; on `main` 13 fail
- e2e stack (lium-io#1312): sign-in for another hotkey → `UnAuthorizedRequest` (main: `AcceptJobRequest`); REST for another miner → 403 (main: 200)
- `pdm run pytest tests/ -q` → 43 passed; `protocol` suite 14/14

**Verified by the loop:** Gate: PASS 7e11548

**Ran it:** e2e stack, websocket sign-in for the stranger hotkey: `AcceptJobRequest` (main) → `UnAuthorizedRequest … wrong miner hotkey`; REST pod-logs for another miner: 200 → 403 · EC2 20260908T050308Z-sdnk · rebased head 7e11548: miners suite 43 passed, EC2 20260909T092953Z-8o6y

**Self-review:** clean at 7e11548 (15 checks, 6 low)

**Parts:** backend ✓ (miner) · migration n/a — no schema · frontend n/a — miner protocol · CLI/SDK n/a — same · docs n/a — below · tests ✓ 16 · dashboards n/a — none

**Docs:** none needed because the wire contract is unchanged for the validator (it names one miner throughout) and the miner's validator API is not on docs.lium.io

<details><summary>Details</summary>

## Origin

External security report, Discord ticket-0253 report 3 (`richardeyyy`, 8 Sep 2026), finding LIUM-003. Verified against `main` `75298589`: `consumers/validator_consumer.py:60-73` (the commented-out comparison went out with DAH-1461 `7da08d90`, the central miner, which serves many portal hotkeys and cannot compare against one), `dependencies/auth.py:59-164` (docstring: "403 if … miner hotkey mismatch"; no comparison in the body), `datura/requests/validator_requests.py:76-102` (`SSHPubKeySubmitRequest`, `SSHPubKeyRemoveRequest`, `GetPodLogsRequest` each carry `miner_hotkey`; `GetPodLogsRequest` is unsigned). Reports 1–2 of the same ticket recorded the commented line as the central-miner design; this PR keeps that design (central mode accepts any portal hotkey in the sign-in) and adds what was missing on both modes: the session is bound to the miner the signature named. lium-io#1312's own protocol suite documents the REST gap (`test_headers_naming_another_miner_still_yield_only_this_miners_executors`, accepts 200/401/403) and still passes.

What a relayed sign-in yielded on another standard miner: its executor list (`AcceptJobRequest`: uuid, address, port) and, through `GetPodLogsRequest`, the lifecycle events of its pods by container name (`executor_service.get_pod_logs`, signed by that miner's own key). `SSHPubKeySubmit/Remove` carry a validator signature over the key, so a relayed one installs or removes the validator's key, not anyone else's.

Cross-PR: **#1316 (DAH-2971, dead code) merged first (`04c971a`) and deleted `from core.config import settings` from `neurons/miners/src/dependencies/auth.py` as unused; this PR's line `from core import config as core_config` conflicted with that deletion. Rebased onto `main` 9 Sep (head `7e11548`), the resolution keeps the PR's import — the only difference from `0b728e5` is that hunk; the miners job re-ran on the rebased head (EC2 `20260909T092953Z-8o6y`, 43 passed).** #1301 (DAH-3114) edits `neurons/miners/src/miner.py`, `core/config.py` and deletes `routes/debug_routes.py`, whose handlers were named `get_executors_for_validator` and `register_pubkey` — the names in the tests here are the `ExecutorService` methods (`services/executor_service.py:198`, `:366`), which #1301 does not touch; no order needed. #1315 (DAH-2958) `clients/miner_portal_api.py` and #1317 (DAH-2967) `neurons/miners/README.md` have merged since; neither touched the files here. Nothing here is only true once another PR merges.

## Design

- Standard mode compares; central mode binds. `CENTRAL_MODE` has no single "own" hotkey to compare with (`check_validator_allowance` looks the named miner up in the portal), so there the sign-in is accepted for any portal hotkey and every later message must name that same one — a relayed sign-in for hotkey A then reaches only A's executors, which A already owns.
- The binding check runs before any handler, on every message type after the sign-in, including the ones replayed from `msg_queue` right after authentication (the replay still runs before `check_validator_allowance`, as on `main`; the binding is the only gate on it). A fresh, validly signed sign-in re-binds the session under its own signature — the same thing a new connection would need. A refused message clears `validator_authenticated` and the replay loop stops, so nothing behind it in the queue is served.
- REST: the header check sits in the dependency (the docstring's 403); the body check is a second, cached dependency (`authenticated_miner_hotkey`) plus one call at the top of each route, outside the route's `try` — a 403, not a 200 `FailedRequest` body. `settings` is read as `core_config.settings` so a test can replace it for one request (the consumer keeps its import-time `settings`, replaced whole in its tests). The miner's own hotkey is read from the wallet file per request, as `/executors` already does on `main`; caching it is a follow-up for the file, not this change.
- `False, "invalid signature"` replaces the implicit `None`: the caller unpacked it into a `TypeError` that `BaseConsumer.handle` swallowed at DEBUG; the refusal is now sent as `UnAuthorizedRequest` and logged at INFO like the other reasons.
- Not changed: `POST /executors` (`SimpleValidatorRequest`, signs only the validator hotkey, read-only, nothing in the validator calls it) and the 10 s one-sided window (`AUTH_MESSAGE_MAX_AGE`) — noted on DAH-2868.

## Ran it

Sandbox EC2 `20260908T050308Z-sdnk` (c6i.4xlarge, Linux), the lium-io#1312 e2e stack (real miner in standard mode with the stack's wallet, real executor) built twice: from the #1312 branch as-is ("before") and with this branch merged ("after"). The probe (kept in the loop's tree until #1312 lands) signs as `MinerClient.generate_authentication_message` / `MinerService._generate_auth_headers` do, once for the stack's miner hotkey and once for the stranger hotkey.

```
# before (main)
destination-websocket.json: for_this_miner AcceptJobRequest (2 executors) · for_another_miner AcceptJobRequest (the same 2 executors)
destination-rest.json:      control 200 · headers_name_another_miner 200 PodLogsResponse · body_names_another_miner 200 PodLogsResponse
e2e before destination rc=2 :: 2 failed — a sign-in signed for another miner was honoured; headers signed for another miner were accepted: 200

# after (this branch)
destination-websocket.json: for_this_miner AcceptJobRequest · for_another_miner UnAuthorizedRequest "… not authenticated due to: wrong miner hotkey (5EHg…!=5Etai…)"
destination-rest.json:      control 200 · headers_name_another_miner 403 {"detail":"Authentication names another miner"} · body_names_another_miner 403 {"detail":"Request names a miner the authentication did not"}
e2e after destination rc=0 :: 2 passed
e2e after protocol rc=0 :: 14 passed   (the stack's own suite, unchanged)
```

Unit suite (miners, python 3.11, `pdm install` from the lock):

```
main + tests/test_validator_auth_names_this_miner.py   → 13 failed, 3 passed  (fail-before; the 3 that pass on main are the socket controls — own sign-in verifies, central mode accepts, a message naming the same miner is served; the six `rest`-fixture tests fail on main because `core_config` does not exist there, the helper test on the missing function, the wiring test on the missing dependency)
branch: tests/test_validator_auth_names_this_miner.py -v → 16 passed
branch: tests/ -q                                      → 43 passed   (main: 27, after #1315's new test)
```

The e2e probe ran at the earlier head of this branch. The current head `0b728e5f` differs from it in the test file (the REST tests call the dependency and the route functions directly — the miners lock has no `httpx`, so `fastapi.testclient` cannot import — a one-executor fixture, a route-wiring test, `ruff format`) and in two source lines from the fresh review: `settings` read as `core_config.settings` in `dependencies/auth.py`, and the replay loop in `validator_consumer.py` stops after a refused queued message. Neither changes what the probe measures (a 403 / an `UnAuthorizedRequest` from the same checks). Unit numbers above were re-run at the rebased head `7e11548` (EC2 `20260909T092953Z-8o6y`: 43 passed); the earlier `0b728e5f` run was `20260908T054014Z-49ch`. Ruff findings on the three source files are the same on `main` and here (the `F401` on the old import went with #1316; the rest are `main`'s lines).

The probe lives in the loop's tree (`security/ticket-0253/e2e/destination/`) until #1312 is on `main`; it then joins that stack's suites.

## Claims

pending — `tools/pr_quality_gate.py lium-io <n> --claims`

## Self-review

pending

### Self-review

Verdict `findings` at `7e11548` · 15 checks · by subagent-r4-rebase · 2026-09-09 09:37Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `neurons/miners/src/dependencies/auth.py:11` | The Cross-PR paragraph still describes #1316 as an open conflict ("the two conflict on that one line in either order — whichever lands second keeps `from core import config as core_config` … Comment left on #1316") and lists #1315 and #1317 as open, but #1316 is on main as 04c971ae (the branch's parent), #1315 as be00fda1 and #1317 as b05764a7; this head is the rebase over #1316 and the resolution it describes has happened (line 11 is `from core import config as core_config`, `settings` is read only as `core_config.settings` at 140-141, the miners job re-ran green on 7e11548). | Rewrite the paragraph in the past tense: #1316 landed as 04c971ae, this branch was rebased onto it, the one-line conflict in dependencies/auth.py kept `from core import config as core_config`, miners job 43 passed on the rebased head; drop #1315/#1317 from the open list or mark them merged. |
| low | STALE-BODY | `neurons/miners/src/dependencies/auth.py:11` | Three body lines still pin the previous head: "Verified by the loop: Gate: PASS 0b728e5", the under-the-fold "Gate: PASS (0b728e5) on EC2 sandbox", and the Ran-it sentence "The current head `0b728e5f` differs from it in the test file … Unit numbers above are from the current head (EC2 20260908T054014Z-49ch)"; the restack tool marked only the Ran-it and Self-review headline lines stale, so a reader is told the gate passed on a commit that is no longer the head. | After the gate re-runs at 7e11548 replace both `0b728e5` gate mentions with the new sha, and rewrite the Ran-it sentence so "the current head" names 7e11548 (a rebase over #1316 with no change to the PR's own patch) and cites the 20260909T092953Z-8o6y unit run. |
| low | STALE-BODY | `neurons/miners/tests/test_validator_auth_names_this_miner.py:1` | Counts that were true against 75298589 are off by the rebase: "`pdm run pytest tests/ -q` → 42 passed" (How to verify) and "tests/ -q → 42 passed (main: 26)" (Ran it) are now 43 / 27 because main gained test_wave_sees_node_added_after_a_recent_rental_refresh (#1315), and "ruff 0.5.1 on the three source files: 11 findings on `main` → 10 here (the `F401` on the old import is gone)" no longer holds because #1316 removed that import on main too — with the repo config and ruff 0.5.1 the branch and 04c971a have the same findings per file (2, 0, 1), all on main's lines. | Write 43 passed (main: 27) in both places and change the ruff sentence to "the same N findings on main and here, all on main's lines; none on the lines this PR touches". |
| low | PROSE-VS-CODE | `neurons/miners/src/consumers/validator_consumer.py:145` | Carried from 0b728e5, narrowed: Design bullet 2 now says a fresh, validly signed sign-in re-binds the session, but the TL;DR still says "a validator whose later messages name another miner is disconnected", while `handle_message` dispatches a second `AuthenticateRequest` at line 145 before the binding check at 161, so in CENTRAL_MODE a validly signed second sign-in naming miner B re-binds `authenticated_miner_hotkey` (line 97) instead of disconnecting; the property holds because re-binding needs a fresh validator signature over B and MinerClient sends one sign-in per connection, so this is wording only. | Qualify the TL;DR: "a validator whose later requests name another miner is disconnected (a second signed sign-in re-binds the session instead)" — or run the binding check on a second AuthenticateRequest too and add the test. |
| low | TEST-GAP | `neurons/miners/tests/test_validator_auth_names_this_miner.py:195` | Carried from 0b728e5, unchanged: the `break` at validator_consumer.py:100-102 has no test that exercises it — test_a_request_queued_before_sign_in_is_held_to_the_same_name queues exactly one message, so the replay loop ends after it with or without the break (the externally visible property already held via the not-authenticated branch at 155-158, which re-queues rather than serves). | Queue two messages naming another miner before the sign-in and assert exactly one UnAuthorizedRequest in send_message.await_args_list, disconnect awaited once, and `len(c.msg_queue) == 2` afterwards (without the break the second is re-appended and the queue grows to 3). |
| low | CODE-QUALITY | `neurons/miners/tests/test_validator_auth_names_this_miner.py:151` | Carried from 0b728e5, unchanged: the four consumer coroutine tests carry `@pytest.mark.asyncio` (151, 165, 194, 220) while the six REST coroutine tests (286-374) do not; `asyncio_mode = "auto"` in neurons/miners/pyproject.toml runs both, so the markers are redundant and the two halves read as written under different conventions. | Pick one style for the file — drop the four markers, or mark the six REST tests too. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/miners/tests/test_validator_auth_names_this_miner.py:17` `datura.requests.miner_requests` is `datura/datura/requests/miner_requests.py` in the sibling package pdm installs from `datura @ file:///${PROJECT_ROOT}/../../datura` (neurons/miners/pyproject.toml:18); main's consumers/validator_consumer.py imports the same module and the Miners Tests job passed on 7e11548 — the scanner looks for a repo-relative path an installed package does not have. · `neurons/miners/tests/test_validator_auth_names_this_miner.py:18` `datura.requests.validator_requests` is `datura/datura/requests/validator_requests.py` in the same installed package, imported on main by consumers/validator_consumer.py and dependencies/auth.py; same false positive as line 17 and as the two earlier rounds.

### Verified

Gate: PASS (7e11548) on EC2 sandbox Linux x86_64 (aws_run gate-own)

</details>
