### PR TITLE
DAH-3217 - [P1] stale vloopback mount repair uses the host's real Docker data-root

### DIFF
--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1269,7 +1269,7 @@ class DockerService:
     async def _docker_root_dir_or_default(
         self,
         ssh_client: asyncssh.SSHClientConnection,
-        log_extra: dict,
+        log_extra: dict[str, Any],
     ) -> str:
         # one `docker info` per repair; a lookup that fails falls back to the default root and says
         # so, so the repair runs where it always did. On the create path a raised lookup error would

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1273,7 +1273,10 @@ class DockerService:
     ) -> str:
         # one `docker info` per repair; a lookup that fails falls back to the default root and says
         # so, so the repair runs where it always did. On the create path a raised lookup error would
-        # replace the original `docker run` failure with no repair event logged.
+        # replace the original `docker run` failure with no repair event logged. The `except` below
+        # also catches a dead SSH transport (asyncssh's connection and timeout errors): then the
+        # fallback event names a broken connection, not a failed `docker info`, through `error`,
+        # and the repair commands that follow fail on the same connection with their own events.
         try:
             docker_root_dir = await self.get_docker_root_dir(
                 ssh_client, timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -219,6 +219,9 @@ _VLOOPBACK_DRIVER_PREFIX = "vloopback"
 # Shared with core.docker_utils so exactly one helper image lands on nodes.
 _VLOOPBACK_REPAIR_IMAGE = ALPINE_HELPER_IMAGE
 _VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC = 30
+# dockerd's default data-root; the repair reads the real one from `docker info` and uses this only
+# when that lookup fails (DAH-3217).
+_DEFAULT_DOCKER_ROOT_DIR = "/var/lib/docker"
 _DOCKER_VOLUME_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 # DAH-2475: slack kept free above a rental's requested volume before we decide the DPHN filler cache
 # has to go. Covers the image layers and scratch the pod needs beyond its own volume.
@@ -1209,7 +1212,14 @@ class DockerService:
         plugin_id = (plugin_result.stdout or "").strip()
         if getattr(plugin_result, "exit_status", 0) != 0 or not plugin_id:
             return False
-        target = f"/var/lib/docker/plugins/{plugin_id}/propagated-mount/{local_volume}"
+        # The plugin's propagated-mount dir lives under dockerd's data-root, which a provider may
+        # move off /var/lib/docker (DAH-3217: `/mnt/lium-xfs/lium-docker` on ticket-0313's host —
+        # the hard-coded default made findmnt look at nothing and rmdir fail every cycle).
+        log_extra = {**default_extra, "local_volume": local_volume}
+        docker_root_dir = await self._docker_root_dir_for_repair(ssh_client, log_extra)
+        propagated_mount_dir = f"{docker_root_dir}/plugins/{plugin_id}/propagated-mount"
+        target = f"{propagated_mount_dir}/{local_volume}"
+        log_extra = {**log_extra, "target": target}
 
         # Recheck that the target is not currently mounted before removing it.
         mounted_result = await ssh_client.run(
@@ -1221,7 +1231,7 @@ class DockerService:
             logger.warning(
                 _m(
                     "VLOOPBACK_STALE_MOUNTPOINT_STILL_MOUNTED",
-                    extra=get_extra_info({**default_extra, "local_volume": local_volume}),
+                    extra=get_extra_info(log_extra),
                 )
             )
             return False
@@ -1231,7 +1241,7 @@ class DockerService:
         # Repair by removing only the empty stale mountpoint directory.
         helper_cmd = (
             "/usr/bin/docker run --rm "
-            f"-v {shlex.quote(str(Path(target).parent))}:/mnt "
+            f"-v {shlex.quote(propagated_mount_dir)}:/mnt "
             f"{_VLOOPBACK_REPAIR_IMAGE} rmdir /mnt/{shlex.quote(local_volume)}"
         )
         repair_result = await ssh_client.run(helper_cmd, timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC)
@@ -1240,8 +1250,7 @@ class DockerService:
                 _m(
                     "VLOOPBACK_STALE_MOUNTPOINT_REPAIR_SKIPPED",
                     extra=get_extra_info({
-                        **default_extra,
-                        "local_volume": local_volume,
+                        **log_extra,
                         "exit_status": getattr(repair_result, "exit_status", None),
                         "stderr": getattr(repair_result, "stderr", ""),
                     }),
@@ -1252,10 +1261,45 @@ class DockerService:
         logger.info(
             _m(
                 "VLOOPBACK_STALE_MOUNTPOINT_REPAIRED",
-                extra=get_extra_info({**default_extra, "local_volume": local_volume}),
+                extra=get_extra_info(log_extra),
             )
         )
         return True
+
+    async def _docker_root_dir_for_repair(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        log_extra: dict,
+    ) -> str:
+        # one `docker info` per repair; a lookup that fails falls back to the default root and says
+        # so, so the repair runs where it always did. On the create path a raised lookup error would
+        # replace the original `docker run` failure with no repair event logged.
+        try:
+            docker_root_dir = await self.get_docker_root_dir(
+                ssh_client, timeout=_VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # asyncssh's TimeoutError carries an empty str(); the type is the diagnosis then
+            docker_root_dir = ""
+            error = f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+        else:
+            error = None if docker_root_dir.startswith("/") else "docker info returned no absolute path"
+        if error is not None:
+            logger.warning(
+                _m(
+                    "VLOOPBACK_REPAIR_DOCKER_ROOT_FALLBACK",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "docker_root_dir": docker_root_dir,
+                        "fallback": _DEFAULT_DOCKER_ROOT_DIR,
+                        "error": error,
+                    }),
+                )
+            )
+            return _DEFAULT_DOCKER_ROOT_DIR
+        return docker_root_dir.rstrip("/")
 
     async def _prepare_known_hosts_policy(
         self,

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -1216,7 +1216,7 @@ class DockerService:
         # move off /var/lib/docker (DAH-3217: `/mnt/lium-xfs/lium-docker` on ticket-0313's host —
         # the hard-coded default made findmnt look at nothing and rmdir fail every cycle).
         log_extra = {**default_extra, "local_volume": local_volume}
-        docker_root_dir = await self._docker_root_dir_for_repair(ssh_client, log_extra)
+        docker_root_dir = await self._docker_root_dir_or_default(ssh_client, log_extra)
         propagated_mount_dir = f"{docker_root_dir}/plugins/{plugin_id}/propagated-mount"
         target = f"{propagated_mount_dir}/{local_volume}"
         log_extra = {**log_extra, "target": target}
@@ -1266,7 +1266,7 @@ class DockerService:
         )
         return True
 
-    async def _docker_root_dir_for_repair(
+    async def _docker_root_dir_or_default(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         log_extra: dict,

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -4174,13 +4174,29 @@ async def test_create_container_skips_mountpoint_repair_without_local_volume(
     repair.assert_not_awaited()
 
 
+_VLOOPBACK_REPAIR_INSPECT = _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n")
+_VLOOPBACK_REPAIR_PLUGIN_ID = _make_ssh_command_result(stdout="plugin123\n")
+_VLOOPBACK_REPAIR_DEFAULT_ROOT = _make_ssh_command_result(stdout="/var/lib/docker\n")
+
+
+def _asyncssh_timeout_error() -> asyncssh.TimeoutError:
+    # what ssh_client.run(timeout=...) raises: it subclasses both asyncssh.Error and OSError, so
+    # every caller that treats those two as "transport died" also swallows a plain command timeout.
+    return asyncssh.TimeoutError(None, None, None, None, None, None, "", "")
+
+
+def _vloopback_repair_commands(ssh_client: AsyncMock) -> list[str]:
+    return [call.args[0] for call in ssh_client.run.await_args_list]
+
+
 @pytest.mark.asyncio
 async def test_repair_stale_vloopback_mountpoint_uses_rmdir_helper(docker_service):
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(
         side_effect=[
-            _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
-            _make_ssh_command_result(stdout="plugin123\n"),
+            _VLOOPBACK_REPAIR_INSPECT,
+            _VLOOPBACK_REPAIR_PLUGIN_ID,
+            _VLOOPBACK_REPAIR_DEFAULT_ROOT,
             _make_ssh_command_result(exit_status=1),
             _make_ssh_command_result(exit_status=0),
         ]
@@ -4193,7 +4209,13 @@ async def test_repair_stale_vloopback_mountpoint_uses_rmdir_helper(docker_servic
     )
 
     assert repaired is True
-    helper_cmd = ssh_client.run.await_args_list[-1].args[0]
+    commands = _vloopback_repair_commands(ssh_client)
+    assert commands[2] == "/usr/bin/docker info --format '{{.DockerRootDir}}'"
+    assert commands[3] == (
+        "/usr/bin/findmnt /var/lib/docker/plugins/plugin123/propagated-mount/volume_test "
+        ">/dev/null 2>&1"
+    )
+    helper_cmd = commands[-1]
     assert "docker.io/library/alpine:3.19" in helper_cmd
     assert "rmdir" in helper_cmd
     assert "rm -rf" not in helper_cmd
@@ -4205,13 +4227,112 @@ async def test_repair_stale_vloopback_mountpoint_uses_rmdir_helper(docker_servic
     )
 
 
+@pytest.mark.parametrize(
+    "docker_info_stdout",
+    [
+        pytest.param("/mnt/lium-xfs/lium-docker\n", id="as_docker_info_prints_it"),
+        pytest.param("/mnt/lium-xfs/lium-docker/\n", id="trailing_slash_dropped"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_repair_stale_vloopback_mountpoint_uses_the_hosts_docker_root(
+    docker_service, docker_info_stdout
+):
+    # DAH-3217 / ticket-0313: the provider's data-root is /mnt/lium-xfs/lium-docker; with the
+    # /var/lib/docker default, findmnt looked at a path that does not exist and rmdir failed
+    # with "No such file or directory" on every cycle. The bind-mount source and the findmnt
+    # target both follow `docker info`; the default appears in no command.
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _VLOOPBACK_REPAIR_INSPECT,
+            _VLOOPBACK_REPAIR_PLUGIN_ID,
+            _make_ssh_command_result(stdout=docker_info_stdout),
+            _make_ssh_command_result(exit_status=1),
+            _make_ssh_command_result(exit_status=0),
+        ]
+    )
+
+    repaired = await docker_service.repair_stale_vloopback_mountpoint(
+        ssh_client=ssh_client,
+        local_volume="volume_test",
+        default_extra={},
+    )
+
+    assert repaired is True
+    commands = _vloopback_repair_commands(ssh_client)
+    assert commands[3] == (
+        "/usr/bin/findmnt /mnt/lium-xfs/lium-docker/plugins/plugin123/propagated-mount/volume_test "
+        ">/dev/null 2>&1"
+    )
+    assert (
+        "-v /mnt/lium-xfs/lium-docker/plugins/plugin123/propagated-mount:/mnt "
+        "docker.io/library/alpine:3.19 rmdir /mnt/volume_test"
+    ) in commands[4]
+    assert not any("/var/lib/docker" in command for command in commands)
+
+
+@pytest.mark.parametrize(
+    "root_lookup",
+    [
+        pytest.param(
+            _make_ssh_command_result(exit_status=1, stdout=""), id="docker_info_fails_with_no_output"
+        ),
+        pytest.param(_make_ssh_command_result(stdout="overlay2\n"), id="docker_info_answers_with_no_path"),
+        pytest.param(_asyncssh_timeout_error(), id="docker_info_times_out"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_repair_stale_vloopback_mountpoint_falls_back_to_the_default_root_when_the_lookup_fails(
+    docker_service, caplog, root_lookup
+):
+    # a root the repair cannot read is not a reason to stop: the repair runs against the default
+    # root as it always did, and the fallback is logged with the cause rather than raised
+    ssh_client = AsyncMock()
+    ssh_client.run = AsyncMock(
+        side_effect=[
+            _VLOOPBACK_REPAIR_INSPECT,
+            _VLOOPBACK_REPAIR_PLUGIN_ID,
+            root_lookup,
+            _make_ssh_command_result(exit_status=1),
+            _make_ssh_command_result(exit_status=0),
+        ]
+    )
+
+    with caplog.at_level(logging.WARNING, logger="services.docker_service"):
+        repaired = await docker_service.repair_stale_vloopback_mountpoint(
+            ssh_client=ssh_client,
+            local_volume="volume_test",
+            default_extra={"executor_id": "executor-1"},
+        )
+
+    assert repaired is True
+    commands = _vloopback_repair_commands(ssh_client)
+    assert "/usr/bin/findmnt /var/lib/docker/plugins/plugin123/propagated-mount/volume_test" in commands[3]
+    assert "-v /var/lib/docker/plugins/plugin123/propagated-mount:/mnt" in commands[4]
+    fallback_extra = next(
+        record.msg.extra
+        for record in caplog.records
+        if str(record.msg) == "VLOOPBACK_REPAIR_DOCKER_ROOT_FALLBACK"
+    )
+    assert fallback_extra["fallback"] == "/var/lib/docker"
+    assert fallback_extra["executor_id"] == "executor-1"
+    assert fallback_extra["local_volume"] == "volume_test"
+    if isinstance(root_lookup, Exception):
+        # asyncssh's TimeoutError has an empty str(); the log still has to name the cause
+        assert fallback_extra["error"].startswith("TimeoutError")
+    else:
+        assert fallback_extra["error"] == "docker info returned no absolute path"
+
+
 @pytest.mark.asyncio
 async def test_repair_stale_vloopback_mountpoint_refuses_active_mount(docker_service):
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(
         side_effect=[
-            _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
-            _make_ssh_command_result(stdout="plugin123\n"),
+            _VLOOPBACK_REPAIR_INSPECT,
+            _VLOOPBACK_REPAIR_PLUGIN_ID,
+            _VLOOPBACK_REPAIR_DEFAULT_ROOT,
             _make_ssh_command_result(exit_status=0),
         ]
     )
@@ -4223,7 +4344,7 @@ async def test_repair_stale_vloopback_mountpoint_refuses_active_mount(docker_ser
     )
 
     assert repaired is False
-    assert ssh_client.run.await_count == 3
+    assert ssh_client.run.await_count == 4
 
 
 @pytest.mark.asyncio
@@ -4281,24 +4402,37 @@ async def test_repair_stale_vloopback_mountpoint_refuses_unexpected_mountpoint(d
 
 
 @pytest.mark.asyncio
-async def test_repair_stale_vloopback_mountpoint_refuses_non_empty_target(docker_service):
+async def test_repair_stale_vloopback_mountpoint_refuses_non_empty_target(docker_service, caplog):
     ssh_client = AsyncMock()
     ssh_client.run = AsyncMock(
         side_effect=[
-            _make_ssh_command_result(stdout="vloopback:latest /mnt/volume_test\n"),
-            _make_ssh_command_result(stdout="plugin123\n"),
+            _VLOOPBACK_REPAIR_INSPECT,
+            _VLOOPBACK_REPAIR_PLUGIN_ID,
+            _make_ssh_command_result(stdout="/mnt/lium-xfs/lium-docker\n"),
             _make_ssh_command_result(exit_status=1),
             _make_ssh_command_result(exit_status=12, stderr="not empty"),
         ]
     )
 
-    repaired = await docker_service.repair_stale_vloopback_mountpoint(
-        ssh_client=ssh_client,
-        local_volume="volume_test",
-        default_extra={},
-    )
+    with caplog.at_level(logging.WARNING, logger="services.docker_service"):
+        repaired = await docker_service.repair_stale_vloopback_mountpoint(
+            ssh_client=ssh_client,
+            local_volume="volume_test",
+            default_extra={},
+        )
 
     assert repaired is False
+    # the skipped-repair line names the path it tried, so the next wrong-root host is readable
+    # from the log alone
+    skipped_extra = next(
+        record.msg.extra
+        for record in caplog.records
+        if str(record.msg) == "VLOOPBACK_STALE_MOUNTPOINT_REPAIR_SKIPPED"
+    )
+    assert skipped_extra["target"] == (
+        "/mnt/lium-xfs/lium-docker/plugins/plugin123/propagated-mount/volume_test"
+    )
+    assert skipped_extra["stderr"] == "not empty"
 
 
 @pytest.mark.asyncio
@@ -5912,12 +6046,6 @@ _STALE_MOUNT_ERROR = (
     "error while mounting volume '': VolumeDriver.Mount: cannot create mount point dir "
     "'/mnt/volume_pod-1': mkdir /mnt/volume_pod-1: file exists"
 )
-
-
-def _asyncssh_timeout_error() -> asyncssh.TimeoutError:
-    # what ssh_client.run(timeout=...) raises: it subclasses both asyncssh.Error and OSError, so
-    # every caller that treats those two as "transport died" also swallows a plain command timeout.
-    return asyncssh.TimeoutError(None, None, None, None, None, None, "", "")
 
 
 def _recovery_ssh_client(

--- a/neurons/validators/tests/test_docker_service.py
+++ b/neurons/validators/tests/test_docker_service.py
@@ -4273,7 +4273,7 @@ async def test_repair_stale_vloopback_mountpoint_uses_the_hosts_docker_root(
 
 
 @pytest.mark.parametrize(
-    "root_lookup",
+    "docker_info_outcome",
     [
         pytest.param(
             _make_ssh_command_result(exit_status=1, stdout=""), id="docker_info_fails_with_no_output"
@@ -4284,7 +4284,7 @@ async def test_repair_stale_vloopback_mountpoint_uses_the_hosts_docker_root(
 )
 @pytest.mark.asyncio
 async def test_repair_stale_vloopback_mountpoint_falls_back_to_the_default_root_when_the_lookup_fails(
-    docker_service, caplog, root_lookup
+    docker_service, caplog, docker_info_outcome
 ):
     # a root the repair cannot read is not a reason to stop: the repair runs against the default
     # root as it always did, and the fallback is logged with the cause rather than raised
@@ -4293,7 +4293,7 @@ async def test_repair_stale_vloopback_mountpoint_falls_back_to_the_default_root_
         side_effect=[
             _VLOOPBACK_REPAIR_INSPECT,
             _VLOOPBACK_REPAIR_PLUGIN_ID,
-            root_lookup,
+            docker_info_outcome,
             _make_ssh_command_result(exit_status=1),
             _make_ssh_command_result(exit_status=0),
         ]
@@ -4318,7 +4318,7 @@ async def test_repair_stale_vloopback_mountpoint_falls_back_to_the_default_root_
     assert fallback_extra["fallback"] == "/var/lib/docker"
     assert fallback_extra["executor_id"] == "executor-1"
     assert fallback_extra["local_volume"] == "volume_test"
-    if isinstance(root_lookup, Exception):
+    if isinstance(docker_info_outcome, Exception):
         # asyncssh's TimeoutError has an empty str(); the log still has to name the cause
         assert fallback_extra["error"].startswith("TimeoutError")
     else:


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Fixes [DAH-3217](https://app.notion.com/p/Stale-vloopback-mount-repair-uses-the-host-s-real-Docker-data-root-not-var-lib-docker-3d5b8bfdbde98175a846d922660dae0c) · reviewer: @taiberium

**TL;DR** — The DAH-2306 stale-mountpoint repair hard-codes `/var/lib/docker`; on ticket-0313's host (data-root `/mnt/lium-xfs/lium-docker`) `rmdir` fails and POD_NOT_RUNNING fires every 15 min with the pod down. The repair now takes the data-root from `docker info` for both `findmnt` and the `rmdir` bind-mount; a failed lookup falls back to the default and logs why. Risk: repair path only.

**What changed**
- `repair_stale_vloopback_mountpoint` builds `<data-root>/plugins/<id>/propagated-mount/<volume>` from `docker info` (`neurons/validators/src/services/docker_service.py`)
- `_docker_root_dir_or_default`: a failed, empty or non-absolute lookup logs `VLOOPBACK_REPAIR_DOCKER_ROOT_FALLBACK`, uses `/var/lib/docker`, never raises (`docker_service.py`)
- the still-mounted / skipped / repaired events log the `target` path (`docker_service.py`)
- tests: default root, the `/mnt/lium-xfs/lium-docker` root (with and without a trailing slash), three lookup-failure fallbacks, the target in `REPAIR_SKIPPED` (`neurons/validators/tests/test_docker_service.py`)

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_docker_service.py -k repair_stale_vloopback_mountpoint -q` → 11 passed
- the same selection against `main`'s `docker_service.py` → 8 failed, 3 passed
- host with `data-root` moved and a stale vloopback mountpoint dir: `docker start` → `file exists`; after the repair → running

**Verified by the loop:** Gate: PASS 45f2dbb

**Ran it:** `repair_stale_vloopback_mountpoint("volume_d92d8482")` data-root `/mnt/lium-xfs/lium-docker` → main: `rmdir` fails, False; branch… · EC2 1s32 · … +1 under Details

**Self-review:** clean at 45f2dbb (15 checks, 1 low)

**Parts:** backend ✓ validator · migration n/a — no schema change · frontend n/a — validator only · CLI/SDK n/a — validator only · docs n/a — internal repair path · tests ✓ 11 · dashboards n/a — Loki on the new event

**Docs:** none needed because no renter- or provider-facing behaviour changes; the new log event is internal to the validator.

<details><summary>Details</summary>

### Origin
lium.io Discord ticket-0313 (provider 5EPGPs…, node a32f08dc, 7 Sep 17:03Z), LIUM_ISSUES B-125, DAH-3217. Loki validator 7 Sep 15:47:28Z → 8 Sep 07:42Z: 65 `POD_STALE_MOUNT_RECOVERY_REPAIR_FAILED` cycles, each preceded by `VLOOPBACK_STALE_MOUNTPOINT_REPAIR_SKIPPED` with stderr `rmdir: '/mnt/volume_d92d8482-…': No such file or directory`. Prod DB: penalty_events 15:47:29Z `EXECUTOR_INACTIVE_MID_RENTAL` $31.87 credited to the renter; executor active=false since; billing $0 since 15:45Z.

### Why the old path failed
`docker run -v <host-dir>:/mnt` creates a missing `<host-dir>` on the host. With the root wrong, the bind source `/var/lib/docker/plugins/<id>/propagated-mount` was created empty, `rmdir /mnt/<volume>` had nothing to remove, and the stale directory under the real root stayed. `findmnt` on the wrong path exits 1 ("not mounted"), which the code reads as "safe to proceed", so nothing in the old sequence could tell the two hosts apart. The Ran-it run below shows the phantom `/var/lib/docker/plugins/<id>/propagated-mount` left behind by main's code.

### Design notes
- The root comes from `get_docker_root_dir` (`docker info --format '{{.DockerRootDir}}'` over the same SSH session), which `create_local_volume` and the volume-sizing paths already use; the repair reads it once, after the cheap driver / mountpoint / plugin-id checks, so a non-vloopback candidate volume costs no extra command.
- Fallback rather than raise. The repair is reached from two places: the recovery cycle (`rented_machine.py` catches a non-transport exception, logs `POD_STALE_MOUNT_RECOVERY_FAILED` and keeps POD_NOT_RUNNING) and the create-with-retry paths (`_run_docker_create_with_port_retry`, `_run_rental_docker_create_with_port_retry`), where a raised lookup error would replace the original `docker run` failure and log no repair event. So a root the repair cannot read is logged — `VLOOPBACK_REPAIR_DOCKER_ROOT_FALLBACK` with `docker_root_dir`, `fallback`, `error` (the exception type when its text is empty, as asyncssh's `TimeoutError` is) — and the repair proceeds against `/var/lib/docker`: right on a default-root host, today's behaviour on a moved-root host, now with the target path in `REPAIR_SKIPPED`.
- `docker plugin inspect --format '{{.Config.PropagatedMount}}'` was considered and not used: it returns the path inside the plugin's rootfs (`/mnt`), not the host directory.
- `/var/lib/docker` appears in no command string of this module any more (`_DEFAULT_DOCKER_ROOT_DIR`). `services/container_cleanup.py:286` and `miner_jobs/machine_scrape.py:854` read the same `docker info` field with their own literal fallback; they already use the real root, so nothing to fix there.

### Ran it
Sandbox EC2 `aws_run 20260908T085351Z-1s32` (c6i.2xlarge, AL2023, Docker 25.0.14; `RECOVERY/aws_run/20260908T085351Z-1s32/out/live_repair.log`). dockerd's `data-root` moved to `/mnt/lium-xfs/lium-docker`; `ashald/docker-volume-loopback` installed as `vloopback` with `DATA_DIR=<root>/loopback` as `create_local_volume` does; a 1 GB sparse volume `volume_d92d8482` mounted at `/root` of `pod_d92d8482`, a file written; the container stopped and the mountpoint directory recreated empty (the reboot leftover). The function under test is the real `DockerService.repair_stale_vloopback_mountpoint`; the `ssh_client` is a shim that runs the same command strings on the box.

```
-- docker start (what dockerd's unless-stopped restart does after the reboot):
Error response from daemon: error while mounting volume '/mnt/volume_d92d8482': VolumeDriver.Mount: …: cannot create mount point dir '/mnt/volume_d92d8482': mkdir /mnt/volume_d92d8482: file exists

== 4. negative control — main's repair (hard-coded /var/lib/docker)
$ /usr/bin/findmnt /var/lib/docker/plugins/8b5dde93…/propagated-mount/volume_d92d8482 >/dev/null 2>&1        exit 1
$ /usr/bin/docker run --rm -v /var/lib/docker/plugins/8b5dde93…/propagated-mount:/mnt docker.io/library/alpine:3.19 rmdir /mnt/volume_d92d8482
  exit 1 stderr="rmdir: '/mnt/volume_d92d8482': No such file or directory"
WARNING VLOOPBACK_STALE_MOUNTPOINT_REPAIR_SKIPPED {"local_volume": "volume_d92d8482", "exit_status": 1, "stderr": "rmdir: …: No such file or directory"}
REPAIRED=False
stale dir still there: /mnt/lium-xfs/lium-docker/plugins/8b5dde93…/propagated-mount/volume_d92d8482
-- what main's rmdir created on the host: /var/lib/docker/plugins/8b5dde93…/propagated-mount (empty)

== 5. the branch's repair, same host, same stale dir
$ /usr/bin/docker info --format '{{.DockerRootDir}}'                                                            exit 0 stdout='/mnt/lium-xfs/lium-docker'
$ /usr/bin/findmnt /mnt/lium-xfs/lium-docker/plugins/8b5dde93…/propagated-mount/volume_d92d8482 >/dev/null 2>&1   exit 1
$ /usr/bin/docker run --rm -v /mnt/lium-xfs/lium-docker/plugins/8b5dde93…/propagated-mount:/mnt docker.io/library/alpine:3.19 rmdir /mnt/volume_d92d8482
  exit 0
INFO VLOOPBACK_STALE_MOUNTPOINT_REPAIRED {"local_volume": "volume_d92d8482", "target": "/mnt/lium-xfs/lium-docker/plugins/8b5dde93…/propagated-mount/volume_d92d8482"}
REPAIRED=True
== 6. dockerd can start the pod again
docker start → exit 0 · State.Status=running State.Error= · docker exec pod_d92d8482 cat /root/keep.txt → renter-data

== 7. fallback: /usr/bin/docker shimmed so `docker info` exits 1
WARNING VLOOPBACK_REPAIR_DOCKER_ROOT_FALLBACK {"local_volume": "volume_d92d8482", "docker_root_dir": "", "fallback": "/var/lib/docker", "error": "docker info returned no absolute path"}
WARNING VLOOPBACK_STALE_MOUNTPOINT_REPAIR_SKIPPED {"target": "/var/lib/docker/plugins/8b5dde93…/propagated-mount/volume_d92d8482", "exit_status": 1, "stderr": "rmdir: …: No such file or directory"}
REPAIRED=False   (returned, not raised)
```

CI suite, same box (`RECOVERY/aws_run/20260908T085351Z-1s32/out/`), the `test.yml` validators command (`pytest tests/ --tb=short --strict-markers` with the CI env, Python 3.11.11, pdm):

| tree | result |
|---|---|
| `main` be00fda1 | 2 failed, 1997 passed, 15 skipped (`test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices`, `test_sshd_bootstrap_script.py::test_adopt_path_hardens_config_for_key_only_auth` — main's own) |
| this branch at the earlier head (and at ea22c7c, EC2 1pv6) | 2 failed, 2002 passed, 15 skipped — the same two; 0 failures beyond main's |
| `-k "repair_stale_vloopback_mountpoint or stale_vloopback or recover_pod"` on the branch | 38 passed |
| negative control: the branch's `test_docker_service.py` against main's `docker_service.py`, `-k repair_stale_vloopback_mountpoint` | 8 failed, 3 passed (`uses_rmdir_helper`, `uses_the_hosts_docker_root[2]`, `falls_back…[3]`, `refuses_active_mount`, `refuses_non_empty_target` fail on main) |
| `ruff format --check` / `ruff check --select F,ASYNC210,ASYNC251` on the two files | same result as main (2 files would be reformatted; 6 pre-existing F401/F841 findings, none on a changed line; lium-io#1316 removed them on main) |

Not exercised: the `#1312` e2e stack — its executors run Docker with the default data-root and no vloopback plugin, so the repair path is not reachable there; the live run above is the exercise.

### Cross-PR
Open loop PRs that also edit `docker_service.py`: #1265 (arhangel66, DAH-2780), #1279, #1295, #1300, #1302, #1316, #1321 — none touches `repair_stale_vloopback_mountpoint`, `get_docker_root_dir` or lines 1184–1300; `git diff` of each against its merge-base has no hunk in that range. #1316 (dead-code sweep) is on main since 9 Sep; its hunks in `test_docker_service.py` do not overlap this PR's.

### Meanwhile, for ticket-0313 (manual, the team)
The provider `rmdir`s the stale dir under `/mnt/lium-xfs/lium-docker/plugins/<id>/propagated-mount/` after `findmnt` shows it unmounted, then the pod is rebooted from the backend so the encrypted volume is remounted (a manual `docker start` reproduces B-71). With this PR deployed the validator does that step itself on the next cycle.

### Self-review

Verdict `findings` at `45f2dbb` · 15 checks · by subagent-fresh-r59i · 2026-09-10 10:14Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | CODE-QUALITY | `neurons/validators/src/services/docker_service.py:1277` | Property: the comment describes the exceptions the clause catches accurately; it files asyncssh.TimeoutError under 'a dead SSH transport (asyncssh's connection and timeout errors)', but a 30 s `docker info` timeout is a hung dockerd on a live connection — this module says so itself (`except TimeoutError` at docker_service.py:5659, 'a command that did not finish in time is not a dead SSH transport'; test helper test_docker_service.py:4181) — so for that case the fallback event does describe a failed `docker info`, and the following `findmnt` need not fail on the same connection (a later `docker run` timeout surfaces as POD_STALE_MOUNT_RECOVERY_TIMED_OUT, not a transport event). | Split the parenthetical: 'a dead SSH transport (asyncssh.ConnectionLost / ChannelOpenError / OSError — the commands that follow then raise on the same connection and the caller logs EXECUTOR_TRANSPORT_UNREACHABLE or the create failure) and a `docker info` that ran past _VLOOPBACK_REPAIR_COMMAND_TIMEOUT_SEC (asyncssh.TimeoutError, empty str(), a slow dockerd — the repair then proceeds against the default root)'. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/src/services/docker_service.py:224` `_DEFAULT_DOCKER_ROOT_DIR` is a string constant used as the fallback data-root prefix; the only bind-mount is `<root>/plugins/<id>/propagated-mount` at line 1244, the plugin's own directory that main already mounted with the hard-coded prefix — no new host path reaches a container. · `neurons/validators/tests/test_docker_service.py:4272` The line is `assert not any("/var/lib/docker" in command for command in commands)` — a negative assertion on recorded command strings; nothing is mounted. · `neurons/validators/tests/test_docker_service.py:4318` The line is `assert fallback_extra["fallback"] == "/var/lib/docker"` — a log-field assertion on the FALLBACK event; nothing is mounted. · `neurons/validators/src/services/docker_service.py:1279` 'the repair commands that follow fail on the same connection with their own events' holds for the dead-transport case: `findmnt` at line 1225 raises ConnectionLost/ChannelOpenError/OSError uncaught inside repair_stale_vloopback_mountpoint, the recovery caller re-raises (rented_machine.py:435) and rented_machine.py:310 logs EXECUTOR_TRANSPORT_UNREACHABLE; the create paths (lines 828, 897) let it propagate to create_container's failure logging. · `neurons/validators/tests/test_docker_service.py:4276` Rename is complete: `root_lookup` appears nowhere in the worktree; `docker_info_outcome` at 4276 (parametrize name), 4287 (argument), 4296, 4321; the three ids and every other line of the commit's test hunks are context-only, and `git show 45f2dbb --stat` is +4/-1 in the comment and 4 one-word swaps in the test. · `review-wave/readability/overrides/lium-io-1326.json:1` Body counts hold at 45f2dbb: `-k repair_stale_vloopback_mountpoint` selects 8 functions = 11 items (2 + 3 parametrized); 1997 on main + 5 new items = 2002 on the branch; the two gjrw failures (test_scrape_infiniband.py chmod-000 tree, test_sshd_bootstrap_script.py) are in files this 2-file PR does not touch and fail identically on main be00fda on the same root-run box, so 'the same two, 0 failures beyond main's' is an honest statement provided the Verified line is re-rendered to gjrw @ 45f2dbb; the `ea22c7c`/`1pv6` mentions in Verified-by-the-loop and Self-review are tool-written and refreshed by --record.

### Verified

Gate: PASS (45f2dbb) on EC2 sandbox Linux x86_64 (aws_run gate-own)

</details>
