### PR TITLE
DAH-3135 - bump lium-core to 0.1.11

### DIFF
--- a/packages/lium-core/pyproject.toml
+++ b/packages/lium-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lium-core"
-version = "0.1.10"
+version = "0.1.11"
 description = "Shared core library for Lium platform"
 requires-python = ">=3.11"
 dependencies = [


### PR DESCRIPTION
PyPI already holds `lium-core` 0.1.10, and `packages/lium-core/pyproject.toml` still declares 0.1.10. The release workflow builds the version from that file, so the first release run from lium-io would upload a duplicate and fail. This bumps the version to 0.1.11.

Order after this merges:
1. Re-point the PyPI trusted publisher of `lium-core` to `Datura-ai/lium-io`, workflow `lium-core-release.yml`, environment `release`.
2. Create the `release` environment in this repository.
3. Run `lium-core-release.yml`.

Follow-up, not in this PR: the workflow accepts a `version` input and never reads it. The input came over unchanged from `Datura-ai/lium-core`. It must either set the version or be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)