### PR TITLE
DAH-3257 - [P2] rent: one host probe for the pre-run listings, removals unchanged

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -29,6 +29,11 @@ HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
 # Gate, threshold and known-host EMA are unchanged. Off by default.
 VERIFYX_COLD_SAMPLE_RETRY_ENABLED=false
 
+# Rental pre-run host probe (DAH-3257): on a rent, read the host listings the steps before `docker run` need (containers,
+# volumes, mounted volumes, GPU minor map, device nodes, nvidia-smi power state, the image's encryption label) in one ssh
+# command instead of ~8. Removals and writes run as before; a failed probe leaves every step on its own commands. Off by default.
+RENTAL_PRERUN_HOST_PROBE_ENABLED=false
+
 # First-pass fast path (DAH-3011): a never-validated executor gets a right-sized matmul (min(card VRAM, this MB)) and a
 # smaller VerifyX write (GB of RAM / disk) on its first pass; scored verifications are unchanged. Off by default.
 FIRST_PASS_FAST_PATH_ENABLED=false

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -211,6 +211,11 @@ class Settings(BaseSettings):
         default=True,
     )
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
+    # DAH-3257: on a rent, read the host listings the pre-run steps need (containers, volumes,
+    # mounted volumes, GPU minor map, device nodes, nvidia-smi power state, the image's
+    # encryption label) in ONE ssh command instead of ~8; every removal and write still runs its
+    # own command, and a probe that fails leaves every step on its own commands. Off: as before.
+    RENTAL_PRERUN_HOST_PROBE_ENABLED: bool = Field(env="RENTAL_PRERUN_HOST_PROBE_ENABLED", default=False)
     # DAH-3011: a never-validated executor's FIRST verification (the express lane's, DAH-2958 —
     # published spec-only, never scored) proves "this GPU exists, is the model claimed, the host is
     # reachable and rentable"; the VRAM-filling matmul and the 128 GB RAM proof exist to make a

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -79,6 +79,15 @@ from services.gpu_power_limit import (
     restore_filler_pod_gpu_power_limits,
     restore_tracked_gpu_power_limits,
 )
+from services.prerun_host_probe import (
+    DOCKER_MOUNTED_VOLUME_NAMES_CMD,
+    DOCKER_PS_ALL_NAMES_CMD,
+    DOCKER_VOLUME_LS_NAME_DRIVER_CMD,
+    PrerunHostProbe,
+    image_label_command,
+    parse_prerun_host_probe,
+    prerun_host_probe_command,
+)
 from services.gpu_wedge import cure_wedged_gpus, query_wedged_gpu_uuids
 from services.nvidia_devices import build_gpu_docker_config_for_executor
 from services.cluster_fabric import WIREGUARD_LISTEN_PORT, cluster_pod_networking
@@ -253,6 +262,10 @@ _CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC = 30
 _CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX = 4
 _DOCKER_PULL_TIMEOUT_SECONDS = DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS
 _INSPECTOR_LIFECYCLE_TIMEOUT_SECONDS = 30
+# DAH-3257: the pre-run probe carries one nvidia-smi query (bounded at 30 s on the per-command
+# path) plus seven docker/procfs listings that take milliseconds; a probe slower than this is a
+# hung host, and the per-command path takes over.
+_PRERUN_HOST_PROBE_TIMEOUT_SECONDS = 60
 
 
 def _missing_rental_docker_host_key_log_text(
@@ -1735,10 +1748,18 @@ class DockerService:
         clear_volume: bool = True,
         active_container_names: list[str] | None = None,
         active_volume_names: list[str] | None = None,
-    ):
-        command = '/usr/bin/docker ps -a --format "{{.Names}}"'
-        result = await ssh_client.run(command)
-        if result.stdout.strip():
+        host_probe: PrerunHostProbe | None = None,
+    ) -> list[str]:
+        """Force-remove stale pod_/filler_ containers (and their volumes); returns the names removed.
+
+        DAH-3257: ``host_probe`` supplies the `docker ps -a` listing; the removals still run here.
+        """
+        if host_probe is not None and host_probe.container_names is not None:
+            all_names: list[str] = list(host_probe.container_names)
+        else:
+            result = await ssh_client.run(DOCKER_PS_ALL_NAMES_CMD)
+            all_names = [name for name in (result.stdout or "").strip().split("\n") if name]
+        if all_names:
             # Optional pre-GC delay (default 0). DAH-1524 removed the 10s
             # deploy-path sleep; the port-race it hedged is now covered by
             # wait_for_port_check_containers + the 90s docker-run retry budget.
@@ -1748,7 +1769,7 @@ class DockerService:
             active_set = set(active_container_names) if active_container_names else set()
             active_volume_set = set(active_volume_names) if active_volume_names else set()
             pod_containers = [
-                name for name in result.stdout.strip().split("\n")
+                name for name in all_names
                 if name == pod_name
                 or name.startswith(POD_CONTAINER_PREFIX)
                 or name.startswith(FILLER_CONTAINER_PREFIX)
@@ -1760,7 +1781,7 @@ class DockerService:
                 stale_containers.append(name)
             container_names = " ".join(shlex.quote(name) for name in stale_containers)
             if not container_names:
-                return
+                return []
 
             logger.info(
                 _m(
@@ -1791,40 +1812,50 @@ class DockerService:
                     volumes = " ".join(shlex.quote(volume) for volume in volumes_to_remove)
                     command = f'/usr/bin/docker volume rm {volumes} 2>/dev/null || true'
                     await retry_ssh_command(ssh_client, command, 'clean_existing_containers')
+            return stale_containers
+        return []
 
     async def clean_stale_vloopback_volumes(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         default_extra: dict,
         skip_volume_names: list[str] | set[str] | None = None,
-    ) -> None:
+        host_probe: PrerunHostProbe | None = None,
+    ) -> list[str]:
+        """Remove vloopback `volume_*` volumes no container mounts (minus ``skip_volume_names``).
+
+        Returns the volumes it asked docker to remove (empty when nothing was stale or the listing
+        failed). DAH-3257: ``host_probe`` supplies the volume and mounted-volume listings; the
+        caller passes it only while nothing has removed a container since the probe ran.
+        """
         skip_set = {name for name in (skip_volume_names or []) if name}
-        list_volumes_cmd = '/usr/bin/docker volume ls --format "{{.Name}} {{.Driver}}"'
-        mounted_volumes_cmd = (
-            "/usr/bin/docker ps -a -q | xargs -r /usr/bin/docker inspect --format "
-            "'{{range .Mounts}}{{if eq .Type \"volume\"}}{{.Name}}{{\"\\n\"}}{{end}}{{end}}'"
-        )
+        list_volumes_cmd = DOCKER_VOLUME_LS_NAME_DRIVER_CMD
+        mounted_volumes_cmd = DOCKER_MOUNTED_VOLUME_NAMES_CMD
 
         try:
-            volume_result = await ssh_client.run(list_volumes_cmd)
-            if getattr(volume_result, "exit_status", 0) != 0:
-                logger.warning(
-                    _m(
-                        "Unable to list vloopback volumes",
-                        extra=get_extra_info({
-                            **default_extra,
-                            "stderr": getattr(volume_result, "stderr", ""),
-                        }),
+            if host_probe is not None and host_probe.volumes is not None:
+                volume_rows: list[tuple[str, str]] = list(host_probe.volumes)
+            else:
+                volume_result = await ssh_client.run(list_volumes_cmd)
+                if getattr(volume_result, "exit_status", 0) != 0:
+                    logger.warning(
+                        _m(
+                            "Unable to list vloopback volumes",
+                            extra=get_extra_info({
+                                **default_extra,
+                                "stderr": getattr(volume_result, "stderr", ""),
+                            }),
+                        )
                     )
-                )
-                return
+                    return []
+                volume_rows = []
+                for line in (volume_result.stdout or "").splitlines():
+                    parts = line.strip().split(maxsplit=1)
+                    if len(parts) == 2:
+                        volume_rows.append((parts[0], parts[1]))
 
             vloopback_volumes = set()
-            for line in (volume_result.stdout or "").splitlines():
-                parts = line.strip().split(maxsplit=1)
-                if len(parts) != 2:
-                    continue
-                name, driver = parts
+            for name, driver in volume_rows:
                 if not (
                     name.startswith("volume_")
                     and (driver == "vloopback" or driver.startswith("vloopback:"))
@@ -1832,27 +1863,30 @@ class DockerService:
                     continue
                 vloopback_volumes.add(name)
             if not vloopback_volumes:
-                return
+                return []
 
-            mounted_result = await ssh_client.run(mounted_volumes_cmd)
-            if getattr(mounted_result, "exit_status", 0) != 0:
-                logger.warning(
-                    _m(
-                        "Unable to inspect mounted Docker volumes",
-                        extra=get_extra_info({
-                            **default_extra,
-                            "stderr": getattr(mounted_result, "stderr", ""),
-                        }),
+            if host_probe is not None and host_probe.mounted_volume_names is not None:
+                mounted_volumes = set(host_probe.mounted_volume_names)
+            else:
+                mounted_result = await ssh_client.run(mounted_volumes_cmd)
+                if getattr(mounted_result, "exit_status", 0) != 0:
+                    logger.warning(
+                        _m(
+                            "Unable to inspect mounted Docker volumes",
+                            extra=get_extra_info({
+                                **default_extra,
+                                "stderr": getattr(mounted_result, "stderr", ""),
+                            }),
+                        )
                     )
-                )
-                return
+                    return []
 
-            mounted_volumes = {
-                name.strip() for name in (mounted_result.stdout or "").splitlines() if name.strip()
-            }
+                mounted_volumes = {
+                    name.strip() for name in (mounted_result.stdout or "").splitlines() if name.strip()
+                }
             stale_volumes = sorted(vloopback_volumes - mounted_volumes - skip_set)
             if not stale_volumes:
-                return
+                return []
 
             logger.info(
                 _m(
@@ -1870,6 +1904,7 @@ class DockerService:
                 f"/usr/bin/docker volume rm {volumes} 2>/dev/null || true",
                 "clean_stale_vloopback_volumes",
             )
+            return stale_volumes
         except asyncio.CancelledError:
             raise
         except Exception as exc:
@@ -1880,6 +1915,7 @@ class DockerService:
                 ),
                 exc_info=True,
             )
+            return []
 
     async def _cache_rented_pod_best_effort(
         self,
@@ -1921,6 +1957,7 @@ class DockerService:
         ssh_client: asyncssh.SSHClientConnection,
         payload: ContainerCreateRequest,
         default_extra: dict,
+        host_probe: PrerunHostProbe | None = None,
     ) -> None:
         """Free the DPHN filler cache when a customer rental needs the disk it occupies.
 
@@ -1937,7 +1974,9 @@ class DockerService:
             return
         requested_gb: int | None = payload.volume_limit_gb
         try:
-            cache_volumes: list[str] = await self._find_cache_volumes_to_sweep(ssh_client, set(), default_extra)
+            cache_volumes: list[str] = await self._find_cache_volumes_to_sweep(
+                ssh_client, set(), default_extra, host_probe=host_probe
+            )
             if not cache_volumes:
                 return
 
@@ -1983,6 +2022,7 @@ class DockerService:
         ssh_client: asyncssh.SSHClientConnection,
         payload: ContainerCreateRequest,
         default_extra: dict,
+        host_probe: PrerunHostProbe | None = None,
     ) -> list[CacheVolume]:
         """Which of the requested cache volumes this node can actually take.
 
@@ -2001,7 +2041,11 @@ class DockerService:
         requested_names: list[str] = [cache_volume.name for cache_volume in payload.cache_volumes]
         existing: set[str] = set(
             await self._find_cache_volumes_to_sweep(
-                ssh_client, set(), default_extra, self._cache_volume_families(requested_names)
+                ssh_client,
+                set(),
+                default_extra,
+                self._cache_volume_families(requested_names),
+                host_probe=host_probe,
             )
         )
         present: list[CacheVolume] = [volume for volume in payload.cache_volumes if volume.name in existing]
@@ -2059,30 +2103,34 @@ class DockerService:
         keep_names: set[str],
         default_extra: dict,
         name_prefixes: tuple[str, ...] = (DPHN_CACHE_VOLUME_PREFIX,),
+        host_probe: PrerunHostProbe | None = None,
     ) -> list[str]:
         # Cache volumes present on the host that this create no longer names, i.e. left by an older
         # model or runtime. Empty on any listing failure — sweeping is never worth failing a launch.
         if not name_prefixes:
             return []
-        try:
-            listed = await ssh_client.run('/usr/bin/docker volume ls --format "{{.Name}}"')
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            logger.warning(
-                _m(
-                    "Failed to list filler cache volumes",
-                    extra=get_extra_info({**default_extra, "error": str(exc)}),
-                ),
-                exc_info=True,
-            )
-            return []
-        if listed.exit_status != 0:
-            return []
+        if host_probe is not None and host_probe.volume_names is not None:
+            # DAH-3257: the pre-run probe's `docker volume ls`, same filter below.
+            names: tuple[str, ...] = host_probe.volume_names
+        else:
+            try:
+                listed = await ssh_client.run('/usr/bin/docker volume ls --format "{{.Name}}"')
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    _m(
+                        "Failed to list filler cache volumes",
+                        extra=get_extra_info({**default_extra, "error": str(exc)}),
+                    ),
+                    exc_info=True,
+                )
+                return []
+            if listed.exit_status != 0:
+                return []
+            names = tuple(line.strip() for line in (listed.stdout or "").splitlines())
         return sorted(
-            name
-            for name in (line.strip() for line in (listed.stdout or "").splitlines())
-            if name.startswith(name_prefixes) and name not in keep_names
+            name for name in names if name.startswith(name_prefixes) and name not in keep_names
         )
 
     async def sweep_stale_cache_volumes(
@@ -2090,13 +2138,16 @@ class DockerService:
         ssh_client: asyncssh.SSHClientConnection,
         payload: ContainerCreateRequest,
         default_extra: dict,
-    ) -> None:
+        host_probe: PrerunHostProbe | None = None,
+    ) -> list[str]:
         """Remove every DPHN cache volume on the host except the ones THIS create asks for.
 
         The cache volume name carries the model + runtime version, so a Dolphin model update makes the
         backend ask for a different name. Without this sweep the previous ~37 GB set would sit on the
         host forever (a named volume outside the `volume_` prefix is untouched by every other GC path)
         and each update would leak another set — the invariant is at most ONE model's cache per host.
+
+        Returns the volumes it asked docker to remove (empty when nothing was swept).
         """
         if payload.workload_kind != WorkloadKind.FILLER or not payload.cache_volumes:
             # No cache requested -> this is version GC with nothing to compare against, NOT a reclaim.
@@ -2106,7 +2157,7 @@ class DockerService:
             # threshold, the next cycle would grant it again, and the node would re-download ~37 GB
             # every cycle. Reclaiming a cache the node can no longer afford is the rental/disk-pressure
             # path's job, where the decision is made against real free space.
-            return
+            return []
         # A live filler SIBLING holds this node's cache and docker cannot remove an in-use volume, so
         # the listing round-trip would be a no-op. The run being created is already STARTING in the
         # backend by the time it builds this request, so its OWN container name is in the list too —
@@ -2116,14 +2167,18 @@ class DockerService:
             name.startswith(FILLER_CONTAINER_PREFIX) and name != own_container_name
             for name in payload.active_container_names or []
         ):
-            return
+            return []
 
         keep_names: set[str] = {cache_volume.name for cache_volume in payload.cache_volumes}
         stale_volumes: list[str] = await self._find_cache_volumes_to_sweep(
-            ssh_client, keep_names, default_extra, self._cache_volume_families(sorted(keep_names))
+            ssh_client,
+            keep_names,
+            default_extra,
+            self._cache_volume_families(sorted(keep_names)),
+            host_probe=host_probe,
         )
         if not stale_volumes:
-            return
+            return []
         logger.info(
             _m(
                 "Sweeping stale filler cache volumes",
@@ -2150,6 +2205,7 @@ class DockerService:
                     extra=get_extra_info({**default_extra, "stale_volumes": stale_volumes, "error": str(exc)}),
                 )
             )
+        return stale_volumes
 
     async def capture_failed_container_diagnostics(
         self,
@@ -2240,15 +2296,83 @@ class DockerService:
             )
         return container_missing
 
+    async def probe_prerun_host(
+        self,
+        ssh_client: asyncssh.SSHClientConnection,
+        *,
+        docker_image: str,
+        with_power: bool,
+        log_extra: dict,
+    ) -> PrerunHostProbe | None:
+        """DAH-3257: the pre-run host listings in one SSH command; None on any failure.
+
+        None means every consumer runs its own listing command, exactly as with the flag off; the
+        probe is then one extra round trip. It reads the host and writes nothing.
+        """
+        command = prerun_host_probe_command(
+            docker_image=docker_image,
+            image_label=_ENCRYPTED_VOLUME_IMAGE_LABEL,
+            with_power=with_power,
+        )
+        started = time.monotonic()
+        try:
+            # Bounded like the nvidia-smi query it carries (a hung driver must not stall the rent);
+            # asyncio.TimeoutError lands in the except below → None → the per-command path.
+            result = await ssh_client.run(command, check=False, timeout=_PRERUN_HOST_PROBE_TIMEOUT_SECONDS)
+            probe = parse_prerun_host_probe(result.stdout or "", with_power=with_power)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "prerun_host_probe_fallback",
+                    extra=get_extra_info({
+                        **log_extra,
+                        "error": str(exc),
+                        "probe_ms": int((time.monotonic() - started) * 1000),
+                    }),
+                )
+            )
+            return None
+        logger.info(
+            _m(
+                "prerun_host_probe",
+                extra=get_extra_info({
+                    **log_extra,
+                    "probe_ms": int((time.monotonic() - started) * 1000),
+                    "containers": len(probe.container_names or ()),
+                    "volumes": len(probe.volumes or ()),
+                    "failed_sections": [
+                        name
+                        for name, value in (
+                            ("ps", probe.container_names),
+                            ("volumes", probe.volumes),
+                            ("mounted", probe.mounted_volume_names),
+                            ("gpu_proc", probe.gpu_proc_stdout),
+                            ("gpu_devices", probe.gpu_device_nodes),
+                            ("shared_nodes", probe.shared_nodes),
+                            ("shared_nodes_whole_host", probe.shared_nodes_whole_host_only),
+                            ("power", probe.power_state_stdout if with_power else ""),
+                            ("image_label", probe.image_label_value),
+                        )
+                        if value is None
+                    ],
+                }),
+            )
+        )
+        return probe
+
     async def _image_has_encrypted_volume_label(
         self,
         ssh_client: asyncssh.SSHClientConnection,
         docker_image: str,
+        *,
+        host_probe: PrerunHostProbe | None = None,
     ) -> bool:
+        if host_probe is not None and host_probe.image_label_value is not None:
+            return host_probe.image_label_value == "1"
         result = await ssh_client.run(
-            "/usr/bin/docker image inspect "
-            f"--format '{{{{index .Config.Labels \"{_ENCRYPTED_VOLUME_IMAGE_LABEL}\"}}}}' "
-            f"{shlex.quote(docker_image)}",
+            image_label_command(docker_image, _ENCRYPTED_VOLUME_IMAGE_LABEL),
             check=False,
         )
         if result.exit_status != 0:
@@ -4479,6 +4603,31 @@ class DockerService:
                 if local_volume:
                     protected_volume_names.add(local_volume)
 
+                # DAH-3257: one SSH command reads every host listing the steps down to `docker run`
+                # need (containers, volumes, mounted volumes, GPU minor map, device nodes, power
+                # state, the image's encryption label). Each consumer takes the probe in place of
+                # its own listing command; every removal and write below still runs as before.
+                # None (flag off, or the probe failed) leaves every consumer on its own commands.
+                host_probe: PrerunHostProbe | None = None
+                if settings.RENTAL_PRERUN_HOST_PROBE_ENABLED:
+                    current_step = "prerun_host_probe"
+                    host_probe = await self.probe_prerun_host(
+                        ssh_client,
+                        docker_image=payload.docker_image,
+                        # A PEARL filler caps its GPUs with live nvidia-smi queries of its own
+                        # (apply_filler_gpu_power_limits) and never reads the probe's power state.
+                        with_power=not (
+                            payload.workload_kind == WorkloadKind.FILLER and bool(payload.gpu_power_limits)
+                        ),
+                        log_extra=default_extra,
+                    )
+                # The probe is a snapshot. Once a step below removes a container or a volume, the
+                # container/volume listings are stale (a removed volume would still read as present,
+                # a removed container as still mounting its volume), so the later sweeps go back to
+                # their own commands. The GPU, power and image-label sections are unaffected by a
+                # docker removal and stay in use.
+                docker_listing_probe: PrerunHostProbe | None = host_probe
+
                 current_step = "container_cleanup"
                 # DAH-1524: the GC below (force-removing stale pod_/filler_
                 # containers + their volumes that aren't in active_*) stays on the
