### PR TITLE
DAH-3236 - [P1] executor image: pin base digest, PerSourcePenalties off

### DIFF
--- a/neurons/executor/Dockerfile
+++ b/neurons/executor/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.11-slim
+# python:3.11-slim as published on 8 Sep 2026 (= 3.11-slim-trixie: Debian 13, OpenSSH 10.0), pinned by
+# digest. The bare tag moved from Debian 12 to Debian 13 on its own and changed sshd's defaults under
+# every executor (DAH-3236); a base bump is now a deliberate edit of this line, checked by sshd_setup.sh.
+FROM python:3.11-slim@sha256:9534e5a8e315485d4061ed659af0fd78a284c015f9b73661b41d6bab25604534
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV ENV=prod
@@ -100,5 +103,9 @@ RUN useradd -m -s /bin/bash liumuser && \
 
 RUN echo 'AcceptEnv CONTAINER_NAME' >>/etc/ssh/sshd_config && \
     printf 'Match User liumuser\n    ForceCommand bash -c '"'"'[ -n "$CONTAINER_NAME" ] && exec docker exec -it "$CONTAINER_NAME" bash || { echo "CONTAINER_NAME not set"; exit 1; }'"'"'\n' >>/etc/ssh/sshd_config
+
+# PerSourcePenalties off via /etc/ssh/sshd_config.d/lium.conf when this sshd knows the directive,
+# then `sshd -T` must accept the whole rendered config or the build fails (sshd_setup.sh says why).
+RUN sh sshd_setup.sh
 
 CMD ["bash", "run.sh"]

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -183,3 +183,7 @@ The above command should show the `nvidia-smi` result if sysbox is installed cor
 ```shell
 sudo systemctl restart docker
 ```
+
+## The executor image
+
+`Dockerfile` starts from `python:3.11-slim` pinned by digest; the comment above the `FROM` line names the tag and the date the digest was taken. To move to a newer base, resolve the tag (`docker buildx imagetools inspect python:3.11-slim`), put the new digest on that line and rebuild. The build ends with `sshd_setup.sh`: it turns sshd's `PerSourcePenalties` off through `/etc/ssh/sshd_config.d/lium.conf` when the base's OpenSSH knows the directive (9.8 and later), and fails the build when `sshd -T` rejects the rendered configuration.

