### PR TITLE
DAH-3246 - [P2] rent: log in to the registry only when a pull follows

### DIFF
--- a/neurons/validators/src/payload_models/payloads.py
+++ b/neurons/validators/src/payload_models/payloads.py
@@ -539,6 +539,9 @@ class ProfilerStepName(str, enum.Enum):
     PORT_MAPPINGS_GENERATED = "Port mappings generated"
     SSH_CONNECTION_ESTABLISHED = "SSH connection established"
     DOCKER_LOGIN = "Docker login step finished"
+    # DAH-3246: the image-presence probe, once folded into DOCKER_PULL (whose value was ~0.4 s
+    # of probe on a rental whose pull was skipped). Its own step from here on.
+    DOCKER_IMAGE_INSPECT = "Docker image inspect step finished"
     CUSTOM_DOCKER_BUILD = "Custom docker build step finished"
     DOCKER_PULL = "Docker pull step finished"
     CONTAINER_CLEANING = "Container cleaning step finished"

--- a/neurons/validators/src/services/docker_service.py
+++ b/neurons/validators/src/services/docker_service.py
@@ -4260,28 +4260,44 @@ class DockerService:
                 # Docker daemon and the credential stays in this validator's client, so nothing is
                 # written to the executor's ~/.docker/config.json for a `docker logout` to clear.
                 #
-                # The default cache-template images are public Docker Hub refs, so a
-                # registry login buys nothing for them — the pull needs no auth and is
-                # itself almost always skipped (the image is pre-cached on the executor).
-                # The backend still attaches credentials whenever the renter has any
-                # saved, which costs a round-trip to auth.docker.io on every such deploy
-                # (~1.1s median in prod). Skip the login on that path.
-                #
-                # `ships_sshd` IS the "renter selected a default image" signal — the
-                # backend sets it from the same check that resolves the recommended image
-                # for this executor's GPU+driver (executor.py: `ships_sshd=is_cached`,
-                # with `is_cached=False` forced for custom builds, so they keep this login
-                # path as-is; the DinD `docker build` never sees this SDK login, and
-                # passing credentials into it is a separate task). Don't re-derive it here:
-                # a second, validator-side notion of "is this a default image?" could
-                # disagree with the backend's and skip a login that was actually needed.
+                # DAH-3246: the login exists for one thing — the pull. When the image is already on
+                # the host there is no pull, and the login was a round trip to auth.docker.io for
+                # nothing (~1.1 s median in prod, 3.9 s on a far node). So the image probe comes
+                # first and the login runs only when a pull will follow and the backend attached
+                # credentials — whatever the image. Before this, the skip was keyed on
+                # `ships_sshd` (the backend's "default image" signal), which also skipped the login
+                # for a default image that still had to be pulled: that pull went anonymous, into
+                # Docker Hub's unauthenticated rate limit, while the credentials sat unused. A custom
+                # build has no image to probe and keeps the login it always had.
                 has_credentials = bool(payload.docker_username and payload.docker_password)
-                skip_login = not has_credentials or bool(payload.ships_sshd)
+                image_present = False
+                if not is_custom_build:
+                    current_step = "docker_image_inspect"
+                    try:
+                        image_present = await run_logged_rental_docker_sdk_operation(
+                            operation="inspect_image",
+                            log_extra=default_extra,
+                            call=lambda: docker_client.image_exists(
+                                image=payload.docker_image
+                            ),
+                            image=payload.docker_image,
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            _m(
+                                "Docker SDK image inspect probe failed; falling back to pull",
+                                extra=get_extra_info({**default_extra, "error": str(exc)}),
+                            )
+                        )
+                    profilers.append(ProfilerStep.since(ProfilerStepName.DOCKER_IMAGE_INSPECT, prev_timestamp))
+                    prev_timestamp = now_ms()
+
+                skip_login = not has_credentials or image_present
                 if skip_login:
                     if has_credentials:
                         logger.info(
                             _m(
-                                "Skipping docker login for default cache-template image",
+                                "Skipping docker login; image already present, nothing to pull",
                                 extra=get_extra_info(default_extra),
                             )
                         )