@@ -4489,20 +4638,26 @@ class DockerService:
                 # wait_for_port_check_containers just before `docker run`, and the
                 # 90s _run_docker_create_with_port_retry budget), so we no longer
                 # block the critical path for ~10s. (sleep defaults to 0.)
-                await self.clean_existing_containers(
+                removed_containers = await self.clean_existing_containers(
                     ssh_client=ssh_client,
                     default_extra=default_extra,
                     pod_name=container_name,
                     clear_volume=False if local_volume else True,
                     active_container_names=payload.active_container_names,
                     active_volume_names=payload.active_volume_names,
+                    host_probe=docker_listing_probe,
                 )
+                if removed_containers:
+                    docker_listing_probe = None
 
-                await self.clean_stale_vloopback_volumes(
+                removed_vloopback_volumes = await self.clean_stale_vloopback_volumes(
                     ssh_client=ssh_client,
                     default_extra=default_extra,
                     skip_volume_names=protected_volume_names,
+                    host_probe=docker_listing_probe,
                 )
+                if removed_vloopback_volumes:
+                    docker_listing_probe = None
 
                 # DAH-2475: sweep FIRST, against the names the backend REQUESTED. The stale old-version
                 # cache is dead weight (its names will never be requested again), and it is often the
@@ -4510,11 +4665,14 @@ class DockerService:
                 # must happen before affordability is judged, or a renamed cache strands the node in a
                 # cold-start loop it can never leave. Sweeping requested-but-not-yet-granted names is
                 # safe: they either do not exist yet or are the current version worth keeping.
-                await self.sweep_stale_cache_volumes(
+                swept_cache_volumes = await self.sweep_stale_cache_volumes(
                     ssh_client=ssh_client,
                     payload=payload,
                     default_extra=default_extra,
+                    host_probe=docker_listing_probe,
                 )
+                if swept_cache_volumes:
+                    docker_listing_probe = None
 
                 # The backend asks for the cache it wants; only the host knows whether those volumes
                 # already exist, and therefore whether mounting them costs a download at all.
@@ -4522,12 +4680,14 @@ class DockerService:
                     ssh_client=ssh_client,
                     payload=payload,
                     default_extra=default_extra,
+                    host_probe=docker_listing_probe,
                 )
 
                 await self.reclaim_dphn_cache_for_rental(
                     ssh_client=ssh_client,
                     payload=payload,
                     default_extra=default_extra,
+                    host_probe=docker_listing_probe,
                 )
 
                 # Add profiler for docker volume creation
@@ -4591,6 +4751,7 @@ class DockerService:
                     if not await self._image_has_encrypted_volume_label(
                         ssh_client,
                         payload.docker_image,
+                        host_probe=host_probe,
                     ):
                         use_encrypted_volume = False
                         volume_encryption_status = VolumeEncryptionStatus.UNSUPPORTED_IMAGE
@@ -4665,6 +4826,7 @@ class DockerService:
                     payload.gpu_uuids,
                     executor_id=payload.executor_id,
                     default_extra=default_extra,
+                    host_probe=host_probe,
                 )
 
                 if payload.cluster_membership is not None:
@@ -4691,22 +4853,29 @@ class DockerService:
                     # without its own cap starts, so a customer (or an uncapped filler) never
                     # inherits a reduced limit. Best-effort, never blocks the rental.
                     if payload.gpu_uuids:
-                        await restore_tracked_gpu_power_limits(
-                            ssh_client, self.redis_service, payload.gpu_uuids, log_extra=default_extra
+                        restored_limits = await restore_tracked_gpu_power_limits(
+                            ssh_client,
+                            self.redis_service,
+                            payload.gpu_uuids,
+                            log_extra=default_extra,
+                            host_probe=host_probe,
                         )
                     else:
                         # empty gpu_uuids = whole-node container (--gpus all) → check every host GPU
-                        await restore_all_host_gpu_power_limits(
-                            ssh_client, self.redis_service, log_extra=default_extra
+                        restored_limits = await restore_all_host_gpu_power_limits(
+                            ssh_client, self.redis_service, log_extra=default_extra, host_probe=host_probe
                         )
                     # State-free last-resort net: if a pre-cap record was lost, the record-based
                     # restore above did nothing — lift anything still below the check's floor back
                     # to the GPU's own default, so the customer never starts on a capped GPU.
+                    # A restore just wrote a limit → the probe's power state is stale → live query
+                    # (restore_* count every `-pl` that stuck, whether or not its record cleared).
                     await raise_low_power_limits_to_default(
                         ssh_client,
                         payload.executor_id,
                         payload.gpu_uuids or None,
                         log_extra=default_extra,
+                        host_probe=host_probe if restored_limits == 0 else None,
                     )
 
                 # DAH-1524: build_gpu_flags issues 2-3 serial SSH probes (proc minor

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -73,6 +73,7 @@ from services.const import (
 )
 from services.cvm_quote_broker import ensure_quote_broker, quote_socket_pod_mount
 from services.gpu_power_limit import (
+    _NVIDIA_SMI_TIMEOUT_SECONDS,
     apply_filler_gpu_power_limits,
     raise_low_power_limits_to_default,
     restore_all_host_gpu_power_limits,
@@ -262,10 +263,10 @@ _CREATE_CONTAINER_SSH_KEEPALIVE_INTERVAL_SEC = 30
 _CREATE_CONTAINER_SSH_KEEPALIVE_COUNT_MAX = 4
 _DOCKER_PULL_TIMEOUT_SECONDS = DEFAULT_DOCKER_PULL_TIMEOUT_SECONDS
 _INSPECTOR_LIFECYCLE_TIMEOUT_SECONDS = 30
-# DAH-3257: the pre-run probe carries one nvidia-smi query (bounded at 30 s on the per-command
-# path) plus seven docker/procfs listings that take milliseconds; a probe slower than this is a
-# hung host, and the per-command path takes over.
-_PRERUN_HOST_PROBE_TIMEOUT_SECONDS = 60
+# DAH-3257: the pre-run probe carries one nvidia-smi query plus seven docker/procfs listings that
+# take milliseconds, so its bound is the one the per-command path puts on that nvidia-smi query
+# (30 s); a probe slower than this is a hung host, and the per-command path takes over.
+_PRERUN_HOST_PROBE_TIMEOUT_SECONDS = _NVIDIA_SMI_TIMEOUT_SECONDS
 
 
 def _missing_rental_docker_host_key_log_text(

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -73,7 +73,7 @@ from services.const import (
 )
 from services.cvm_quote_broker import ensure_quote_broker, quote_socket_pod_mount
 from services.gpu_power_limit import (
-    _NVIDIA_SMI_TIMEOUT_SECONDS,
+    NVIDIA_SMI_TIMEOUT_SECONDS,
     apply_filler_gpu_power_limits,
     raise_low_power_limits_to_default,
     restore_all_host_gpu_power_limits,
@@ -266,7 +266,7 @@ _INSPECTOR_LIFECYCLE_TIMEOUT_SECONDS = 30
 # DAH-3257: the pre-run probe carries one nvidia-smi query plus seven docker/procfs listings that
 # take milliseconds, so its bound is the one the per-command path puts on that nvidia-smi query
 # (30 s); a probe slower than this is a hung host, and the per-command path takes over.
-_PRERUN_HOST_PROBE_TIMEOUT_SECONDS = _NVIDIA_SMI_TIMEOUT_SECONDS
+_PRERUN_HOST_PROBE_TIMEOUT_SECONDS = NVIDIA_SMI_TIMEOUT_SECONDS
 
 
 def _missing_rental_docker_host_key_log_text(
@@ -1835,7 +1835,9 @@ class DockerService:
 
         try:
             if host_probe is not None and host_probe.volumes is not None:
-                volume_rows: list[tuple[str, str]] = list(host_probe.volumes)
+                volume_rows: list[tuple[str, str]] = [
+                    (volume.name, volume.driver) for volume in host_probe.volumes
+                ]
             else:
                 volume_result = await ssh_client.run(list_volumes_cmd)
                 if getattr(volume_result, "exit_status", 0) != 0:
@@ -2349,7 +2351,7 @@ class DockerService:
                             ("ps", probe.container_names),
                             ("volumes", probe.volumes),
                             ("mounted", probe.mounted_volume_names),
-                            ("gpu_proc", probe.gpu_proc_stdout),
+                            ("gpu_minor_map", probe.gpu_minor_map_stdout),
                             ("gpu_devices", probe.gpu_device_nodes),
                             ("shared_nodes", probe.shared_nodes),
                             ("shared_nodes_whole_host", probe.shared_nodes_whole_host_only),
@@ -4854,7 +4856,7 @@ class DockerService:
                     # without its own cap starts, so a customer (or an uncapped filler) never
                     # inherits a reduced limit. Best-effort, never blocks the rental.
                     if payload.gpu_uuids:
-                        restored_limits = await restore_tracked_gpu_power_limits(
+                        await restore_tracked_gpu_power_limits(
                             ssh_client,
                             self.redis_service,
                             payload.gpu_uuids,
@@ -4863,20 +4865,19 @@ class DockerService:
                         )
                     else:
                         # empty gpu_uuids = whole-node container (--gpus all) → check every host GPU
-                        restored_limits = await restore_all_host_gpu_power_limits(
+                        await restore_all_host_gpu_power_limits(
                             ssh_client, self.redis_service, log_extra=default_extra, host_probe=host_probe
                         )
                     # State-free last-resort net: if a pre-cap record was lost, the record-based
                     # restore above did nothing — lift anything still below the check's floor back
                     # to the GPU's own default, so the customer never starts on a capped GPU.
-                    # A restore just wrote a limit → the probe's power state is stale → live query
-                    # (restore_* count every `-pl` that stuck, whether or not its record cleared).
+                    # Always a live query: volume creation and a bootstrap restore ran since the
+                    # probe, so its power state can be minutes old.
                     await raise_low_power_limits_to_default(
                         ssh_client,
                         payload.executor_id,
                         payload.gpu_uuids or None,
                         log_extra=default_extra,
-                        host_probe=host_probe if restored_limits == 0 else None,
                     )
 
                 # DAH-1524: build_gpu_flags issues 2-3 serial SSH probes (proc minor

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -55,12 +55,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_POWER_STATE_CMD = (
+POWER_STATE_CMD = (
     "nvidia-smi --query-gpu=uuid,power.limit,power.default_limit,power.min_limit,power.max_limit "
     "--format=csv,noheader,nounits"
 )
 # Bound each nvidia-smi call so a hung driver can't stall filler deploy/undeploy (PoC #1120).
-_NVIDIA_SMI_TIMEOUT_SECONDS = 30
+NVIDIA_SMI_TIMEOUT_SECONDS = 30
 _RESTORE_KEY_PREFIX = "gpu_power_restore:"
 _POD_INDEX_KEY_PREFIX = "gpu_power_restore_pod:"
 # A record younger than this may belong to a filler the check's backend snapshot doesn't report yet
@@ -190,11 +190,11 @@ async def _query_power_state(
     *,
     host_probe: PrerunHostProbe | None = None,
 ) -> dict[str, GpuPowerState]:
-    # DAH-3257: the pre-run probe already ran _POWER_STATE_CMD; a probe without the section
+    # DAH-3257: the pre-run probe already ran POWER_STATE_CMD; a probe without the section
     # (nvidia-smi failed there, or the caller did not ask for it) means the live query below.
     if host_probe is not None and host_probe.power_state_stdout is not None:
         return _parse_power_state_csv(host_probe.power_state_stdout)
-    result = await ssh.run(_POWER_STATE_CMD, timeout=_NVIDIA_SMI_TIMEOUT_SECONDS)
+    result = await ssh.run(POWER_STATE_CMD, timeout=NVIDIA_SMI_TIMEOUT_SECONDS)
     if result.exit_status != 0:
         raise RuntimeError(
             f"nvidia-smi power-state query failed: exit_status={result.exit_status}, "
@@ -215,7 +215,7 @@ async def _enable_persistence_mode(
     failure: str | None = None
     try:
         result = await ssh.run(
-            f"nvidia-smi -i {shlex.quote(uuid)} -pm 1", timeout=_NVIDIA_SMI_TIMEOUT_SECONDS
+            f"nvidia-smi -i {shlex.quote(uuid)} -pm 1", timeout=NVIDIA_SMI_TIMEOUT_SECONDS
         )
         if result.exit_status != 0:
             failure = f"exit={result.exit_status}, stderr={result.stderr!r}"
@@ -239,7 +239,7 @@ async def _read_back_power_state(ssh: asyncssh.SSHClientConnection, uuid: str) -
         f"--format=csv,noheader,nounits"
     )
     try:
-        result = await ssh.run(readback_command, timeout=_NVIDIA_SMI_TIMEOUT_SECONDS)
+        result = await ssh.run(readback_command, timeout=NVIDIA_SMI_TIMEOUT_SECONDS)
     except Exception:
         return _UNREADABLE_READBACK
     if result.exit_status != 0:
@@ -257,7 +257,7 @@ async def _set_power_limit(
     proves the cap exists."""
     try:
         result = await ssh.run(
-            f"nvidia-smi -i {shlex.quote(uuid)} -pl {watts}", timeout=_NVIDIA_SMI_TIMEOUT_SECONDS
+            f"nvidia-smi -i {shlex.quote(uuid)} -pl {watts}", timeout=NVIDIA_SMI_TIMEOUT_SECONDS
         )
     except Exception as exc:
         return PowerLimitSetOutcome(failure=f"nvidia-smi -pl errored: {exc}", persistence_enabled=None)
@@ -407,8 +407,7 @@ async def _restore_records(
     log_extra: dict[str, object] | None,
 ) -> int:
     """Apply each record with ``nvidia-smi -pl``; delete a record ONLY after its restore succeeded
-    (a failed restore keeps it for the safety nets to retry). Returns the number of limits written
-    back (a record whose delete then failed still counts: the GPU's limit did change)."""
+    (a failed restore keeps it for the safety nets to retry). Returns the restored count."""
     restored = 0
     for record in records:
         state = state_by_uuid.get(record.gpu_uuid)
@@ -418,9 +417,9 @@ async def _restore_records(
         )
         if not changed:
             continue
-        restored += 1
         try:
             await redis.delete(_restore_key(record.gpu_uuid))
+            restored += 1
         except Exception as exc:
             _log(
                 logging.ERROR,
@@ -481,8 +480,6 @@ async def raise_low_power_limits_to_default(
     executor_id: str,
     gpu_uuids: list[str] | None,
     log_extra: dict[str, object] | None = None,
-    *,
-    host_probe: PrerunHostProbe | None = None,
 ) -> int:
     """State-free last-resort net for rental start: lift every GPU sitting below
     ``MIN_POWER_LIMIT_RATIO`` x its default limit back to the default.
@@ -493,11 +490,12 @@ async def raise_low_power_limits_to_default(
     floor and the default are left alone (a miner may legitimately run there). ``gpu_uuids=None``
     means every host GPU. Best-effort (never raises); returns the raised count.
 
-    ``host_probe`` (DAH-3257) stands in for the state query only while nothing has changed a
-    limit since the probe ran — the caller passes None after a restore wrote one.
+    Always a live query, never the pre-run probe (DAH-3257): volume creation and a bootstrap
+    restore run between the probe and this call, so the probe's power state can be minutes old,
+    and this net is the last read before the customer's container starts.
     """
     try:
-        state_by_uuid = await _query_power_state(ssh, host_probe=host_probe)
+        state_by_uuid = await _query_power_state(ssh)
     except Exception as exc:
         _log(logging.ERROR, f"gpu power raise: state query failed: {exc}; leaving limits as-is", {}, log_extra)
         return 0

--- a/neurons/validators/src/services/gpu_power_limit.py
+++ b/neurons/validators/src/services/gpu_power_limit.py
@@ -41,7 +41,7 @@ import logging
 import shlex
 import time
 from dataclasses import dataclass
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import asyncssh
 from payload_models.payloads import GpuPowerLimit
@@ -49,6 +49,9 @@ from pydantic import BaseModel, ValidationError
 from services.redis_service import RedisService
 
 from core.utils import _m, get_extra_info
+
+if TYPE_CHECKING:
+    from services.prerun_host_probe import PrerunHostProbe
 
 logger = logging.getLogger(__name__)
 
@@ -182,7 +185,15 @@ def _log(level: int, message: str, fields: dict[str, object], log_extra: dict[st
     logger.log(level, _m(message, extra=get_extra_info({**(log_extra or {}), **fields})))
 
 
-async def _query_power_state(ssh: asyncssh.SSHClientConnection) -> dict[str, GpuPowerState]:
+async def _query_power_state(
+    ssh: asyncssh.SSHClientConnection,
+    *,
+    host_probe: PrerunHostProbe | None = None,
+) -> dict[str, GpuPowerState]:
+    # DAH-3257: the pre-run probe already ran _POWER_STATE_CMD; a probe without the section
+    # (nvidia-smi failed there, or the caller did not ask for it) means the live query below.
+    if host_probe is not None and host_probe.power_state_stdout is not None:
+        return _parse_power_state_csv(host_probe.power_state_stdout)
     result = await ssh.run(_POWER_STATE_CMD, timeout=_NVIDIA_SMI_TIMEOUT_SECONDS)
     if result.exit_status != 0:
         raise RuntimeError(
@@ -396,7 +407,8 @@ async def _restore_records(
     log_extra: dict[str, object] | None,
 ) -> int:
     """Apply each record with ``nvidia-smi -pl``; delete a record ONLY after its restore succeeded
-    (a failed restore keeps it for the safety nets to retry). Returns the restored count."""
+    (a failed restore keeps it for the safety nets to retry). Returns the number of limits written
+    back (a record whose delete then failed still counts: the GPU's limit did change)."""
     restored = 0
     for record in records:
         state = state_by_uuid.get(record.gpu_uuid)
@@ -406,9 +418,9 @@ async def _restore_records(
         )
         if not changed:
             continue
+        restored += 1
         try:
             await redis.delete(_restore_key(record.gpu_uuid))
-            restored += 1
         except Exception as exc:
             _log(
                 logging.ERROR,
@@ -425,6 +437,8 @@ async def restore_tracked_gpu_power_limits(
     redis: RedisService,
     gpu_uuids: list[str],
     log_extra: dict[str, object] | None = None,
+    *,
+    host_probe: PrerunHostProbe | None = None,
 ) -> int:
     """Restore the frozen pre-cap limit of every tracked GPU among ``gpu_uuids``.
 
@@ -434,7 +448,8 @@ async def restore_tracked_gpu_power_limits(
     if not read_result.records:
         return 0
     try:
-        state_by_uuid = await _query_power_state(ssh)  # before-values for the change log only
+        # before-values for the change log only
+        state_by_uuid = await _query_power_state(ssh, host_probe=host_probe)
     except Exception as exc:
         _log(logging.WARNING, f"gpu power restore: state query failed: {exc}; restoring without before-values", {}, log_extra)
         state_by_uuid = {}
@@ -445,11 +460,13 @@ async def restore_all_host_gpu_power_limits(
     ssh: asyncssh.SSHClientConnection,
     redis: RedisService,
     log_extra: dict[str, object] | None = None,
+    *,
+    host_probe: PrerunHostProbe | None = None,
 ) -> int:
     """Enumerate the host's GPUs over SSH and restore every tracked one — for whole-node containers
     whose payload names no gpu_uuids. Best-effort; returns the restored count."""
     try:
-        state_by_uuid = await _query_power_state(ssh)
+        state_by_uuid = await _query_power_state(ssh, host_probe=host_probe)
     except Exception as exc:
         _log(logging.ERROR, f"gpu power restore: state query failed: {exc}; will retry later", {}, log_extra)
         return 0
@@ -464,6 +481,8 @@ async def raise_low_power_limits_to_default(
     executor_id: str,
     gpu_uuids: list[str] | None,
     log_extra: dict[str, object] | None = None,
+    *,
+    host_probe: PrerunHostProbe | None = None,
 ) -> int:
     """State-free last-resort net for rental start: lift every GPU sitting below
     ``MIN_POWER_LIMIT_RATIO`` x its default limit back to the default.
@@ -473,9 +492,12 @@ async def raise_low_power_limits_to_default(
     never starts on a below-floor GPU no matter what happened to our state. GPUs between the
     floor and the default are left alone (a miner may legitimately run there). ``gpu_uuids=None``
     means every host GPU. Best-effort (never raises); returns the raised count.
+
+    ``host_probe`` (DAH-3257) stands in for the state query only while nothing has changed a
+    limit since the probe ran — the caller passes None after a restore wrote one.
     """
     try:
-        state_by_uuid = await _query_power_state(ssh)
+        state_by_uuid = await _query_power_state(ssh, host_probe=host_probe)
     except Exception as exc:
         _log(logging.ERROR, f"gpu power raise: state query failed: {exc}; leaving limits as-is", {}, log_extra)
         return 0

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -148,7 +148,7 @@ def _emit_kernel_xml_disagreement(
     )
 
 
-_PROC_GPU_INFO_CMD = (
+PROC_GPU_INFO_CMD = (
     "for f in /proc/driver/nvidia/gpus/*/information; do "
     '[ -r "$f" ] || continue; '
     "awk -F: '"
@@ -262,7 +262,7 @@ def _device_flags(nodes: Sequence[str]) -> str:
     return " ".join(f"--device={node}" for node in nodes)
 
 
-_GPU_DEVICE_NODES_CMD = "ls -1d /dev/nvidia[0-9]* 2>/dev/null || true"
+GPU_DEVICE_NODES_CMD = "ls -1d /dev/nvidia[0-9]* 2>/dev/null || true"
 
 
 async def _query_all_gpu_nodes(
@@ -272,7 +272,7 @@ async def _query_all_gpu_nodes(
 ) -> tuple[str, ...]:
     if host_probe is not None and host_probe.gpu_device_nodes is not None:
         return host_probe.gpu_device_nodes
-    res = await ssh.run(_GPU_DEVICE_NODES_CMD)
+    res = await ssh.run(GPU_DEVICE_NODES_CMD)
     return _stdout_lines(res.stdout)
 
 
@@ -295,7 +295,7 @@ async def _query_gpu_nodes_for_uuids(
     except RuntimeError as exc:
         errors.append(str(exc))
         uuid_to_minor = {}
-    # An empty map is the real signal, not the exception: _PROC_GPU_INFO_CMD swallows an
+    # An empty map is the real signal, not the exception: PROC_GPU_INFO_CMD swallows an
     # unreadable procfs (unexpanded glob, `|| continue`, stderr discarded) and exits 0, so an
     # honest host with no readable procfs would otherwise log identically to a spoof.
     proc_unreadable = not uuid_to_minor
@@ -374,9 +374,9 @@ async def _query_gpu_minor_map_from_proc(
     *,
     host_probe: PrerunHostProbe | None = None,
 ) -> dict[str, int]:
-    if host_probe is not None and host_probe.gpu_proc_stdout is not None:
-        return _parse_uuid_minor_csv(host_probe.gpu_proc_stdout)
-    res = await ssh.run(_PROC_GPU_INFO_CMD)
+    if host_probe is not None and host_probe.gpu_minor_map_stdout is not None:
+        return _parse_uuid_minor_csv(host_probe.gpu_minor_map_stdout)
+    res = await ssh.run(PROC_GPU_INFO_CMD)
     if res.exit_status != 0:
         raise RuntimeError(
             "NVIDIA /proc GPU minor query failed on executor: "

--- a/neurons/validators/src/services/nvidia_devices.py
+++ b/neurons/validators/src/services/nvidia_devices.py
@@ -41,11 +41,15 @@ import logging
 import shlex
 import xml.etree.ElementTree as ET
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import asyncssh
 
 from core.config import settings
 from services.rental_docker_sdk import GpuDockerConfig, build_gpu_docker_config
+
+if TYPE_CHECKING:
+    from services.prerun_host_probe import PrerunHostProbe
 
 logger = logging.getLogger(__name__)
 
@@ -194,16 +198,26 @@ async def build_gpu_docker_config_for_executor(
     *,
     executor_id: str | None = None,
     default_extra: dict | None = None,
+    host_probe: PrerunHostProbe | None = None,
 ) -> GpuDockerConfig:
-    """Resolve structured GPU Docker options for SDK container creation."""
+    """Resolve structured GPU Docker options for SDK container creation.
+
+    DAH-3257: with ``host_probe`` the kernel minor map, the /dev/nvidiaN list and the shared
+    nodes are read from the pre-run probe instead of three SSH commands; the nvidia-smi XML
+    fallback and every verdict below are unchanged.
+    """
     try:
         if gpu_uuids:
             per_gpu, host_total = await _query_gpu_nodes_for_uuids(
-                ssh_client, gpu_uuids, executor_id=executor_id, default_extra=default_extra
+                ssh_client,
+                gpu_uuids,
+                executor_id=executor_id,
+                default_extra=default_extra,
+                host_probe=host_probe,
             )
             is_partial_rental = len(per_gpu) < host_total
         else:
-            per_gpu = await _query_all_gpu_nodes(ssh_client)
+            per_gpu = await _query_all_gpu_nodes(ssh_client, host_probe=host_probe)
             is_partial_rental = False
 
         # On partial rentals (some-but-not-all GPUs on the host), withhold every host-wide node:
@@ -211,7 +225,9 @@ async def build_gpu_docker_config_for_executor(
         # manipulate another tenant's GPU, and the RDMA verbs devices belong to cards the other
         # tenant may be renting (DAH-2571). We don't sell MIG slices today, but stripping both
         # under partial rental closes the leak before either ever ships.
-        shared = await _query_shared_nodes(ssh_client, is_whole_host_rental=not is_partial_rental)
+        shared = await _query_shared_nodes(
+            ssh_client, is_whole_host_rental=not is_partial_rental, host_probe=host_probe
+        )
         return build_gpu_docker_config(gpu_uuids, device_nodes=(*per_gpu, *shared))
     except Exception as exc:
         # 1a: the kernel-truth verdict (a rented UUID absent from procfs) otherwise dies as a bare
@@ -246,8 +262,17 @@ def _device_flags(nodes: Sequence[str]) -> str:
     return " ".join(f"--device={node}" for node in nodes)
 
 
-async def _query_all_gpu_nodes(ssh: asyncssh.SSHClientConnection) -> tuple[str, ...]:
-    res = await ssh.run("ls -1d /dev/nvidia[0-9]* 2>/dev/null || true")
+_GPU_DEVICE_NODES_CMD = "ls -1d /dev/nvidia[0-9]* 2>/dev/null || true"
+
+
+async def _query_all_gpu_nodes(
+    ssh: asyncssh.SSHClientConnection,
+    *,
+    host_probe: PrerunHostProbe | None = None,
+) -> tuple[str, ...]:
+    if host_probe is not None and host_probe.gpu_device_nodes is not None:
+        return host_probe.gpu_device_nodes
+    res = await ssh.run(_GPU_DEVICE_NODES_CMD)
     return _stdout_lines(res.stdout)
 
 
@@ -257,6 +282,7 @@ async def _query_gpu_nodes_for_uuids(
     *,
     executor_id: str | None = None,
     default_extra: dict | None = None,
+    host_probe: PrerunHostProbe | None = None,
 ) -> tuple[tuple[str, ...], int]:
     """Resolve requested UUIDs to /dev/nvidiaN nodes, plus return host GPU count.
 
@@ -265,7 +291,7 @@ async def _query_gpu_nodes_for_uuids(
     """
     errors: list[str] = []
     try:
-        uuid_to_minor = await _query_gpu_minor_map_from_proc(ssh)
+        uuid_to_minor = await _query_gpu_minor_map_from_proc(ssh, host_probe=host_probe)
     except RuntimeError as exc:
         errors.append(str(exc))
         uuid_to_minor = {}
@@ -345,7 +371,11 @@ def _missing_gpu_uuids(gpu_uuids: Sequence[str], uuid_to_minor: dict[str, int]) 
 
 async def _query_gpu_minor_map_from_proc(
     ssh: asyncssh.SSHClientConnection,
+    *,
+    host_probe: PrerunHostProbe | None = None,
 ) -> dict[str, int]:
+    if host_probe is not None and host_probe.gpu_proc_stdout is not None:
+        return _parse_uuid_minor_csv(host_probe.gpu_proc_stdout)
     res = await ssh.run(_PROC_GPU_INFO_CMD)
     if res.exit_status != 0:
         raise RuntimeError(
@@ -367,10 +397,43 @@ async def _query_gpu_minor_map_from_nvidia_smi_xml(
     return _parse_nvidia_smi_xml_minor_map(res.stdout)
 
 
+def shared_device_nodes_command(*, is_whole_host_rental: bool, whole_host_only: bool = False) -> str:
+    """The `sh` command listing the shared device nodes a rental of this shape gets.
+
+    ``whole_host_only`` prints just the nodes a whole-host rental gets ON TOP of a partial one (the
+    RDMA verbs devices and the caps/IMEX directories), in the order the full command prints them
+    after the common nodes — the pre-run probe (DAH-3257) lists both parts once and picks later.
+    """
+    common_globs = (
+        "/dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm "
+        "/dev/nvidia-uvm-tools /dev/nvidia-nvswitchctl "
+        "/dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]*"
+    )
+    whole_host_globs = "/dev/infiniband/uverbs[0-9]* /dev/infiniband/rdma_cm"
+    if whole_host_only:
+        globs = whole_host_globs
+    elif is_whole_host_rental:
+        globs = f"{common_globs} {whole_host_globs}"
+    else:
+        globs = common_globs
+    cmd = (
+        f"for p in {globs}; do "
+        '[ -e "$p" ] && printf "%s\\n" "$p"; '
+        "done"
+    )
+    if is_whole_host_rental:
+        cmd += (
+            "; find /dev/nvidia-caps /dev/nvidia-caps-imex-channels "
+            "-mindepth 1 -maxdepth 1 -print 2>/dev/null || true"
+        )
+    return cmd
+
+
 async def _query_shared_nodes(
     ssh: asyncssh.SSHClientConnection,
     *,
     is_whole_host_rental: bool = True,
+    host_probe: PrerunHostProbe | None = None,
 ) -> tuple[str, ...]:
     """Enumerate shared NVIDIA control nodes, and the RDMA verbs nodes, that exist on the host.
 
@@ -387,24 +450,11 @@ async def _query_shared_nodes(
     that also carries `issm*`, the subnet-manager interface, and `umad*`, raw MAD access. A renter
     holding `issm` can interfere with the fabric every other tenant on it depends on (DAH-2571).
     """
-    globs = (
-        "/dev/nvidiactl /dev/nvidia-modeset /dev/nvidia-uvm "
-        "/dev/nvidia-uvm-tools /dev/nvidia-nvswitchctl "
-        "/dev/nvidia-nvswitch[0-9]* /dev/nvidia-nvlink[0-9]*"
-    )
-    if is_whole_host_rental:
-        globs += " /dev/infiniband/uverbs[0-9]* /dev/infiniband/rdma_cm"
-    cmd = (
-        f"for p in {globs}; do "
-        '[ -e "$p" ] && printf "%s\\n" "$p"; '
-        "done"
-    )
-    if is_whole_host_rental:
-        cmd += (
-            "; find /dev/nvidia-caps /dev/nvidia-caps-imex-channels "
-            "-mindepth 1 -maxdepth 1 -print 2>/dev/null || true"
-        )
-    res = await ssh.run(cmd)
+    if host_probe is not None:
+        probed = host_probe.shared_nodes_for(is_whole_host_rental=is_whole_host_rental)
+        if probed is not None:
+            return probed
+    res = await ssh.run(shared_device_nodes_command(is_whole_host_rental=is_whole_host_rental))
     return _stdout_lines(res.stdout)
 
 

--- a/neurons/validators/src/services/prerun_host_probe.py
+++ b/neurons/validators/src/services/prerun_host_probe.py
@@ -22,10 +22,10 @@ import shlex
 from dataclasses import dataclass
 
 # The probe reads the same commands the per-command path runs, so the two paths cannot drift.
-from services.gpu_power_limit import _POWER_STATE_CMD
+from services.gpu_power_limit import POWER_STATE_CMD
 from services.nvidia_devices import (
-    _GPU_DEVICE_NODES_CMD,
-    _PROC_GPU_INFO_CMD,
+    GPU_DEVICE_NODES_CMD,
+    PROC_GPU_INFO_CMD,
     shared_device_nodes_command,
 )
 
@@ -33,7 +33,7 @@ from services.nvidia_devices import (
 PS_TAG = "PS"
 VOL_TAG = "VOL"
 MNT_TAG = "MNT"
-GPUPROC_TAG = "GPUPROC"
+GPU_MINOR_MAP_TAG = "GPUMINORMAP"
 GPUDEV_TAG = "GPUDEV"
 SHARED_TAG = "SHARED"
 SHAREDW_TAG = "SHAREDW"
@@ -43,7 +43,7 @@ _ALWAYS_TAGS = (
     PS_TAG,
     VOL_TAG,
     MNT_TAG,
-    GPUPROC_TAG,
+    GPU_MINOR_MAP_TAG,
     GPUDEV_TAG,
     SHARED_TAG,
     SHAREDW_TAG,
@@ -79,6 +79,14 @@ def image_label_command(docker_image: str, label: str) -> str:
 
 
 @dataclass(frozen=True)
+class ProbedVolume:
+    """One `docker volume ls` row."""
+
+    name: str
+    driver: str  # `local`, `vloopback`, `vloopback:latest`, …
+
+
+@dataclass(frozen=True)
 class PrerunHostProbe:
     """The host listings a rent reads before `docker run`, from one SSH command.
 
@@ -87,9 +95,9 @@ class PrerunHostProbe:
     """
 
     container_names: tuple[str, ...] | None
-    volumes: tuple[tuple[str, str], ...] | None  # (name, driver), as `docker volume ls` prints them
+    volumes: tuple[ProbedVolume, ...] | None
     mounted_volume_names: tuple[str, ...] | None
-    gpu_proc_stdout: str | None  # raw `uuid, minor` lines for `_parse_uuid_minor_csv`
+    gpu_minor_map_stdout: str | None  # raw `uuid, minor` lines (the kernel's GPU UUID→minor map)
     gpu_device_nodes: tuple[str, ...] | None  # /dev/nvidiaN
     shared_nodes: tuple[str, ...] | None  # nodes every rental gets
     shared_nodes_whole_host_only: tuple[str, ...] | None  # nodes only a whole-host rental gets
@@ -102,7 +110,7 @@ class PrerunHostProbe:
     def volume_names(self) -> tuple[str, ...] | None:
         if self.volumes is None:
             return None
-        return tuple(name for name, _driver in self.volumes)
+        return tuple(volume.name for volume in self.volumes)
 
     def shared_nodes_for(self, *, is_whole_host_rental: bool) -> tuple[str, ...] | None:
         """The node list `_query_shared_nodes` would have printed for this rental shape."""
@@ -130,7 +138,7 @@ def prerun_host_probe_command(*, docker_image: str, image_label: str, with_power
     """
     parts = [
         # awk, not sed: `\t` in a sed replacement is GNU-only; awk's "\t" is POSIX (and
-        # _PROC_GPU_INFO_CMD already needs awk on the host).
+        # PROC_GPU_INFO_CMD already needs awk on the host).
         't() { tag=$1; shift; out="$(sh -c "$1" 2>/dev/null)"; rc=$?; '
         'if [ -n "$out" ]; then printf \'%s\\n\' "$out" | awk -v t="$tag" \'{ print t "\\t" $0 }\' '
         f"|| echo {PREFIX_FAILED_MARKER}; fi; "
@@ -138,8 +146,8 @@ def prerun_host_probe_command(*, docker_image: str, image_label: str, with_power
         _section(PS_TAG, DOCKER_PS_ALL_NAMES_CMD),
         _section(VOL_TAG, DOCKER_VOLUME_LS_NAME_DRIVER_CMD),
         _section(MNT_TAG, DOCKER_MOUNTED_VOLUME_NAMES_CMD),
-        _section(GPUPROC_TAG, _PROC_GPU_INFO_CMD),
-        _section(GPUDEV_TAG, _GPU_DEVICE_NODES_CMD),
+        _section(GPU_MINOR_MAP_TAG, PROC_GPU_INFO_CMD),
+        _section(GPUDEV_TAG, GPU_DEVICE_NODES_CMD),
         _section(SHARED_TAG, shared_device_nodes_command(is_whole_host_rental=False)),
         _section(
             SHAREDW_TAG,
@@ -147,7 +155,7 @@ def prerun_host_probe_command(*, docker_image: str, image_label: str, with_power
         ),
     ]
     if with_power:
-        parts.append(_section(POWER_TAG, _POWER_STATE_CMD))
+        parts.append(_section(POWER_TAG, POWER_STATE_CMD))
     parts.append(_section(LABEL_TAG, image_label_command(docker_image, image_label)))
     return "; ".join(parts)
 
@@ -204,14 +212,14 @@ def parse_prerun_host_probe(stdout: str, *, with_power: bool) -> PrerunHostProbe
     def stripped_lines(tag: str) -> tuple[str, ...]:
         return tuple(line.strip() for line in lines.get(tag, ()) if line.strip())
 
-    volumes: tuple[tuple[str, str], ...] | None = None
+    volumes: tuple[ProbedVolume, ...] | None = None
     if ok(VOL_TAG):
         # `{{.Name}} {{.Driver}}` — the per-command path splits on the first space too.
         parsed = []
         for line in lines.get(VOL_TAG, ()):
             parts = line.strip().split(maxsplit=1)
             if len(parts) == 2:
-                parsed.append((parts[0], parts[1]))
+                parsed.append(ProbedVolume(name=parts[0], driver=parts[1]))
         volumes = tuple(parsed)
 
     label_value: str | None = None
@@ -224,7 +232,9 @@ def parse_prerun_host_probe(stdout: str, *, with_power: bool) -> PrerunHostProbe
         container_names=stripped_lines(PS_TAG) if ok(PS_TAG) else None,
         volumes=volumes,
         mounted_volume_names=stripped_lines(MNT_TAG) if ok(MNT_TAG) else None,
-        gpu_proc_stdout="\n".join(lines.get(GPUPROC_TAG, ())) if ok(GPUPROC_TAG) else None,
+        gpu_minor_map_stdout="\n".join(lines.get(GPU_MINOR_MAP_TAG, ()))
+        if ok(GPU_MINOR_MAP_TAG)
+        else None,
         gpu_device_nodes=stripped_lines(GPUDEV_TAG) if ok(GPUDEV_TAG) else None,
         shared_nodes=stripped_lines(SHARED_TAG) if ok(SHARED_TAG) else None,
         shared_nodes_whole_host_only=stripped_lines(SHAREDW_TAG) if ok(SHAREDW_TAG) else None,

--- a/neurons/validators/src/services/prerun_host_probe.py
+++ b/neurons/validators/src/services/prerun_host_probe.py
@@ -1,0 +1,235 @@
+"""DAH-3257 — one SSH command for the read-only host listings a rent runs before `docker run`.
+
+Between the image pull and `docker run`, `create_container` asks the executor host eight
+questions, each its own SSH round trip: the container list (`clean_existing_containers`), the
+volume list and the mounted-volume list (`clean_stale_vloopback_volumes`), the volume names
+again (`reclaim_dphn_cache_for_rental`), the kernel's GPU UUID→minor map and the shared device
+nodes (`build_gpu_docker_config_for_executor`), the nvidia-smi power state
+(`raise_low_power_limits_to_default`) and the image's volume-encryption label. On the far half of
+the fleet a round trip is 0.2–0.6 s, so the listings cost more than the work they inform.
+
+With ``RENTAL_PRERUN_HOST_PROBE_ENABLED`` the same listings come back from ONE command, each
+section tagged (``PS\\t<name>``, ``VOL\\t<name>\\t<driver>``, …) and closed by its exit status
+(``PS_RC\\t0``). The consumers read the section instead of running their own listing command and
+keep every removal / write / retry exactly as it is. A section whose command failed (non-zero
+``_RC``) is ``None`` and that consumer runs its own command; a probe that does not parse is ``None``
+as a whole and every consumer runs as before. The probe reads, never writes.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+# The probe reads the same commands the per-command path runs, so the two paths cannot drift.
+from services.gpu_power_limit import _POWER_STATE_CMD
+from services.nvidia_devices import (
+    _GPU_DEVICE_NODES_CMD,
+    _PROC_GPU_INFO_CMD,
+    shared_device_nodes_command,
+)
+
+# Tags, in the order the probe prints them. Every tag ends with a `<TAG>_RC` line.
+PS_TAG = "PS"
+VOL_TAG = "VOL"
+MNT_TAG = "MNT"
+GPUPROC_TAG = "GPUPROC"
+GPUDEV_TAG = "GPUDEV"
+SHARED_TAG = "SHARED"
+SHAREDW_TAG = "SHAREDW"
+POWER_TAG = "POWER"
+LABEL_TAG = "LABEL"
+_ALWAYS_TAGS = (
+    PS_TAG,
+    VOL_TAG,
+    MNT_TAG,
+    GPUPROC_TAG,
+    GPUDEV_TAG,
+    SHARED_TAG,
+    SHAREDW_TAG,
+    LABEL_TAG,
+)
+# The per-command path never looks at these commands' exit status (a `for p in …; [ -e "$p" ] && …`
+# loop exits 1 when the last node is absent; `ls … || true` exits 0), so neither does the parser.
+_RC_IGNORED_TAGS = (GPUDEV_TAG, SHARED_TAG, SHAREDW_TAG)
+_RC_SUFFIX = "_RC"
+# How much of an unparseable probe output reaches the log line.
+PROBE_OUTPUT_LOG_CAP = 512
+
+# The docker listings, shared with the per-command path in docker_service.py (imported there, so
+# the two paths run the same text).
+DOCKER_PS_ALL_NAMES_CMD = '/usr/bin/docker ps -a --format "{{.Names}}"'
+DOCKER_VOLUME_LS_NAME_DRIVER_CMD = '/usr/bin/docker volume ls --format "{{.Name}} {{.Driver}}"'
+DOCKER_MOUNTED_VOLUME_NAMES_CMD = (
+    "/usr/bin/docker ps -a -q | xargs -r /usr/bin/docker inspect --format "
+    '\'{{range .Mounts}}{{if eq .Type "volume"}}{{.Name}}{{"\\n"}}{{end}}{{end}}\''
+)
+# Printed (untagged) when the awk that prefixes a section's lines fails: an untagged line makes
+# the parser raise, so a prefixing failure is a whole-probe fallback, never an empty listing.
+PREFIX_FAILED_MARKER = "PRERUN_PROBE_PREFIX_FAILED"
+
+
+def image_label_command(docker_image: str, label: str) -> str:
+    """`docker image inspect` printing one label's value — the command `_image_has_encrypted_volume_label` runs."""
+    return (
+        "/usr/bin/docker image inspect "
+        f"--format '{{{{index .Config.Labels \"{label}\"}}}}' "
+        f"{shlex.quote(docker_image)}"
+    )
+
+
+@dataclass(frozen=True)
+class PrerunHostProbe:
+    """The host listings a rent reads before `docker run`, from one SSH command.
+
+    A ``None`` field means that section's command failed on the host; its consumer runs the
+    command itself (and sees the failure the way it does today).
+    """
+
+    container_names: tuple[str, ...] | None
+    volumes: tuple[tuple[str, str], ...] | None  # (name, driver), as `docker volume ls` prints them
+    mounted_volume_names: tuple[str, ...] | None
+    gpu_proc_stdout: str | None  # raw `uuid, minor` lines for `_parse_uuid_minor_csv`
+    gpu_device_nodes: tuple[str, ...] | None  # /dev/nvidiaN
+    shared_nodes: tuple[str, ...] | None  # nodes every rental gets
+    shared_nodes_whole_host_only: tuple[str, ...] | None  # nodes only a whole-host rental gets
+    power_state_stdout: (
+        str | None
+    )  # raw nvidia-smi CSV for `_parse_power_state_csv`; None when not asked
+    image_label_value: str | None  # the label's value, stripped; None when inspect failed
+
+    @property
+    def volume_names(self) -> tuple[str, ...] | None:
+        if self.volumes is None:
+            return None
+        return tuple(name for name, _driver in self.volumes)
+
+    def shared_nodes_for(self, *, is_whole_host_rental: bool) -> tuple[str, ...] | None:
+        """The node list `_query_shared_nodes` would have printed for this rental shape."""
+        if self.shared_nodes is None:
+            return None
+        if not is_whole_host_rental:
+            return self.shared_nodes
+        if self.shared_nodes_whole_host_only is None:
+            return None
+        return (*self.shared_nodes, *self.shared_nodes_whole_host_only)
+
+
+def _section(tag: str, command: str) -> str:
+    # `t <TAG> <command>`: the command's stdout, one `<TAG>\t<line>` per line (an empty output
+    # prints nothing), then `<TAG>_RC\t<exit status>`. stderr is dropped — the consumer that falls
+    # back re-runs the command and logs the real stderr.
+    return f"t {tag} {shlex.quote(command)}"
+
+
+def prerun_host_probe_command(*, docker_image: str, image_label: str, with_power: bool) -> str:
+    """One `sh` command line printing every section; see the module docstring for the format.
+
+    ``with_power`` adds the nvidia-smi power-state query (the customer-rental path reads it; a
+    PEARL filler applies its own cap with live queries and never reads this section).
+    """
+    parts = [
+        # awk, not sed: `\t` in a sed replacement is GNU-only; awk's "\t" is POSIX (and
+        # _PROC_GPU_INFO_CMD already needs awk on the host).
+        't() { tag=$1; shift; out="$(sh -c "$1" 2>/dev/null)"; rc=$?; '
+        'if [ -n "$out" ]; then printf \'%s\\n\' "$out" | awk -v t="$tag" \'{ print t "\\t" $0 }\' '
+        f"|| echo {PREFIX_FAILED_MARKER}; fi; "
+        f'printf \'%s{_RC_SUFFIX}\\t%s\\n\' "$tag" "$rc"; }}',
+        _section(PS_TAG, DOCKER_PS_ALL_NAMES_CMD),
+        _section(VOL_TAG, DOCKER_VOLUME_LS_NAME_DRIVER_CMD),
+        _section(MNT_TAG, DOCKER_MOUNTED_VOLUME_NAMES_CMD),
+        _section(GPUPROC_TAG, _PROC_GPU_INFO_CMD),
+        _section(GPUDEV_TAG, _GPU_DEVICE_NODES_CMD),
+        _section(SHARED_TAG, shared_device_nodes_command(is_whole_host_rental=False)),
+        _section(
+            SHAREDW_TAG,
+            shared_device_nodes_command(is_whole_host_rental=True, whole_host_only=True),
+        ),
+    ]
+    if with_power:
+        parts.append(_section(POWER_TAG, _POWER_STATE_CMD))
+    parts.append(_section(LABEL_TAG, image_label_command(docker_image, image_label)))
+    return "; ".join(parts)
+
+
+class PrerunHostProbeParseError(ValueError):
+    pass
+
+
+def _cap(text: str) -> str:
+    return text if len(text) <= PROBE_OUTPUT_LOG_CAP else text[:PROBE_OUTPUT_LOG_CAP] + " …"
+
+
+def parse_prerun_host_probe(stdout: str, *, with_power: bool) -> PrerunHostProbe:
+    """Split the probe output into sections; raise on anything that is not the expected shape.
+
+    Every expected tag must close with its ``_RC`` line — a section cut short (the ssh channel
+    closed, a host `sh` that died) raises, so a truncated listing can never read as "nothing
+    there". A failed section (``_RC`` ≠ 0) is ``None``.
+    """
+    lines: dict[str, list[str]] = {}
+    rcs: dict[str, str] = {}
+    for raw in stdout.split("\n"):
+        if raw == "":
+            continue
+        tag, sep, value = raw.partition("\t")
+        if not sep:
+            raise PrerunHostProbeParseError(
+                f"prerun host probe: untagged line {raw[:80]!r} in {_cap(stdout)!r}"
+            )
+        if tag.endswith(_RC_SUFFIX):
+            rcs[tag[: -len(_RC_SUFFIX)]] = value.strip()
+        else:
+            lines.setdefault(tag, []).append(value)
+
+    expected = (*_ALWAYS_TAGS, POWER_TAG) if with_power else _ALWAYS_TAGS
+    for tag in expected:
+        if tag not in rcs:
+            raise PrerunHostProbeParseError(
+                f"prerun host probe: no {tag}{_RC_SUFFIX} in {_cap(stdout)!r}"
+            )
+        if not rcs[tag].isdigit():
+            raise PrerunHostProbeParseError(
+                f"prerun host probe: {tag}{_RC_SUFFIX} is {rcs[tag]!r} in {_cap(stdout)!r}"
+            )
+    unexpected = set(lines) - set(expected)
+    if unexpected:
+        raise PrerunHostProbeParseError(
+            f"prerun host probe: unknown section(s) {sorted(unexpected)} in {_cap(stdout)!r}"
+        )
+
+    def ok(tag: str) -> bool:
+        return tag in _RC_IGNORED_TAGS or rcs[tag] == "0"
+
+    def stripped_lines(tag: str) -> tuple[str, ...]:
+        return tuple(line.strip() for line in lines.get(tag, ()) if line.strip())
+
+    volumes: tuple[tuple[str, str], ...] | None = None
+    if ok(VOL_TAG):
+        # `{{.Name}} {{.Driver}}` — the per-command path splits on the first space too.
+        parsed = []
+        for line in lines.get(VOL_TAG, ()):
+            parts = line.strip().split(maxsplit=1)
+            if len(parts) == 2:
+                parsed.append((parts[0], parts[1]))
+        volumes = tuple(parsed)
+
+    label_value: str | None = None
+    if ok(LABEL_TAG):
+        # The per-command path compares the whole stripped stdout; a label value with newlines
+        # arrives as several LABEL lines and is joined back before the strip.
+        label_value = "\n".join(lines.get(LABEL_TAG, ())).strip()
+
+    return PrerunHostProbe(
+        container_names=stripped_lines(PS_TAG) if ok(PS_TAG) else None,
+        volumes=volumes,
+        mounted_volume_names=stripped_lines(MNT_TAG) if ok(MNT_TAG) else None,
+        gpu_proc_stdout="\n".join(lines.get(GPUPROC_TAG, ())) if ok(GPUPROC_TAG) else None,
+        gpu_device_nodes=stripped_lines(GPUDEV_TAG) if ok(GPUDEV_TAG) else None,
+        shared_nodes=stripped_lines(SHARED_TAG) if ok(SHARED_TAG) else None,
+        shared_nodes_whole_host_only=stripped_lines(SHAREDW_TAG) if ok(SHAREDW_TAG) else None,
+        power_state_stdout=(
+            "\n".join(lines.get(POWER_TAG, ())) if with_power and ok(POWER_TAG) else None
+        ),
+        image_label_value=label_value,
+    )

--- a/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
+++ b/neurons/validators/tests/test_nvidia_devices_kernel_verdict.py
@@ -146,7 +146,7 @@ async def test_unreadable_proc_recorded_distinctly(monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_silently_empty_proc_still_records_unreadable(monkeypatch, caplog):
-    # The usual shape of the honest casualty: _PROC_GPU_INFO_CMD exits 0 with no rows (unexpanded
+    # The usual shape of the honest casualty: PROC_GPU_INFO_CMD exits 0 with no rows (unexpanded
     # glob, `|| continue`, stderr discarded), so no RuntimeError is raised. The map is still empty,
     # and without proc_unreadable=True this host would log identically to a real spoof.
     monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_ENFORCEMENT_ENABLED", True, raising=False)

--- a/neurons/validators/tests/test_prerun_host_probe.py
+++ b/neurons/validators/tests/test_prerun_host_probe.py
@@ -5,8 +5,8 @@ volumes, mounted volumes, volume names again, GPU minor map, shared device nodes
 state, the image's encryption label). With the flag on, one probe command returns them all; every
 consumer reads its section and keeps its removals / writes as they are. Covered here:
 
-- the probe command carries every section and the exact per-command texts (`_PROC_GPU_INFO_CMD`,
-  `_POWER_STATE_CMD`, the shared-node loop, the label inspect); `with_power=False` has no nvidia-smi;
+- the probe command carries every section and the exact per-command texts (`PROC_GPU_INFO_CMD`,
+  `POWER_STATE_CMD`, the shared-node loop, the label inspect); `with_power=False` has no nvidia-smi;
 - the parser: every section, a failed section → None, a missing `_RC` / an untagged line / an
   unknown tag → raise, the label's whole-stdout semantics;
 - the command and the parser together through `sh -c` with a docker stub (containers, volumes,
@@ -15,11 +15,12 @@ consumer reads its section and keeps its removals / writes as they are. Covered 
 - each consumer with a probe runs no listing command and produces the same result / the same
   removal commands as the per-command path for the same host facts; a failed section falls back;
 - `create_container`: flag off → never probes; flag on → one probe handed to every consumer; the
-  docker listings are withdrawn after a removal; the power state is withdrawn after a restore.
+  docker listings are withdrawn after a removal; the last-resort power raise never reads the probe.
 """
 
 from __future__ import annotations
 
+import inspect
 import os
 import stat
 import subprocess
@@ -30,13 +31,13 @@ from core.config import settings
 from services import nvidia_devices as nd
 from services.docker_service import DockerService, _ENCRYPTED_VOLUME_IMAGE_LABEL
 from services.gpu_power_limit import (
-    _POWER_STATE_CMD,
+    POWER_STATE_CMD,
     raise_low_power_limits_to_default,
     restore_tracked_gpu_power_limits,
 )
 from services.nvidia_devices import (
-    _GPU_DEVICE_NODES_CMD,
-    _PROC_GPU_INFO_CMD,
+    GPU_DEVICE_NODES_CMD,
+    PROC_GPU_INFO_CMD,
     build_gpu_docker_config_for_executor,
     shared_device_nodes_command,
 )
@@ -47,6 +48,7 @@ from services.prerun_host_probe import (
     PREFIX_FAILED_MARKER,
     PrerunHostProbe,
     PrerunHostProbeParseError,
+    ProbedVolume,
     image_label_command,
     parse_prerun_host_probe,
     prerun_host_probe_command,
@@ -67,7 +69,7 @@ def _probe(**over) -> PrerunHostProbe:
         container_names=(),
         volumes=(),
         mounted_volume_names=(),
-        gpu_proc_stdout="",
+        gpu_minor_map_stdout="",
         gpu_device_nodes=(),
         shared_nodes=(),
         shared_nodes_whole_host_only=(),
@@ -90,8 +92,8 @@ def _stdout(
     vol_rc: int = 0,
     mnt: tuple[str, ...] = ("volume_a",),
     mnt_rc: int = 0,
-    gpuproc: tuple[str, ...] = ("GPU-1, 0", "GPU-2, 1"),
-    gpuproc_rc: int = 0,
+    gpu_minor_map: tuple[str, ...] = ("GPU-1, 0", "GPU-2, 1"),
+    gpu_minor_map_rc: int = 0,
     gpudev: tuple[str, ...] = ("/dev/nvidia0", "/dev/nvidia1"),
     shared: tuple[str, ...] = ("/dev/nvidiactl", "/dev/nvidia-uvm"),
     sharedw: tuple[str, ...] = ("/dev/infiniband/uverbs0", "/dev/nvidia-caps/nvidia-cap1"),
@@ -104,7 +106,7 @@ def _stdout(
         _tagged("PS", *ps, rc=ps_rc)
         + _tagged("VOL", *vol, rc=vol_rc)
         + _tagged("MNT", *mnt, rc=mnt_rc)
-        + _tagged("GPUPROC", *gpuproc, rc=gpuproc_rc)
+        + _tagged("GPUMINORMAP", *gpu_minor_map, rc=gpu_minor_map_rc)
         + _tagged("GPUDEV", *gpudev)
         + _tagged("SHARED", *shared)
         + _tagged("SHAREDW", *sharedw)
@@ -144,7 +146,7 @@ def test_probe_command_carries_every_section_and_the_per_command_texts():
         docker_image=_IMAGE, image_label=_ENCRYPTED_VOLUME_IMAGE_LABEL, with_power=True
     )
     assert "\n" not in cmd
-    for tag in ("PS", "VOL", "MNT", "GPUPROC", "GPUDEV", "SHARED", "SHAREDW", "POWER", "LABEL"):
+    for tag in ("PS", "VOL", "MNT", "GPUMINORMAP", "GPUDEV", "SHARED", "SHAREDW", "POWER", "LABEL"):
         assert f"t {tag} " in cmd
     # shlex.quote wraps each section command; the quoted forms of the shared texts are inside
     import shlex
@@ -154,9 +156,9 @@ def test_probe_command_carries_every_section_and_the_per_command_texts():
     assert shlex.quote(DOCKER_MOUNTED_VOLUME_NAMES_CMD) in cmd
     assert f"|| echo {PREFIX_FAILED_MARKER}" in cmd
 
-    assert shlex.quote(_PROC_GPU_INFO_CMD) in cmd
-    assert shlex.quote(_GPU_DEVICE_NODES_CMD) in cmd
-    assert shlex.quote(_POWER_STATE_CMD) in cmd
+    assert shlex.quote(PROC_GPU_INFO_CMD) in cmd
+    assert shlex.quote(GPU_DEVICE_NODES_CMD) in cmd
+    assert shlex.quote(POWER_STATE_CMD) in cmd
     assert shlex.quote(shared_device_nodes_command(is_whole_host_rental=False)) in cmd
     assert (
         shlex.quote(shared_device_nodes_command(is_whole_host_rental=True, whole_host_only=True))
@@ -206,10 +208,13 @@ def test_shared_device_nodes_command_whole_host_only_is_the_tail_of_the_whole_ho
 def test_parser_reads_every_section():
     probe = parse_prerun_host_probe(_stdout(), with_power=True)
     assert probe.container_names == ("pod_a", "other")
-    assert probe.volumes == (("volume_a", "vloopback:latest"), ("dphn_cache_x", "local"))
+    assert probe.volumes == (
+        ProbedVolume("volume_a", "vloopback:latest"),
+        ProbedVolume("dphn_cache_x", "local"),
+    )
     assert probe.volume_names == ("volume_a", "dphn_cache_x")
     assert probe.mounted_volume_names == ("volume_a",)
-    assert probe.gpu_proc_stdout == "GPU-1, 0\nGPU-2, 1"
+    assert probe.gpu_minor_map_stdout == "GPU-1, 0\nGPU-2, 1"
     assert probe.gpu_device_nodes == ("/dev/nvidia0", "/dev/nvidia1")
     assert probe.shared_nodes_for(is_whole_host_rental=False) == (
         "/dev/nvidiactl",
@@ -242,7 +247,7 @@ def test_parser_empty_sections_are_empty_not_none():
         ({"ps_rc": 1}, "container_names"),
         ({"vol_rc": 125}, "volumes"),
         ({"mnt_rc": 123}, "mounted_volume_names"),
-        ({"gpuproc_rc": 2}, "gpu_proc_stdout"),
+        ({"gpu_minor_map_rc": 2}, "gpu_minor_map_stdout"),
         ({"power_rc": 127}, "power_state_stdout"),
         ({"label_rc": 1}, "image_label_value"),
     ],
@@ -394,12 +399,15 @@ def test_probe_through_sh_lists_docker_sections_and_marks_absent_nvidia_smi(tmp_
     out = _run_probe_in_sh(tmp_path)
     probe = parse_prerun_host_probe(out, with_power=True)
     assert probe.container_names == ("pod_a", "filler_b", "other")
-    assert probe.volumes == (("volume_a", "vloopback:latest"), ("volume_b", "local"))
+    assert probe.volumes == (
+        ProbedVolume("volume_a", "vloopback:latest"),
+        ProbedVolume("volume_b", "local"),
+    )
     assert probe.mounted_volume_names == ("volume_a", "volume_a")  # blank lines dropped as before
     assert probe.image_label_value == "1"
     # the GPU / device-node sections list whatever the test host has (a GPU workstation has
     # /dev/nvidia*, a CI runner may have /dev/infiniband/*) — they are listings, never failures
-    assert probe.gpu_proc_stdout is not None and probe.gpu_device_nodes is not None
+    assert probe.gpu_minor_map_stdout is not None and probe.gpu_device_nodes is not None
     assert probe.shared_nodes_for(is_whole_host_rental=True) is not None
     # the nvidia-smi stub exits 1 → the section failed → None → the live query would run
     assert probe.power_state_stdout is None
@@ -600,11 +608,11 @@ async def test_clean_stale_vloopback_with_probe_removes_the_same_and_lists_nothi
     ran.clear()
     probe = _probe(
         volumes=(
-            ("volume_a", "vloopback:latest"),
-            ("volume_b", "vloopback"),
-            ("volume_c", "local"),
-            ("volume_d", "vloopback:latest"),
-            ("other", "vloopback"),
+            ProbedVolume("volume_a", "vloopback:latest"),
+            ProbedVolume("volume_b", "vloopback"),
+            ProbedVolume("volume_c", "local"),
+            ProbedVolume("volume_d", "vloopback:latest"),
+            ProbedVolume("other", "vloopback"),
         ),
         mounted_volume_names=("volume_a", "volume_c"),
     )
@@ -627,7 +635,7 @@ async def test_clean_stale_vloopback_probe_without_vloopback_volumes_runs_nothin
         await docker_service.clean_stale_vloopback_volumes(
             ssh_client=ssh,
             default_extra={},
-            host_probe=_probe(volumes=(("volume_c", "local"),)),
+            host_probe=_probe(volumes=(ProbedVolume("volume_c", "local"),)),
         )
         == []
     )
@@ -639,7 +647,7 @@ async def test_clean_stale_vloopback_failed_mount_section_inspects_itself(
     docker_service, monkeypatch
 ):
     monkeypatch.setattr("services.docker_service.retry_ssh_command", AsyncMock())
-    probe = _probe(volumes=(("volume_a", "vloopback"),), mounted_volume_names=None)
+    probe = _probe(volumes=(ProbedVolume("volume_a", "vloopback"),), mounted_volume_names=None)
     ssh = _ssh(_ssh_result(stdout="volume_a\n"))
     assert (
         await docker_service.clean_stale_vloopback_volumes(
@@ -656,9 +664,9 @@ async def test_find_cache_volumes_with_probe_matches_live(docker_service):
     from_live = await docker_service._find_cache_volumes_to_sweep(live, {"dphn_cache_new"}, {})
     probe = _probe(
         volumes=(
-            ("dphn_cache_old", "local"),
-            ("dphn_cache_new", "local"),
-            ("volume_a", "vloopback"),
+            ProbedVolume("dphn_cache_old", "local"),
+            ProbedVolume("dphn_cache_new", "local"),
+            ProbedVolume("volume_a", "vloopback"),
         )
     )
     probed = _ssh()
@@ -709,7 +717,7 @@ async def test_gpu_config_with_probe_matches_live_partial_rental(monkeypatch):
     live = _ssh(_ssh_result(stdout=proc), _ssh_result(stdout="/dev/nvidiactl\n/dev/nvidia-uvm\n"))
     from_live = await build_gpu_docker_config_for_executor(live, ["GPU-2"])
     probe = _probe(
-        gpu_proc_stdout=proc,
+        gpu_minor_map_stdout=proc,
         shared_nodes=("/dev/nvidiactl", "/dev/nvidia-uvm"),
         shared_nodes_whole_host_only=("/dev/infiniband/uverbs0", "/dev/nvidia-caps/nvidia-cap1"),
     )
@@ -728,7 +736,7 @@ async def test_gpu_config_with_probe_matches_live_partial_rental(monkeypatch):
 async def test_gpu_config_with_probe_whole_host_gets_the_whole_host_nodes(monkeypatch):
     monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False)
     probe = _probe(
-        gpu_proc_stdout="GPU-1, 0\nGPU-2, 1\n",
+        gpu_minor_map_stdout="GPU-1, 0\nGPU-2, 1\n",
         gpu_device_nodes=("/dev/nvidia0", "/dev/nvidia1"),
         shared_nodes=("/dev/nvidiactl",),
         shared_nodes_whole_host_only=("/dev/infiniband/uverbs0", "/dev/nvidia-caps/nvidia-cap1"),
@@ -751,7 +759,7 @@ async def test_gpu_config_with_probe_whole_host_gets_the_whole_host_nodes(monkey
 @pytest.mark.asyncio
 async def test_gpu_config_with_probe_missing_uuid_still_consults_xml_live(monkeypatch):
     monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False)
-    probe = _probe(gpu_proc_stdout="GPU-1, 0\n", shared_nodes=("/dev/nvidiactl",))
+    probe = _probe(gpu_minor_map_stdout="GPU-1, 0\n", shared_nodes=("/dev/nvidiactl",))
     ssh = _ssh(_ssh_result(exit_status=1, stderr="no nvidia-smi"))
     config = await build_gpu_docker_config_for_executor(ssh, ["GPU-9"], host_probe=probe)
     # the kernel map lacks GPU-9 → nvidia-smi XML is asked live → fails → legacy --gpus-only fallback
@@ -762,41 +770,21 @@ async def test_gpu_config_with_probe_missing_uuid_still_consults_xml_live(monkey
 @pytest.mark.asyncio
 async def test_gpu_config_failed_proc_section_queries_live(monkeypatch):
     monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False)
-    probe = _probe(gpu_proc_stdout=None, shared_nodes=("/dev/nvidiactl",))
+    probe = _probe(gpu_minor_map_stdout=None, shared_nodes=("/dev/nvidiactl",))
     ssh = _ssh(_ssh_result(stdout="GPU-1, 0\n"))
     config = await build_gpu_docker_config_for_executor(ssh, ["GPU-1"], host_probe=probe)
-    assert _cmds(ssh) == [_PROC_GPU_INFO_CMD]
+    assert _cmds(ssh) == [PROC_GPU_INFO_CMD]
     assert [d.path_on_host for d in config.device_mounts] == ["/dev/nvidia0", "/dev/nvidiactl"]
 
 
 @pytest.mark.asyncio
-async def test_raise_low_power_limits_with_probe_queries_nothing_and_still_raises():
-    state = "GPU-1, 100.00, 450.00, 100.00, 450.00\nGPU-2, 450.00, 450.00, 100.00, 450.00\n"
-    probe = _probe(power_state_stdout=state)
-    # -pm 1, -pl 450, readback
-    ssh = _ssh(
-        _ssh_result(stdout=""),
-        _ssh_result(stdout=""),
-        _ssh_result(stdout="450, Enabled\n"),
-    )
-    raised = await raise_low_power_limits_to_default(
-        ssh, "exec-1", ["GPU-1", "GPU-2"], host_probe=probe
-    )
-    assert raised == 1
-    assert _POWER_STATE_CMD not in _cmds(ssh)
-    assert any("-pl 450" in c and "GPU-1" in c for c in _cmds(ssh))
-
-
-@pytest.mark.asyncio
-async def test_raise_low_power_limits_failed_power_section_queries_live():
+async def test_raise_low_power_limits_takes_no_probe_and_queries_live():
+    # The last-resort raise runs minutes after the probe (volume creation, bootstrap restore), so
+    # it has no probe parameter at all: the state it acts on is always a live query.
+    assert "host_probe" not in inspect.signature(raise_low_power_limits_to_default).parameters
     ssh = _ssh(_ssh_result(stdout="GPU-1, 450.00, 450.00, 100.00, 450.00\n"))
-    assert (
-        await raise_low_power_limits_to_default(
-            ssh, "exec-1", ["GPU-1"], host_probe=_probe(power_state_stdout=None)
-        )
-        == 0
-    )
-    assert _cmds(ssh) == [_POWER_STATE_CMD]
+    assert await raise_low_power_limits_to_default(ssh, "exec-1", ["GPU-1"]) == 0
+    assert _cmds(ssh) == [POWER_STATE_CMD]
 
 
 @pytest.mark.asyncio
@@ -809,25 +797,7 @@ async def test_restore_tracked_limits_with_probe_uses_it_for_before_values():
     probe = _probe(power_state_stdout="GPU-1, 250.00, 450.00, 100.00, 450.00\n")
     ssh = _ssh(_ssh_result(stdout=""), _ssh_result(stdout=""), _ssh_result(stdout="400, Enabled\n"))
     assert await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-1"], host_probe=probe) == 1
-    assert _POWER_STATE_CMD not in _cmds(ssh)
-
-
-@pytest.mark.asyncio
-async def test_restore_counts_a_written_limit_even_when_its_record_cannot_be_cleared():
-    # create_container withdraws the probe's power state from the raise when restore_* returns > 0;
-    # a limit that was written but whose Redis record could not be deleted still changed the GPU
-    redis = AsyncMock()
-    redis.get = AsyncMock(
-        return_value='{"gpu_uuid":"GPU-1","watts":400,"pod_id":"p","executor_id":"e","capped_at":1.0}'
-    )
-    redis.delete = AsyncMock(side_effect=ConnectionError("redis gone"))
-    ssh = _ssh(
-        _ssh_result(stdout="GPU-1, 250.00, 450.00, 100.00, 450.00\n"),
-        _ssh_result(stdout=""),
-        _ssh_result(stdout=""),
-        _ssh_result(stdout="400, Enabled\n"),
-    )
-    assert await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-1"]) == 1
+    assert POWER_STATE_CMD not in _cmds(ssh)
 
 
 # ------------------------------------------------------------------
@@ -918,7 +888,8 @@ async def test_create_container_flag_on_probes_once_and_hands_it_to_every_consum
 
     assert _probe_kwarg(ds.build_gpu_docker_config_for_executor) is probe
     assert _probe_kwarg(ds.restore_tracked_gpu_power_limits) is probe
-    assert _probe_kwarg(ds.raise_low_power_limits_to_default) is probe
+    # the last-resort raise runs minutes after the probe and never takes it
+    assert "host_probe" not in ds.raise_low_power_limits_to_default.await_args.kwargs
 
 
 @pytest.mark.asyncio
@@ -943,7 +914,7 @@ async def test_create_container_withdraws_docker_listings_after_a_removal(svc_fi
 
     # a docker removal does not touch the GPU / power sections
     assert _probe_kwarg(ds.build_gpu_docker_config_for_executor) is probe
-    assert _probe_kwarg(ds.raise_low_power_limits_to_default) is probe
+    assert _probe_kwarg(ds.restore_tracked_gpu_power_limits) is probe
 
 
 @pytest.mark.asyncio
@@ -962,24 +933,6 @@ async def test_create_container_withdraws_docker_listings_after_a_vloopback_swee
     assert _probe_kwarg(svc.clean_stale_vloopback_volumes) is probe
     assert _probe_kwarg(svc.sweep_stale_cache_volumes) is None
     assert _probe_kwarg(svc.reclaim_dphn_cache_for_rental) is None
-
-
-@pytest.mark.asyncio
-async def test_create_container_withdraws_power_state_after_a_restore(svc_fixture, monkeypatch):
-    svc = svc_fixture
-    monkeypatch.setattr(settings, "RENTAL_PRERUN_HOST_PROBE_ENABLED", True)
-    ssh_client = _deploy_ssh_client()
-    probe = _probe()
-    _wire(svc, monkeypatch, ssh_client, probe_result=probe)
-    from services import docker_service as ds
-
-    monkeypatch.setattr(
-        "services.docker_service.restore_tracked_gpu_power_limits", AsyncMock(return_value=1)
-    )
-    result = await _run_create_container(svc, _deploy_payload())
-    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
-    assert _probe_kwarg(ds.restore_tracked_gpu_power_limits) is probe
-    assert _probe_kwarg(ds.raise_low_power_limits_to_default) is None
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_prerun_host_probe.py
+++ b/neurons/validators/tests/test_prerun_host_probe.py
@@ -1,0 +1,1036 @@
+"""DAH-3257 — rental pre-run host probe (RENTAL_PRERUN_HOST_PROBE_ENABLED).
+
+Before `docker run`, a rent read eight host listings over eight serial SSH commands (containers,
+volumes, mounted volumes, volume names again, GPU minor map, shared device nodes, nvidia-smi power
+state, the image's encryption label). With the flag on, one probe command returns them all; every
+consumer reads its section and keeps its removals / writes as they are. Covered here:
+
+- the probe command carries every section and the exact per-command texts (`_PROC_GPU_INFO_CMD`,
+  `_POWER_STATE_CMD`, the shared-node loop, the label inspect); `with_power=False` has no nvidia-smi;
+- the parser: every section, a failed section → None, a missing `_RC` / an untagged line / an
+  unknown tag → raise, the label's whole-stdout semantics;
+- the command and the parser together through `sh -c` with a docker stub (containers, volumes,
+  mounts, label; nvidia-smi absent → power None);
+- `probe_prerun_host` is never fatal (SSH error or garbage → None);
+- each consumer with a probe runs no listing command and produces the same result / the same
+  removal commands as the per-command path for the same host facts; a failed section falls back;
+- `create_container`: flag off → never probes; flag on → one probe handed to every consumer; the
+  docker listings are withdrawn after a removal; the power state is withdrawn after a restore.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from core.config import settings
+from services import nvidia_devices as nd
+from services.docker_service import DockerService, _ENCRYPTED_VOLUME_IMAGE_LABEL
+from services.gpu_power_limit import (
+    _POWER_STATE_CMD,
+    raise_low_power_limits_to_default,
+    restore_tracked_gpu_power_limits,
+)
+from services.nvidia_devices import (
+    _GPU_DEVICE_NODES_CMD,
+    _PROC_GPU_INFO_CMD,
+    build_gpu_docker_config_for_executor,
+    shared_device_nodes_command,
+)
+from services.prerun_host_probe import (
+    DOCKER_MOUNTED_VOLUME_NAMES_CMD,
+    DOCKER_PS_ALL_NAMES_CMD,
+    DOCKER_VOLUME_LS_NAME_DRIVER_CMD,
+    PREFIX_FAILED_MARKER,
+    PrerunHostProbe,
+    PrerunHostProbeParseError,
+    image_label_command,
+    parse_prerun_host_probe,
+    prerun_host_probe_command,
+)
+from test_deploy_optimizations import (
+    _patch_happy,
+    _payload as _deploy_payload,
+    _run as _run_create_container,
+    _ssh_client as _deploy_ssh_client,
+    _ssh_result,
+)
+
+_IMAGE = "daturaai/pytorch:1.0.0"
+
+
+def _probe(**over) -> PrerunHostProbe:
+    base = dict(
+        container_names=(),
+        volumes=(),
+        mounted_volume_names=(),
+        gpu_proc_stdout="",
+        gpu_device_nodes=(),
+        shared_nodes=(),
+        shared_nodes_whole_host_only=(),
+        power_state_stdout="",
+        image_label_value="",
+    )
+    base.update(over)
+    return PrerunHostProbe(**base)
+
+
+def _tagged(tag: str, *lines: str, rc: int = 0) -> str:
+    return "".join(f"{tag}\t{line}\n" for line in lines) + f"{tag}_RC\t{rc}\n"
+
+
+def _stdout(
+    *,
+    ps: tuple[str, ...] = ("pod_a", "other"),
+    ps_rc: int = 0,
+    vol: tuple[str, ...] = ("volume_a vloopback:latest", "dphn_cache_x local"),
+    vol_rc: int = 0,
+    mnt: tuple[str, ...] = ("volume_a",),
+    mnt_rc: int = 0,
+    gpuproc: tuple[str, ...] = ("GPU-1, 0", "GPU-2, 1"),
+    gpuproc_rc: int = 0,
+    gpudev: tuple[str, ...] = ("/dev/nvidia0", "/dev/nvidia1"),
+    shared: tuple[str, ...] = ("/dev/nvidiactl", "/dev/nvidia-uvm"),
+    sharedw: tuple[str, ...] = ("/dev/infiniband/uverbs0", "/dev/nvidia-caps/nvidia-cap1"),
+    power: tuple[str, ...] | None = ("GPU-1, 300.00, 450.00, 100.00, 450.00",),
+    power_rc: int = 0,
+    label: tuple[str, ...] = ("1",),
+    label_rc: int = 0,
+) -> str:
+    out = (
+        _tagged("PS", *ps, rc=ps_rc)
+        + _tagged("VOL", *vol, rc=vol_rc)
+        + _tagged("MNT", *mnt, rc=mnt_rc)
+        + _tagged("GPUPROC", *gpuproc, rc=gpuproc_rc)
+        + _tagged("GPUDEV", *gpudev)
+        + _tagged("SHARED", *shared)
+        + _tagged("SHAREDW", *sharedw)
+    )
+    if power is not None:
+        out += _tagged("POWER", *power, rc=power_rc)
+    out += _tagged("LABEL", *label, rc=label_rc)
+    return out
+
+
+@pytest.fixture
+def docker_service():
+    return DockerService(
+        ssh_service=Mock(),
+        redis_service=Mock(),
+        attestation_service=Mock(),
+    )
+
+
+def _ssh(*results):
+    client = AsyncMock()
+    client.run = AsyncMock(side_effect=list(results))
+    return client
+
+
+def _cmds(client) -> list[str]:
+    return [c.args[0] for c in client.run.await_args_list if c.args]
+
+
+# ------------------------------------------------------------------
+# the command
+# ------------------------------------------------------------------
+
+
+def test_probe_command_carries_every_section_and_the_per_command_texts():
+    cmd = prerun_host_probe_command(
+        docker_image=_IMAGE, image_label=_ENCRYPTED_VOLUME_IMAGE_LABEL, with_power=True
+    )
+    assert "\n" not in cmd
+    for tag in ("PS", "VOL", "MNT", "GPUPROC", "GPUDEV", "SHARED", "SHAREDW", "POWER", "LABEL"):
+        assert f"t {tag} " in cmd
+    # shlex.quote wraps each section command; the quoted forms of the shared texts are inside
+    import shlex
+
+    assert shlex.quote(DOCKER_PS_ALL_NAMES_CMD) in cmd
+    assert shlex.quote(DOCKER_VOLUME_LS_NAME_DRIVER_CMD) in cmd
+    assert shlex.quote(DOCKER_MOUNTED_VOLUME_NAMES_CMD) in cmd
+    assert f"|| echo {PREFIX_FAILED_MARKER}" in cmd
+
+    assert shlex.quote(_PROC_GPU_INFO_CMD) in cmd
+    assert shlex.quote(_GPU_DEVICE_NODES_CMD) in cmd
+    assert shlex.quote(_POWER_STATE_CMD) in cmd
+    assert shlex.quote(shared_device_nodes_command(is_whole_host_rental=False)) in cmd
+    assert (
+        shlex.quote(shared_device_nodes_command(is_whole_host_rental=True, whole_host_only=True))
+        in cmd
+    )
+    assert shlex.quote(image_label_command(_IMAGE, _ENCRYPTED_VOLUME_IMAGE_LABEL)) in cmd
+    # the probe reads; it never removes, installs or writes
+    for verb in (" rm ", "volume rm", "plugin install", "nvidia-smi -pl", "-pm 1"):
+        assert verb not in cmd
+
+
+def test_probe_command_without_power_has_no_nvidia_smi():
+    cmd = prerun_host_probe_command(
+        docker_image=_IMAGE, image_label=_ENCRYPTED_VOLUME_IMAGE_LABEL, with_power=False
+    )
+    assert "nvidia-smi" not in cmd
+    assert "t POWER " not in cmd
+
+
+def test_image_label_command_is_the_one_the_label_check_ran():
+    cmd = image_label_command("a b/c:1", _ENCRYPTED_VOLUME_IMAGE_LABEL)
+    assert cmd == (
+        "/usr/bin/docker image inspect --format "
+        f"'{{{{index .Config.Labels \"{_ENCRYPTED_VOLUME_IMAGE_LABEL}\"}}}}' 'a b/c:1'"
+    )
+
+
+def test_shared_device_nodes_command_whole_host_only_is_the_tail_of_the_whole_host_command():
+    partial = shared_device_nodes_command(is_whole_host_rental=False)
+    whole = shared_device_nodes_command(is_whole_host_rental=True)
+    tail = shared_device_nodes_command(is_whole_host_rental=True, whole_host_only=True)
+    assert "/dev/infiniband" not in partial and "nvidia-caps" not in partial
+    assert (
+        "/dev/infiniband/uverbs[0-9]* /dev/infiniband/rdma_cm" in whole
+        and "find /dev/nvidia-caps" in whole
+    )
+    assert tail.startswith("for p in /dev/infiniband/uverbs[0-9]* /dev/infiniband/rdma_cm; do")
+    assert "find /dev/nvidia-caps" in tail
+    assert "/dev/nvidiactl" not in tail
+
+
+# ------------------------------------------------------------------
+# the parser
+# ------------------------------------------------------------------
+
+
+def test_parser_reads_every_section():
+    probe = parse_prerun_host_probe(_stdout(), with_power=True)
+    assert probe.container_names == ("pod_a", "other")
+    assert probe.volumes == (("volume_a", "vloopback:latest"), ("dphn_cache_x", "local"))
+    assert probe.volume_names == ("volume_a", "dphn_cache_x")
+    assert probe.mounted_volume_names == ("volume_a",)
+    assert probe.gpu_proc_stdout == "GPU-1, 0\nGPU-2, 1"
+    assert probe.gpu_device_nodes == ("/dev/nvidia0", "/dev/nvidia1")
+    assert probe.shared_nodes_for(is_whole_host_rental=False) == (
+        "/dev/nvidiactl",
+        "/dev/nvidia-uvm",
+    )
+    assert probe.shared_nodes_for(is_whole_host_rental=True) == (
+        "/dev/nvidiactl",
+        "/dev/nvidia-uvm",
+        "/dev/infiniband/uverbs0",
+        "/dev/nvidia-caps/nvidia-cap1",
+    )
+    assert probe.power_state_stdout == "GPU-1, 300.00, 450.00, 100.00, 450.00"
+    assert probe.image_label_value == "1"
+
+
+def test_parser_empty_sections_are_empty_not_none():
+    probe = parse_prerun_host_probe(
+        _stdout(ps=(), vol=(), mnt=(), gpudev=(), shared=(), sharedw=()), with_power=True
+    )
+    assert probe.container_names == ()
+    assert probe.volumes == ()
+    assert probe.mounted_volume_names == ()
+    assert probe.gpu_device_nodes == ()
+    assert probe.shared_nodes_for(is_whole_host_rental=True) == ()
+
+
+@pytest.mark.parametrize(
+    "kwargs, attr",
+    [
+        ({"ps_rc": 1}, "container_names"),
+        ({"vol_rc": 125}, "volumes"),
+        ({"mnt_rc": 123}, "mounted_volume_names"),
+        ({"gpuproc_rc": 2}, "gpu_proc_stdout"),
+        ({"power_rc": 127}, "power_state_stdout"),
+        ({"label_rc": 1}, "image_label_value"),
+    ],
+)
+def test_parser_failed_section_is_none_and_the_rest_survive(kwargs, attr):
+    probe = parse_prerun_host_probe(_stdout(**kwargs), with_power=True)
+    assert getattr(probe, attr) is None
+    others = {f for f in probe.__dataclass_fields__ if f != attr}
+    assert all(getattr(probe, f) is not None for f in others)
+
+
+def test_parser_device_node_sections_ignore_the_exit_status_like_the_per_command_path():
+    # `for p in …; do [ -e "$p" ] && …; done` exits 1 when the last node is absent; the live path
+    # never read that status, so an exit 1 with nodes listed is still a listing (and an empty one
+    # is "no nodes", not a failure)
+    stdout = (
+        _stdout()
+        .replace("GPUDEV_RC\t0", "GPUDEV_RC\t2")
+        .replace("SHARED_RC\t0", "SHARED_RC\t1")
+        .replace("SHAREDW_RC\t0", "SHAREDW_RC\t1")
+    )
+    probe = parse_prerun_host_probe(stdout, with_power=True)
+    assert probe.gpu_device_nodes == ("/dev/nvidia0", "/dev/nvidia1")
+    assert probe.shared_nodes_for(is_whole_host_rental=True) == (
+        "/dev/nvidiactl",
+        "/dev/nvidia-uvm",
+        "/dev/infiniband/uverbs0",
+        "/dev/nvidia-caps/nvidia-cap1",
+    )
+
+
+def test_parser_failed_volume_listing_hides_volume_names_too():
+    probe = parse_prerun_host_probe(_stdout(vol_rc=1), with_power=True)
+    assert probe.volumes is None and probe.volume_names is None
+
+
+def test_parser_shared_nodes_for_whole_host_needs_both_sections():
+    probe = _probe(shared_nodes=("/dev/nvidiactl",), shared_nodes_whole_host_only=None)
+    assert probe.shared_nodes_for(is_whole_host_rental=False) == ("/dev/nvidiactl",)
+    assert probe.shared_nodes_for(is_whole_host_rental=True) is None
+
+
+def test_parser_without_power_ignores_the_power_section_requirement():
+    probe = parse_prerun_host_probe(_stdout(power=None), with_power=False)
+    assert probe.power_state_stdout is None
+    assert probe.container_names == ("pod_a", "other")
+
+
+def test_parser_missing_rc_line_raises():
+    stdout = _stdout().replace("MNT_RC\t0\n", "")
+    with pytest.raises(PrerunHostProbeParseError, match="no MNT_RC"):
+        parse_prerun_host_probe(stdout, with_power=True)
+
+
+def test_parser_missing_power_rc_raises_only_when_power_was_asked():
+    stdout = _stdout(power=None)
+    with pytest.raises(PrerunHostProbeParseError, match="no POWER_RC"):
+        parse_prerun_host_probe(stdout, with_power=True)
+    parse_prerun_host_probe(stdout, with_power=False)
+
+
+def test_parser_untagged_line_raises():
+    with pytest.raises(PrerunHostProbeParseError, match="untagged line"):
+        parse_prerun_host_probe("garbage\n" + _stdout(), with_power=True)
+
+
+def test_parser_unknown_tag_raises():
+    with pytest.raises(PrerunHostProbeParseError, match="unknown section"):
+        parse_prerun_host_probe(_stdout() + "NEW\tx\nNEW_RC\t0\n", with_power=True)
+
+
+def test_parser_non_numeric_rc_raises():
+    with pytest.raises(PrerunHostProbeParseError, match="PS_RC is 'x'"):
+        parse_prerun_host_probe(_stdout().replace("PS_RC\t0", "PS_RC\tx"), with_power=True)
+
+
+def test_parser_error_message_is_capped():
+    with pytest.raises(PrerunHostProbeParseError) as exc:
+        parse_prerun_host_probe(
+            _stdout(ps=("x" * 5000,)).replace("MNT_RC\t0\n", ""), with_power=True
+        )
+    assert len(str(exc.value)) < 800
+
+
+@pytest.mark.parametrize(
+    "lines, expected",
+    [
+        (("1",), "1"),
+        (("",), ""),  # no such label → `{{index …}}` prints an empty line
+        (("<no value>",), "<no value>"),
+        (
+            ("", "1"),
+            "1",
+        ),  # a value with a leading newline arrives as two LABEL lines; strip() as before
+        (("1", "x"), "1\nx"),
+        (
+            ("1\tx",),
+            "1\tx",
+        ),  # a tab in the value stays in the value: only the first tab separates the tag
+    ],
+)
+def test_parser_label_value_matches_the_stripped_stdout_semantics(lines, expected):
+    probe = parse_prerun_host_probe(_stdout(label=lines), with_power=True)
+    assert probe.image_label_value == expected
+    assert (probe.image_label_value == "1") is (expected == "1")
+
+
+# ------------------------------------------------------------------
+# the command and the parser together (sh -c, docker stub)
+# ------------------------------------------------------------------
+
+
+_DOCKER_STUB = """#!/bin/sh
+case "$1 $2" in
+  "ps -a")
+    if [ "$3" = "-q" ]; then printf 'c1\\nc2\\n'; else printf 'pod_a\\nfiller_b\\nother\\n'; fi ;;
+  "volume ls") printf 'volume_a vloopback:latest\\nvolume_b local\\n' ;;
+  "inspect --format") printf 'volume_a\\n\\nvolume_a\\n' ;;
+  "image inspect") printf '%s\\n' "$LABEL_VALUE" ;;
+  *) echo "unexpected: $*" >&2; exit 9 ;;
+esac
+"""
+
+
+_NVIDIA_SMI_STUB = (
+    "#!/bin/sh\nexit 1\n"  # a host without a working driver: the section fails, never lists
+)
+
+
+def _run_probe_in_sh(tmp_path, *, label_value: str = "1", with_power: bool = True) -> str:
+    stub = tmp_path / "docker"
+    stub.write_text(_DOCKER_STUB)
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+    # PATH starts with tmp_path, so this stub shadows a real nvidia-smi on a GPU test host
+    smi = tmp_path / "nvidia-smi"
+    smi.write_text(_NVIDIA_SMI_STUB)
+    smi.chmod(smi.stat().st_mode | stat.S_IXUSR)
+    cmd = prerun_host_probe_command(
+        docker_image=_IMAGE, image_label=_ENCRYPTED_VOLUME_IMAGE_LABEL, with_power=with_power
+    )
+    cmd = cmd.replace("/usr/bin/docker", str(stub))
+    env = {**os.environ, "LABEL_VALUE": label_value, "PATH": f"{tmp_path}:/usr/bin:/bin"}
+    return subprocess.run(
+        ["sh", "-c", cmd], capture_output=True, text=True, env=env, check=False
+    ).stdout
+
+
+def test_probe_through_sh_lists_docker_sections_and_marks_absent_nvidia_smi(tmp_path):
+    out = _run_probe_in_sh(tmp_path)
+    probe = parse_prerun_host_probe(out, with_power=True)
+    assert probe.container_names == ("pod_a", "filler_b", "other")
+    assert probe.volumes == (("volume_a", "vloopback:latest"), ("volume_b", "local"))
+    assert probe.mounted_volume_names == ("volume_a", "volume_a")  # blank lines dropped as before
+    assert probe.image_label_value == "1"
+    # the GPU / device-node sections list whatever the test host has (a GPU workstation has
+    # /dev/nvidia*, a CI runner may have /dev/infiniband/*) — they are listings, never failures
+    assert probe.gpu_proc_stdout is not None and probe.gpu_device_nodes is not None
+    assert probe.shared_nodes_for(is_whole_host_rental=True) is not None
+    # the nvidia-smi stub exits 1 → the section failed → None → the live query would run
+    assert probe.power_state_stdout is None
+
+
+def test_probe_through_sh_label_absent_is_not_encrypted(tmp_path):
+    probe = parse_prerun_host_probe(_run_probe_in_sh(tmp_path, label_value=""), with_power=True)
+    assert probe.image_label_value == ""
+
+
+def test_probe_through_sh_multiline_label_cannot_forge_another_section(tmp_path):
+    # every line of a command's output gets that command's tag — an image label cannot inject a PS line
+    probe = parse_prerun_host_probe(
+        _run_probe_in_sh(tmp_path, label_value="1\nPS\tpod_evil"), with_power=True
+    )
+    assert probe.container_names == ("pod_a", "filler_b", "other")
+    assert probe.image_label_value == "1\nPS\tpod_evil"
+    assert probe.image_label_value != "1"
+
+
+def test_probe_through_sh_prefix_failure_is_a_whole_probe_fallback(tmp_path):
+    # awk missing on the host → the marker line (untagged) → the parser raises → probe None →
+    # every step on its own command; never an empty listing
+    stub = tmp_path / "docker"
+    stub.write_text(_DOCKER_STUB)
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+    broken_awk = tmp_path / "awk"
+    broken_awk.write_text("#!/bin/sh\nexit 1\n")
+    broken_awk.chmod(broken_awk.stat().st_mode | stat.S_IXUSR)
+    cmd = prerun_host_probe_command(
+        docker_image=_IMAGE, image_label=_ENCRYPTED_VOLUME_IMAGE_LABEL, with_power=False
+    ).replace("/usr/bin/docker", str(stub))
+    env = {**os.environ, "LABEL_VALUE": "1", "PATH": f"{tmp_path}:/usr/bin:/bin"}
+    out = subprocess.run(
+        ["sh", "-c", cmd], capture_output=True, text=True, env=env, check=False
+    ).stdout
+    assert PREFIX_FAILED_MARKER in out
+    with pytest.raises(PrerunHostProbeParseError, match="untagged line"):
+        parse_prerun_host_probe(out, with_power=False)
+
+
+# ------------------------------------------------------------------
+# probe_prerun_host is never fatal
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_prerun_host_runs_one_command_and_parses(docker_service):
+    ssh = _ssh(_ssh_result(stdout=_stdout()))
+    probe = await docker_service.probe_prerun_host(
+        ssh, docker_image=_IMAGE, with_power=True, log_extra={}
+    )
+    assert probe is not None and probe.container_names == ("pod_a", "other")
+    assert _cmds(ssh) == [
+        prerun_host_probe_command(
+            docker_image=_IMAGE, image_label=_ENCRYPTED_VOLUME_IMAGE_LABEL, with_power=True
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_probe_prerun_host_ssh_error_is_none(docker_service):
+    ssh = _ssh(ConnectionError("channel closed"))
+    assert (
+        await docker_service.probe_prerun_host(
+            ssh, docker_image=_IMAGE, with_power=True, log_extra={}
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_probe_prerun_host_is_bounded_and_a_timeout_is_none(docker_service):
+    import asyncio
+
+    from services.docker_service import _PRERUN_HOST_PROBE_TIMEOUT_SECONDS
+
+    ssh = _ssh(asyncio.TimeoutError())
+    assert (
+        await docker_service.probe_prerun_host(
+            ssh, docker_image=_IMAGE, with_power=True, log_extra={}
+        )
+        is None
+    )
+    assert ssh.run.await_args.kwargs["timeout"] == _PRERUN_HOST_PROBE_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_probe_prerun_host_garbage_is_none(docker_service):
+    ssh = _ssh(_ssh_result(stdout="sh: t: not found\n"))
+    assert (
+        await docker_service.probe_prerun_host(
+            ssh, docker_image=_IMAGE, with_power=True, log_extra={}
+        )
+        is None
+    )
+
+
+# ------------------------------------------------------------------
+# consumers: same result, no listing command
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clean_existing_containers_with_probe_removes_the_same_and_lists_nothing(
+    docker_service, monkeypatch
+):
+    ran: list[str] = []
+
+    async def _retry(ssh, command, _tag):
+        ran.append(command)
+
+    monkeypatch.setattr("services.docker_service.retry_ssh_command", _retry)
+    live = _ssh(_ssh_result(stdout="pod_new\npod_old\nfiller_x\nsomething\n"))
+    removed_live = await docker_service.clean_existing_containers(
+        ssh_client=live,
+        default_extra={},
+        pod_name="pod_new",
+        active_container_names=["pod_keep"],
+        active_volume_names=["volume_old"],
+    )
+    live_cmds = list(ran)
+    ran.clear()
+    probe = _probe(container_names=("pod_new", "pod_old", "filler_x", "something"))
+    probed = _ssh()
+    removed_probed = await docker_service.clean_existing_containers(
+        ssh_client=probed,
+        default_extra={},
+        pod_name="pod_new",
+        active_container_names=["pod_keep"],
+        active_volume_names=["volume_old"],
+        host_probe=probe,
+    )
+    assert removed_live == removed_probed == ["pod_new", "pod_old", "filler_x"]
+    assert (
+        ran
+        == live_cmds
+        == [
+            "/usr/bin/docker rm -fv pod_new pod_old filler_x",
+            "/usr/bin/docker volume rm volume_new volume_x 2>/dev/null || true",
+        ]
+    )
+    assert _cmds(live) == ['/usr/bin/docker ps -a --format "{{.Names}}"']
+    assert _cmds(probed) == []
+
+
+@pytest.mark.asyncio
+async def test_clean_existing_containers_nothing_stale_returns_empty(docker_service):
+    probe = _probe(container_names=("other", "pod_keep"))
+    ssh = _ssh()
+    assert (
+        await docker_service.clean_existing_containers(
+            ssh_client=ssh,
+            default_extra={},
+            pod_name="pod_new",
+            active_container_names=["pod_keep"],
+            host_probe=probe,
+        )
+        == []
+    )
+    assert _cmds(ssh) == []
+
+
+@pytest.mark.asyncio
+async def test_clean_existing_containers_failed_ps_section_lists_itself(docker_service):
+    probe = _probe(container_names=None)
+    ssh = _ssh(_ssh_result(stdout=""))
+    assert (
+        await docker_service.clean_existing_containers(
+            ssh_client=ssh,
+            default_extra={},
+            pod_name="pod_new",
+            host_probe=probe,
+        )
+        == []
+    )
+    assert _cmds(ssh) == ['/usr/bin/docker ps -a --format "{{.Names}}"']
+
+
+@pytest.mark.asyncio
+async def test_clean_stale_vloopback_with_probe_removes_the_same_and_lists_nothing(
+    docker_service, monkeypatch
+):
+    ran: list[str] = []
+
+    async def _retry(ssh, command, _tag):
+        ran.append(command)
+
+    monkeypatch.setattr("services.docker_service.retry_ssh_command", _retry)
+    volumes = "volume_a vloopback:latest\nvolume_b vloopback\nvolume_c local\nvolume_d vloopback:latest\nother vloopback\n"
+    live = _ssh(_ssh_result(stdout=volumes), _ssh_result(stdout="volume_a\n\nvolume_c\n"))
+    removed_live = await docker_service.clean_stale_vloopback_volumes(
+        ssh_client=live,
+        default_extra={},
+        skip_volume_names={"volume_d"},
+    )
+    live_cmds = list(ran)
+    ran.clear()
+    probe = _probe(
+        volumes=(
+            ("volume_a", "vloopback:latest"),
+            ("volume_b", "vloopback"),
+            ("volume_c", "local"),
+            ("volume_d", "vloopback:latest"),
+            ("other", "vloopback"),
+        ),
+        mounted_volume_names=("volume_a", "volume_c"),
+    )
+    probed = _ssh()
+    removed_probed = await docker_service.clean_stale_vloopback_volumes(
+        ssh_client=probed,
+        default_extra={},
+        skip_volume_names={"volume_d"},
+        host_probe=probe,
+    )
+    assert removed_live == removed_probed == ["volume_b"]
+    assert ran == live_cmds == ["/usr/bin/docker volume rm volume_b 2>/dev/null || true"]
+    assert len(_cmds(live)) == 2 and _cmds(probed) == []
+
+
+@pytest.mark.asyncio
+async def test_clean_stale_vloopback_probe_without_vloopback_volumes_runs_nothing(docker_service):
+    ssh = _ssh()
+    assert (
+        await docker_service.clean_stale_vloopback_volumes(
+            ssh_client=ssh,
+            default_extra={},
+            host_probe=_probe(volumes=(("volume_c", "local"),)),
+        )
+        == []
+    )
+    assert _cmds(ssh) == []
+
+
+@pytest.mark.asyncio
+async def test_clean_stale_vloopback_failed_mount_section_inspects_itself(
+    docker_service, monkeypatch
+):
+    monkeypatch.setattr("services.docker_service.retry_ssh_command", AsyncMock())
+    probe = _probe(volumes=(("volume_a", "vloopback"),), mounted_volume_names=None)
+    ssh = _ssh(_ssh_result(stdout="volume_a\n"))
+    assert (
+        await docker_service.clean_stale_vloopback_volumes(
+            ssh_client=ssh, default_extra={}, host_probe=probe
+        )
+        == []
+    )
+    assert len(_cmds(ssh)) == 1 and "docker inspect" in _cmds(ssh)[0]
+
+
+@pytest.mark.asyncio
+async def test_find_cache_volumes_with_probe_matches_live(docker_service):
+    live = _ssh(_ssh_result(stdout="dphn_cache_old\ndphn_cache_new\nvolume_a\n"))
+    from_live = await docker_service._find_cache_volumes_to_sweep(live, {"dphn_cache_new"}, {})
+    probe = _probe(
+        volumes=(
+            ("dphn_cache_old", "local"),
+            ("dphn_cache_new", "local"),
+            ("volume_a", "vloopback"),
+        )
+    )
+    probed = _ssh()
+    from_probe = await docker_service._find_cache_volumes_to_sweep(
+        probed, {"dphn_cache_new"}, {}, host_probe=probe
+    )
+    assert from_live == from_probe == ["dphn_cache_old"]
+    assert _cmds(probed) == []
+
+
+@pytest.mark.asyncio
+async def test_find_cache_volumes_failed_volume_section_lists_itself(docker_service):
+    ssh = _ssh(_ssh_result(stdout="dphn_cache_old\n"))
+    assert await docker_service._find_cache_volumes_to_sweep(
+        ssh, set(), {}, host_probe=_probe(volumes=None)
+    ) == ["dphn_cache_old"]
+    assert _cmds(ssh) == ['/usr/bin/docker volume ls --format "{{.Name}}"']
+
+
+@pytest.mark.asyncio
+async def test_image_label_with_probe_runs_nothing_and_matches(docker_service):
+    ssh = _ssh()
+    assert await docker_service._image_has_encrypted_volume_label(
+        ssh, _IMAGE, host_probe=_probe(image_label_value="1")
+    )
+    assert not await docker_service._image_has_encrypted_volume_label(
+        ssh, _IMAGE, host_probe=_probe(image_label_value="")
+    )
+    assert not await docker_service._image_has_encrypted_volume_label(
+        ssh, _IMAGE, host_probe=_probe(image_label_value="<no value>")
+    )
+    assert _cmds(ssh) == []
+
+
+@pytest.mark.asyncio
+async def test_image_label_failed_section_inspects_itself(docker_service):
+    ssh = _ssh(_ssh_result(stdout="1\n"))
+    assert await docker_service._image_has_encrypted_volume_label(
+        ssh, _IMAGE, host_probe=_probe(image_label_value=None)
+    )
+    assert _cmds(ssh) == [image_label_command(_IMAGE, _ENCRYPTED_VOLUME_IMAGE_LABEL)]
+
+
+@pytest.mark.asyncio
+async def test_gpu_config_with_probe_matches_live_partial_rental(monkeypatch):
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False)
+    proc = "GPU-1, 0\nGPU-2, 1\n"
+    live = _ssh(_ssh_result(stdout=proc), _ssh_result(stdout="/dev/nvidiactl\n/dev/nvidia-uvm\n"))
+    from_live = await build_gpu_docker_config_for_executor(live, ["GPU-2"])
+    probe = _probe(
+        gpu_proc_stdout=proc,
+        shared_nodes=("/dev/nvidiactl", "/dev/nvidia-uvm"),
+        shared_nodes_whole_host_only=("/dev/infiniband/uverbs0", "/dev/nvidia-caps/nvidia-cap1"),
+    )
+    probed = _ssh()
+    from_probe = await build_gpu_docker_config_for_executor(probed, ["GPU-2"], host_probe=probe)
+    assert from_probe == from_live
+    assert [d.path_on_host for d in from_probe.device_mounts] == [
+        "/dev/nvidia1",
+        "/dev/nvidiactl",
+        "/dev/nvidia-uvm",
+    ]
+    assert len(_cmds(live)) == 2 and _cmds(probed) == []
+
+
+@pytest.mark.asyncio
+async def test_gpu_config_with_probe_whole_host_gets_the_whole_host_nodes(monkeypatch):
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False)
+    probe = _probe(
+        gpu_proc_stdout="GPU-1, 0\nGPU-2, 1\n",
+        gpu_device_nodes=("/dev/nvidia0", "/dev/nvidia1"),
+        shared_nodes=("/dev/nvidiactl",),
+        shared_nodes_whole_host_only=("/dev/infiniband/uverbs0", "/dev/nvidia-caps/nvidia-cap1"),
+    )
+    ssh = _ssh()
+    by_uuid = await build_gpu_docker_config_for_executor(ssh, ["GPU-1", "GPU-2"], host_probe=probe)
+    whole_node = await build_gpu_docker_config_for_executor(ssh, None, host_probe=probe)
+    expected = [
+        "/dev/nvidia0",
+        "/dev/nvidia1",
+        "/dev/nvidiactl",
+        "/dev/infiniband/uverbs0",
+        "/dev/nvidia-caps/nvidia-cap1",
+    ]
+    assert [d.path_on_host for d in by_uuid.device_mounts] == expected
+    assert [d.path_on_host for d in whole_node.device_mounts] == expected
+    assert _cmds(ssh) == []
+
+
+@pytest.mark.asyncio
+async def test_gpu_config_with_probe_missing_uuid_still_consults_xml_live(monkeypatch):
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False)
+    probe = _probe(gpu_proc_stdout="GPU-1, 0\n", shared_nodes=("/dev/nvidiactl",))
+    ssh = _ssh(_ssh_result(exit_status=1, stderr="no nvidia-smi"))
+    config = await build_gpu_docker_config_for_executor(ssh, ["GPU-9"], host_probe=probe)
+    # the kernel map lacks GPU-9 → nvidia-smi XML is asked live → fails → legacy --gpus-only fallback
+    assert _cmds(ssh) == ["nvidia-smi -q -x"]
+    assert config.device_mounts == ()
+
+
+@pytest.mark.asyncio
+async def test_gpu_config_failed_proc_section_queries_live(monkeypatch):
+    monkeypatch.setattr(nd.settings, "KERNEL_GPU_VERDICT_CHECK_ENABLED", False)
+    probe = _probe(gpu_proc_stdout=None, shared_nodes=("/dev/nvidiactl",))
+    ssh = _ssh(_ssh_result(stdout="GPU-1, 0\n"))
+    config = await build_gpu_docker_config_for_executor(ssh, ["GPU-1"], host_probe=probe)
+    assert _cmds(ssh) == [_PROC_GPU_INFO_CMD]
+    assert [d.path_on_host for d in config.device_mounts] == ["/dev/nvidia0", "/dev/nvidiactl"]
+
+
+@pytest.mark.asyncio
+async def test_raise_low_power_limits_with_probe_queries_nothing_and_still_raises():
+    state = "GPU-1, 100.00, 450.00, 100.00, 450.00\nGPU-2, 450.00, 450.00, 100.00, 450.00\n"
+    probe = _probe(power_state_stdout=state)
+    # -pm 1, -pl 450, readback
+    ssh = _ssh(
+        _ssh_result(stdout=""),
+        _ssh_result(stdout=""),
+        _ssh_result(stdout="450, Enabled\n"),
+    )
+    raised = await raise_low_power_limits_to_default(
+        ssh, "exec-1", ["GPU-1", "GPU-2"], host_probe=probe
+    )
+    assert raised == 1
+    assert _POWER_STATE_CMD not in _cmds(ssh)
+    assert any("-pl 450" in c and "GPU-1" in c for c in _cmds(ssh))
+
+
+@pytest.mark.asyncio
+async def test_raise_low_power_limits_failed_power_section_queries_live():
+    ssh = _ssh(_ssh_result(stdout="GPU-1, 450.00, 450.00, 100.00, 450.00\n"))
+    assert (
+        await raise_low_power_limits_to_default(
+            ssh, "exec-1", ["GPU-1"], host_probe=_probe(power_state_stdout=None)
+        )
+        == 0
+    )
+    assert _cmds(ssh) == [_POWER_STATE_CMD]
+
+
+@pytest.mark.asyncio
+async def test_restore_tracked_limits_with_probe_uses_it_for_before_values():
+    redis = AsyncMock()
+    redis.get = AsyncMock(
+        return_value='{"gpu_uuid":"GPU-1","watts":400,"pod_id":"p","executor_id":"e","capped_at":1.0}'
+    )
+    redis.delete = AsyncMock()
+    probe = _probe(power_state_stdout="GPU-1, 250.00, 450.00, 100.00, 450.00\n")
+    ssh = _ssh(_ssh_result(stdout=""), _ssh_result(stdout=""), _ssh_result(stdout="400, Enabled\n"))
+    assert await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-1"], host_probe=probe) == 1
+    assert _POWER_STATE_CMD not in _cmds(ssh)
+
+
+@pytest.mark.asyncio
+async def test_restore_counts_a_written_limit_even_when_its_record_cannot_be_cleared():
+    # create_container withdraws the probe's power state from the raise when restore_* returns > 0;
+    # a limit that was written but whose Redis record could not be deleted still changed the GPU
+    redis = AsyncMock()
+    redis.get = AsyncMock(
+        return_value='{"gpu_uuid":"GPU-1","watts":400,"pod_id":"p","executor_id":"e","capped_at":1.0}'
+    )
+    redis.delete = AsyncMock(side_effect=ConnectionError("redis gone"))
+    ssh = _ssh(
+        _ssh_result(stdout="GPU-1, 250.00, 450.00, 100.00, 450.00\n"),
+        _ssh_result(stdout=""),
+        _ssh_result(stdout=""),
+        _ssh_result(stdout="400, Enabled\n"),
+    )
+    assert await restore_tracked_gpu_power_limits(ssh, redis, ["GPU-1"]) == 1
+
+
+# ------------------------------------------------------------------
+# create_container wiring
+# ------------------------------------------------------------------
+
+
+def _wire(svc, monkeypatch, ssh_client, *, probe_result):
+    _patch_happy(svc, monkeypatch, ssh_client)
+    # so a payload with is_sysbox + enable_volume_encryption reaches the label check
+    monkeypatch.setattr(settings, "ENABLE_VOLUME_ENCRYPTION", True)
+    monkeypatch.setattr(svc, "probe_prerun_host", AsyncMock(return_value=probe_result))
+    monkeypatch.setattr(svc, "clean_existing_containers", AsyncMock(return_value=[]))
+    monkeypatch.setattr(svc, "clean_stale_vloopback_volumes", AsyncMock(return_value=[]))
+    monkeypatch.setattr(svc, "sweep_stale_cache_volumes", AsyncMock(return_value=[]))
+    monkeypatch.setattr(svc, "select_affordable_cache_volumes", AsyncMock(return_value=[]))
+    monkeypatch.setattr(svc, "reclaim_dphn_cache_for_rental", AsyncMock())
+    monkeypatch.setattr(svc, "_image_has_encrypted_volume_label", AsyncMock(return_value=False))
+    monkeypatch.setattr(
+        "services.docker_service.restore_tracked_gpu_power_limits", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(
+        "services.docker_service.restore_all_host_gpu_power_limits", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(
+        "services.docker_service.raise_low_power_limits_to_default", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(svc, "add_ssh_public_keys_with_rental_docker", AsyncMock())
+    monkeypatch.setattr(
+        svc, "add_environment_variables_with_rental_docker", AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(svc, "_run_inspector_collector_lifecycle", AsyncMock())
+
+
+def _probe_kwarg(mock) -> object:
+    return mock.await_args.kwargs.get("host_probe")
+
+
+@pytest.mark.asyncio
+async def test_create_container_flag_off_never_probes(svc_fixture, monkeypatch):
+    svc = svc_fixture
+    monkeypatch.setattr(settings, "RENTAL_PRERUN_HOST_PROBE_ENABLED", False)
+    ssh_client = _deploy_ssh_client()
+    _wire(svc, monkeypatch, ssh_client, probe_result=_probe())
+    payload = _deploy_payload(enable_volume_encryption=True, is_sysbox=True)
+    result = await _run_create_container(svc, payload)
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    svc.probe_prerun_host.assert_not_awaited()
+    for m in (
+        svc.clean_existing_containers,
+        svc.clean_stale_vloopback_volumes,
+        svc.sweep_stale_cache_volumes,
+        svc.select_affordable_cache_volumes,
+        svc.reclaim_dphn_cache_for_rental,
+    ):
+        assert _probe_kwarg(m) is None
+    from services import docker_service as ds
+
+    assert _probe_kwarg(ds.build_gpu_docker_config_for_executor) is None
+    assert _probe_kwarg(ds.raise_low_power_limits_to_default) is None
+
+
+@pytest.mark.asyncio
+async def test_create_container_flag_on_probes_once_and_hands_it_to_every_consumer(
+    svc_fixture, monkeypatch
+):
+    svc = svc_fixture
+    monkeypatch.setattr(settings, "RENTAL_PRERUN_HOST_PROBE_ENABLED", True)
+    ssh_client = _deploy_ssh_client()
+    probe = _probe()
+    _wire(svc, monkeypatch, ssh_client, probe_result=probe)
+    payload = _deploy_payload(enable_volume_encryption=True, is_sysbox=True)
+    result = await _run_create_container(svc, payload)
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    svc.probe_prerun_host.assert_awaited_once()
+    assert svc.probe_prerun_host.await_args.kwargs["docker_image"] == payload.docker_image
+    assert svc.probe_prerun_host.await_args.kwargs["with_power"] is True
+    for m in (
+        svc.clean_existing_containers,
+        svc.clean_stale_vloopback_volumes,
+        svc.sweep_stale_cache_volumes,
+        svc.select_affordable_cache_volumes,
+        svc.reclaim_dphn_cache_for_rental,
+        svc._image_has_encrypted_volume_label,
+    ):
+        assert _probe_kwarg(m) is probe, m
+    from services import docker_service as ds
+
+    assert _probe_kwarg(ds.build_gpu_docker_config_for_executor) is probe
+    assert _probe_kwarg(ds.restore_tracked_gpu_power_limits) is probe
+    assert _probe_kwarg(ds.raise_low_power_limits_to_default) is probe
+
+
+@pytest.mark.asyncio
+async def test_create_container_withdraws_docker_listings_after_a_removal(svc_fixture, monkeypatch):
+    svc = svc_fixture
+    monkeypatch.setattr(settings, "RENTAL_PRERUN_HOST_PROBE_ENABLED", True)
+    ssh_client = _deploy_ssh_client()
+    probe = _probe()
+    _wire(svc, monkeypatch, ssh_client, probe_result=probe)
+    svc.clean_existing_containers = AsyncMock(return_value=["pod_old"])
+    result = await _run_create_container(svc, _deploy_payload())
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    assert _probe_kwarg(svc.clean_existing_containers) is probe
+    for m in (
+        svc.clean_stale_vloopback_volumes,
+        svc.sweep_stale_cache_volumes,
+        svc.select_affordable_cache_volumes,
+        svc.reclaim_dphn_cache_for_rental,
+    ):
+        assert _probe_kwarg(m) is None, m
+    from services import docker_service as ds
+
+    # a docker removal does not touch the GPU / power sections
+    assert _probe_kwarg(ds.build_gpu_docker_config_for_executor) is probe
+    assert _probe_kwarg(ds.raise_low_power_limits_to_default) is probe
+
+
+@pytest.mark.asyncio
+async def test_create_container_withdraws_docker_listings_after_a_vloopback_sweep(
+    svc_fixture, monkeypatch
+):
+    svc = svc_fixture
+    monkeypatch.setattr(settings, "RENTAL_PRERUN_HOST_PROBE_ENABLED", True)
+    ssh_client = _deploy_ssh_client()
+    probe = _probe()
+    _wire(svc, monkeypatch, ssh_client, probe_result=probe)
+    svc.clean_stale_vloopback_volumes = AsyncMock(return_value=["volume_b"])
+    result = await _run_create_container(svc, _deploy_payload())
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    assert _probe_kwarg(svc.clean_existing_containers) is probe
+    assert _probe_kwarg(svc.clean_stale_vloopback_volumes) is probe
+    assert _probe_kwarg(svc.sweep_stale_cache_volumes) is None
+    assert _probe_kwarg(svc.reclaim_dphn_cache_for_rental) is None
+
+
+@pytest.mark.asyncio
+async def test_create_container_withdraws_power_state_after_a_restore(svc_fixture, monkeypatch):
+    svc = svc_fixture
+    monkeypatch.setattr(settings, "RENTAL_PRERUN_HOST_PROBE_ENABLED", True)
+    ssh_client = _deploy_ssh_client()
+    probe = _probe()
+    _wire(svc, monkeypatch, ssh_client, probe_result=probe)
+    from services import docker_service as ds
+
+    monkeypatch.setattr(
+        "services.docker_service.restore_tracked_gpu_power_limits", AsyncMock(return_value=1)
+    )
+    result = await _run_create_container(svc, _deploy_payload())
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    assert _probe_kwarg(ds.restore_tracked_gpu_power_limits) is probe
+    assert _probe_kwarg(ds.raise_low_power_limits_to_default) is None
+
+
+@pytest.mark.asyncio
+async def test_create_container_probe_failure_leaves_every_consumer_on_its_own_commands(
+    svc_fixture, monkeypatch
+):
+    svc = svc_fixture
+    monkeypatch.setattr(settings, "RENTAL_PRERUN_HOST_PROBE_ENABLED", True)
+    ssh_client = _deploy_ssh_client()
+    _wire(svc, monkeypatch, ssh_client, probe_result=None)
+    result = await _run_create_container(
+        svc, _deploy_payload(enable_volume_encryption=True, is_sysbox=True)
+    )
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    svc.probe_prerun_host.assert_awaited_once()
+    from services import docker_service as ds
+
+    for m in (
+        svc.clean_existing_containers,
+        svc.clean_stale_vloopback_volumes,
+        svc._image_has_encrypted_volume_label,
+        ds.build_gpu_docker_config_for_executor,
+        ds.raise_low_power_limits_to_default,
+    ):
+        assert _probe_kwarg(m) is None
+
+
+@pytest.mark.asyncio
+async def test_create_container_pearl_filler_does_not_ask_for_power(svc_fixture, monkeypatch):
+    from payload_models.payloads import GpuPowerLimit, WorkloadKind
+
+    svc = svc_fixture
+    monkeypatch.setattr(settings, "RENTAL_PRERUN_HOST_PROBE_ENABLED", True)
+    ssh_client = _deploy_ssh_client()
+    _wire(svc, monkeypatch, ssh_client, probe_result=_probe())
+    monkeypatch.setattr(
+        "services.docker_service.apply_filler_gpu_power_limits", AsyncMock(return_value=True)
+    )
+    payload = _deploy_payload(
+        workload_kind=WorkloadKind.FILLER,
+        gpu_power_limits=[GpuPowerLimit(gpu_uuid="GPU-test", watts=300)],
+    )
+    result = await _run_create_container(svc, payload)
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    assert svc.probe_prerun_host.await_args.kwargs["with_power"] is False
+
+
+@pytest.fixture
+def svc_fixture():
+    return DockerService(
+        ssh_service=Mock(),
+        redis_service=Mock(),
+        attestation_service=Mock(),
+    )


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3257](https://app.notion.com/p/Rent-pre-run-host-stage-is-8-serial-SSH-commands-cleaning-GPU-probe-power-limit-check-port-che-3d6b8bfdbde981f39961f67991083d2c) · reviewer: @taiberium

**TL;DR** — Between the pull and `docker run` a rent asks the host eight read-only listings over eight serial SSH commands: 0.9 s cleaning + 1.1 s GPU probe p50 on a far node, for ~80 ms of host work. Behind `RENTAL_PRERUN_HOST_PROBE_ENABLED` (off) one tagged command returns them all; each step reads its section, removals and writes unchanged. A failed section, or an unparseable probe, puts that step, or every step, back on its own command.

**What changed**
- `RENTAL_PRERUN_HOST_PROBE_ENABLED` (False) + `.env.template` line (`src/core/config.py`)
- `services/prerun_host_probe.py` (new): the one-line probe command (nine tagged sections, `<TAG>_RC` each), its parser
- `probe_prerun_host`: runs it once after the pull, bounded at 30 s (the nvidia-smi bound); None on any error → per-command path
- The cleanup, the three volume sweeps and the image-label check take `host_probe=`; the sweeps return what they removed
- `build_gpu_docker_config_for_executor(host_probe=)`, `shared_device_nodes_command`; `_query_power_state(host_probe=)` behind the two restore helpers — the last-resort raise always queries live
- `create_container` probes once with the flag on; withdraws the docker listings after any removal

**How to verify**
- `pytest tests/test_prerun_host_probe.py -q` → 58 passed · `pytest tests/ -q` → 1 failed (main's own), 2058 passed
- flag on, one rent → profiling "Container cleaning" + "GPU device probe" shrink to the probe's wall; log `prerun_host_probe`

**Verified by the loop:** 9 Sep 2026 · sandbox EC2 · pytest 2058 passed · Result: PASS 37ee708 · Gate: PASS 37ee708

**Ran it:** probe vs the 8 commands: RTX 4090 (far) 6.0 s → 0.95 s, L40S (near) 3.3 s → 0.62 s · two pods, 9 Sep, the earlier head · validators suite at `37ee708`: 2058 passed, 1 failed (main's own) · EC2 warm box 20260909T131205Z-43b8

**Self-review:** clean at 37ee708 (15 checks, 5 low)

**Parts:** backend n/a — validator-only · migration n/a — no schema · frontend n/a — nothing renter-visible · CLI/SDK n/a — no API surface · docs n/a — operator flag in `.env.template` · tests ✓ 58 · dashboards n/a — existing profiler steps

**Docs:** `neurons/validators/.env.template` (the flag and what it replaces); no renter docs — a renter sees a shorter stage.

<details><summary>Details</summary>

### Where the time goes

Prod `rental_history.profilers`, 7 d to 8 Sep 22:00Z (`~/lium-ads/speed/DEPLOY_UNDER_10S.md` §1): on a cached rental with no filler to stop, "container cleaning" p50 0.92 s / p90 1.65 s and "GPU device probe + power-limit restore" 1.12 / 1.61 s. The steps between the pull and `docker run` run these commands, one SSH channel each, on the customer-rental path:

1. `docker ps -a --format {{.Names}}` — `clean_existing_containers`
2. `docker volume ls --format "{{.Name}} {{.Driver}}"` — `clean_stale_vloopback_volumes`
3. `docker ps -a -q | xargs -r docker inspect --format '{{range .Mounts}}…'` — same (mounted volumes)
4. `docker volume ls --format {{.Name}}` — `reclaim_dphn_cache_for_rental` → `_find_cache_volumes_to_sweep`
5. the `/proc/driver/nvidia/gpus/*/information` awk loop — `_query_gpu_minor_map_from_proc`
6. the `for p in /dev/nvidiactl …` loop (+ `find /dev/nvidia-caps …` on a whole-host rental) — `_query_shared_nodes`
7. `nvidia-smi --query-gpu=uuid,power.limit,…` — `raise_low_power_limits_to_default` → `_query_power_state`
8. `docker image inspect --format '{{index .Config.Labels "lium.volume_encryption.enable"}}' <image>` — `_image_has_encrypted_volume_label` (86 % of pods)

A filler adds `docker volume ls` for the cache sweep / selection; a pod with a filler to remove adds the `rm -fv` calls (unchanged here). On the consumer-GPU half of the fleet a channel round trip is 0.2–0.6 s; the host work behind all eight is ~80 ms (measured below).

### What the flag changes

`probe_prerun_host` runs `prerun_host_probe_command(docker_image, image_label, with_power)` once, right after the pull and before the cleanup:

```
t() { tag=$1; shift; out="$(sh -c "$1" 2>/dev/null)"; rc=$?; [ -n "$out" ] && printf '%s\n' "$out" | awk -v t="$tag" '{ print t "\t" $0 }'; printf '%s_RC\t%s\n' "$tag" "$rc"; }; t PS '<docker ps -a …>'; t VOL '<docker volume ls …>'; t MNT '<docker ps -a -q | xargs -r docker inspect …>'; t GPUMINORMAP '<PROC_GPU_INFO_CMD>'; t GPUDEV 'ls -1d /dev/nvidia[0-9]* 2>/dev/null || true'; t SHARED '<shared_device_nodes_command(partial)>'; t SHAREDW '<shared_device_nodes_command(whole-host extras)>'; t POWER '<POWER_STATE_CMD>'; t LABEL '<docker image inspect … label … image>'
```

- Every section command is the per-command path's own text: `PROC_GPU_INFO_CMD`, `POWER_STATE_CMD`, `shared_device_nodes_command` and `image_label_command` are imported from their modules (the four names the probe shares with `nvidia_devices` / `gpu_power_limit` are public now, `NVIDIA_SMI_TIMEOUT_SECONDS` included), and the three docker listings (`DOCKER_PS_ALL_NAMES_CMD`, `DOCKER_VOLUME_LS_NAME_DRIVER_CMD`, `DOCKER_MOUNTED_VOLUME_NAMES_CMD`) now live in `prerun_host_probe.py` and are imported by `clean_existing_containers` / `clean_stale_vloopback_volumes` for their own path — one text, two callers. The one listing without a section of its own is `_find_cache_volumes_to_sweep`'s `docker volume ls --format {{.Name}}`: the probe answers it from the `VOL` section (`ProbedVolume(name, driver)` rows; `volume_names`), the live path keeps its `{{.Name}}`-only literal. Each output line is prefixed with its tag by awk, so a command's output — an image label a renter's image controls included — can only ever produce lines of its own tag (`test_probe_through_sh_multiline_label_cannot_forge_another_section`). If the awk prefixing itself fails (awk missing or killed), the helper prints the untagged `PRERUN_PROBE_PREFIX_FAILED` line, which the parser refuses — a prefixing failure is a whole-probe fallback, never an empty listing (`test_probe_through_sh_prefix_failure_is_a_whole_probe_fallback`).
- The probe runs with `timeout=_PRERUN_HOST_PROBE_TIMEOUT_SECONDS` (30 s, the bound the per-command path puts on the nvidia-smi query it carries — `NVIDIA_SMI_TIMEOUT_SECONDS`; the seven other listings take milliseconds); `asyncio.TimeoutError`, like any other error, → None → the per-command path (`test_probe_prerun_host_is_bounded_and_a_timeout_is_none`).
- `<TAG>_RC` closes every section. A missing `_RC`, an untagged line, an unknown tag or a non-numeric status makes the parser raise → `probe_prerun_host` logs `prerun_host_probe_fallback` and returns None → every step runs its own commands, as with the flag off. A section with a non-zero status is None on its own → that one step runs its own command and sees the real stderr. `GPUDEV`/`SHARED`/`SHAREDW` ignore the status like the per-command path does (`ls … || true`; the `[ -e ] &&` loop exits 1 when the last node is absent).
- The shared device nodes are listed once as the partial-rental set (`SHARED`) plus the whole-host extras (`SHAREDW`: `/dev/infiniband/uverbs*`, `rdma_cm`, the caps/IMEX directories); `_query_shared_nodes` picks `SHARED` or `SHARED + SHAREDW` after the minor map says whether the rental covers the whole host — the same order the single command printed (DAH-2571's partial-rental withholding is unchanged).
- The kernel minor map goes through `_parse_uuid_minor_csv` unchanged; a UUID the kernel does not know still asks `nvidia-smi -q -x` live and still raises `MissingRentedGpuError` under enforcement (`test_gpu_config_with_probe_missing_uuid_still_consults_xml_live`).
- The probe is a snapshot. `create_container` hands it to the cleanup; if that removed a container, the volume sweeps that follow get `host_probe=None` (a removed volume would still read as present, a removed container as still mounting its volume); the same after the vloopback sweep or the cache sweep removed something. `raise_low_power_limits_to_default` never takes the probe: volume creation and a bootstrap restore run between the probe and that call, so its power state can be minutes old, and the last-resort net reads live (`test_raise_low_power_limits_takes_no_probe_and_queries_live`). The two `restore_*` helpers read the probe's power state for the GPU list and the before-values only. The GPU, power and label sections are unaffected by a docker removal and stay in use.
- `with_power=False` for a PEARL filler with `gpu_power_limits`: it caps with live nvidia-smi queries of its own and never reads the section.
- Not in the probe: the port-check force-rm (`wait_for_port_check_containers`, 1 channel, 0.15–0.3 s p50). DAH-2018 placed it immediately before `docker run` so a backend `health_check_*` probe landing during the pull cannot hold a port; reading it 3–5 s earlier would reopen that window for a 0.2 s gain. Also not in the probe: `docker volume create`/`plugin install` (lium-io#1332, DAH-3240) — different stage, different flag, no shared lines.

Commands per rent between pull and `docker run`, customer rental, nothing stale on the host: 8 → 1 (plus the volume-stage commands #1332 covers).

### Ran it

Two live pods (dind template, so `docker` inside the pod stands in for the executor host's daemon; `/usr/bin/docker` symlinked; a container `pod_bench` with a named volume so `PS`/`MNT` have entries; the probe's `LABEL` section inspects `alpine:3.20` there since the pod's inner daemon does not hold the pytorch image), 9 Sep 02:25–02:28Z, `~/lium-ads/speed/proof/lever45/{bench.sh,far.txt,near.txt}`. One ssh connection (`ControlMaster`), a new channel per command; three runs each, median:

```
RTX 4090, Ukraine (far):  new channel RTT 635 ms
  TODAY  8 serial channels:  5567 / 6011 ms   (two runs of the script)
  FAST   1 probe channel:     946 /  945 ms
  host-local, no RTT: today's 8 commands 80 ms · probe 89 ms
L40S, United States (near): new channel RTT 427 ms
  TODAY  8 serial channels:  3255 ms
  FAST   1 probe channel:     619 ms
  host-local, no RTT: today's 8 commands 123 ms · probe 143 ms
probe output on the 4090 (tabs shown as \t):
  PS\tpod_bench · PS_RC\t0 · VOL\tvolume_bench local · VOL_RC\t0 · MNT\tvolume_bench · MNT_RC\t0
  GPUMINORMAP\tGPU-f0e787c2-…, 0 · GPUMINORMAP_RC\t0 · GPUDEV\t/dev/nvidia0 · GPUDEV_RC\t0
  SHARED\t/dev/nvidiactl · SHARED\t/dev/nvidia-modeset · SHARED\t/dev/nvidia-uvm · SHARED\t/dev/nvidia-uvm-tools · SHARED_RC\t1
  SHAREDW\t/dev/nvidia-caps/nvidia-cap1 · SHAREDW\t/dev/nvidia-caps/nvidia-cap2 · SHAREDW_RC\t0
  POWER\tGPU-f0e787c2-…, 410.00, 450.00, 150.00, 500.00 · POWER_RC\t0 · LABEL_RC\t0
```

The saving is the round trips, not the work: 7 channels × RTT. From this Mac that is 4.6 s (far) / 2.6 s (near); the validator's RTT to the far nodes is 0.2–0.6 s per the prod profilers, so the expected prod effect is −1.5 to −4 s on the 3090/4090/5090 classes and −0.5 to −1 s on the near ones. `SHARED_RC 1` is the `[ -e ] &&` loop's last-node-absent status, ignored by both paths.

Validator suite on EC2 (`tools/aws_run_jobs/io_validators_pytest.sh`, run `20260909T025119Z-zs8l`, the first head `1fcf606` merged onto `main@b05764a7`, Python 3.11.11): `2 failed, 2060 passed, 15 skipped` — the two failures are main's own (`test_scrape_infiniband::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices`, `test_sshd_bootstrap_script::test_adopt_path_hardens_config_for_key_only_auth`; main baseline `2 failed, 1999 passed`). `ruff format --check` under the CI pin (`uvx ruff@0.5.1`): the new module and test module are formatted; touched existing files were not ruff-formatted on main and are left as they are (report-only in CI). Not run on a real validator against a real executor: the loop has no validator it may point at prod nodes; the staging validator is where the flag goes first.

### Tests (`tests/test_prerun_host_probe.py`, 58)

- command: every section present, the exact per-command texts embedded (via `shlex.quote`, the three docker listings included), the prefix-failure marker, no `rm`/`plugin install`/`-pl`/`-pm` anywhere; `with_power=False` has no nvidia-smi; `image_label_command` equals the text the label check ran; `shared_device_nodes_command(whole_host_only=True)` is the tail of the whole-host command
- parser: every section; empty sections are `()` not None; each failed section → None with the others intact (6 cases); device-node sections ignore the status; missing `_RC` / untagged line / unknown tag / non-numeric status → raise; the error message is capped; the label value keeps the stripped-stdout semantics (6 cases: `1`, empty, `<no value>`, leading newline, extra line, tab)
- through `sh -c` with a docker stub and an `nvidia-smi` stub that exits 1 (so the test does not depend on the host's GPUs, `/dev/infiniband/*` or a real driver): containers, volumes, mounts, label parsed; the GPU / device-node sections are listings, not failures; the failing nvidia-smi → `POWER` None; a multi-line label cannot forge another section; a broken awk → the marker → the parser raises
- `probe_prerun_host`: one command with the exact text and the 30-s timeout; SSH error → None; timeout → None; garbage → None
- consumers, each with a probe vs live for the same host facts: `clean_existing_containers` (same `rm -fv` / `volume rm`, no `ps -a`; nothing stale → `[]`; failed section → lists itself), `clean_stale_vloopback_volumes` (same `volume rm`; no vloopback volumes → nothing; failed mount section → inspects itself), `_find_cache_volumes_to_sweep`, `_image_has_encrypted_volume_label`, `build_gpu_docker_config_for_executor` (partial rental equal to live; whole host by UUIDs and by `None`; missing UUID → XML live; failed proc section → live), `raise_low_power_limits_to_default` (takes no probe, always the live state query), `restore_tracked_gpu_power_limits` (probe for the before-values)
- `create_container`: flag off → never probes, `host_probe=None` everywhere; flag on → one probe with the payload's image and `with_power=True`, the same object at every consumer; a removal by the cleanup / the vloopback sweep withdraws the docker listings from the later sweeps and keeps the GPU/power sections; the raise is never handed the probe; probe None → every consumer on its own commands; a PEARL filler with `gpu_power_limits` → `with_power=False`

### Risk

- A section's command failing on the host costs one extra round trip (the step re-runs it) — never a different decision.
- The listings are a few hundred ms older than they were when each step read them itself. The only writers this create controls are its own removals, and those withdraw the listings; anything concurrent on the host (the cleanup block runs outside `acquire_executor_lock`, which covers the port mapping) makes the snapshot older by the same few hundred ms and can only hide a removal from a sweep (a volume still read as mounted is skipped) — never add one.
- A hung nvidia driver costs the rent the probe's 30 s and then the per-command query's own 30 s (30 s today): the fallback re-asks so the DAH-2356 power-floor read is never skipped. The docker listings the probe also carries run with no bound on the per-command path.
- Rollback: the flag.

### Cross-PR

Cross-PR: lium-io#1334 (DAH-3258, this worker's other PR) edits `create_container` after the running check (inspector / keys exec); lium-io#1332 (DAH-3240) edits the volume-sizing hunk ~60 lines below the cleanup block this PR edits and adds `probe_volume_host`. The `create_container` hunks of the three do not overlap. All three add their flag at the same two anchors — `.env.template` after `VERIFYX_COLD_SAMPLE_RETRY_ENABLED`, `config.py` after `SKIP_RENTAL_VERIFICATION` — so whichever lands second conflicts on those two files; the resolution is keep-both (three independent flags), and this PR gets rebased after the first of them merges. Either order works.

Cross-PR: lium-io#1316 (DAH-2971, the dead-code sweep) removes `/usr/bin/docker` lines that are the dead s3fs plugin commands in `miner_jobs/backup_storage.py`; this PR's `/usr/bin/docker` strings are the live cleanup listings and the test module's stub substitution — different files, neither order breaks the tree; #1316 re-checks `test_prerun_host_probe.py` on its pre-merge rebase (#1316's body says the same). lium-io#1295 (DAH-3004) touches the SSH connect ~250 lines above. lium-io#1326 (DAH-3217) touches the stale-mount repair. lium-io#1283 is executor-side.

### Self-review

Verdict `clean` at `37ee708` · 15 checks · by subagent-fresh-r45-1333 · 2026-09-09 13:31Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `PR body §Details 'Ran it' (live body line 87):87` | The EC2 paragraph in Details still reads 'run `20260909T025119Z-zs8l`, this head merged onto `main@b05764a7` …: `2 failed, 2060 passed, 15 skipped`' — that run and count belong to the first head (1fcf606; 37ee708 deleted three tests, so the module collects 58 and the suite total is 2058 per run 20260909T131205Z-43b8), and 'this head' now reads as 37ee708. The top-level '61 passed' / 'tests ✓ 61' / '2060 passed' lines (live body 15, 20, 23) are already 58 / 2058 in the overrides file and re-render from it, so they are not counted here. | Write 'the first head (1fcf606)' in place of 'this head' in that paragraph, or replace the run id and counts with 20260909T131205Z-43b8: 1 failed, 2058 passed. |
| low | CODE-QUALITY | `neurons/validators/src/services/prerun_host_probe.py:12` | The module docstring describes the volume section as ``VOL\t<name>\t<driver>`` but the section line is `VOL\t<name> <driver>`: `DOCKER_VOLUME_LS_NAME_DRIVER_CMD` prints `{{.Name}} {{.Driver}}` space-separated (line 62) and the parser splits the value on whitespace with `maxsplit=1` (lines 208-211), never on a second tab. | Write ``VOL\t<name> <driver>`` in the docstring. |
| low | TEST-GAP | `neurons/validators/src/services/gpu_power_limit.py:468` | `restore_all_host_gpu_power_limits(host_probe=)` uses the probe's power state both as the before-values and as the host GPU enumeration the Redis records are read for (line 472), but no test drives it with a probe: tests/test_prerun_host_probe.py:791 covers only `restore_tracked_gpu_power_limits`, and the create_container wiring tests replace `restore_all_host_gpu_power_limits` with an AsyncMock (line 822). | Add the whole-node twin of the test at line 791: a probe with two UUIDs, `redis.get` answering one record, assert `POWER_STATE_CMD not in _cmds(ssh)`, the record read keyed by the probe's UUIDs and the return value 1. |
| low | PROSE-VS-CODE | `neurons/validators/tests/test_prerun_host_probe.py:398` | Carried known nit, still true at 37ee708: `test_probe_through_sh_lists_docker_sections_and_marks_absent_nvidia_smi` and the module docstring (line 13, 'nvidia-smi absent → power None') say 'absent' while `_run_probe_in_sh` installs an `nvidia-smi` stub that exists and exits 1 (`_NVIDIA_SMI_STUB`, line 375). | Rename to `…_marks_failed_nvidia_smi` and write 'nvidia-smi failing (stub exits 1) → power None' in the docstring. |
| low | CODE-QUALITY | `neurons/validators/src/services/docker_service.py:268` | Carried known nit, still true at 37ee708: the comment repeats the imported constant's value as the literal '(30 s)' next to `_PRERUN_HOST_PROBE_TIMEOUT_SECONDS = NVIDIA_SMI_TIMEOUT_SECONDS`, which drifts silently if `gpu_power_limit.NVIDIA_SMI_TIMEOUT_SECONDS` changes. | Drop '(30 s)' or write '(currently 30 s)'. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `PR body §Details 'What the flag changes' / §Tests (live body lines 57, 95-96) — the earlier medium STALE-BODY on the withdrawn-after-restore / restore-count design:57` Re-read `gh pr view 1333 -R Datura-ai/lium-io --json body` at head 37ee708 and `review-wave/readability/overrides/lium-io-1333.json`: the snapshot bullet now says '`raise_low_power_limits_to_default` never takes the probe … the last-resort net reads live (`test_raise_low_power_limits_takes_no_probe_and_queries_live`). The two `restore_*` helpers read the probe's power state for the GPU list and the before-values only' — matching gpu_power_limit.py:478-498 (no `host_probe` parameter, live `_query_power_state(ssh)`), :451 and :468-472, and tests/test_prerun_host_probe.py:781; the Tests bullets read '`raise_low_power_limits_to_default` (takes no probe, always the live state query)', '`restore_tracked_gpu_power_limits` (probe for the before-values)', 'the raise is never handed the probe' (tests:892); the restore-count sentence and `test_restore_counts_a_written_limit_even_when_its_record_cannot_be_cleared` are gone (`grep` of the body finds neither 'count every' nor that name; `_restore_records` at :420-422 is main's); the overrides' What-changed lines read '`_query_power_state(host_probe=)` behind the two restore helpers — the last-resort raise always queries live' and 'withdraws the docker listings after any removal' with no power-state clause. · `PR body §Details 'What the flag changes' command sketch and bullets, 'Ran it' transcript (live body lines 50-54, 78-79) — the earlier medium PROSE-VS-CODE on the pre-rename names:50` Re-read the live body: the command sketch reads `t GPUMINORMAP '<PROC_GPU_INFO_CMD>'` and `t POWER '<POWER_STATE_CMD>'`, the next bullet names `PROC_GPU_INFO_CMD`, `POWER_STATE_CMD`, `shared_device_nodes_command`, `image_label_command` and says the four shared names are public now, `NVIDIA_SMI_TIMEOUT_SECONDS` included, the timeout bullet cites `_PRERUN_HOST_PROBE_TIMEOUT_SECONDS` (still docker_service-private, docker_service.py:269) and `NVIDIA_SMI_TIMEOUT_SECONDS`, the VOL sentence names `ProbedVolume(name, driver)`, and the transcript lines read `GPUMINORMAP\t…` — each matching `GPU_MINOR_MAP_TAG = "GPUMINORMAP"` (prerun_host_probe.py:36), `PROC_GPU_INFO_CMD` (nvidia_devices.py:151), `POWER_STATE_CMD` / `NVIDIA_SMI_TIMEOUT_SECONDS` (gpu_power_limit.py:58, 63) and `ProbedVolume` (prerun_host_probe.py:82). Outside the old `### Self-review` block and the old `**Verified by the loop**` paragraph (both replaced by tooling) `grep -n 'GPUPROC\|_PROC_GPU_INFO_CMD\|_POWER_STATE_CMD\|_NVIDIA_SMI_TIMEOUT_SECONDS\|gpu_proc'` over the body returns nothing. · `neurons/ (grep for the pre-rename names):1` `rg 'gpu_proc_stdout|GPUPROC|_POWER_STATE_CMD|_NVIDIA_SMI_TIMEOUT_SECONDS|_GPU_DEVICE_NODES_CMD|_PROC_GPU_INFO_CMD' neurons/` returns only `_PRERUN_HOST_PROBE_TIMEOUT_SECONDS` (docker_service.py:269 and its test at tests/test_prerun_host_probe.py:486), a docker_service-private constant that keeps its underscore on purpose; no stale reference to the four renamed names or the old tag. · `neurons/validators/src/services/docker_service.py:1837` Every consumer of `PrerunHostProbe.volumes` handles `ProbedVolume`: `clean_stale_vloopback_volumes` unpacks `volume.name, volume.driver` (1837-1840), `_find_cache_volumes_to_sweep` reads `host_probe.volume_names` (2115-2117, the property at prerun_host_probe.py:110-113) and is what `select_affordable_cache_volumes` (2044-2052) and `reclaim_dphn_cache_for_rental` (1980-1982) call, and the `prerun_host_probe` log line only takes `len(probe.volumes or ())` / `is None` (2347, 2352); tests at test_prerun_host_probe.py:591-687 build `ProbedVolume` tuples and assert probe == live. · `neurons/validators/src/services/gpu_power_limit.py:478` The raise helper's live-only query is right: between the probe and this call `create_container` runs volume sizing/creation, `_run_bootstrap_restore` and s3fs volume creation (docker_service.py ~4700-4830), and `restore_tracked_*`/`restore_all_host_*` may just have written `-pl`; `test_raise_low_power_limits_takes_no_probe_and_queries_live` (tests:781) pins the signature and the live command, and the create_container wiring test (tests:892) asserts no `host_probe` kwarg reaches it. Keeping the probe for the two `restore_*` helpers is sound: nothing writes a power limit before them on this path and their state is before-values / enumeration only. · `neurons/validators/src/services/gpu_power_limit.py:420` `_restore_records` is byte-identical to main (`restored += 1` after a successful `redis.delete`; `git diff origin/main...HEAD` shows no hunk there), so the 8db32f7 count change is fully reverted as the commit message says. · `brief §3 scanner note: large PR:48` The whole `git diff origin/main...HEAD` was read hunk by hunk; the delta from the reviewed parent is `git diff 8db32f7 HEAD --stat` = 6 files, +108 −146 (renames, the `ProbedVolume` dataclass, the raise helper losing `host_probe`, three tests removed, one renamed), and every hunk of it was checked against the 15 classes. · `STACK-HYGIENE:1` Branch is 1fcf6068 → 8db32f75 → 37ee7089 directly on merge-base b05764a7, now pushed (GitHub headRefOid = 37ee7089); `git merge-tree --write-tree origin/main HEAD` (origin/main = 04c971ae) is clean; the Cross-PR paragraph on the shared `.env.template`/`config.py` anchors still describes the only foreseeable conflict.

### Verified

Gate: PASS (37ee708) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1333)

**Verified by the loop on 9 Sep 2026 (taiberium's timeout nit, one commit on top of the approved head):** head `8db32f7` on sandbox EC2 warm box, run 20260909T090812Z-a9w5 (c6i.2xlarge, Linux, Python 3.11): validators pytest: 2060 passed, 15 skipped, 2 failed — the same two main has on that box (`test_scrape_infiniband::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices`, `test_sshd_bootstrap_script::test_adopt_path_hardens_config_for_key_only_auth`, root and sshd on the box), unchanged from the earlier head. Result: PASS. The commit changes one constant: the probe bound is `_NVIDIA_SMI_TIMEOUT_SECONDS` (30 s), not 60.

**Verified by the loop on 9 Sep 2026 (taiberium's four nits, one commit on top of the earlier head):** head `37ee708` on sandbox EC2 warm box, run 20260909T131205Z-43b8 (c6i.2xlarge, Linux, Python 3.11): validators pytest: 2058 passed, 15 skipped, 1 failed — main's own `test_scrape_infiniband::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices` (root on the box; the same failure on every run of the day). Result: PASS. The commit renames, adds `ProbedVolume`, and drops the probe from the last-resort power raise; 58 probe tests.

</details>