--- a/neurons/executor/sshd_setup.sh
+++ b/neurons/executor/sshd_setup.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Build-time sshd configuration of the executor image (run by the Dockerfile after the
+# executor's own sshd_config lines are appended).
+#
+# OpenSSH 9.8+ enables PerSourcePenalties: a source address whose connections keep failing
+# authentication is refused for a while ("Not allowed at this time", or the connection is
+# closed during the handshake). On an executor whose port 2200 collapses every client into
+# one source address — a CVM behind QEMU slirp (every connection arrives from 10.0.2.2), a
+# Docker userland-proxy host — scanner noise fills that one bucket and the validator is
+# locked out; after a silent hour the backend fires EXECUTOR_INACTIVE_MID_RENTAL
+# (DAH-3236, ticket-0287, ticket-0302).
+#
+# The directive is unknown to OpenSSH < 9.8, where sshd refuses to start on it, so it is
+# written only when this sshd accepts it. It goes into a drop-in that sshd_config's
+# `Include /etc/ssh/sshd_config.d/*.conf` reads ahead of the `Match User liumuser` block
+# (a line appended after that block would become part of the Match).
+#
+# Whatever the sshd version, the last step is `sshd -T` over the rendered config: the image
+# build fails on any directive sshd would refuse at container start.
+set -eu
+
+SSHD_CONFIG="${SSHD_CONFIG:-/etc/ssh/sshd_config}"
+SSHD_CONFIG_DIR="${SSHD_CONFIG_DIR:-/etc/ssh/sshd_config.d}"
+SSHD_PRIVSEP_DIR="${SSHD_PRIVSEP_DIR:-/run/sshd}"
+DROP_IN="$SSHD_CONFIG_DIR/lium.conf"
+
+# The image ships no host keys (run.sh generates them at start) and `sshd -T` exits
+# without one, so the checks use a throwaway key. OpenSSH < 9.8's `sshd -T` also wants
+# the privilege-separation directory the init script creates at start.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+ssh-keygen -q -t ed25519 -N '' -f "$tmp/hostkey"
+mkdir -p "$SSHD_PRIVSEP_DIR"
+sshd_test() { sshd -T -f "$SSHD_CONFIG" -h "$tmp/hostkey" "$@"; }
+sshd_version="$(ssh -V 2>&1 | head -n 1)"
+
+# Does this sshd know the directive? Only "Bad configuration option: PerSourcePenalties"
+# means no; any other failure is a broken config and fails the build here.
+if probe="$(sshd_test -o PerSourcePenalties=no 2>&1 >/dev/null)"; then
+    supported=yes
+elif printf '%s\n' "$probe" | grep -q 'Bad configuration option: PerSourcePenalties'; then
+    supported=no
+else
+    echo "sshd_setup: sshd -T failed: $probe" >&2
+    exit 1
+fi
+
+mkdir -p "$SSHD_CONFIG_DIR"
+if [ "$supported" = yes ]; then
+    printf '# written by sshd_setup.sh at image build (DAH-3236); that script says why\nPerSourcePenalties no\n' >"$DROP_IN"
+    if ! sshd_test | grep -qx 'persourcepenalties no'; then
+        echo "sshd_setup: $DROP_IN is not in effect; does $SSHD_CONFIG include $SSHD_CONFIG_DIR/*.conf?" >&2
+        exit 1
+    fi
+    echo "sshd_setup: PerSourcePenalties no ($sshd_version)"
+else
+    rm -f "$DROP_IN"
+    echo "sshd_setup: this sshd predates PerSourcePenalties, nothing to turn off ($sshd_version)"
+fi
+
+sshd_test >/dev/null
+echo "sshd_setup: sshd -T accepts $SSHD_CONFIG"

--- a/neurons/executor/tests/test_sshd_setup.py
+++ b/neurons/executor/tests/test_sshd_setup.py
@@ -1,0 +1,121 @@
+"""The executor image's sshd drop-in (DAH-3236).
+
+``sshd_setup.sh`` runs at image build. With an sshd that knows ``PerSourcePenalties``
+(OpenSSH 9.8+) it renders ``sshd_config.d/lium.conf`` with the directive off and proves
+through ``sshd -T`` that the drop-in is in effect; with an older sshd it writes nothing,
+so that sshd still starts; either way it fails the build when ``sshd -T`` rejects the
+rendered config, and when it rejects it for any other reason. The tests drive the script
+with stand-in ``sshd`` binaries on PATH; the real OpenSSH 10.0 and 9.2 runs are in the
+PR's Ran-it section.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+EXECUTOR_DIR = Path(__file__).resolve().parents[1]
+SCRIPT = EXECUTOR_DIR / "sshd_setup.sh"
+DOCKERFILE = EXECUTOR_DIR / "Dockerfile"
+
+# sshd -T stand-ins. OpenSSH 10's dump line for the directive follows the drop-in when the
+# main config includes sshd_config.d/*.conf; OpenSSH 9.2 rejects the keyword outright.
+SSHD_MODERN = """#!/bin/sh
+case " $* " in *" PerSourcePenalties="*) exit 0;; esac
+echo "port 22"
+if grep -qi '^PerSourcePenalties no' "$SSHD_CONFIG_DIR"/*.conf 2>/dev/null; then
+    echo "persourcepenalties no"
+else
+    echo "persourcepenalties crash:90 authfail:5 noauth:1 grace-exceeded:20 max:600 min:15"
+fi
+"""
+SSHD_MODERN_WITHOUT_INCLUDE = """#!/bin/sh
+case " $* " in *" PerSourcePenalties="*) exit 0;; esac
+echo "port 22"
+echo "persourcepenalties crash:90 authfail:5 noauth:1 grace-exceeded:20 max:600 min:15"
+"""
+SSHD_OLD = """#!/bin/sh
+case " $* " in *" PerSourcePenalties="*)
+    echo "command-line line 0: Bad configuration option: PerSourcePenalties" >&2
+    exit 255;;
+esac
+echo "port 22"
+"""
+SSHD_BROKEN_CONFIG = """#!/bin/sh
+echo "/etc/ssh/sshd_config line 7: Bad configuration option: AcceptEnvv" >&2
+exit 255
+"""
+
+pytestmark = pytest.mark.skipif(shutil.which("ssh-keygen") is None, reason="sshd_setup.sh needs ssh-keygen")
+
+
+def run_setup(tmp_path: Path, sshd_script: str) -> tuple[subprocess.CompletedProcess, Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    sshd = bin_dir / "sshd"
+    sshd.write_text(sshd_script)
+    sshd.chmod(0o755)
+    config_dir = tmp_path / "sshd_config.d"
+    config = tmp_path / "sshd_config"
+    config.write_text(f"Include {config_dir}/*.conf\nPort 22\n")
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+        "SSHD_CONFIG": str(config),
+        "SSHD_CONFIG_DIR": str(config_dir),
+        "SSHD_PRIVSEP_DIR": str(tmp_path / "run" / "sshd"),
+    }
+    result = subprocess.run(["sh", str(SCRIPT)], env=env, capture_output=True, text=True, timeout=30)
+    return result, config_dir / "lium.conf"
+
+
+def test_modern_sshd_gets_per_source_penalties_off(tmp_path):
+    result, drop_in = run_setup(tmp_path, SSHD_MODERN)
+
+    assert result.returncode == 0, result.stderr
+    assert "PerSourcePenalties no" in drop_in.read_text().splitlines()
+    assert "sshd_setup: PerSourcePenalties no" in result.stdout
+    assert "sshd_setup: sshd -T accepts" in result.stdout
+
+
+def test_old_sshd_gets_no_drop_in_and_still_passes(tmp_path):
+    # a stale drop-in from an earlier layer must go too, or sshd would refuse to start on it
+    (tmp_path / "sshd_config.d").mkdir()
+    (tmp_path / "sshd_config.d" / "lium.conf").write_text("PerSourcePenalties no\n")
+
+    result, drop_in = run_setup(tmp_path, SSHD_OLD)
+
+    assert result.returncode == 0, result.stderr
+    assert not drop_in.exists()
+    assert "predates PerSourcePenalties" in result.stdout
+    assert "sshd_setup: sshd -T accepts" in result.stdout
+
+
+def test_drop_in_that_sshd_does_not_read_fails_the_build(tmp_path):
+    result, drop_in = run_setup(tmp_path, SSHD_MODERN_WITHOUT_INCLUDE)
+
+    assert result.returncode == 1
+    assert drop_in.exists()
+    assert "is not in effect" in result.stderr
+
+
+def test_config_sshd_rejects_for_another_reason_fails_the_build(tmp_path):
+    result, drop_in = run_setup(tmp_path, SSHD_BROKEN_CONFIG)
+
+    assert result.returncode == 1
+    assert not drop_in.exists()
+    assert "sshd -T failed: /etc/ssh/sshd_config line 7: Bad configuration option: AcceptEnvv" in result.stderr
+
+
+def test_dockerfile_pins_the_base_by_digest_and_runs_the_setup():
+    lines = DOCKERFILE.read_text().splitlines()
+    from_lines = [line for line in lines if line.startswith("FROM ")]
+
+    assert len(from_lines) == 1
+    assert re.fullmatch(r"FROM python:3\.11-slim@sha256:[0-9a-f]{64}", from_lines[0])
+    # the setup checks the executor's own sshd_config lines too, so it runs after they are appended
+    accept_env = next(i for i, line in enumerate(lines) if line.startswith("RUN echo 'AcceptEnv CONTAINER_NAME'"))
+    assert lines.index("RUN sh sshd_setup.sh") > accept_env


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3236](https://app.notion.com/p/Executor-image-pin-base-digest-PerSourcePenalties-off-validator-lockouts-behind-NAT-B-126-3d5b8bfdbde9817a91ceffcacbb579a2) · reviewer: @arhangel66

**TL;DR** — The executor image's unpinned `python:3.11-slim` drifted to Debian 13, whose OpenSSH 10 refuses a source address after a few failed logins (`PerSourcePenalties`); behind QEMU slirp or a Docker userland proxy every client is one address, so scanner noise locks the validator out and `EXECUTOR_INACTIVE_MID_RENTAL` follows (ticket-0302, $78.40). Fix: base pinned by digest, `PerSourcePenalties no`, `sshd -T` asserted.

**What changed**
- `FROM python:3.11-slim@sha256:9534e5a8…` — the tag's digest on 8 Sep 2026 (Debian 13 / OpenSSH 10.0), tag and date in a comment (`neurons/executor/Dockerfile`)
- `sshd_setup.sh` writes `sshd_config.d/lium.conf` = `PerSourcePenalties no` when `sshd -T -o PerSourcePenalties=no` is accepted; older sshd: no drop-in (`neurons/executor/sshd_setup.sh`)
- then `sshd -T` over the rendered config: a rejected directive, or a drop-in not reported back, fails the build (`neurons/executor/Dockerfile`)
- tests: modern sshd → drop-in; old → none; unread drop-in fails; rejected config fails; `FROM` pinned (`neurons/executor/tests/test_sshd_setup.py`)
- README: bumping the digest, `sshd_setup.sh` (`neurons/executor/README.md`)

**How to verify**
- `cd neurons/executor && pdm run pytest tests/test_sshd_setup.py -q` → 5 passed; on `main` → 5 failed
- `TAG=x bash docker_build.sh` → last RUN prints `sshd_setup: PerSourcePenalties no (OpenSSH_10.0p2 …)`, `sshd -T accepts`
- 30 bad-key logins from one address, then the good key → `main` image: refused; this one: `CONNECTED`
- `sh sshd_setup.sh` in `python:3.11-slim-bookworm` + openssh-server 9.2 → `predates PerSourcePenalties`, sshd starts

**Verified by the loop:** Gate: PASS c1faa12

**Ran it:** 30 bad-key logins + the good key from one address → `main` image: dropped after 4 (`penalty: failed authentication`), good key refused; this image: `CONNECTED` · OpenSSH 9.2: no drop-in, sshd starts · suite 137 passed (EC2)

**Self-review:** clean at c1faa12 (18 checks, 1 low)

**Parts:** backend ✓ executor image · migration n/a — no schema · frontend n/a — image only · CLI/SDK n/a — image only · docs ✓ lium-docs#246 · tests ✓ 5 · dashboards n/a — no metric

**Docs:** `neurons/executor/README.md` — new section "The executor image"; lium-docs#246 — troubleshooting row.

<details><summary>Details</summary>

### Origin
LIUM_ISSUES B-126; lium.io Discord ticket-0287 (22 Aug: the provider's root-cause — a CVM behind QEMU slirp sees every inbound connection from 10.0.2.2, scanner noise fills the one penalty bucket, the validator gets `Not allowed at this time` / `Connection lost`; Mikhail: "we'll pin the base image", "shipping your exact suggestion" — neither is on `main`) and ticket-0302 (8 Sep: the ticket's node, `asyncssh ConnectionLost` in the handshake on 11 of 12 validator cycles 01:16–03:53Z while the HTTP `/ping` never failed; the hourly sweep set the executor inactive, `EXECUTOR_INACTIVE_MID_RENTAL` withheld $78.40, reverted by hand today). Team backlog row: DAH-3218 (Rustam). Backstop while images roll: lium-platform#91 (B-69, two-signal penalty).

### Why the executor is exposed
`main`'s image today is Debian 13 with `OpenSSH_10.0p2 Debian-7+deb13u4`; its `sshd -T` reports `persourcepenalties crash:90 authfail:5 noauth:1 grace-exceeded:10 refuseconnection:10 max:600 min:15 …`. Each connection that fails authentication adds 5 s to its source address; once the total reaches 15 s the address is dropped before the banner (`drop connection #0 from [addr] … penalty: failed authentication`), for the accumulated time up to 600 s. Nothing in the image exempts anyone (`PerSourcePenaltyExemptList` unset). On a host where port 2200 is reached through QEMU slirp (10.0.2.2) or Docker's userland proxy (the bridge gateway), sshd sees one address for the validator, every renter and every scanner, so four failed logins by anyone refuse the validator. The backend's 5-minute HTTP `/ping` does not go through sshd, which is why the backend saw a healthy executor while the validator could not connect (ticket-0302).

### Design notes
- **Digest, same content.** `docker buildx imagetools inspect python:3.11-slim` on the box: `Digest: sha256:9534e5a8e315485d4061ed659af0fd78a284c015f9b73661b41d6bab25604534` — the digest on the `FROM` line, so this PR changes nothing about what the base is, only that it stops moving. The digest is the multi-arch index digest, so `docker_build.sh` resolves it as before. `Dockerfile.runner` (`FROM docker:26-cli`, the compose wrapper without an sshd) is left as it is; it is a separate image and a separate decision.
- **A drop-in, not an appended line.** Debian's `sshd_config` starts with `Include /etc/ssh/sshd_config.d/*.conf`; the Dockerfile's `printf … >>/etc/ssh/sshd_config` ends the file with `Match User liumuser`, so a line appended after it would belong to that Match block (and `PerSourcePenalties` is not a Match keyword). `lium.conf` is read at the top, before the Match.
- **Probe the directive, not the version.** `sshd -T -o PerSourcePenalties=no` succeeds where the keyword exists; only `Bad configuration option: PerSourcePenalties` means "too old" and takes the no-write path; any other failure is printed and fails the build at once. Version parsing (`ssh -V`) would have needed a table of distro backports.
- **`sshd -T` needs a host key and, on OpenSSH < 9.8, `/run/sshd`.** The image removes host keys at build (run.sh regenerates them at start), so the checks use a throwaway ed25519 key via `-h`; `$SSHD_PRIVSEP_DIR` (default `/run/sshd`) is created before the checks (the init script creates it at start anyway). Without the latter, 9.2's `sshd -T` exits `Missing privilege separation directory` — an earlier EC2 run found this (aws_run 20260908T214043Z-1tyw); the run below is with the fix. The directory, like the config paths, is overridable (`SSHD_PRIVSEP_DIR`) so the tests stay inside `tmp_path`.
- **Not an exempt list.** `PerSourcePenaltyExemptList 10.0.2.2` (Mikhail's 22 Aug plan) covers slirp only; the userland-proxy gateway differs per host and the validator's own address is not knowable at build. Turning penalties off returns the image to the OpenSSH 9.2 behaviour every executor ran until the tag drifted. Everything else in the image's sshd config is unchanged.
- **Rollout.** The change ships with the next `executor-v*` tag through `executor_cd_prod.yml`; the image digest changes, so the CVM measured config / expected-digest side is the team's step (B-126 row), not this PR.

### Ran it
Sandbox EC2 `aws_run 20260908T220741Z-jox1` (c6i.2xlarge, AL2023, Docker 25.0.14, buildx v0.37.0; `RECOVERY/aws_run/20260908T220741Z-jox1/out/`, job `RECOVERY/b126/lockout_proof.sh`). `main` = b05764a7; branch = this commit's patch applied on it — the box's `git rev-parse HEAD^{tree}` equals the pushed commit's tree, so what ran is what was pushed. Both images built with `TAG=<label> bash docker_build.sh` (main 89 s, branch 50 s on the shared cache).

```
$ docker buildx imagetools inspect python:3.11-slim
Digest:    sha256:9534e5a8e315485d4061ed659af0fd78a284c015f9b73661b41d6bab25604534     # == the FROM line → DIGEST MATCH

-- build-branch.log, the last RUN
#23 [stage-0 17/17] RUN sh sshd_setup.sh
#23 0.531 sshd_setup: PerSourcePenalties no (OpenSSH_10.0p2 Debian-7+deb13u4, OpenSSL 3.5.7 9 Jun 2026)
#23 0.534 sshd_setup: sshd -T accepts /etc/ssh/sshd_config
```

Lockout test, per image: `docker run -p 127.0.0.1:<port>:22 <image> sh -c 'ssh-keygen -A && mkdir -p /run/sshd && exec /usr/sbin/sshd -D -e'` (the image's sshd as `run.sh` starts it, logging to stderr), the good key put in `/root/.ssh/authorized_keys`, then from the box (client OpenSSH_9.9p1; every connection reaches the container from the one Docker bridge address, the userland-proxy case; bridge addresses below rewritten to TEST-NET 203.0.113.x) 30× `ssh -i bad -o BatchMode=yes … root@127.0.0.1 true`, then once with the good key. Excerpt, identical lines elided with `…`:

```
== lockout test: main on 127.0.0.1:2201          (control — main's image, unpinned FROM, no drop-in)
# lium.conf: (absent)
# sshd -T: persourcepenalties crash:90 authfail:5 noauth:1 grace-exceeded:10 refuseconnection:10 max:600 min:15 max-sources4:65536 max-sources6:65536 overflow:permissive overflow6:permissive
bad key #01 rc=255 root@127.0.0.1: Permission denied (publickey,password).
bad key #02 rc=255 root@127.0.0.1: Permission denied (publickey,password).
bad key #03 rc=255 root@127.0.0.1: Permission denied (publickey,password).
bad key #04 rc=255 root@127.0.0.1: Permission denied (publickey,password).
bad key #05 rc=255                                  ← dropped before the banner, no message
…
bad key #30 rc=255
elapsed for 30 bad-key attempts: 0.5s
GOOD KEY rc=255                                     ← the validator's case: a valid key, refused
# sshd log:
  drop connection #0 from [203.0.113.1]:60148 on [203.0.113.2]:22 penalty: failed authentication
  … (one per attempt from #05 on, the good key included)

== lockout test: branch on 127.0.0.1:2202        (this PR's image)
# /etc/ssh/sshd_config.d/: lium.conf
# lium.conf: PerSourcePenalties no
# sshd -T: persourcepenalties no
bad key #01 rc=255 root@127.0.0.1: Permission denied (publickey,password).
…
bad key #30 rc=255 root@127.0.0.1: Permission denied (publickey,password).
elapsed for 30 bad-key attempts: 2.5s
GOOD KEY rc=0 CONNECTED as root on <container id>
# sshd log:
  Connection closed by authenticating user root 203.0.113.1 port 42590 [preauth]
  Accepted publickey for root from 203.0.113.1 port 42594 ssh2: ED25519 SHA256:ZykPiE0k…
```

The older-sshd path — the same `sshd_setup.sh` inside `python:3.11-slim-bookworm` with `openssh-server` installed:

```
Debian GNU/Linux 12 (bookworm) · OpenSSH_9.2p1 Debian-2+deb12u10, OpenSSL 3.0.20 7 Apr 2026
-- sshd_setup.sh:
sshd_setup: this sshd predates PerSourcePenalties, nothing to turn off (OpenSSH_9.2p1 Debian-2+deb12u10, OpenSSL 3.0.20 7 Apr 2026)
sshd_setup: sshd -T accepts /etc/ssh/sshd_config
exit 0
-- drop-in dir: (empty means none written)
-- sshd starts: Starting OpenBSD Secure Shell server: sshd. · 1 sshd process(es)
-- why the guard: the directive written unconditionally on this sshd
sshd -t exit 255
/etc/ssh/sshd_config.d/unguarded.conf: line 1: Bad configuration option: PerSourcePenalties
/etc/ssh/sshd_config.d/unguarded.conf: terminating, 1 bad configuration options
```

Tests, same box — `test.yml`'s `pytest tests/` for the executor, run with the branch image's venv (Python 3.11, the pinned `pdm.lock`) on the branch checkout:

| tree | result |
|---|---|
| this branch, `neurons/executor/tests/` | 137 passed (18 deprecation warnings from dependencies) |
| `test_sshd_setup.py` on `main`'s tree (control: no `sshd_setup.sh`, unpinned `FROM`) | 5 failed |

Not exercised: a real CVM behind slirp. The bridge-gateway collapse above is the same mechanism (one source address for every client) and the one B-126 names for Docker userland-proxy hosts.

### Security
Touches sshd configuration (PR_PROCESS §5). Properties checked on the branch: the drop-in holds one directive and nothing from a request or a peer reaches the script (build time only); authentication methods, `PermitRootLogin`, `MaxAuthTries`, the `Match User liumuser` ForceCommand and every other sshd default are unchanged; `PerSourcePenalties` is OpenSSH's per-address throttle after failed logins, sshd-session crashes, no-auth disconnects, grace-time expiry and refused connections; the drop-in turns all of these off, which is the OpenSSH 9.2 behaviour the image had before the base drifted. No secret, address or token in the diff or this body (the transcript's Docker bridge addresses are rewritten to TEST-NET 203.0.113.x; 127.0.0.1 is the box's loopback).

### Cross-PR
Open PRs that also edit `neurons/executor/Dockerfile`: #1328 (loop, DAH-3137: a `RUN` installing `gpu_sig` before the host-key removal) and #1268 (jam6099, DAH-2774: drops `speedtest-cli` from the apt list). Both touch other hunks; either order merges clean (`git merge-tree --write-tree` of this head with each: no conflict). #946 (2024, external) rewrites the file and conflicts with `main` regardless of this PR.

### Verified

Gate: PASS (c1faa12) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1330)

### Self-review

Verdict `clean` at `c1faa12` · 18 checks · by subagent-b126-r2 · 2026-09-08 22:28Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | PROSE-VS-CODE | `RECOVERY/b126/body.md:39` | "`/run/sshd` is created when running as root" describes the previous head's uid-0 guard; at this head `neurons/executor/sshd_setup.sh:33` runs `mkdir -p "$SSHD_PRIVSEP_DIR"` unconditionally (the Dockerfile has no USER, so the build is root either way, and the tests point it into tmp_path). | Say "`$SSHD_PRIVSEP_DIR` (default `/run/sshd`) is created before the checks (the init script creates it at start anyway)". |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `RECOVERY/b126/body.md:44` r1 medium fixed: no tree hash in the body; `git -C wt rev-parse HEAD^{tree}` = 4f1deb90d20c4e8c19f13b29dbe673ac0a595959 = the tree on job.log's `branch ebb0616a tree …` line of aws_run 20260908T220741Z-jox1, so the 137-passed suite and the 5-failed control ran this head's test file; timings 22:09:02→22:10:31 = 89 s and 22:10:31→22:11:21 = 50 s match; `main b05764a7` is the merge-base. · `RECOVERY/b126/body.md:83` r1 low fixed: `CONNECTED as root on <container id>` and `the ticket's node` replace the two hex literals; the remaining 8+-hex runs are the Notion URL id (line 2), the `sha256:`-prefixed digest (lines 7, 35, 47, also in the diff) and the reachable commit b05764a7 (line 44). · `RECOVERY/b126/body.md:39` r1 low fixed: "an earlier EC2 run found this (aws_run 20260908T214043Z-1tyw); the run below is with the fix" — 1tyw's job.log line 143 shows `Missing privilege separation directory: /run/sshd` on the bookworm step with a patch that had no privsep mkdir, while its trixie (OpenSSH 10.0) build passed `sshd -T`, which also supports the body's "on OpenSSH < 9.8" qualifier. · `RECOVERY/b126/body.md:115` r1 low fixed: the §5 sentence now names failed logins, sshd-session crashes, no-auth disconnects, grace-time expiry and refused connections and says the drop-in turns all of them off. · `neurons/executor/sshd_setup.sh:24` r1 low fixed: `SSHD_PRIVSEP_DIR="${SSHD_PRIVSEP_DIR:-/run/sshd}"` and `mkdir -p "$SSHD_PRIVSEP_DIR"` (line 33); run_setup() sets it to tmp_path/run/sshd (test_sshd_setup.py:69), so the suite no longer writes outside tmp_path. · `RECOVERY/b126/body.md:51` Quoted evidence matches the run's files: build-branch.log lines 232-234 (`#23 [stage-0 17/17] RUN sh sshd_setup.sh`, `#23 0.531 … PerSourcePenalties no (OpenSSH_10.0p2 Debian-7+deb13u4, OpenSSL 3.5.7 9 Jun 2026)`, `#23 0.534 … sshd -T accepts`); imagetools.txt digest; lockout-main.txt `drop connection #0 from [172.17.0.1]:60148 on [172.17.0.2]:22`, 0.5s, GOOD KEY rc=255, denied through #04 and silent from #05; lockout-branch.txt ports 42590/42594, `SHA256:ZykPiE0k…`, 2.5s, GOOD KEY rc=0; bookworm.txt verbatim; pytest.txt `137 passed, 18 warnings` and `5 failed`. · `RECOVERY/b126/body.md:109` "18 deprecation warnings from dependencies": pytest.txt's tail shows 17 PydanticDeprecatedSince20 from the venv's pydantic/fields.py and a total of 18; the 18th is cut by `tail -n 6`. Not a claim a reviewer acts on. · `RECOVERY/b126/body.md:118` Cross-PR re-verified on refs/remotes/pr/1328 (deb8cbf4) and pr/1268 (fae9e328): `git merge-tree --write-tree HEAD <pr>` is clean for both; 1328 adds one RUN before `# Remove existing SSH host keys`, 1268 removes `speedtest-cli`; neither adds a FROM or touches the AcceptEnv RUN, so test_dockerfile_pins_the_base_by_digest_and_runs_the_setup (len(from_lines)==1, ordering) stays green after either merge.

</details>
