### PR TITLE
DAH-3258 - [P2] rent: inspector start alongside the encrypted-volume mount

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -39,6 +39,10 @@ RENTAL_VOLUME_FAST_PATH_ENABLED=false
 # volumes, mounted volumes, GPU minor map, device nodes, nvidia-smi power state, the image's encryption label) in one ssh
 # command instead of ~8. Removals and writes run as before; a failed probe leaves every step on its own commands. Off by default.
 RENTAL_PRERUN_HOST_PROBE_ENABLED=false
+# Rental post-run concurrency (DAH-3258): after `docker run`, start the inspector collector while the encrypted volume is
+# being mounted, and write authorized_keys + /etc/environment in one `docker exec` (two today). Every step still completes
+# before the pod is reported RUNNING. Off by default.
+RENTAL_POSTRUN_CONCURRENT_ENABLED=false
 
 # First-pass fast path (DAH-3011): a never-validated executor gets a right-sized matmul (min(card VRAM, this MB)) and a
 # smaller VerifyX write (GB of RAM / disk) on its first pass; scored verifications are unchanged. Off by default.

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -226,6 +226,11 @@ class Settings(BaseSettings):
     # encryption label) in ONE ssh command instead of ~8; every removal and write still runs its
     # own command, and a probe that fails leaves every step on its own commands. Off: as before.
     RENTAL_PRERUN_HOST_PROBE_ENABLED: bool = Field(env="RENTAL_PRERUN_HOST_PROBE_ENABLED", default=False)
+    # DAH-3258: after `docker run`, start the inspector collector concurrently with the encrypted
+    # volume mount (a host-side process, independent of the container's filesystem) and write
+    # authorized_keys and /etc/environment in ONE `docker exec` after the mount. Every step still
+    # completes before ContainerCreated is returned. Off: the serial order as before.
+    RENTAL_POSTRUN_CONCURRENT_ENABLED: bool = Field(env="RENTAL_POSTRUN_CONCURRENT_ENABLED", default=False)
     # DAH-3011: a never-validated executor's FIRST verification (the express lane's, DAH-2958 —
     # published spec-only, never scored) proves "this GPU exists, is the model claimed, the host is
     # reachable and rentable"; the VRAM-filling matmul and the 128 GB RAM proof exist to make a

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -115,7 +115,6 @@ from services.rental_docker_sdk import (
     RentalDockerSdkClientFactory,
     VolumeMount,
     build_authorized_keys_and_environment_exec_spec,
-    build_authorized_keys_exec_spec,
     build_container_command_argv,
     build_environment_exec_spec,
     environment_fits_exec_variable,
@@ -3020,19 +3019,14 @@ class DockerService:
     ) -> None:
         """Append the renter's keys to authorized_keys — and, with ``environment`` (DAH-3258), the
         renter's `/etc/environment` lines in the same exec. Raises on a non-zero exit."""
-        if environment:
-            exec_spec = build_authorized_keys_and_environment_exec_spec(
-                container_name=container_name,
-                public_keys=public_keys,
-                environment=environment,
-            )
-        else:
-            exec_spec = build_authorized_keys_exec_spec(
-                container_name=container_name,
-                public_keys=public_keys,
-            )
+        # falls back to the keys-only spec when there are no environment lines
+        exec_spec = build_authorized_keys_and_environment_exec_spec(
+            container_name=container_name,
+            public_keys=public_keys,
+            environment=environment,
+        )
         with_environment = bool(exec_spec.environment)