@@ -4351,25 +4367,6 @@ class DockerService:
                     profilers.append(ProfilerStep.since(ProfilerStepName.CUSTOM_DOCKER_BUILD, prev_timestamp))
                     prev_timestamp = now_ms()
                 else:
-                    current_step = "docker_image_inspect"
-                    image_present = False
-                    try:
-                        image_present = await run_logged_rental_docker_sdk_operation(
-                            operation="inspect_image",
-                            log_extra=default_extra,
-                            call=lambda: docker_client.image_exists(
-                                image=payload.docker_image
-                            ),
-                            image=payload.docker_image,
-                        )
-                    except Exception as exc:
-                        logger.warning(
-                            _m(
-                                "Docker SDK image inspect probe failed; falling back to pull",
-                                extra=get_extra_info({**default_extra, "error": str(exc)}),
-                            )
-                        )
-
                     current_step = "docker_pull"
                     if image_present:
                         logger.info(

--- a/neurons/validators/tests/test_deploy_optimizations.py
+++ b/neurons/validators/tests/test_deploy_optimizations.py
@@ -98,9 +98,13 @@ class _FakeRentalDockerClient:
         self.run_specs = []
         self.exec_specs = []
         self.login_calls = []
+        self.login_error = None
+        self.pull_error = None
 
     async def login(self, *, username: str, password: str, image: str) -> None:
         self.login_calls.append({"username": username, "password": password, "image": image})
+        if self.login_error is not None:
+            raise self.login_error
 
     async def image_exists(self, *, image: str) -> bool:
         self.image_exists_calls.append(image)
@@ -110,6 +114,8 @@ class _FakeRentalDockerClient:
 
     async def pull(self, *, image: str) -> None:
         self.pulled_images.append(image)
+        if self.pull_error is not None:
+            raise self.pull_error
 
     async def run_container(self, spec) -> None:
         self.run_specs.append(spec)
@@ -800,7 +806,7 @@ def test_container_created_profilers_round_trip():
 
 
 # ------------------------------------------------------------------
-# #4 — docker-login skip for default cache-template images
+# #4 — docker login only when a pull follows (DAH-3246)
 # ------------------------------------------------------------------
 
 _DEFAULT_IMAGE = "daturaai/pytorch:2.12.0-py3.12-cuda12.8-devel-ubuntu24.04-dind"
@@ -811,29 +817,77 @@ def _login_step(result):
     return next(p for p in result.profilers if p.name == ProfilerStepName.DOCKER_LOGIN)
 
 
-@pytest.mark.asyncio
-async def test_docker_login_skipped_for_default_image_even_with_credentials(svc, monkeypatch):
-    """The default images are public and pre-cached, so the login is pure latency —
-    skip it even though the backend attached the renter's saved credentials.
+def _inspect_step(result):
+    return next(p for p in result.profilers if p.name == ProfilerStepName.DOCKER_IMAGE_INSPECT)
 
-    `ships_sshd` IS the "renter selected a default image" signal: the backend sets it
-    from the same check that resolves the recommended image (`ships_sshd=is_cached`).
-    The validator trusts it rather than re-deriving default-ness from the image ref.
-    """
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ships_sshd", [False, True, None])
+async def test_docker_login_skipped_when_the_image_is_present(svc, monkeypatch, ships_sshd):
+    """DAH-3246: the login exists for the pull. An image already on the host is not pulled,
+    so the login is pure latency — skipped even though the backend attached the renter's
+    saved credentials, and whatever `ships_sshd` says."""
     ssh_client = _ssh_client(inspect_exit=0)
+    _patch_happy(svc, monkeypatch, ssh_client)
+    payload = _payload(docker_image="private/repo:1.0.0", **_CREDS)
+    payload.ships_sshd = ships_sshd
+
+    result = await _run(svc, payload)
+
+    assert isinstance(result, ContainerCreated)
+    assert _docker_client(svc).login_calls == [], "docker login must NOT run when nothing is pulled"
+    assert _login_step(result).skipped is True
+    assert _inspect_step(result).skipped is False
+
+
+@pytest.mark.asyncio
+async def test_docker_login_runs_before_a_pull_even_for_a_default_image(svc, monkeypatch):
+    """DAH-3246: a default image that is NOT on the host must be pulled, and with credentials
+    attached that pull is authenticated. Before, `ships_sshd=True` skipped the login here and the
+    pull went anonymous into Docker Hub's unauthenticated rate limit."""
+    ssh_client = _ssh_client(inspect_exit=1)
     _patch_happy(svc, monkeypatch, ssh_client)
 
     result = await _run(svc, _payload(docker_image=_DEFAULT_IMAGE, ships_sshd=True, **_CREDS))
 
     assert isinstance(result, ContainerCreated)
-    assert _docker_client(svc).login_calls == [], "docker login must NOT run for a default image"
-    assert _login_step(result).skipped is True
+    assert _docker_client(svc).login_calls == [
+        {"username": "renter", "password": "renter-secret", "image": _DEFAULT_IMAGE}
+    ]
+    assert _login_step(result).skipped is False
+    assert _pulled_images(svc) == [_DEFAULT_IMAGE]
+    # the login step sits between the probe and the pull, in that order
+    names = [p.name for p in result.profilers]
+    inspect_at, login_at, pull_at = (
+        names.index(ProfilerStepName.DOCKER_IMAGE_INSPECT),
+        names.index(ProfilerStepName.DOCKER_LOGIN),
+        names.index(ProfilerStepName.DOCKER_PULL),
+    )
+    assert inspect_at < login_at < pull_at
+
+
+@pytest.mark.asyncio
+async def test_failed_login_then_failed_pull_is_reported_as_the_login(svc, monkeypatch):
+    """A saved credential for another registry fails the login (logged); docker-py then pulls
+    anonymously, and when that pull fails too the rental is reported as `docker_login` with the
+    login error appended — the attribution user images always had, now for default images."""
+    ssh_client = _ssh_client(inspect_exit=1)
+    _patch_happy(svc, monkeypatch, ssh_client)
+    _docker_client(svc).login_error = RuntimeError("unauthorized: incorrect username or password")
+    _docker_client(svc).pull_error = RuntimeError("toomanyrequests: rate limit")
+
+    result = await _run(svc, _payload(docker_image=_DEFAULT_IMAGE, ships_sshd=True, **_CREDS))
+
+    assert isinstance(result, FailedContainerRequest)
+    assert result.failure_step == "docker_login"
+    assert "earlier login failure" in (result.detail or "") and "unauthorized" in (result.detail or "")
+    assert _pulled_images(svc) == [_DEFAULT_IMAGE]
 
 
 @pytest.mark.asyncio
 async def test_docker_login_runs_for_non_default_image_with_credentials(svc, monkeypatch):
-    """DEFAULT-PATH REGRESSION GUARD: a user image with credentials still logs in —
-    a private registry pull depends on it. The backend sends ships_sshd=False here."""
+    """DEFAULT-PATH REGRESSION GUARD: a user image with credentials still logs in before
+    its pull — a private registry pull depends on it."""
     ssh_client = _ssh_client(inspect_exit=1)
     _patch_happy(svc, monkeypatch, ssh_client)
 
@@ -850,8 +904,8 @@ async def test_docker_login_runs_for_non_default_image_with_credentials(svc, mon
 
 @pytest.mark.asyncio
 async def test_docker_login_runs_when_ships_sshd_is_none(svc, monkeypatch):
-    """LEGACY-PATH REGRESSION GUARD: retry/filler rentals omit ships_sshd (None). That
-    is not a default-image signal, so the login must still run when credentials exist."""
+    """LEGACY-PATH REGRESSION GUARD: retry/filler rentals omit ships_sshd (None); with
+    credentials and a pull ahead the login must still run."""
     ssh_client = _ssh_client(inspect_exit=1)
     _patch_happy(svc, monkeypatch, ssh_client)
 
@@ -865,10 +919,11 @@ async def test_docker_login_runs_when_ships_sshd_is_none(svc, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_docker_login_step_marked_skipped_when_no_credentials(svc, monkeypatch):
-    """No credentials was always a no-op login; now the profile says so instead of
-    reporting a 0ms step that looks like real work."""
-    ssh_client = _ssh_client(inspect_exit=0)
+@pytest.mark.parametrize("inspect_exit", [0, 1])
+async def test_docker_login_step_marked_skipped_when_no_credentials(svc, monkeypatch, inspect_exit):
+    """No credentials was always a no-op login; the profile says so instead of
+    reporting a 0ms step that looks like real work — image present or not."""
+    ssh_client = _ssh_client(inspect_exit=inspect_exit)
     _patch_happy(svc, monkeypatch, ssh_client)
 
     result = await _run(svc, _payload(docker_image="private/repo:1.0.0"))
@@ -879,11 +934,24 @@ async def test_docker_login_step_marked_skipped_when_no_credentials(svc, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_probe_failure_logs_in_and_pulls(svc, monkeypatch):
+    """Fail-open: when the presence probe raises, the rental pulls — and with credentials
+    attached, it logs in first, even for a default image (`ships_sshd=True` used to skip it)."""
+    ssh_client = _ssh_client(inspect_raises=True)
+    _patch_happy(svc, monkeypatch, ssh_client)
+
+    result = await _run(svc, _payload(docker_image=_DEFAULT_IMAGE, ships_sshd=True, **_CREDS))
+
+    assert isinstance(result, ContainerCreated)
+    assert len(_docker_client(svc).login_calls) == 1
+    assert _pulled_images(svc) == [_DEFAULT_IMAGE]
+
+
+@pytest.mark.asyncio
 async def test_docker_login_runs_for_custom_build(svc, monkeypatch):
-    """Custom builds keep ships_sshd=False (the backend forces is_cached=False for them,
-    even when the base image happens to be a default ref), so they keep the login path
-    as-is. The DinD `docker build` never sees this SDK login; passing credentials into
-    it is a separate task."""
+    """A custom build has no image to probe, so it keeps the login it always had when
+    credentials are attached. The DinD `docker build` never sees this SDK login; passing
+    credentials into it is a separate task."""
     ssh_client = _ssh_client(inspect_exit=0)
     _patch_happy(svc, monkeypatch, ssh_client)
     monkeypatch.setattr(svc, "_custom_build_image", AsyncMock(return_value=(True, None)))


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3246](https://app.notion.com/p/3d5b8bfdbde981f7b39ced1ab80a1835) · reviewer: @taiberium

**TL;DR** — The rent path logged in to the registry before knowing whether it would pull: an image still needing a pull went anonymous into Docker Hub's rate limit, and a rental with a saved credential and the image already on the host paid the login for nothing (3.9 s on a 4090). The image probe now runs first; the login runs only when a pull follows and credentials exist.

**What changed**
- Image probe ahead of the login; `skip_login = not has_credentials or image_present` replaces the `ships_sshd` coupling; custom builds keep their login (`neurons/validators/src/services/docker_service.py`)
- `ProfilerStepName.DOCKER_IMAGE_INSPECT` — the probe reports its own time instead of riding inside "Docker pull" (`src/payload_models/payloads.py`)
- Login tests for the new rule: 1 replaced (parametrized image-present), 3 added, 1 parametrized, 3 docstrings (`tests/test_deploy_optimizations.py`)

**Risks**
- None beyond the diff: no migration, no pod restart, no config change, no data rewrite.

**How to verify**
- `cd neurons/validators && pytest tests/test_deploy_optimizations.py tests/test_custom_dockerfile_build.py -q` → 55 passed
- `pytest tests -q` → 2005 passed, 2 failed (main's own `test_scrape_infiniband`, `test_sshd_bootstrap_script`)
- a rent with a saved credential of an image on the host → profilers: `Docker image inspect` ~0.4 s, `Docker login` `skipped=true`, `Docker pull` `skipped=true`

**Verified by the loop:** Gate: PASS 71ad785

**Ran it:** not run against a live executor — two existing SDK calls reordered plus a profiler step; both branches run through `create_container` with the fake host in `tests/test_deploy_optimizations.py` · EC2 suite 20260909T042259Z-tiid at this commit

**Self-review:** clean at 71ad785 (15 checks, 2 low)

**Parts:** backend n/a — lium-platform#267 lands after this · validator ✓ · migration n/a — no schema change · frontend n/a — nothing renter-visible changes · CLI/SDK n/a — no API shape change · docs n/a — no setting; visible only in the deploy profile · tests ✓ 3 added, 1 replaced, 1 rewritten · dashboards n/a — follow-up column `docker_image_inspect_ms` in lium-platform (Details)

**Docs:** none changed in this PR — no flag, no renter-visible behaviour; the profiler-step change is under Details for the Grafana readers.

<details><summary>Details</summary>

### Why

`rental_history.profilers`, 7 days to 9 Sep 02:30Z, uncached `daturaai/pytorch:*-ubuntu24.04-dind*` rentals (n=365): 97 pulled, 268 had the image on the host. The login ran on 237 (a renter credential was attached — the backend attaches the renter's first saved credential to every rent); 176 of those had the image on the host — a login for a pull that never happened — and 61 pulled after it. On the measured RTX 4090 rental (pod f96628ae, 9 Sep 02:50Z) that login took 3,886 ms. Conversely, cached rentals (`ships_sshd=True`) skipped the login even when the pre-warm had missed and a pull followed — 36 such rentals in the window pulled anonymously with a credential sitting unused.

lium-platform#267 makes `ships_sshd=True` for every tag of the family (not only the node's recommended one), which would have widened the anonymous-pull case to the 61 credentialed uncached family rentals a week that really pull (97 pull in all; the other 36 carry no credential and pull anonymously either way). This PR removes the coupling instead: the login is about the pull, so it follows the probe.

### Behaviour, before → after

| rental | before | after |
|---|---|---|
| credential attached, image on host, `ships_sshd=False` | login (≈1.1 s median, 3.9 s far node), no pull | **no login**, no pull |
| credential attached, image on host, `ships_sshd=True` | no login, no pull | no login, no pull |
| credential attached, image absent, `ships_sshd=True` | **anonymous pull** | login, authenticated pull — when the saved credential is for the image's registry (`RentalDockerSdkClient.login` resolves the registry from the image); a credential for another registry fails the login (logged), the pull proceeds anonymously, and if that pull then fails the rental is reported as `docker_login` with the login error appended — the attribution user images already get |
| credential attached, image absent, `ships_sshd=False`/None | login, pull | login, pull |
| no credential | no login | no login |
| custom build, credential | login, build | login, build (no image to probe) |
| probe raises | login (if credential and not `ships_sshd`), pull | login (if credential), pull |

### The credential now reaches the executor on default-image pulls

The login is a POST /auth to the executor's Docker daemon: the renter's first saved credential (attached by the backend whatever registry it is for) is presented to the miner-controlled daemon, and onward to the image's registry, on every pull that has one. Before, `ships_sshd=True` rentals never handed it over; now the ~36 default-image pulls a week with a credential attached do, exactly as every user-image pull always has. Nothing is written on the executor (no `docker logout` counterpart is needed, see the comment in code).

### Profiler steps

Order on a pull-skipped rental is now `Docker image inspect step finished` (the probe, ~0.4 s) → `Docker login step finished` (skipped) → `Docker pull step finished` (skipped, ~0 ms). Before, the probe's time was the whole value of "Docker pull" on such rentals (cached p50 0.41 s in `speed/DEPLOY_UNDER_10S.md` §1). The stats ETL (`container_profiler_events`) has no column for the new name, so it lands in `extra_steps` like `Encrypted volume setup` and `Inspector collector start` did, and the dashboard's unknown-step panel (Panel 6, the drift watchdog) will list `Docker image inspect step finished` until lium-platform adds a `docker_image_inspect_ms` column (follow-up, the way migration 050 added the backend steps). The "Docker pull" panels of Container Creation Profiling will read ~0 on pull-skipped rentals from the first validator release with this change. No alert keys on `docker_pull_ms`.

### Verification

- EC2 warm box `i-0c56dcf0d1dbd56a6`, run `20260909T042259Z-tiid` at this commit: full validator suite → 2005 passed, 15 skipped, 2 failed (main's own `test_scrape_infiniband::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices`, `test_sshd_bootstrap_script::test_adopt_path_hardens_config_for_key_only_auth`); targeted run `20260909T042152Z-rly4`: `tests/test_deploy_optimizations.py tests/test_custom_dockerfile_build.py` → 55 passed. Earlier heads of this branch (before the fresh-review rounds): `20260909T033907Z-xpkp` 2001 passed, `20260909T035533Z-1z7d` 2003 passed, same 2 failures.

### Self-review

Verdict `findings` at `71ad785` · 15 checks · by subagent-fresh-k · 2026-09-09 07:46Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `speed/pr_body_dah3246_io.md:19` | The Parts line marks `dashboards ✓` although the diff touches no dashboard, ETL or migration file (3 files: payloads.py, docker_service.py, test_deploy_optimizations.py); the ✓ reads as 'carried in this PR' while the text after it describes a lium-platform follow-up (a `docker_image_inspect_ms` column, migration-050 style). | Write `dashboards n/a — follow-up in lium-platform: ... ` (or `dashboards follow-up: ...`) so the mark matches the diff; keep the note about `extra_steps` and the drift watchdog. |
| low | PROSE-VS-CODE | `speed/pr_body_dah3246_io.md:29` | The Why numbers do not close: line 27 gives 237 credentialed rentals of which 176 had the image present (so 61 credentialed rentals pulled), and line 29 says the anonymous-pull case would widen to 'the 61 uncached family rentals a week that really pull' — the sibling body speed/pr_body_dah3246.md:63 states the same 61 as '61 of the 365 uncached family rentals pulled' (all rentals, credential or not); both can only be right if none of the 128 credential-less rentals pulled. | Re-run the profilers query and state the pull count twice if they differ — 'N uncached family rentals pulled, M of them with a credential' — and use the same figure in both bodies. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/src/services/docker_service.py:4295` CORRECTNESS: `skip_login = not has_credentials or image_present` with `image_present=False` for custom builds reproduces the old custom-build and no-credential outcomes; the probe is the same `image_exists` call moved ahead of the login, exceptions still fall open to pull (4285-4291), `login_error` (4067/4319) still only attributes a pull that fails after a failed login (4400-4407); no new external call, no new timeout surface. · `neurons/validators/src/services/docker_service.py:4404` CORRECTNESS/billing: `failure_step=docker_login` now reaches default-image rentals too, but nothing branches on it — the validator has no consumer (grep) and lium-platform validator_consumer.py:643 only appends it to the renter-facing text. · `neurons/validators/src/services/docker_service.py:4310` SECURITY: the renter's saved credential now reaches the miner's daemon on ~36 default-image pulls/week that previously skipped the login; this is the path every user-image and `ships_sshd` False/None pull has always taken, the body states it under 'The credential now reaches the executor', and narrowing it (attach only a matching-registry credential) is backend work outside this diff. · `neurons/validators/src/payload_models/payloads.py:544` CROSS-PR/PLATFORM: a new ProfilerStepName is safe downstream — lium-platform stores profilers raw and the stats ETL (apps/stats/.../container_profiler_events.sql:93-117) routes unknown names to `extra_steps`, the 'Step-name drift watchdog' panel exists, and no alert file references docker_pull_ms; lium-io#1337 adds WARM_POOL_LOOKUP at enum line 552, a separate hunk. · `neurons/validators/tests/test_deploy_optimizations.py:951` TEST-GAP: test_docker_login_runs_for_custom_build does not assert image_exists_calls == [], but it runs with inspect_exit=0, so if the probe were consulted for a custom build the login would be skipped and the test would fail — the property is covered indirectly. · `neurons/validators/tests/test_deploy_optimizations.py:826` TEST-GAP: each new/changed test fails on origin/main — ships_sshd=False → login_calls non-empty; ships_sshd=True → `_inspect_step` raises StopIteration (no DOCKER_IMAGE_INSPECT step); the failed-login test would report docker_pull; EC2 55/55 and 2005 passed at tree dbcade8d (matches HEAD^{tree}). · `speed/pr_body_dah3246_io.md:65` SCOPE: the ticket is split as documented in speed/DEPLOY_UNDER_10S.md §3 lever 2 — backend in lium-platform#267 (open, base main, 'lands after this'), validator here; branch is origin/main + 1 commit, base main.

### Verified

Gate: PASS (71ad785) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1336)

</details>