-        what = "SSH public keys and environment" if with_environment else "SSH public keys"
+        added_items = "SSH public keys and environment" if with_environment else "SSH public keys"
         result = await exec_logged_rental_docker_sdk_operation(
             docker_client=docker_client,
             operation=(
@@ -3043,13 +3037,13 @@ class DockerService:
         )
         if result.exit_status != 0:
             await self.stream_log(
-                result.stderr or result.stdout or f"Failed to add {what}",
+                result.stderr or result.stdout or f"Failed to add {added_items}",
                 "error",
                 log_tag,
             )
             logger.warning(
                 _m(
-                    f"Failed to add {what}",
+                    f"Failed to add {added_items}",
                     extra=get_extra_info({
                         **log_extra,
                         "container_name": container_name,
@@ -3060,7 +3054,7 @@ class DockerService:
                 )
             )
             raise Exception(
-                f"Failed to add {what}: "
+                f"Failed to add {added_items}: "
                 f"exit_status={result.exit_status}; "
                 f"stderr={result.stderr}; stdout={result.stdout}"
             )

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -114,9 +114,11 @@ from services.rental_docker_sdk import (
     RentalDockerSdkClient,
     RentalDockerSdkClientFactory,
     VolumeMount,
+    build_authorized_keys_and_environment_exec_spec,
     build_authorized_keys_exec_spec,
     build_container_command_argv,
     build_environment_exec_spec,
+    environment_fits_exec_variable,
     build_remove_authorized_keys_exec_spec,
     require_rental_docker_ssh_host_key,
 )
@@ -870,6 +872,39 @@ class DockerService:
     ) -> bool:
         rented_machine = await self.redis_service.get_rented_machine(executor_info)
         return bool(rented_machine and rented_machine.get("containers"))
+
+    async def _settle_inspector_after_failed_create(
+        self,
+        inspector_task: asyncio.Task,
+        *,
+        ssh_client: asyncssh.SSHClientConnection,
+        executor_info: ExecutorSSHInfo,
+        default_extra: dict,
+    ) -> None:
+        """DAH-3258: the collector was started alongside the mount and the create then failed.
+
+        Let the start finish (it never raises), then leave the host as a delete would: stop the
+        collector when no other rented container keeps it needed. Best-effort — the create's
+        own failure is what gets reported.
+        """
+        try:
+            await inspector_task
+            if not await self._has_rented_containers(executor_info):
+                await self._run_inspector_collector_lifecycle(
+                    ssh_client=ssh_client,
+                    executor_info=executor_info,
+                    action="stop",
+                    default_extra=default_extra,
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            logger.warning(
+                _m(
+                    "Inspector collector could not be settled after a failed create",
+                    extra=get_extra_info({**default_extra, "error": str(exc)}),
+                ),
+            )
 
     def _ssh_bootstrap_script_path(self) -> Path:
         return Path(__file__).resolve().parent / "assets" / "sshd_bootstrap.sh"
@@ -2981,26 +3016,40 @@ class DockerService:
         public_keys: list[str] | tuple[str, ...],
         log_tag: str,
         log_extra: dict,
+        environment: dict[str, str] | None = None,
     ) -> None:
-        exec_spec = build_authorized_keys_exec_spec(
-            container_name=container_name,
-            public_keys=public_keys,
-        )
+        """Append the renter's keys to authorized_keys — and, with ``environment`` (DAH-3258), the
+        renter's `/etc/environment` lines in the same exec. Raises on a non-zero exit."""
+        if environment:
+            exec_spec = build_authorized_keys_and_environment_exec_spec(
+                container_name=container_name,
+                public_keys=public_keys,
+                environment=environment,
+            )
+        else:
+            exec_spec = build_authorized_keys_exec_spec(
+                container_name=container_name,
+                public_keys=public_keys,
+            )
+        with_environment = bool(exec_spec.environment)
+        what = "SSH public keys and environment" if with_environment else "SSH public keys"
         result = await exec_logged_rental_docker_sdk_operation(
             docker_client=docker_client,
-            operation="exec_add_authorized_keys",
+            operation=(
+                "exec_add_authorized_keys_and_environment" if with_environment else "exec_add_authorized_keys"
+            ),
             exec_spec=exec_spec,
             log_extra=log_extra,
         )
         if result.exit_status != 0:
             await self.stream_log(
-                result.stderr or result.stdout or "Failed to add SSH public keys",
+                result.stderr or result.stdout or f"Failed to add {what}",
                 "error",
                 log_tag,
             )
             logger.warning(
                 _m(
-                    "Failed to add SSH public keys",
+                    f"Failed to add {what}",
                     extra=get_extra_info({
                         **log_extra,
                         "container_name": container_name,
@@ -3011,7 +3060,7 @@ class DockerService:
                 )
             )
             raise Exception(
-                "Failed to add SSH public keys: "
+                f"Failed to add {what}: "
                 f"exit_status={result.exit_status}; "
                 f"stderr={result.stderr}; stdout={result.stdout}"
             )
@@ -5241,6 +5290,24 @@ class DockerService:
 
                 await self.stream_log("Created Docker Container", "success", log_tag)
 
+                # DAH-3258: the inspector collector is a host-side process that reads the container
+                # from outside; it needs neither the encrypted mount nor the keys, so with the flag on
+                # it starts now and runs alongside them. It is awaited before ContainerCreated is
+                # returned (nothing here moves past RUNNING), and a create that fails after this
+                # point settles it the way a delete does (_settle_inspector_after_failed_create).
+                postrun_concurrent = settings.RENTAL_POSTRUN_CONCURRENT_ENABLED
+                inspector_extra = {**default_extra, "container_name": container_name}
+                inspector_task: asyncio.Task | None = None
+                if postrun_concurrent and settings.ENABLE_INSPECTOR:
+                    inspector_task = asyncio.create_task(
+                        self._run_inspector_collector_lifecycle(
+                            ssh_client=ssh_client,
+                            executor_info=executor_info,
+                            action="start",
+                            default_extra=inspector_extra,
+                        )
+                    )
+
                 try:
                     if use_encrypted_volume:
                         current_step = "encrypted_volume_setup"
@@ -5263,12 +5330,25 @@ class DockerService:
                     # a grace period waiting for an image-provided sshd — whichever
                     # sshd comes up first must already find the keys in place.
                     current_step = "add_public_keys"
+                    # DAH-3258: with the flag on the renter's /etc/environment lines ride in this
+                    # exec (one exec instead of two); they are plain data with no dependency on the
+                    # bootstrap, and the file is read at login, so writing them before sshd is up
+                    # changes nothing for the renter. An environment too large for one exec
+                    # variable keeps its own stdin exec below.
+                    environment_in_keys_exec = postrun_concurrent and environment_fits_exec_variable(
+                        custom_options.environment if custom_options else None
+                    )
                     await self.add_ssh_public_keys_with_rental_docker(
                         docker_client=docker_client,
                         container_name=container_name,
                         public_keys=payload.user_public_keys,
                         log_tag=log_tag,
                         log_extra=default_extra,
+                        environment=(
+                            custom_options.environment
+                            if environment_in_keys_exec and custom_options
+                            else None
+                        ),
                     )
 
                     current_step = "ssh_bootstrap"
@@ -5326,21 +5406,28 @@ class DockerService:
                     profilers.append(ProfilerStep.since(ProfilerStepName.SSH_SERVICE_INSTALLATION, prev_timestamp))
                     prev_timestamp = now_ms()
 
-                    # add environment variables
+                    # add environment variables (already written by the keys exec with DAH-3258 on)
                     current_step = "set_environment"
-                    environment_error = await self.add_environment_variables_with_rental_docker(
-                        docker_client=docker_client,
-                        container_name=container_name,
-                        environment=custom_options.environment if custom_options else None,
-                        log_tag=log_tag,
-                        log_extra=default_extra,
-                    )
-                    if environment_error:
-                        raise RuntimeError(f"Failed to set environment variables: {environment_error}")
+                    if not environment_in_keys_exec:
+                        environment_error = await self.add_environment_variables_with_rental_docker(
+                            docker_client=docker_client,
+                            container_name=container_name,
+                            environment=custom_options.environment if custom_options else None,
+                            log_tag=log_tag,
+                            log_extra=default_extra,
+                        )
+                        if environment_error:
+                            raise RuntimeError(f"Failed to set environment variables: {environment_error}")
 
                     # Historical name — key injection moved before the bootstrap
                     # (DAH-2341), so this step now times the environment setup.
-                    profilers.append(ProfilerStep.since(ProfilerStepName.ADDING_PUBLIC_KEYS, prev_timestamp))
+                    profilers.append(
+                        ProfilerStep.since(
+                            ProfilerStepName.ADDING_PUBLIC_KEYS,
+                            prev_timestamp,
+                            skipped=environment_in_keys_exec,
+                        )
+                    )
                     prev_timestamp = now_ms()
 
                     await self.finish_stream_logs()
@@ -5356,15 +5443,15 @@ class DockerService:
                         container_name=container_name,
                         default_extra=default_extra,
                     )
-                    if settings.ENABLE_INSPECTOR:
+                    if inspector_task is not None:
+                        # started alongside the mount above; this step times only what is left of it
+                        await inspector_task
+                    elif settings.ENABLE_INSPECTOR:
                         await self._run_inspector_collector_lifecycle(
                             ssh_client=ssh_client,
                             executor_info=executor_info,
                             action="start",
-                            default_extra={
-                                **default_extra,
-                                "container_name": container_name,
-                            },
+                            default_extra=inspector_extra,
                         )
                     profilers.append(
                         ProfilerStep.since(
@@ -5375,6 +5462,13 @@ class DockerService:
                     )
                     prev_timestamp = now_ms()
                 except Exception:
+                    if inspector_task is not None:
+                        await self._settle_inspector_after_failed_create(
+                            inspector_task,
+                            ssh_client=ssh_client,
+                            executor_info=executor_info,
+                            default_extra=inspector_extra,
+                        )
                     container_missing = await self.cleanup_failed_container_creation(
                         ssh_client=ssh_client,
                         default_extra=default_extra,

--- a/neurons/validators/src/services/rental_docker_sdk.py
+++ b/neurons/validators/src/services/rental_docker_sdk.py
@@ -709,22 +709,74 @@ def build_remove_authorized_keys_exec_spec(
     )
 
 
-def build_environment_exec_spec(
-    *,
-    container_name: str,
-    environment: dict[str, str] | None,
-) -> ContainerExecSpec | None:
+def _environment_file_text(environment: dict[str, str] | None) -> str:
+    """The `/etc/environment` lines a rental's custom environment appends ('' when there are none)."""
     env_lines = [
         f"{key}={value}"
         for key, value in (environment or {}).items()
         if key and value and key.strip() and str(value).strip()
     ]
-    if not env_lines:
+    return "".join(f"{line}\n" for line in env_lines)
+
+
+def build_environment_exec_spec(
+    *,
+    container_name: str,
+    environment: dict[str, str] | None,
+) -> ContainerExecSpec | None:
+    env_text = _environment_file_text(environment)
+    if not env_text:
         return None
     return ContainerExecSpec(
         container_name=container_name,
         argv=("sh", "-c", "cat >> /etc/environment"),
-        stdin="".join(f"{line}\n" for line in env_lines),
+        stdin=env_text,
+    )
+
+
+# The exec-process variable that carries the renter's environment lines into the combined exec.
+ENVIRONMENT_LINES_EXEC_VAR = "LIUM_ENVIRONMENT_LINES"
+# Linux refuses a single environment string above MAX_ARG_STRLEN (128 KiB) at execve; a renter
+# environment larger than this stays on the stdin-based exec of its own.
+MAX_ENVIRONMENT_EXEC_VAR_BYTES = 64 * 1024
+
+
+def environment_fits_exec_variable(environment: dict[str, str] | None) -> bool:
+    """True when the renter's /etc/environment lines may ride in the combined keys exec."""
+    return len(_environment_file_text(environment).encode()) <= MAX_ENVIRONMENT_EXEC_VAR_BYTES
+
+
+def build_authorized_keys_and_environment_exec_spec(
+    *,
+    container_name: str,
+    public_keys: list[str] | tuple[str, ...],
+    environment: dict[str, str] | None,
+    target_path: str = "/root/.ssh/authorized_keys",
+) -> ContainerExecSpec:
+    """DAH-3258: the authorized_keys exec and the /etc/environment exec as ONE `docker exec`.
+
+    The keys travel on stdin exactly as in `build_authorized_keys_exec_spec`; the environment
+    lines travel as an exec-process variable (the SDK sends only its NAME to the log, as it sends
+    only the stdin size), so no renter value lands in argv or in a log line. Without environment
+    lines the spec is the keys spec itself. The caller checks `environment_fits_exec_variable`
+    first: lines above MAX_ENVIRONMENT_EXEC_VAR_BYTES keep their own stdin-based exec.
+    """
+    keys_spec = build_authorized_keys_exec_spec(
+        container_name=container_name, public_keys=public_keys, target_path=target_path
+    )
+    env_text = _environment_file_text(environment)
+    if not env_text:
+        return keys_spec
+    keys_script = keys_spec.argv[2]
+    return ContainerExecSpec(
+        container_name=container_name,
+        argv=(
+            "sh",
+            "-c",
+            f'{keys_script} && printf \'%s\' "${ENVIRONMENT_LINES_EXEC_VAR}" >> /etc/environment',
+        ),
+        stdin=keys_spec.stdin,
+        environment={ENVIRONMENT_LINES_EXEC_VAR: env_text},
     )
 
 

--- a/neurons/validators/tests/test_postrun_concurrent.py
+++ b/neurons/validators/tests/test_postrun_concurrent.py
@@ -1,0 +1,485 @@
+"""DAH-3258 — rental post-run concurrency (RENTAL_POSTRUN_CONCURRENT_ENABLED).
+
+After `docker run` a rent ran, serially: the gocryptfs mount (4 SSH commands), the authorized_keys
+exec, the sshd bootstrap / Jupyter, the /etc/environment exec and the inspector collector start.
+With the flag on the inspector start runs alongside the mount and the keys and environment are one
+exec; the mount → keys order and every step's completion before ContainerCreated are unchanged.
+Covered here:
+
+- the combined exec spec: without environment it IS the keys spec; with it the keys stay on stdin,
+  the lines ride in one exec-process variable, argv and the log fields carry no renter value;
+- the combined script through `sh -c` writes both files with the same bytes the two specs wrote;
+- `add_ssh_public_keys_with_rental_docker(environment=…)` runs one exec and names both on failure;
+- `create_container`: flag off → the serial order and two execs; flag on → the collector starts
+  before the mount finishes and is awaited before the return, one exec carries keys + environment,
+  the environment step is skipped; no environment → the plain keys exec; an environment above
+  MAX_ENVIRONMENT_EXEC_VAR_BYTES keeps its own exec; a failed mount settles the collector (stop when
+  no other rented container) before the cleanup; ENABLE_INSPECTOR off → no task.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from core.config import settings
+from payload_models.payloads import CustomOptions, FailedContainerRequest, ProfilerStepName
+from services.docker_service import DockerService
+from services.rental_docker_observability import rental_exec_spec_log_fields
+from services.rental_docker_sdk import (
+    ENVIRONMENT_LINES_EXEC_VAR,
+    MAX_ENVIRONMENT_EXEC_VAR_BYTES,
+    ContainerExecResult,
+    build_authorized_keys_and_environment_exec_spec,
+    build_authorized_keys_exec_spec,
+    build_environment_exec_spec,
+    environment_fits_exec_variable,
+)
+from test_deploy_optimizations import (
+    _patch_happy,
+    _payload as _deploy_payload,
+    _run as _run_create_container,
+    _ssh_client as _deploy_ssh_client,
+)
+
+_KEYS = ["ssh-ed25519 AAAAkey1 a@b", "ssh-rsa AAAAkey2"]
+_ENV = {"HF_TOKEN": "hf_secret_value", "EMPTY": "", " ": "x", "MODEL": "llama"}
+
+
+@pytest.fixture
+def svc():
+    return DockerService(ssh_service=Mock(), redis_service=Mock(), attestation_service=Mock())
+
+
+# ------------------------------------------------------------------
+# the combined exec spec
+# ------------------------------------------------------------------
+
+
+def test_combined_spec_without_environment_is_the_keys_spec():
+    combined = build_authorized_keys_and_environment_exec_spec(
+        container_name="pod_x", public_keys=_KEYS, environment=None
+    )
+    assert combined == build_authorized_keys_exec_spec(container_name="pod_x", public_keys=_KEYS)
+    assert combined.environment == {}
+    blank_only = build_authorized_keys_and_environment_exec_spec(
+        container_name="pod_x", public_keys=_KEYS, environment={"EMPTY": "", " ": "x"}
+    )
+    assert blank_only == combined
+
+
+def test_combined_spec_keys_on_stdin_environment_in_one_exec_variable():
+    keys_spec = build_authorized_keys_exec_spec(container_name="pod_x", public_keys=_KEYS)
+    env_spec = build_environment_exec_spec(container_name="pod_x", environment=_ENV)
+    combined = build_authorized_keys_and_environment_exec_spec(
+        container_name="pod_x", public_keys=_KEYS, environment=_ENV
+    )
+    assert combined.stdin == keys_spec.stdin
+    assert combined.environment == {ENVIRONMENT_LINES_EXEC_VAR: env_spec.stdin}
+    assert (
+        env_spec.stdin == "HF_TOKEN=hf_secret_value\nMODEL=llama\n"
+    )  # blank key / value filtered as before
+    assert combined.argv[:2] == ("sh", "-c")
+    assert combined.argv[2].startswith(keys_spec.argv[2] + " && ")
+    assert f"printf '%s' \"${ENVIRONMENT_LINES_EXEC_VAR}\" >> /etc/environment" in combined.argv[2]
+    assert len(combined.argv) == 3
+
+
+def test_combined_spec_no_renter_value_in_argv_or_log_fields():
+    combined = build_authorized_keys_and_environment_exec_spec(
+        container_name="pod_x", public_keys=_KEYS, environment=_ENV
+    )
+    fields = rental_exec_spec_log_fields(combined)
+    for secret in ("hf_secret_value", "llama", "AAAAkey1"):
+        assert secret not in " ".join(combined.argv)
+        assert secret not in repr(fields)
+    assert fields["environment_keys"] == [ENVIRONMENT_LINES_EXEC_VAR]
+    assert fields["stdin_bytes"] == len(combined.stdin.encode())
+
+
+def test_combined_script_through_sh_writes_both_files_like_the_two_execs(tmp_path):
+    keys_path = tmp_path / "home" / ".ssh" / "authorized_keys"
+    env_path = tmp_path / "environment"
+    env_path.write_text("PRE=1\n")
+    combined = build_authorized_keys_and_environment_exec_spec(
+        container_name="pod_x", public_keys=_KEYS, environment=_ENV, target_path=str(keys_path)
+    )
+    script = combined.argv[2].replace("/etc/environment", str(env_path))
+    proc = subprocess.run(
+        ["sh", "-c", script],
+        input=combined.stdin,
+        text=True,
+        capture_output=True,
+        env={"PATH": "/usr/bin:/bin", **combined.environment},
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert (
+        keys_path.read_text()
+        == build_authorized_keys_exec_spec(container_name="pod_x", public_keys=_KEYS).stdin
+    )
+    assert oct(keys_path.parent.stat().st_mode & 0o777) == "0o700"
+    env_spec = build_environment_exec_spec(container_name="pod_x", environment=_ENV)
+    assert env_path.read_text() == "PRE=1\n" + env_spec.stdin
+
+
+def test_combined_script_percent_in_a_value_is_literal(tmp_path):
+    env_path = tmp_path / "environment"
+    keys_path = tmp_path / "authorized_keys"
+    combined = build_authorized_keys_and_environment_exec_spec(
+        container_name="pod_x",
+        public_keys=_KEYS,
+        environment={"PCT": "100%s done %d"},
+        target_path=str(keys_path),
+    )
+    script = combined.argv[2].replace("/etc/environment", str(env_path))
+    subprocess.run(
+        ["sh", "-c", script],
+        input=combined.stdin,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", **combined.environment},
+        check=True,
+    )
+    assert env_path.read_text() == "PCT=100%s done %d\n"
+
+
+# ------------------------------------------------------------------
+# add_ssh_public_keys_with_rental_docker(environment=…)
+# ------------------------------------------------------------------
+
+
+class _ExecClient:
+    def __init__(self, exit_status: int = 0):
+        self.exec_specs = []
+        self.exit_status = exit_status
+
+    async def exec_in_container(self, spec):
+        self.exec_specs.append(spec)
+        return ContainerExecResult(
+            exit_status=self.exit_status, stdout="", stderr="boom" if self.exit_status else ""
+        )
+
+
+@pytest.mark.asyncio
+async def test_add_keys_with_environment_runs_one_combined_exec(svc, monkeypatch):
+    monkeypatch.setattr(svc, "stream_log", AsyncMock())
+    client = _ExecClient()
+    await svc.add_ssh_public_keys_with_rental_docker(
+        client,
+        container_name="pod_x",
+        public_keys=_KEYS,
+        log_tag="t",
+        log_extra={},
+        environment=_ENV,
+    )
+    assert client.exec_specs == [
+        build_authorized_keys_and_environment_exec_spec(
+            container_name="pod_x", public_keys=_KEYS, environment=_ENV
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_add_keys_without_environment_runs_the_keys_exec_as_before(svc, monkeypatch):
+    monkeypatch.setattr(svc, "stream_log", AsyncMock())
+    client = _ExecClient()
+    await svc.add_ssh_public_keys_with_rental_docker(
+        client, container_name="pod_x", public_keys=_KEYS, log_tag="t", log_extra={}
+    )
+    await svc.add_ssh_public_keys_with_rental_docker(
+        client, container_name="pod_x", public_keys=_KEYS, log_tag="t", log_extra={}, environment={}
+    )
+    keys_spec = build_authorized_keys_exec_spec(container_name="pod_x", public_keys=_KEYS)
+    assert client.exec_specs == [keys_spec, keys_spec]
+
+
+@pytest.mark.asyncio
+async def test_add_keys_with_environment_failure_names_both(svc, monkeypatch):
+    monkeypatch.setattr(svc, "stream_log", AsyncMock())
+    with pytest.raises(Exception, match="Failed to add SSH public keys and environment"):
+        await svc.add_ssh_public_keys_with_rental_docker(
+            _ExecClient(exit_status=1),
+            container_name="pod_x",
+            public_keys=_KEYS,
+            log_tag="t",
+            log_extra={},
+            environment=_ENV,
+        )
+    with pytest.raises(Exception, match="Failed to add SSH public keys: "):
+        await svc.add_ssh_public_keys_with_rental_docker(
+            _ExecClient(exit_status=1),
+            container_name="pod_x",
+            public_keys=_KEYS,
+            log_tag="t",
+            log_extra={},
+        )
+
+
+# ------------------------------------------------------------------
+# create_container wiring
+# ------------------------------------------------------------------
+
+
+class _Trace:
+    """Records the post-run steps in the order they start and finish. The mount blocks until the
+    inspector start has been observed (or a short timeout), so the trace shows whether the two
+    overlapped; the inspector start itself takes 50 ms after that, so it can only be complete at
+    the return when create_container awaited it."""
+
+    async def cleanup(self, **_):
+        self.events.append("cleanup")
+        return False
+
+    def __init__(self, *, mount_fails: bool = False):
+        self.events: list[str] = []
+        self.mount_fails = mount_fails
+        self.inspector_started = asyncio.Event()
+        self.lifecycle_actions: list[str] = []
+
+    async def mount(self, **_):
+        self.events.append("mount_start")
+        try:
+            await asyncio.wait_for(self.inspector_started.wait(), timeout=0.2)
+        except asyncio.TimeoutError:
+            pass
+        self.events.append("mount_done")
+        if self.mount_fails:
+            raise RuntimeError("mount failed")
+
+    async def lifecycle(self, *, action, **_):
+        self.lifecycle_actions.append(action)
+        self.events.append(f"inspector_{action}_start")
+        if action == "start":
+            self.inspector_started.set()
+            await asyncio.sleep(0.05)
+        else:
+            await asyncio.sleep(0)
+        self.events.append(f"inspector_{action}_done")
+
+
+def _wire(
+    svc, monkeypatch, *, trace: _Trace, inspector: bool = True, rented_elsewhere: bool = False
+):
+    ssh_client = _deploy_ssh_client()
+    _patch_happy(svc, monkeypatch, ssh_client)
+    monkeypatch.setattr(settings, "ENABLE_VOLUME_ENCRYPTION", True)
+    monkeypatch.setattr(settings, "ENABLE_INSPECTOR", inspector)
+    monkeypatch.setattr(svc, "_image_has_encrypted_volume_label", AsyncMock(return_value=True))
+    monkeypatch.setattr(svc, "setup_encrypted_local_volume", trace.mount)
+    monkeypatch.setattr(svc, "_run_inspector_collector_lifecycle", trace.lifecycle)
+    monkeypatch.setattr(svc, "_has_rented_containers", AsyncMock(return_value=rented_elsewhere))
+    monkeypatch.setattr(
+        "services.docker_service.restore_tracked_gpu_power_limits", AsyncMock(return_value=0)
+    )
+    monkeypatch.setattr(
+        "services.docker_service.raise_low_power_limits_to_default", AsyncMock(return_value=0)
+    )
+    original_keys = svc.add_ssh_public_keys_with_rental_docker
+    original_env = svc.add_environment_variables_with_rental_docker
+
+    async def _keys(**kw):
+        trace.events.append("keys_exec")
+        await asyncio.sleep(0)  # the SDK exec yields to the loop; the fake client does not
+        result = await original_keys(**kw)
+        trace.events.append("keys_exec_done")
+        return result
+
+    async def _env(**kw):
+        trace.events.append("env_exec")
+        return await original_env(**kw)
+
+    monkeypatch.setattr(svc, "add_ssh_public_keys_with_rental_docker", _keys)
+    monkeypatch.setattr(svc, "add_environment_variables_with_rental_docker", _env)
+    return ssh_client
+
+
+def _payload(**over):
+    base = dict(
+        enable_volume_encryption=True,
+        is_sysbox=True,
+        ships_sshd=True,
+        custom_options=CustomOptions(environment={"HF_TOKEN": "hf_secret_value"}),
+    )
+    base.update(over)
+    return _deploy_payload(**base)
+
+
+def _exec_specs(svc):
+    return svc.rental_docker_client_factory.client.exec_specs
+
+
+def _step(result, name: ProfilerStepName):
+    return next(p for p in result.profilers if p.name == name)
+
+
+@pytest.mark.asyncio
+async def test_flag_off_keeps_the_serial_order_and_two_execs(svc, monkeypatch):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", False)
+    trace = _Trace()
+    _wire(svc, monkeypatch, trace=trace)
+    result = await _run_create_container(svc, _payload())
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    assert trace.events == [
+        "mount_start",
+        "mount_done",
+        "keys_exec",
+        "keys_exec_done",
+        "env_exec",
+        "inspector_start_start",
+        "inspector_start_done",
+    ]
+    specs = _exec_specs(svc)
+    assert len(specs) == 2
+    assert specs[0].environment == {} and "authorized_keys" in specs[0].argv[2]
+    assert (
+        specs[1].argv == ("sh", "-c", "cat >> /etc/environment")
+        and specs[1].stdin == "HF_TOKEN=hf_secret_value\n"
+    )
+    assert _step(result, ProfilerStepName.ADDING_PUBLIC_KEYS).skipped is False
+    assert _step(result, ProfilerStepName.INSPECTOR_START).skipped is False
+
+
+@pytest.mark.asyncio
+async def test_flag_on_inspector_overlaps_the_mount_and_one_exec_carries_keys_and_environment(
+    svc, monkeypatch
+):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", True)
+    trace = _Trace()
+    _wire(svc, monkeypatch, trace=trace)
+    result = await _run_create_container(svc, _payload())
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    ev = trace.events
+    assert ev.index("inspector_start_start") < ev.index("mount_done"), ev
+    assert ev.index("mount_done") < ev.index(
+        "keys_exec"
+    ), ev  # keys land on the mounted /root, never before
+    assert "env_exec" not in ev
+    # awaited before ContainerCreated: the start takes 50 ms after the mount let go of it, so it can
+    # only be complete here because create_container waited for it (drop that await and this fails)
+    assert ev[-1] == "inspector_start_done", ev
+    assert _step(result, ProfilerStepName.INSPECTOR_START).duration is not None
+    specs = _exec_specs(svc)
+    assert len(specs) == 1
+    assert specs[0] == build_authorized_keys_and_environment_exec_spec(
+        container_name=result.container_name,
+        public_keys=["ssh-ed25519 test-key"],
+        environment={"HF_TOKEN": "hf_secret_value"},
+    )
+    assert _step(result, ProfilerStepName.ADDING_PUBLIC_KEYS).skipped is True
+    assert _step(result, ProfilerStepName.INSPECTOR_START).skipped is False
+    assert trace.lifecycle_actions == ["start"]
+
+
+@pytest.mark.asyncio
+async def test_flag_on_without_environment_runs_the_plain_keys_exec(svc, monkeypatch):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", True)
+    trace = _Trace()
+    _wire(svc, monkeypatch, trace=trace)
+    result = await _run_create_container(svc, _payload(custom_options=None))
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    specs = _exec_specs(svc)
+    assert len(specs) == 1
+    assert specs[0] == build_authorized_keys_exec_spec(
+        container_name=result.container_name, public_keys=["ssh-ed25519 test-key"]
+    )
+    assert "env_exec" not in trace.events
+
+
+@pytest.mark.asyncio
+async def test_flag_on_unencrypted_pod_still_overlaps_the_inspector_with_the_exec(svc, monkeypatch):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", True)
+    trace = _Trace()
+    _wire(svc, monkeypatch, trace=trace)
+    result = await _run_create_container(svc, _payload(enable_volume_encryption=False))
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    ev = trace.events
+    assert "mount_start" not in ev
+    # the exec yields to the loop; the collector start runs during it, not after it
+    assert ev.index("inspector_start_start") < ev.index("keys_exec_done"), ev
+    assert ev[-1] == "inspector_start_done", ev
+    assert trace.lifecycle_actions == ["start"]
+
+
+@pytest.mark.asyncio
+async def test_flag_on_failed_mount_settles_the_inspector_before_cleanup(svc, monkeypatch):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", True)
+    trace = _Trace(mount_fails=True)
+    _wire(svc, monkeypatch, trace=trace)
+    monkeypatch.setattr(svc, "cleanup_failed_container_creation", trace.cleanup)
+    result = await _run_create_container(svc, _payload())
+    assert isinstance(result, FailedContainerRequest)
+    assert result.failure_step == "encrypted_volume_setup"
+    assert trace.lifecycle_actions == [
+        "start",
+        "stop",
+    ]  # no other rented container → the host is left as before
+    ev = trace.events
+    assert (
+        ev.index("inspector_start_done")
+        < ev.index("inspector_stop_start")
+        < ev.index("inspector_stop_done")
+        < ev.index("cleanup")
+    ), ev
+    assert ev.count("cleanup") == 1
+    assert _exec_specs(svc) == []
+
+
+@pytest.mark.asyncio
+async def test_flag_on_failed_mount_keeps_the_inspector_when_another_pod_is_rented(
+    svc, monkeypatch
+):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", True)
+    trace = _Trace(mount_fails=True)
+    _wire(svc, monkeypatch, trace=trace, rented_elsewhere=True)
+    monkeypatch.setattr(svc, "cleanup_failed_container_creation", AsyncMock(return_value=False))
+    result = await _run_create_container(svc, _payload())
+    assert isinstance(result, FailedContainerRequest)
+    assert trace.lifecycle_actions == ["start"]
+
+
+@pytest.mark.asyncio
+async def test_flag_on_oversized_environment_keeps_its_own_exec(svc, monkeypatch):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", True)
+    trace = _Trace()
+    _wire(svc, monkeypatch, trace=trace)
+    big = {"BLOB": "x" * (MAX_ENVIRONMENT_EXEC_VAR_BYTES + 1)}
+    assert not environment_fits_exec_variable(big)
+    assert environment_fits_exec_variable({"BLOB": "x" * (MAX_ENVIRONMENT_EXEC_VAR_BYTES - 10)})
+    result = await _run_create_container(
+        svc, _payload(custom_options=CustomOptions(environment=big))
+    )
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    specs = _exec_specs(svc)
+    assert len(specs) == 2
+    assert specs[0] == build_authorized_keys_exec_spec(
+        container_name=result.container_name, public_keys=["ssh-ed25519 test-key"]
+    )
+    assert specs[1] == build_environment_exec_spec(
+        container_name=result.container_name, environment=big
+    )
+    assert "env_exec" in trace.events
+    assert _step(result, ProfilerStepName.ADDING_PUBLIC_KEYS).skipped is False
+
+
+@pytest.mark.asyncio
+async def test_flag_on_inspector_disabled_starts_nothing(svc, monkeypatch):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", True)
+    trace = _Trace()
+    _wire(svc, monkeypatch, trace=trace, inspector=False)
+    result = await _run_create_container(svc, _payload())
+    assert type(result).__name__ == "ContainerCreated", getattr(result, "msg", "")
+    assert trace.lifecycle_actions == []
+    assert _step(result, ProfilerStepName.INSPECTOR_START).skipped is True
+
+
+@pytest.mark.asyncio
+async def test_flag_off_failed_mount_never_started_the_inspector(svc, monkeypatch):
+    monkeypatch.setattr(settings, "RENTAL_POSTRUN_CONCURRENT_ENABLED", False)
+    trace = _Trace(mount_fails=True)
+    _wire(svc, monkeypatch, trace=trace)
+    monkeypatch.setattr(svc, "cleanup_failed_container_creation", AsyncMock(return_value=False))
+    result = await _run_create_container(svc, _payload())
+    assert isinstance(result, FailedContainerRequest)
+    assert trace.lifecycle_actions == []


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3258](https://app.notion.com/p/Rent-post-run-stage-runs-the-inspector-start-the-keys-exec-and-the-env-exec-serially-after-the-enc-3d6b8bfdbde98113b280f219e9e396df) · reviewer: @taiberium

**TL;DR** — After `docker run` a rent runs serially the gocryptfs mount (4 SSH commands), the keys exec, the bootstrap / Jupyter (skipped on a cached template), the `/etc/environment` exec and the inspector collector start: 2.3 + 2.4 + 0.45 s p50 on a far node. Behind `RENTAL_POSTRUN_CONCURRENT_ENABLED` (off) the collector starts alongside the mount (a host-side process) and keys + `/etc/environment` are ONE exec after the mount. Nothing moves past RUNNING.

**What changed**
- `RENTAL_POSTRUN_CONCURRENT_ENABLED` (False) + `.env.template` line (`src/core/config.py`)
- `build_authorized_keys_and_environment_exec_spec`: keys on stdin, `/etc/environment` lines in one exec variable — one exec, no renter value in argv or logs
- `add_ssh_public_keys_with_rental_docker(environment=)` runs the combined spec (one builder; keys-only without lines)
- `create_container`: inspector start as a task before the mount, awaited before `ContainerCreated`; > 64 KiB environments keep their own exec
- `_settle_inspector_after_failed_create`: a post-run failure awaits the start, stops the collector when no other pod is rented, then cleans up

**How to verify**
- `pytest tests/test_postrun_concurrent.py -q` → 17 passed · `pytest tests/ -q` → 2 failed (main's own), 2016 passed
- flag on, one rent → profiling "Inspector collector start" ≈ 0, "Adding public keys" (the environment step) skipped; log `exec_add_authorized_keys_and_environment`

**Verified by the loop:** Gate: PASS eeb6d28

**Ran it:** keys exec + env exec + inspector start (3 serial channels) vs 1 combined exec ‖ inspector start, one open connection: RTX 4090 (far)… · EC2 `20260911T072224Z-v0w5` · … +2 under Details

**Self-review:** clean at eeb6d28 (15 checks, 6 low)

**Parts:** backend n/a — validator-only change · migration n/a — no schema change · frontend n/a — nothing renter-visible changes · CLI/SDK n/a — no API or CLI surface · docs n/a — operator flag in `.env.template` · tests ✓ 17 · dashboards n/a — existing profiler steps show it

**Docs:** `neurons/validators/.env.template` (the flag and what it reorders); no renter docs — a renter sees only a shorter stage.

<details><summary>Details</summary>

### Where the time goes

Prod `rental_history.profilers`, 7 d to 8 Sep 22:00Z (`~/lium-ads/speed/DEPLOY_UNDER_10S.md` §1), cached rental, no filler to stop: "encrypted volume" p50 2.29 s (86 % of pods), "ssh keys exec + bootstrap-skip + jupyter" 2.36 s, "env vars exec" 0 s p50 / 1.97 s p90 (most rentals carry no custom environment; an image-managed Jupyter pod carries `JUPYTER_PASSWORD`), "inspector collector start" 0.48 s. The steps are serial, and each `docker exec` over the rental Docker SDK is `exec_create` + `exec_start` (stdin socket) + `exec_inspect` over the SSH-tunnelled daemon socket — three round trips per exec on top of the exec itself.

### What moves, what stays, and why

| step | today | flag on | why it may / may not move |
|---|---|---|---|
| gocryptfs mount (upload, run, wipe, verify) | first | first, unchanged | the keys go to `/root/.ssh` and `/root` IS the mount point — written before the mount they would be hidden under it. Stays before the keys. |
| inspector collector start | last | **alongside the mount**, awaited before the return | `nohup <python> inspector_executor.py --start-collector &` on the host; reads the container from outside, needs neither the mount, the keys nor sshd. It does not gate SSH readiness, but it is still awaited before `ContainerCreated` — nothing runs after RUNNING, so no trust-window question arises. |
| authorized_keys exec | after the mount | after the mount, **carries `/etc/environment` too** | the environment lines are plain data; `/etc/environment` is read by PAM at login, so writing them before sshd is up (they were written after the bootstrap) changes nothing a renter sees. The bootstrap itself does not read the file. |
| sshd bootstrap / Jupyter | after the keys | after the keys, unchanged | DAH-2341: whichever sshd comes up first must already find the keys. |
| `/etc/environment` exec | after Jupyter | folded into the keys exec | one exec instead of two; `ADDING_PUBLIC_KEYS` (the step that timed it) is recorded `skipped`. |
| `_abort_if_cancelled_by_delete`, rented-pod cache, `ContainerCreated` | last | last, unchanged | the delete-cancel check still runs after every write. |

Everything that affects security — the mount before the keys, the keys before sshd, the delete-cancel check, the container cleanup on failure — keeps its order. What changes is only that a host-side process start no longer waits for the container's filesystem, and two writes into the container ride one exec.

### The combined exec

`build_authorized_keys_and_environment_exec_spec(container_name, public_keys, environment)`:

```
argv  = sh -c 'mkdir -p /root/.ssh && chmod 700 /root/.ssh && cat >> /root/.ssh/authorized_keys && printf '\''%s'\'' "$LIUM_ENVIRONMENT_LINES" >> /etc/environment'
stdin = <one public key per line>           (exactly build_authorized_keys_exec_spec's stdin)
env   = LIUM_ENVIRONMENT_LINES=<KEY=VALUE\n…>  (exactly build_environment_exec_spec's stdin)
```

- The keys stay on stdin, as today. The environment lines travel as an exec-process variable: the SDK's `exec_create(environment=…)` carries them in the request body, `rental_exec_spec_log_fields` logs `environment_keys` (the variable's NAME) and `stdin_bytes` — a renter's `HF_TOKEN` value is in neither argv nor any log line (`test_combined_spec_no_renter_value_in_argv_or_log_fields`). `printf '%s' "$VAR"` writes the value verbatim (`%` in a value is literal — `test_combined_script_percent_in_a_value_is_literal`).
- `_environment_file_text` is the one filter both `build_environment_exec_spec` and the combined spec use (blank key or value dropped), so the bytes appended to `/etc/environment` are the same on both paths (`test_combined_script_through_sh_writes_both_files_like_the_two_execs`).
- No environment lines → the combined spec IS `build_authorized_keys_exec_spec`'s spec, byte for byte.
- Linux caps one environment string at `MAX_ARG_STRLEN` (128 KiB) and `CustomOptions` caps nothing, so `environment_fits_exec_variable` (≤ `MAX_ENVIRONMENT_EXEC_VAR_BYTES` = 64 KiB of lines) gates the merge: a larger environment keeps its own stdin-based exec exactly as with the flag off (`test_flag_on_oversized_environment_keeps_its_own_exec`).
- The exec runs as uid 0 as every rental-bootstrap exec does (DAH-2534, `_exec_in_container_sync`).

### Failure paths

- The combined exec exits non-zero → `Failed to add SSH public keys and environment: exit_status=…` → the post-run `except` → `cleanup_failed_container_creation` as today (`failure_step=add_public_keys`).
- The mount fails with the collector already started → `_settle_inspector_after_failed_create`: await the start task (it never raises — `_run_inspector_collector_lifecycle` logs its own failures), then, when `_has_rented_containers` is False, `--stop-collector` so the host is left as a delete would leave it; another rented container on the executor keeps the collector, as on delete. Best-effort: a Redis or SSH error there is logged and the create's own failure is what is reported. Then the existing cleanup runs. With the flag off nothing precedes the mount, so this path does not exist there (`test_flag_off_failed_mount_never_started_the_inspector`).
- `ENABLE_INSPECTOR=false` → no task, `INSPECTOR_START` recorded `skipped` as today.
- The whole create being cancelled (`CancelledError`) while the task runs is the one path not covered by the settle: the connection closes and the task's `ssh_client.run` fails, which `_run_inspector_collector_lifecycle` logs as `Inspector collector start failed` — the same line a lost connection produces today.

### Ran it

Two live pods (dind template, `pod_bench` = an alpine container standing in for the rental container), 9 Sep 02:25–02:28Z, `~/lium-ads/speed/proof/lever45/{bench.sh,far.txt,near.txt}`. One ssh connection, a new channel per command (as asyncssh does), three runs each, median. TODAY = `docker exec -i … sh -c '<keys script>' < keys`, `docker exec -i … sh -c 'cat >> /etc/environment' < env`, `nohup sh -c 'sleep 0' >/dev/null 2>&1 &` (the inspector start's shape), serial; FAST = one `docker exec -i -e LIUM_ENVIRONMENT_LINES=… sh -c '<combined script>' < keys` with the nohup channel launched concurrently:

```
RTX 4090, Ukraine (far):  new channel RTT 635 ms
  TODAY  3 serial channels:  2931 / 2401 ms   (two runs of the script)
  FAST   1 exec ‖ inspector:  949 /  919 ms
L40S, United States (near): new channel RTT 427 ms
  TODAY  3 serial channels:  1965 ms
  FAST   1 exec ‖ inspector:   630 ms
written by the FAST exec (on the pod): authorized_keys 12 lines (3 runs × 2 keys + earlier runs) · /etc/environment tail: HF_TOKEN=hf_bench MODEL=bench
```

This is a lower bound for the prod effect: a `docker exec` through the ssh CLI is one channel, while the validator's SDK exec is three tunnelled HTTP round trips — the exec that disappears costs more there than here. The measurement does not include the gocryptfs mount (the alpine stand-in has no gocryptfs); the mount's own four commands are unchanged by this PR, and the inspector's 0.45 s hides under them.

Validator suite on EC2 (`tools/aws_run_jobs/io_validators_pytest.sh`, run `20260911T072224Z-v0w5` at `eeb6d28c`, Python 3.11.11): `2 failed, 2124 passed, 15 skipped` — the two failures are main's own (`test_scrape_infiniband::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices`, `test_sshd_bootstrap_script::test_adopt_path_hardens_config_for_key_only_auth`; main baseline `2 failed, 1999 passed`). `ruff format --check` (`uvx ruff@0.5.1`): the new test module is formatted. Not run on a real validator against a real executor; the staging validator is where the flag goes first.

### Tests (`tests/test_postrun_concurrent.py`, 17)

- the combined spec: without environment it equals the keys spec (blank-only environment too); keys on stdin, lines in the one variable, argv is the keys script + the printf; no renter value in argv or log fields; through `sh -c` both files get the same bytes the two specs wrote and `.ssh` is 0700; `%` literal
- `add_ssh_public_keys_with_rental_docker`: with environment → one combined exec; without / `{}` → the keys spec as before; the failure names both / names keys only
- `create_container`, with a trace whose mount waits for the inspector start and whose inspector start then takes 50 ms (so it can only be complete at the return when `create_container` awaited it): flag off → `mount → keys → env → inspector`, two execs, `ADDING_PUBLIC_KEYS` not skipped; flag on → the inspector starts before the mount finishes and is the last event before the return, the mount finishes before the keys exec, one exec equal to the combined spec, `ADDING_PUBLIC_KEYS` skipped; no environment → the plain keys exec; an environment above 64 KiB → the keys exec + its own environment exec; an unencrypted pod: the inspector start runs during the keys exec (before `keys_exec_done`); a failed mount → `start`, `stop`, then the cleanup, in that order, no exec ran, `failure_step=encrypted_volume_setup`; a failed mount with another rented container → `start` only; `ENABLE_INSPECTOR=false` → no lifecycle call, step skipped; flag off + failed mount → no lifecycle call

### Risk

- The collector observes the container ~2 s earlier than today (during the mount). It is a metrics collector for rented containers; it does not gate anything in the create.
- A post-run failure after the collector started now issues a `--stop-collector` when no other rented container is on the executor — the delete path's exact rule; with another tenant the collector stays.
- Rollback: the flag.

### Cross-PR

Cross-PR: lium-io#1332 (DAH-3240) and lium-io#1333 (DAH-3257) are merged and under this branch's merge-base (the restack onto main kept all three flags); the branch merges clean onto `origin/main`. The only open sibling touching `docker_service.py` is lium-io#1295 (DAH-3004, SSH connect), which shares no line with this PR.

### Self-review

Verdict `findings` at `eeb6d28` · 15 checks · by subagent-r105 · 2026-09-11 07:21Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `neurons/validators/src/core/config.py:233` | The body's Cross-PR paragraph (and the folded self-review row at config.py:216) describes lium-io#1332 and lium-io#1333 as open siblings whose flag hunks conflict at the same anchor, but both are merged and are ancestors of this branch's merge-base (067ec878 IS #1332's merge commit; #1333 merged as 3d326758 before it), and `git merge-tree --write-tree HEAD origin/main` at dd27dc39 merges clean — the property 'every PR named as open in Cross-PR is open' does not hold. | Re-render the Cross-PR paragraph: '#1332 and #1333 are on main and under this branch; the branch merges clean onto main; only lium-io#1295 (DAH-3004, SSH connect) is still open and shares no line.' and drop the obsolete CROSS-PR row from the folded self-review table. |
| low | STALE-BODY | `neurons/validators/tests/test_postrun_concurrent.py:1` | The body cites `fece0d5` three times (Verified by the loop, Self-review verdict, Verified/Gate) and a suite count measured on `main@b05764a7` (2 failed / 2016 passed); `fece0d5` is not reachable from HEAD after the restack (`git merge-base --is-ancestor fece0d5 HEAD` fails), so the property 'every sha in the body is reachable on the branch' does not hold until the gate and self-review are re-recorded at eeb6d28. | After the push, re-run the gate and `tools/pr_self_review.py lium-io 1334 --record <this verdict> --apply` so every sha in the body is eeb6d28 or an ancestor; re-run `pytest tests/ -q` on the restacked head and update the counts. |
| low | TEST-GAP | `neurons/validators/src/services/docker_service.py:900` | The body's Failure-paths section states 'a Redis or SSH error there is logged and the create's own failure is what is reported', but no test drives the `except Exception` branch of `_settle_inspector_after_failed_create`: both failed-mount tests wire `_has_rented_containers=AsyncMock(return_value=...)` and never raise (unchanged since fece0d5). | Add one test where `_has_rented_containers` raises RuntimeError with the flag on and a failing mount; assert the result is still `FailedContainerRequest(failure_step='encrypted_volume_setup')`, cleanup ran once and `lifecycle_actions == ['start']`. |
| low | PROSE-VS-CODE | `neurons/validators/src/services/docker_service.py:3010` | The 'What changed' bullet reads as if `add_ssh_public_keys_with_rental_docker(environment=)` itself keeps a >64 KiB environment on its own exec; the gate (`environment_fits_exec_variable`) lives in `create_container` at line 5332, and a direct caller passing an oversized dict would get one combined spec with an oversized exec variable. | Move the '> 64 KiB keeps its own exec' clause to the `create_container` bullet, or add the size check (fall back to the keys spec and let the caller run the env exec) inside `add_ssh_public_keys_with_rental_docker`. |
| low | CODE-QUALITY | `neurons/validators/src/services/docker_service.py:120` | `environment_fits_exec_variable` sits between `build_environment_exec_spec` and `build_remove_authorized_keys_exec_spec`, breaking the alphabetical order the rest of the `services.rental_docker_sdk` import block keeps (known nit from the fece0d5 review, still present). | Move `environment_fits_exec_variable` below `build_remove_authorized_keys_exec_spec`. |
| low | CODE-QUALITY | `neurons/validators/tests/test_postrun_concurrent.py:231` | `_Trace.cleanup` is defined above `__init__`, unlike every other class in the tests directory (known nit from the fece0d5 review, still present). | Move `cleanup` below `__init__`, next to `mount` and `lifecycle`. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/tests/test_postrun_concurrent.py:123` `0o777` is the permission MASK in `stat().st_mode & 0o777`, used to assert the `.ssh` directory the combined script created is exactly `0o700`; nothing is chmod'ed 0o777 and the script under test runs `chmod 700`.

### Verified

Gate: PASS (eeb6d28) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1334)

</details>
