### PR TITLE
DAH-3275 - [P1] inspector: provider-origin verdict, renter access event, enforcement flag

### DIFF
--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -212,8 +212,8 @@ class Settings(BaseSettings):
     )
     # DAH-3275: a provider-origin Inspector finding on a rented pod fails the check, zeroes the
     # score and asks the backend for an inspector_auto quarantine (off the marketplace + renters
-    # told; nothing deleted). Off = shadow: the verdict, the evidence hashes and the renter's
-    # pod event are still recorded, the score is untouched.
+    # told; nothing deleted). Off = shadow: the verdict and the evidence hashes are recorded in
+    # the inspector event, no renter is told, the score is untouched.
     INSPECTOR_ENFORCE_ENABLED: bool = Field(env="INSPECTOR_ENFORCE_ENABLED", default=False)
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
     # DAH-3011: a never-validated executor's FIRST verification (the express lane's, DAH-2958 —

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -210,6 +210,11 @@ class Settings(BaseSettings):
         env="INSPECTOR_ENSURE_COLLECTOR_ON_RENTED_CHECK",
         default=True,
     )
+    # DAH-3275: a provider-origin Inspector finding on a rented pod fails the check, zeroes the
+    # score and asks the backend for an inspector_auto quarantine (off the marketplace + renters
+    # told; nothing deleted). Off = shadow: the verdict, the evidence hashes and the renter's
+    # pod event are still recorded, the score is untouched.
+    INSPECTOR_ENFORCE_ENABLED: bool = Field(env="INSPECTOR_ENFORCE_ENABLED", default=False)
     SKIP_RENTAL_VERIFICATION: bool = Field(env="SKIP_RENTAL_VERIFICATION", default=False)
     # DAH-3011: a never-validated executor's FIRST verification (the express lane's, DAH-2958 —
     # published spec-only, never scored) proves "this GPU exists, is the model claimed, the host is

--- a/neurons/validators/src/services/inspector_validation_service.py
+++ b/neurons/validators/src/services/inspector_validation_service.py
@@ -24,6 +24,10 @@ INSPECTOR_LIB_PATH = "/usr/lib/libinspector.so"
 INSPECTOR_COMMAND_TIMEOUT_SECONDS = 30
 INSPECTOR_STDERR_CAPTURE_TIMEOUT_SECONDS = 10
 INSPECTOR_STDERR_CAPTURE_MAX_BYTES = 8192
+# the sensor is inside the executor image measured by the CVM's TDX quote
+SENSOR_INTEGRITY_MEASURED = "tdx_measured_image"
+# a sha256sum run through the provider's own shell — unattested
+SENSOR_INTEGRITY_SHELL = "shell_sha256_unattested"
 
 
 class InspectionFailed(Exception):
@@ -133,6 +137,8 @@ class InspectorValidationService:
         ssh: asyncssh.SSHClientConnection,
         executor: ExecutorSSHInfo,
         default_extra: dict[str, Any],
+        *,
+        sensor_attested: bool = False,
     ) -> InspectorValidationResponse:
         from services.task.messages import InspectorMessages as Msg
 
@@ -142,24 +148,31 @@ class InspectorValidationService:
         diagnostics: dict[str, Any] = {
             "command": command,
             "executor_uuid": executor.uuid,
+            # DAH-3275: what vouches for the sensor binary this report came from. On a dstack
+            # CVM the executor image (and the .so in it) is part of the stack the validator
+            # measured against TDX_WHITELIST; asking the provider's shell for a sha256sum on
+            # top proves nothing (the shell is theirs), so the shell read is skipped there and
+            # every other host is marked as what it is.
+            "sensor_integrity": SENSOR_INTEGRITY_MEASURED if sensor_attested else SENSOR_INTEGRITY_SHELL,
         }
 
         try:
-            executor_checksum = await sha256_from_executor(shell, self.lib_path)
-            if self.local_checksum != executor_checksum:
-                return self._failure_response(
-                    error=(
-                        "Executor using outdated libinspector library. "
-                        "Run docker compose restart to update to the latest executor image"
-                    ),
-                    message=Msg.FAILED_LIB_MISMATCH,
-                    diagnostics={
-                        **diagnostics,
-                        "local_sha256": self.local_checksum,
-                        "executor_sha256": executor_checksum or None,
-                    },
-                    default_extra=default_extra,
-                )
+            if not sensor_attested:
+                executor_checksum = await sha256_from_executor(shell, self.lib_path)
+                if self.local_checksum != executor_checksum:
+                    return self._failure_response(
+                        error=(
+                            "Executor using outdated libinspector library. "
+                            "Run docker compose restart to update to the latest executor image"
+                        ),
+                        message=Msg.FAILED_LIB_MISMATCH,
+                        diagnostics={
+                            **diagnostics,
+                            "local_sha256": self.local_checksum,
+                            "executor_sha256": executor_checksum or None,
+                        },
+                        default_extra=default_extra,
+                    )
 
             validator = InspectorValidator(self.inspector_lib)
             validator.start_session()

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -148,7 +148,11 @@ class InspectorRentedCheck:
             inspector_event = _build_inspector_event(
                 ctx, event, rented_pods, result, outcome="MALICIOUS", report=report, verdict=verdict
             )
-            await _tell_renters(ctx, verdict, when=event.when.isoformat())
+            if enforce:
+                # The renter hears about it only when the verdict acts: in shadow mode the
+                # classifier is still being measured against the sensor's false positives, and a
+                # "the provider read your pod" event on a wrong call cannot be taken back.
+                await _tell_renters(ctx, verdict, when=event.when.isoformat())
             updates: dict[str, Any] = {
                 "default_extra": extra,
                 "state": replace(ctx.state, inspector_event=inspector_event),

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -91,6 +91,24 @@ class InspectorRentedCheck:
 
         report = dict(result.report or {})
         findings = _findings(report)
+        if findings is None:
+            # a report whose findings are not a list of objects is a broken sensor, not a
+            # provider caught in the act — it must not zero a score or request a quarantine
+            event = render_message(
+                Msg.VALIDATION_ERROR,
+                ctx=ctx,
+                check_id=self.check_id,
+                what={"error": "inspector report findings are not a list of objects", "findings": report.get("findings")},
+                extra=extra,
+            )
+            inspector_event = _build_inspector_event(
+                ctx, event, rented_pods, result, outcome="ERROR", report=report
+            )
+            return CheckResult(
+                passed=True,
+                event=event,
+                updates={"default_extra": extra, "state": replace(ctx.state, inspector_event=inspector_event)},
+            )
         warnings = _collector_start_warnings(report)
         enforce = settings.INSPECTOR_ENFORCE_ENABLED
         verdict = build_verdict(
@@ -309,8 +327,9 @@ def _collector_start_warnings(report: dict[str, Any]) -> list[dict[str, Any]]:
     ]
 
 
-def _findings(report: dict[str, Any]) -> list[dict[str, Any]]:
+def _findings(report: dict[str, Any]) -> list[dict[str, Any]] | None:
+    """The report's findings as a list of objects, or None when the report is malformed."""
     findings = report.get("findings") or []
-    if not isinstance(findings, list):
-        return [{"value": findings}]
-    return [item if isinstance(item, dict) else {"value": item} for item in findings]
+    if not isinstance(findings, list) or not all(isinstance(item, dict) for item in findings):
+        return None
+    return findings

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -329,7 +329,9 @@ def _collector_start_warnings(report: dict[str, Any]) -> list[dict[str, Any]]:
 
 def _findings(report: dict[str, Any]) -> list[dict[str, Any]] | None:
     """The report's findings as a list of objects, or None when the report is malformed."""
-    findings = report.get("findings") or []
+    findings = report.get("findings")
+    if findings is None:
+        findings = []
     if not isinstance(findings, list) or not all(isinstance(item, dict) for item in findings):
         return None
     return findings

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -98,7 +98,11 @@ class InspectorRentedCheck:
                 Msg.VALIDATION_ERROR,
                 ctx=ctx,
                 check_id=self.check_id,
-                what={"error": "inspector report findings are not a list of objects", "findings": report.get("findings")},
+                what={
+                    "error": "inspector report findings are not a list of objects",
+                    "findings_type": type(report.get("findings")).__name__,
+                    "findings_preview": repr(report.get("findings"))[:200],
+                },
                 extra=extra,
             )
             inspector_event = _build_inspector_event(

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -123,55 +123,26 @@ class InspectorRentedCheck:
             enforce=enforce,
         )
         if verdict.provider_origin:
-            what: dict[str, Any] = {
-                "findings": verdict.provider_findings,
-                "platform_findings": len(verdict.platform_findings),
-                "verdict": verdict.as_payload(),
-                "summary": report.get("summary", {}),
-                "canary_ok": report.get("canary_ok"),
-            }
-            if warnings:
-                what["warnings"] = warnings
-            event = render_message(
-                Msg.MALICIOUS_FINDINGS,
-                ctx=ctx,
-                check_id=self.check_id,
-                severity="error" if enforce else None,
-                impact=(
-                    "Provider-origin access to a rented pod: score zeroed, quarantine requested"
-                    if enforce
-                    else "Provider-origin access to a rented pod recorded; score unchanged (INSPECTOR_ENFORCE_ENABLED off)"
-                ),
-                what=what,
+            return await self._act_on_provider_origin(
+                ctx,
+                verdict=verdict,
+                report=report,
+                warnings=warnings,
+                rented_pods=rented_pods,
+                result=result,
                 extra=extra,
             )
-            inspector_event = _build_inspector_event(
-                ctx, event, rented_pods, result, outcome="MALICIOUS", report=report, verdict=verdict
-            )
-            if enforce:
-                # The renter hears about it only when the verdict acts: in shadow mode the
-                # classifier is still being measured against the sensor's false positives, and a
-                # "the provider read your pod" event on a wrong call cannot be taken back.
-                await _tell_renters(ctx, verdict, when=event.when.isoformat())
-            updates: dict[str, Any] = {
-                "default_extra": extra,
-                "state": replace(ctx.state, inspector_event=inspector_event),
-            }
-            if enforce:
-                # Non-fatal check: passed=False alone changes nothing downstream, the score gate
-                # in calculate_scores reads this flag (same mechanics as cpu_truth_passed).
-                updates["inspector_passed"] = False
-            return CheckResult(passed=not enforce, event=event, updates=updates)
 
         clean_what: dict[str, Any] = {
             "summary": report.get("summary", {}),
             "canary_ok": report.get("canary_ok"),
-            "verdict": verdict.as_payload(),
+            "verdict": verdict.as_payload().model_dump(),
         }
         if verdict.platform_findings:
             # every finding was one of our own execs seen from a host whose Tetragon lost the
-            # sshd ancestry — recorded, not malicious (the 8 Sep false positives)
-            clean_what["platform_findings"] = verdict.platform_findings
+            # sshd ancestry — recorded, not malicious (the 8 Sep false positives); the findings
+            # themselves are in the inspector event's report
+            clean_what["platform_findings"] = len(verdict.platform_findings)
         if _canary_failed(report):
             outcome = "CANARY_FAILED"
             event = render_message(
@@ -235,6 +206,60 @@ class InspectorRentedCheck:
             },
         )
 
+    async def _act_on_provider_origin(
+        self,
+        ctx: Context,
+        *,
+        verdict: InspectorVerdict,
+        report: dict[str, Any],
+        warnings: list[dict[str, Any]],
+        rented_pods: list[RentedPod],
+        result: InspectorValidationResponse,
+        extra: dict[str, Any],
+    ) -> CheckResult:
+        """The act-and-publish half of the check: a provider-origin verdict becomes the MALICIOUS
+        event and, under INSPECTOR_ENFORCE_ENABLED, fails the check and tells the renters."""
+        enforce = verdict.enforce
+        what: dict[str, Any] = {
+            "findings": verdict.provider_findings,
+            "platform_findings": len(verdict.platform_findings),
+            "verdict": verdict.as_payload().model_dump(),
+            "summary": report.get("summary", {}),
+            "canary_ok": report.get("canary_ok"),
+        }
+        if warnings:
+            what["warnings"] = warnings
+        event = render_message(
+            Msg.MALICIOUS_FINDINGS,
+            ctx=ctx,
+            check_id=self.check_id,
+            severity="error" if enforce else None,
+            impact=(
+                "Provider-origin access to a rented pod: score zeroed, quarantine requested"
+                if enforce
+                else "Provider-origin access to a rented pod recorded; score unchanged (INSPECTOR_ENFORCE_ENABLED off)"
+            ),
+            what=what,
+            extra=extra,
+        )
+        inspector_event = _build_inspector_event(
+            ctx, event, rented_pods, result, outcome="MALICIOUS", report=report, verdict=verdict
+        )
+        if enforce:
+            # The renter hears about it only when the verdict acts: in shadow mode the
+            # classifier is still being measured against the sensor's false positives, and a
+            # "the provider read your pod" event on a wrong call cannot be taken back.
+            await _tell_renters(ctx, verdict, when=event.when.isoformat())
+        updates: dict[str, Any] = {
+            "default_extra": extra,
+            "state": replace(ctx.state, inspector_event=inspector_event),
+        }
+        if enforce:
+            # Non-fatal check: passed=False alone changes nothing downstream, the score gate
+            # in calculate_scores reads this flag (same mechanics as cpu_truth_passed).
+            updates["inspector_passed"] = False
+        return CheckResult(passed=not enforce, event=event, updates=updates)
+
 
 def _build_inspector_event(
     ctx: Context,
@@ -269,7 +294,7 @@ def _build_inspector_event(
         # so the consumer can act on it without re-deriving the classification.
         payload["context"] = {
             **(result.diagnostics or {}),
-            **({"verdict": verdict.as_payload()} if verdict is not None else {}),
+            **({"verdict": verdict.as_payload().model_dump()} if verdict is not None else {}),
         }
     return payload
 
@@ -294,7 +319,7 @@ async def _tell_renters(ctx: Context, verdict: InspectorVerdict, *, when: str) -
             await redis.publish(
                 STREAMING_LOG_CHANNEL,
                 {
-                    "logs": [renter_access_event(verdict, pod_id=pod_id, when=when)],
+                    "logs": [renter_access_event(verdict, pod_id=pod_id, when=when).model_dump()],
                     "miner_hotkey": ctx.miner_hotkey,
                     "executor_uuid": ctx.executor.uuid,
                     "pod_id": pod_id,

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -276,10 +276,13 @@ def _build_inspector_event(
 
 def _sensor_attested(ctx: Context) -> bool:
     # The sensor (libinspector.so + Tetragon) ships inside the executor image. On a dstack CVM
-    # the image is part of the measured stack the validator checked against TDX_WHITELIST, so
-    # the report comes from a measured binary; elsewhere its checksum was read through the
-    # provider's own shell and proves nothing — say so in the verdict.
-    return bool(ctx.tdx_attestation_passed)
+    # the image is part of the measured stack — but only when ENABLE_ATTESTATION_WHITELIST is on
+    # does the validator compare that stack against TDX_WHITELIST (attestation_service._verify_tdx);
+    # with the flag off (prod today) a passed attestation says the quote is genuine, not that the
+    # image is ours, so the report is not from a measured binary and the shell checksum stays.
+    # Elsewhere the checksum was read through the provider's own shell and proves nothing — say
+    # so in the verdict.
+    return bool(ctx.tdx_attestation_passed) and settings.ENABLE_ATTESTATION_WHITELIST
 
 
 async def _tell_renters(ctx: Context, verdict: InspectorVerdict, *, when: str) -> None:

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -12,7 +12,7 @@ from services.redis_service import STREAMING_LOG_CHANNEL
 from core.config import settings
 from core.utils import _m, get_extra_info
 
-from ..inspector_verdict import InspectorVerdict, build_verdict, renter_access_event
+from ..inspector_verdict import ACTION_QUARANTINE, InspectorVerdict, build_verdict, renter_access_event
 from ..messages import InspectorMessages as Msg
 from ..messages import render_message
 from ..pipeline import CheckResult, Context
@@ -218,8 +218,16 @@ class InspectorRentedCheck:
         extra: dict[str, Any],
     ) -> CheckResult:
         """The act-and-publish half of the check: a provider-origin verdict becomes the MALICIOUS
-        event and, under INSPECTOR_ENFORCE_ENABLED, fails the check and tells the renters."""
-        enforce = verdict.enforce
+        event and, when the verdict's action is quarantine (INSPECTOR_ENFORCE_ENABLED and a rented
+        pod affected), fails the check and tells the renters. A finding that names no rented pod
+        is recorded with `unmatched_containers` and acts on nobody, whatever the flag."""
+        acts = verdict.action == ACTION_QUARANTINE
+        if acts:
+            impact = "Provider-origin access to a rented pod: score zeroed, quarantine requested"
+        elif verdict.enforce:
+            impact = "Provider-origin finding on a container that is not a rented pod recorded; score unchanged"
+        else:
+            impact = "Provider-origin access to a rented pod recorded; score unchanged (INSPECTOR_ENFORCE_ENABLED off)"
         what: dict[str, Any] = {
             "findings": verdict.provider_findings,
             "platform_findings": len(verdict.platform_findings),
@@ -233,19 +241,15 @@ class InspectorRentedCheck:
             Msg.MALICIOUS_FINDINGS,
             ctx=ctx,
             check_id=self.check_id,
-            severity="error" if enforce else None,
-            impact=(
-                "Provider-origin access to a rented pod: score zeroed, quarantine requested"
-                if enforce
-                else "Provider-origin access to a rented pod recorded; score unchanged (INSPECTOR_ENFORCE_ENABLED off)"
-            ),
+            severity="error" if acts else None,
+            impact=impact,
             what=what,
             extra=extra,
         )
         inspector_event = _build_inspector_event(
             ctx, event, rented_pods, result, outcome="MALICIOUS", report=report, verdict=verdict
         )
-        if enforce:
+        if acts:
             # The renter hears about it only when the verdict acts: in shadow mode the
             # classifier is still being measured against the sensor's false positives, and a
             # "the provider read your pod" event on a wrong call cannot be taken back.
@@ -254,11 +258,11 @@ class InspectorRentedCheck:
             "default_extra": extra,
             "state": replace(ctx.state, inspector_event=inspector_event),
         }
-        if enforce:
+        if acts:
             # Non-fatal check: passed=False alone changes nothing downstream, the score gate
             # in calculate_scores reads this flag (same mechanics as cpu_truth_passed).
             updates["inspector_passed"] = False
-        return CheckResult(passed=not enforce, event=event, updates=updates)
+        return CheckResult(passed=not acts, event=event, updates=updates)
 
 
 def _build_inspector_event(

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -1,19 +1,25 @@
 from __future__ import annotations
 
+import logging
 import time
 from dataclasses import replace
 from typing import Any
 
 from services.const import SECONDS_PER_BLOCK
 from services.inspector_validation_service import InspectorValidationResponse
+from services.redis_service import STREAMING_LOG_CHANNEL
 
 from core.config import settings
+from core.utils import _m, get_extra_info
 
+from ..inspector_verdict import InspectorVerdict, build_verdict, renter_access_event
 from ..messages import InspectorMessages as Msg
 from ..messages import render_message
 from ..pipeline import CheckResult, Context
 from ..models import ValidationEvent
 from protocol.vc_protocol.compute_requests import RentedPod
+
+logger = logging.getLogger(__name__)
 
 
 class InspectorRentedCheck:
@@ -50,11 +56,13 @@ class InspectorRentedCheck:
             "rented_pods": [{"name": p.container_name, "pod_id": p.pod_id} for p in rented_pods],
         }
 
+        sensor_attested = _sensor_attested(ctx)
         result = await ctx.services.inspector.validate_rented_executor(
             ctx.services.shell,
             ctx.ssh,
             ctx.executor,
             ctx.default_extra,
+            sensor_attested=sensor_attested,
         )
 
         if result.error:
@@ -84,9 +92,19 @@ class InspectorRentedCheck:
         report = dict(result.report or {})
         findings = _findings(report)
         warnings = _collector_start_warnings(report)
-        if findings:
+        enforce = settings.INSPECTOR_ENFORCE_ENABLED
+        verdict = build_verdict(
+            report,
+            findings,
+            rented_pod_ids=[p.pod_id for p in rented_pods],
+            sensor_attested=sensor_attested,
+            enforce=enforce,
+        )
+        if verdict.provider_origin:
             what: dict[str, Any] = {
-                "findings": findings,
+                "findings": verdict.provider_findings,
+                "platform_findings": len(verdict.platform_findings),
+                "verdict": verdict.as_payload(),
                 "summary": report.get("summary", {}),
                 "canary_ok": report.get("canary_ok"),
             }
@@ -96,25 +114,38 @@ class InspectorRentedCheck:
                 Msg.MALICIOUS_FINDINGS,
                 ctx=ctx,
                 check_id=self.check_id,
+                severity="error" if enforce else None,
+                impact=(
+                    "Provider-origin access to a rented pod: score zeroed, quarantine requested"
+                    if enforce
+                    else "Provider-origin access to a rented pod recorded; score unchanged (INSPECTOR_ENFORCE_ENABLED off)"
+                ),
                 what=what,
                 extra=extra,
             )
             inspector_event = _build_inspector_event(
-                ctx, event, rented_pods, result, outcome="MALICIOUS", report=report
+                ctx, event, rented_pods, result, outcome="MALICIOUS", report=report, verdict=verdict
             )
-            return CheckResult(
-                passed=True,
-                event=event,
-                updates={
-                    "default_extra": extra,
-                    "state": replace(ctx.state, inspector_event=inspector_event),
-                },
-            )
+            await _tell_renters(ctx, verdict, when=event.when.isoformat())
+            updates: dict[str, Any] = {
+                "default_extra": extra,
+                "state": replace(ctx.state, inspector_event=inspector_event),
+            }
+            if enforce:
+                # Non-fatal check: passed=False alone changes nothing downstream, the score gate
+                # in calculate_scores reads this flag (same mechanics as cpu_truth_passed).
+                updates["inspector_passed"] = False
+            return CheckResult(passed=not enforce, event=event, updates=updates)
 
         clean_what: dict[str, Any] = {
             "summary": report.get("summary", {}),
             "canary_ok": report.get("canary_ok"),
+            "verdict": verdict.as_payload(),
         }
+        if verdict.platform_findings:
+            # every finding was one of our own execs seen from a host whose Tetragon lost the
+            # sshd ancestry — recorded, not malicious (the 8 Sep false positives)
+            clean_what["platform_findings"] = verdict.platform_findings
         if _canary_failed(report):
             outcome = "CANARY_FAILED"
             event = render_message(
@@ -148,6 +179,15 @@ class InspectorRentedCheck:
                 },
                 extra=extra,
             )
+        elif verdict.platform_findings:
+            outcome = "CLEAN"
+            event = render_message(
+                Msg.PLATFORM_ORIGIN_ONLY,
+                ctx=ctx,
+                check_id=self.check_id,
+                what=clean_what,
+                extra=extra,
+            )
         else:
             outcome = "CLEAN"
             event = render_message(
@@ -158,7 +198,7 @@ class InspectorRentedCheck:
                 extra=extra,
             )
         inspector_event = _build_inspector_event(
-            ctx, event, rented_pods, result, outcome=outcome, report=report
+            ctx, event, rented_pods, result, outcome=outcome, report=report, verdict=verdict
         )
         return CheckResult(
             passed=True,
@@ -178,6 +218,7 @@ def _build_inspector_event(
     *,
     outcome: str,
     report: dict[str, Any] | None = None,
+    verdict: InspectorVerdict | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
         "executor_id": ctx.executor.uuid,
@@ -197,8 +238,47 @@ def _build_inspector_event(
     else:
         payload["report"] = report
         payload["error"] = None
-        payload["context"] = result.diagnostics or {}
+        # `context` is the one free-form field InspectorEventRequest carries to the backend;
+        # the verdict rides there (evidence hashes, sensor state, requested action + ban source)
+        # so the consumer can act on it without re-deriving the classification.
+        payload["context"] = {
+            **(result.diagnostics or {}),
+            **({"verdict": verdict.as_payload()} if verdict is not None else {}),
+        }
     return payload
+
+
+def _sensor_attested(ctx: Context) -> bool:
+    # The sensor (libinspector.so + Tetragon) ships inside the executor image. On a dstack CVM
+    # the image is part of the measured stack the validator checked against TDX_WHITELIST, so
+    # the report comes from a measured binary; elsewhere its checksum was read through the
+    # provider's own shell and proves nothing — say so in the verdict.
+    return bool(ctx.tdx_attestation_passed)
+
+
+async def _tell_renters(ctx: Context, verdict: InspectorVerdict, *, when: str) -> None:
+    redis = ctx.services.redis
+    if redis is None or not verdict.affected_pod_ids:
+        return
+    for pod_id in verdict.affected_pod_ids:
+        try:
+            await redis.publish(
+                STREAMING_LOG_CHANNEL,
+                {
+                    "logs": [renter_access_event(verdict, pod_id=pod_id, when=when)],
+                    "miner_hotkey": ctx.miner_hotkey,
+                    "executor_uuid": ctx.executor.uuid,
+                    "pod_id": pod_id,
+                },
+            )
+        except Exception as exc:  # the verdict itself is already in the inspector event
+            logger.warning(
+                _m(
+                    "Failed to publish provider_access_detected to the pod stream",
+                    extra=get_extra_info({**ctx.default_extra, "pod_id": pod_id, "error": str(exc)}),
+                )
+            )
+
 
 def _canary_failed(report: dict[str, Any]) -> bool:
     return report.get("canary_ok") is False

--- a/neurons/validators/src/services/task/checks/inspector.py
+++ b/neurons/validators/src/services/task/checks/inspector.py
@@ -224,7 +224,7 @@ class InspectorRentedCheck:
         acts = verdict.action == ACTION_QUARANTINE
         if acts:
             impact = "Provider-origin access to a rented pod: score zeroed, quarantine requested"
-        elif verdict.enforce:
+        elif not verdict.affected_pod_ids:
             impact = "Provider-origin finding on a container that is not a rented pod recorded; score unchanged"
         else:
             impact = "Provider-origin access to a rented pod recorded; score unchanged (INSPECTOR_ENFORCE_ENABLED off)"

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -40,6 +40,12 @@ _EXEC_FLAGS = {"-i", "-t", "-it", "-ti", "-d", "--detach", "--privileged", "--in
 _SHELL_WRAPPERS = {"sh", "/bin/sh", "bash", "/bin/bash", "/usr/bin/sh", "/usr/bin/bash"}
 _SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ec", "-lec"}
 _DOCKER_EXEC_KINDS = {"DockerExec"}
+_PATH_SHAPED_KINDS = {"OverlayFsRead", "OverlayFsWrite", "DockerVolumeMount"}
+RENTAL_VOLUME_TAG = "rental_volume"
+# the renter's pod-log entry carries at most this many evidence hashes; the finding count is the
+# sensor's to choose (21,694 OverlayFsRead in one day, 8 Sep), the full list stays in the
+# inspector event's `context.verdict`
+_RENTER_EVIDENCE_MAX = 20
 # The sensor's `RuntimeInterferenceKind` (celium-gpu-verifier inspector/src/collector/analysis/
 # types.rs, serde PascalCase) — the only strings a renter is shown as a class. Anything else — the
 # report is produced on the provider's root when the sensor is unattested — is shown as `unknown`
@@ -187,6 +193,31 @@ def pod_id_of(name: str) -> str | None:
     return None
 
 
+def volume_name_from_path(path: str) -> str | None:
+    """The sensor's own rule (rental.rs `volume_name_from_path`): the segment after `volumes`
+    (`/var/lib/docker/volumes/<name>/_data/…`) or after `propagated-mount` (vloopback)."""
+    segments = [segment for segment in path.split("/") if segment]
+    for first, second in zip(segments, segments[1:]):
+        if first in ("volumes", "propagated-mount"):
+            return second
+    return None
+
+
+def _named_resource(finding: dict[str, Any]) -> str | None:
+    """What the finding is about: the container it names, or — for the path-shaped kinds the
+    sensor emits with `container: None` (`OverlayFsRead`/`OverlayFsWrite` from fs.rs,
+    `DockerVolumeMount` from mount.rs; the path is in `command`, tag `rental_volume`) — the
+    volume named in that path."""
+    name = _named_container(finding)
+    if name is not None:
+        return name
+    if finding.get("kind") in _PATH_SHAPED_KINDS or RENTAL_VOLUME_TAG in (finding.get("tags") or []):
+        command = finding.get("command")
+        if isinstance(command, str):
+            return volume_name_from_path(command)
+    return None
+
+
 def _platform_payloads(platform: list[dict[str, Any]]) -> list[str]:
     seen: list[str] = []
     for finding in platform:
@@ -217,7 +248,7 @@ def build_verdict(
     unmatched: set[str] = set()
     unnamed = False
     for finding in provider:
-        name = _named_container(finding)
+        name = _named_resource(finding)
         pod_id = pod_id_of(name) if name else None
         if name is None:
             unnamed = True
@@ -270,7 +301,10 @@ def renter_access_event(
         "pod_id": pod_id,
         "when": when,
         "classes": verdict.classes,
-        "evidence_sha256": verdict.evidence,
+        "provider_findings": len(verdict.provider_findings),
+        "report_sha256": verdict.report_sha256,
+        "evidence_sha256": verdict.evidence[:_RENTER_EVIDENCE_MAX],
+        "evidence_sha256_truncated": len(verdict.evidence) > _RENTER_EVIDENCE_MAX,
         "sensor": verdict.sensor,
         "action": verdict.action,
     }

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -1,22 +1,29 @@
 """Turn an Inspector report into a verdict the validator can act on (DAH-3275).
 
-The sensor reports every `docker exec` / `nsenter` / memory read against a rented pod. Some of
-those are ours: the validator's own liveness exec (`cat /root/.ssh/authorized_keys`), the
-executor's disk metric (`df -k`), the executor's legacy volume restore (`tar`). They run from
-inside the executor container (the SSH session lands there), so the sensor tags them
-`nested_from:executor-…` and `host=false`; on hosts where Tetragon loses the ancestry to sshd
-they still surface as findings — 607 of the 632 MALICIOUS rounds on 8 Sep were exactly that.
+The sensor reports every `docker exec` / `nsenter` / memory read against a rented pod. Many of
+those are the platform's own: the liveness exec (`checks/rented_machine.py`, `cat
+/root/.ssh/authorized_keys`), the executor's disk metric (`executor/services/hardware_service.py`,
+`df -k <mount>`), the validator's miner jobs (`miner_jobs/restore_storage.py` `mkdir`/`chown`/`tar
+… --strip-components=1`, `miner_jobs/backup_storage.py` `du`/`tar -czf`), key injection, the
+sshd bootstrap and the gocryptfs setup scripts (`docker_service.py`, `sh -c '<script>'`). They
+all run from inside the executor container — the validator's SSH session lands there — so the
+sensor tags them `nested_from:executor-…` with `host=false`. On hosts where Tetragon lost the
+ancestry to sshd they surfaced as findings: 607 of the 632 MALICIOUS rounds on 8 Sep.
 
-A finding is *platform-origin* only when BOTH hold: it came from inside the executor container
-and its exec payload is one of the exact commands the platform runs. Everything else is
-*provider-origin* and is what the check, the score gate and the renter event act on.
+Classification is by that ancestry, as `design/RENTER_DATA_PRIVACY.md` row 16 intends: a
+`DockerExec` from inside the executor container is *platform-origin*; anything from the host, a
+`NamespaceEnter`, a memory read, an exec the sensor could not attribute is *provider-origin* and is
+what the check, the score gate and the renter event act on. The payloads are too many and too
+script-shaped for an exact allow-list to be honest, so the platform execs' payloads are recorded
+in the verdict (`platform_payloads`) for the daily digest instead of gating anything. What keeps
+the tag trustworthy — a provider `docker exec`-ing into the executor container to borrow its
+ancestry — is the verifier's job: DAH-3278 (stack-binary ancestry gating, sysbox-fs exemption).
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
-import re
 import shlex
 from dataclasses import dataclass, field
 from typing import Any
@@ -24,24 +31,20 @@ from typing import Any
 EXECUTOR_CONTAINER_TAG_PREFIX = "nested_from:executor"
 POD_CONTAINER_PREFIX = "pod_"
 
-# Exact exec payloads the platform runs against a rented pod. Keep this list in step with the
-# code that runs them: rented_machine.py (_check_pod_running), the executor's
-# hardware_service.py (disk metric) — nothing else may be added without a matching caller.
-PLATFORM_EXEC_PAYLOADS = frozenset(
-    {
-        "cat /root/.ssh/authorized_keys",
-        "df -k /",
-        "df -k /lium-cipher",
-    }
-)
-# The executor's legacy tar restore streams an archive into one directory of the pod.
-PLATFORM_EXEC_PAYLOAD_PATTERNS = (
-    re.compile(r"^tar --xattrs --acls -xzpf - -C /[A-Za-z0-9._/-]+$"),
-)
 _EXEC_OPTIONS_WITH_VALUE = {"-u", "--user", "-e", "--env", "-w", "--workdir"}
 _EXEC_FLAGS = {"-i", "-t", "-it", "-ti", "-d", "--detach", "--privileged", "--interactive", "--tty"}
 _SHELL_WRAPPERS = {"sh", "/bin/sh", "bash", "/bin/bash", "/usr/bin/sh", "/usr/bin/bash"}
+_SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ec", "-lec"}
 _DOCKER_EXEC_KINDS = {"DockerExec"}
+# The sensor's finding classes the renter may be told about, verbatim. Anything else — the report
+# is produced on the provider's root when the sensor is unattested — is shown as `unknown` and
+# kept raw only inside the evidence.
+KNOWN_FINDING_KINDS = frozenset(
+    {"DockerExec", "NamespaceEnter", "ProcFsRead", "ProcessMemoryRead", "PtraceAttach", "FileRead", "MountAccess"}
+)
+UNKNOWN_KIND = "unknown"
+_PAYLOAD_PREVIEW_CHARS = 160
+_PAYLOAD_PREVIEW_MAX = 20
 
 SENSOR_ATTESTED = "attested"
 SENSOR_UNATTESTED = "unattested"
@@ -114,7 +117,7 @@ def exec_payload(command: str) -> str | None:
     if index >= len(tokens) or not tokens[index].startswith(POD_CONTAINER_PREFIX):
         return None
     payload = tokens[index + 1 :]
-    if len(payload) >= 3 and payload[0] in _SHELL_WRAPPERS and payload[1] == "-c":
+    if len(payload) >= 3 and payload[0] in _SHELL_WRAPPERS and payload[1] in _SHELL_COMMAND_FLAGS:
         payload = payload[2:]
         if len(payload) == 1:
             # the shell's -c argument is one string; normalise its whitespace
@@ -123,31 +126,40 @@ def exec_payload(command: str) -> str | None:
 
 
 def is_platform_origin(finding: dict[str, Any]) -> bool:
+    """A `docker exec` that the sensor traced to inside the executor container (`host=false`,
+    `nested_from:executor-…`). Everything else is the provider's."""
     if finding.get("kind") not in _DOCKER_EXEC_KINDS:
         return False
     if finding.get("host") is True:
         return False
     tags = finding.get("tags") or []
-    if not any(isinstance(tag, str) and tag.startswith(EXECUTOR_CONTAINER_TAG_PREFIX) for tag in tags):
-        return False
-    payload = exec_payload(str(finding.get("command") or ""))
-    if payload is None:
-        return False
-    if payload in PLATFORM_EXEC_PAYLOADS:
-        return True
-    return any(pattern.match(payload) for pattern in PLATFORM_EXEC_PAYLOAD_PATTERNS)
+    return any(isinstance(tag, str) and tag.startswith(EXECUTOR_CONTAINER_TAG_PREFIX) for tag in tags)
 
 
-def _finding_pod_id(finding: dict[str, Any], rented_pod_ids: set[str]) -> str | None:
+def finding_class(finding: dict[str, Any]) -> str:
+    kind = finding.get("kind")
+    return kind if isinstance(kind, str) and kind in KNOWN_FINDING_KINDS else UNKNOWN_KIND
+
+
+def _named_container(finding: dict[str, Any]) -> str | None:
     container = finding.get("container")
     docker = finding.get("docker") or {}
-    candidates = [container, docker.get("resolved_name") if isinstance(docker, dict) else None]
-    for name in candidates:
-        if isinstance(name, str) and name.startswith(POD_CONTAINER_PREFIX):
-            pod_id = name[len(POD_CONTAINER_PREFIX) :]
-            if pod_id in rented_pod_ids:
-                return pod_id
+    for name in (container, docker.get("resolved_name") if isinstance(docker, dict) else None):
+        if isinstance(name, str) and name:
+            return name
     return None
+
+
+def _platform_payloads(platform: list[dict[str, Any]]) -> list[str]:
+    seen: list[str] = []
+    for finding in platform:
+        payload = exec_payload(str(finding.get("command") or "")) or "(not a docker exec argv)"
+        payload = payload[:_PAYLOAD_PREVIEW_CHARS]
+        if payload not in seen:
+            seen.append(payload)
+        if len(seen) >= _PAYLOAD_PREVIEW_MAX:
+            break
+    return seen
 
 
 def build_verdict(
@@ -164,22 +176,38 @@ def build_verdict(
         (platform if is_platform_origin(finding) else provider).append(finding)
 
     rented = set(rented_pod_ids)
-    affected = sorted({pod for pod in (_finding_pod_id(f, rented) for f in provider) if pod})
-    if provider and not affected:
-        # the sensor did not name the pod: every renter on this host is told
-        affected = sorted(rented)
-    classes = sorted({str(f.get("kind") or "unknown") for f in provider})
+    affected: set[str] = set()
+    unmatched: set[str] = set()
+    unnamed = False
+    for finding in provider:
+        name = _named_container(finding)
+        if name is None:
+            unnamed = True
+        elif name.startswith(POD_CONTAINER_PREFIX) and name[len(POD_CONTAINER_PREFIX) :] in rented:
+            affected.add(name[len(POD_CONTAINER_PREFIX) :])
+        else:
+            # a pod that left or joined since the rented list was fetched, or not a pod at all:
+            # recorded, but no renter is told about a container that was not theirs
+            unmatched.add(name)
+    if unnamed:
+        # the sensor named no container at all: every renter on this host is told
+        affected |= rented
+    classes = sorted({finding_class(f) for f in provider})
     action = ACTION_QUARANTINE if (provider and enforce) else ACTION_NONE
+    extra: dict[str, Any] = {"platform_payloads": _platform_payloads(platform)}
+    if unmatched:
+        extra["unmatched_containers"] = sorted(unmatched)
     return InspectorVerdict(
         provider_findings=provider,
         platform_findings=platform,
         evidence=[canonical_sha256(f) for f in provider],
         report_sha256=canonical_sha256(report),
         classes=classes,
-        affected_pod_ids=affected,
+        affected_pod_ids=sorted(affected),
         sensor=SENSOR_ATTESTED if sensor_attested else SENSOR_UNATTESTED,
         enforce=enforce,
         action=action,
+        extra=extra,
     )
 
 

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -150,9 +150,20 @@ def is_executor_stack_container(name: str) -> bool:
     return name == "executor" or name.startswith("executor-") or "-executor-" in name
 
 
+def _kind(finding: dict[str, Any]) -> str | None:
+    """`kind` as a string, or None — the report is peer-produced, a field may be any JSON type."""
+    kind = finding.get("kind")
+    return kind if isinstance(kind, str) else None
+
+
+def _tags(finding: dict[str, Any]) -> list[str]:
+    tags = finding.get("tags")
+    return [tag for tag in tags if isinstance(tag, str)] if isinstance(tags, list) else []
+
+
 def nested_from_executor(finding: dict[str, Any]) -> bool:
-    for tag in finding.get("tags") or []:
-        if isinstance(tag, str) and tag.startswith(NESTED_FROM_TAG_PREFIX):
+    for tag in _tags(finding):
+        if tag.startswith(NESTED_FROM_TAG_PREFIX):
             if is_executor_stack_container(tag[len(NESTED_FROM_TAG_PREFIX) :]):
                 return True
     return False
@@ -164,7 +175,7 @@ def is_platform_origin(finding: dict[str, Any]) -> bool:
     reaches sshd or the container's pid 1, so every such finding is one whose ancestry it could
     not trust; until DAH-3278 hardens that on the verifier, all of them count as the platform's.
     Everything else is the provider's."""
-    if finding.get("kind") not in _DOCKER_EXEC_KINDS:
+    if _kind(finding) not in _DOCKER_EXEC_KINDS:
         return False
     if finding.get("host") is True:
         return False
@@ -172,8 +183,8 @@ def is_platform_origin(finding: dict[str, Any]) -> bool:
 
 
 def finding_class(finding: dict[str, Any]) -> str:
-    kind = finding.get("kind")
-    return kind if isinstance(kind, str) and kind in KNOWN_FINDING_KINDS else UNKNOWN_KIND
+    kind = _kind(finding)
+    return kind if kind in KNOWN_FINDING_KINDS else UNKNOWN_KIND
 
 
 def _named_container(finding: dict[str, Any]) -> str | None:
@@ -211,7 +222,7 @@ def _named_resource(finding: dict[str, Any]) -> str | None:
     name = _named_container(finding)
     if name is not None:
         return name
-    if finding.get("kind") in _PATH_SHAPED_KINDS or RENTAL_VOLUME_TAG in (finding.get("tags") or []):
+    if _kind(finding) in _PATH_SHAPED_KINDS or RENTAL_VOLUME_TAG in _tags(finding):
         command = finding.get("command")
         if isinstance(command, str):
             return volume_name_from_path(command)
@@ -265,7 +276,9 @@ def build_verdict(
     action = ACTION_QUARANTINE if (provider and enforce) else ACTION_NONE
     extra: dict[str, Any] = {"platform_payloads": _platform_payloads(platform)}
     if unmatched:
-        extra["unmatched_containers"] = sorted(unmatched)
+        names = sorted(unmatched)
+        extra["unmatched_containers"] = [name[:128] for name in names[:_PAYLOAD_PREVIEW_MAX]]
+        extra["unmatched_containers_count"] = len(names)
     return InspectorVerdict(
         provider_findings=provider,
         platform_findings=platform,

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -15,9 +15,11 @@ control-plane action (`DockerExec`, and the `docker cp` / `docker rm` / … the 
 pod's behalf) from inside the executor container is *platform-origin* (the sensor itself already
 drops docker-policy findings whose ancestry reaches sshd or pid 1, so these are the ones it could
 not trust); anything from the host, a `NamespaceEnter`, a memory read, an exec the sensor could not attribute is *provider-origin* and is
-what the check, the score gate and the renter event act on. The payloads are too many and too
+what the check, the score gate and the renter event act on when it names a rented pod (or names no
+container at all); a finding on any other container is recorded under `unmatched_containers` and
+acts on nobody. The payloads are too many and too
 script-shaped for an exact allow-list to be honest, so the platform execs' payloads are recorded
-in the verdict (`platform_payloads`) for the daily digest instead of gating anything. What keeps
+in the verdict (`platform_exec_commands`) for the daily digest instead of gating anything. What keeps
 the tag trustworthy — a provider `docker exec`-ing into the executor container to borrow its
 ancestry — is the verifier's job: DAH-3278 (stack-binary ancestry gating, sysbox-fs exemption).
 """
@@ -105,8 +107,9 @@ class VerdictPayload(BaseModel):
     action: str
     ban_source: str | None
     # the platform execs' payloads, deduplicated, for the daily digest (never gate on them)
-    platform_payloads: list[str]
-    # provider findings on a container that is not in the rented list: recorded, no renter told
+    platform_exec_commands: list[str]
+    # provider findings on a container that is not in the rented list: recorded, no renter told,
+    # no action
     unmatched_containers: list[str]
     unmatched_containers_count: int
 
@@ -141,8 +144,9 @@ class InspectorVerdict:
     enforce: bool
     action: str
     # the platform execs' payloads, deduplicated, for the daily digest (never gate on them)
-    platform_payloads: list[str] = field(default_factory=list)
-    # provider findings on a container that is not in the rented list: recorded, no renter told
+    platform_exec_commands: list[str] = field(default_factory=list)
+    # provider findings on a container that is not in the rented list: recorded, no renter told,
+    # no action
     unmatched_containers: list[str] = field(default_factory=list)
     unmatched_containers_count: int = 0
 
@@ -162,7 +166,7 @@ class InspectorVerdict:
             enforce=self.enforce,
             action=self.action,
             ban_source=BAN_SOURCE if self.action == ACTION_QUARANTINE else None,
-            platform_payloads=self.platform_payloads,
+            platform_exec_commands=self.platform_exec_commands,
             unmatched_containers=self.unmatched_containers,
             unmatched_containers_count=self.unmatched_containers_count,
         )
@@ -174,7 +178,7 @@ def canonical_sha256(value: Any) -> str:
     ).hexdigest()
 
 
-def exec_payload(command: str) -> str | None:
+def docker_exec_command(command: str) -> str | None:
     """The command a `docker exec` ran inside the target container, or None if not an exec.
 
     `docker exec -u 0 -i pod_x sh -c 'cat /root/.ssh/authorized_keys'` → the cat; a bare
@@ -293,10 +297,10 @@ def _named_resource(finding: dict[str, Any]) -> str | None:
     return None
 
 
-def _platform_payloads(platform: list[dict[str, Any]]) -> list[str]:
+def _platform_exec_commands(platform: list[dict[str, Any]]) -> list[str]:
     seen: list[str] = []
     for finding in platform:
-        payload = exec_payload(str(finding.get("command") or "")) or "(not a docker exec argv)"
+        payload = docker_exec_command(str(finding.get("command") or "")) or "(not a docker exec argv)"
         payload = payload[:_PAYLOAD_PREVIEW_CHARS]
         if payload not in seen:
             seen.append(payload)
@@ -336,7 +340,9 @@ def build_verdict(
     if has_unnamed_finding:
         # the sensor named no container at all: every renter on this host is told
         affected |= rented
-    action = ACTION_QUARANTINE if (provider and enforce) else ACTION_NONE
+    # Enforcement acts only for a rented pod: a provider inside their own container (a finding
+    # that names no rented pod) is recorded in `unmatched_containers` and quarantines nobody.
+    action = ACTION_QUARANTINE if (affected and enforce) else ACTION_NONE
     names = sorted(unmatched)
     return InspectorVerdict(
         provider_findings=provider,
@@ -348,7 +354,7 @@ def build_verdict(
         sensor_attestation=SENSOR_ATTESTED if sensor_attested else SENSOR_UNATTESTED,
         enforce=enforce,
         action=action,
-        platform_payloads=_platform_payloads(platform),
+        platform_exec_commands=_platform_exec_commands(platform),
         unmatched_containers=[name[:_UNMATCHED_NAME_CHARS] for name in names[:_UNMATCHED_MAX]],
         unmatched_containers_count=len(names),
     )

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -11,7 +11,8 @@ sensor tags them `nested_from:executor-…` with `host=false`. On hosts where Te
 ancestry to sshd they surfaced as findings: 607 of the 632 MALICIOUS rounds on 8 Sep.
 
 Classification is by that ancestry, as `design/RENTER_DATA_PRIVACY.md` row 16 intends: a
-`DockerExec` from inside the executor container is *platform-origin*; anything from the host, a
+`DockerExec` from inside the executor container is *platform-origin* (the sensor itself already
+drops execs whose ancestry reaches sshd or pid 1, so these are the ones it could not trust); anything from the host, a
 `NamespaceEnter`, a memory read, an exec the sensor could not attribute is *provider-origin* and is
 what the check, the score gate and the renter event act on. The payloads are too many and too
 script-shaped for an exact allow-list to be honest, so the platform execs' payloads are recorded
@@ -28,19 +29,31 @@ import shlex
 from dataclasses import dataclass, field
 from typing import Any
 
-EXECUTOR_CONTAINER_TAG_PREFIX = "nested_from:executor"
+NESTED_FROM_TAG_PREFIX = "nested_from:"
 POD_CONTAINER_PREFIX = "pod_"
+# the pod's volume is `volume_<pod_id>` (docker_service.py create flow; the sensor's
+# RENTAL_VOLUME_PREFIXES) — an OverlayFsRead on it is a finding about that pod
+VOLUME_CONTAINER_PREFIX = "volume_"
 
 _EXEC_OPTIONS_WITH_VALUE = {"-u", "--user", "-e", "--env", "-w", "--workdir"}
 _EXEC_FLAGS = {"-i", "-t", "-it", "-ti", "-d", "--detach", "--privileged", "--interactive", "--tty"}
 _SHELL_WRAPPERS = {"sh", "/bin/sh", "bash", "/bin/bash", "/usr/bin/sh", "/usr/bin/bash"}
 _SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ec", "-lec"}
 _DOCKER_EXEC_KINDS = {"DockerExec"}
-# The sensor's finding classes the renter may be told about, verbatim. Anything else — the report
-# is produced on the provider's root when the sensor is unattested — is shown as `unknown` and
-# kept raw only inside the evidence.
+# The sensor's `RuntimeInterferenceKind` (celium-gpu-verifier inspector/src/collector/analysis/
+# types.rs, serde PascalCase) — the only strings a renter is shown as a class. Anything else — the
+# report is produced on the provider's root when the sensor is unattested — is shown as `unknown`
+# and kept raw only inside the evidence. Keep in step with types.rs and inspector_summary/sql.py.
 KNOWN_FINDING_KINDS = frozenset(
-    {"DockerExec", "NamespaceEnter", "ProcFsRead", "ProcessMemoryRead", "PtraceAttach", "FileRead", "MountAccess"}
+    {
+        "DockerExec", "DockerAttach", "DockerCp", "DockerRun", "DockerCreate", "DockerStart", "DockerStop",
+        "DockerKill", "DockerPause", "DockerRm", "DockerRestart", "DockerRename", "DockerUpdate", "DockerCommit",
+        "DockerExport", "DockerPrune", "DockerInspect", "DockerPull", "DockerPush", "DockerBuild", "DockerLoad",
+        "DockerImport", "DockerRmi", "DockerNetworkConnect", "DockerNetworkDisconnect", "DockerNetworkRm",
+        "DockerVolumeRm", "DockerSave", "NamespaceEnter", "DockerSocketWrite", "OverlayFsRead", "OverlayFsWrite",
+        "ProcFsRead", "ProcFsWrite", "ContainerChroot", "ProcessAttach", "ProcessMemoryRead", "ProcessMemoryWrite",
+        "DockerVolumeMount",
+    }
 )
 UNKNOWN_KIND = "unknown"
 _PAYLOAD_PREVIEW_CHARS = 160
@@ -125,15 +138,31 @@ def exec_payload(command: str) -> str | None:
     return " ".join(payload) if payload else None
 
 
+def is_executor_stack_container(name: str) -> bool:
+    """The sensor's own rule for the executor stack (docker_cli.rs): the compose project may be
+    `executor`, `executor-…` or `lium-executor-executor-1`."""
+    return name == "executor" or name.startswith("executor-") or "-executor-" in name
+
+
+def nested_from_executor(finding: dict[str, Any]) -> bool:
+    for tag in finding.get("tags") or []:
+        if isinstance(tag, str) and tag.startswith(NESTED_FROM_TAG_PREFIX):
+            if is_executor_stack_container(tag[len(NESTED_FROM_TAG_PREFIX) :]):
+                return True
+    return False
+
+
 def is_platform_origin(finding: dict[str, Any]) -> bool:
-    """A `docker exec` that the sensor traced to inside the executor container (`host=false`,
-    `nested_from:executor-…`). Everything else is the provider's."""
+    """A `docker exec` the sensor traced to inside the executor container (`host=false`, a
+    `nested_from:<executor-stack container>` tag). The sensor already drops execs whose ancestry
+    reaches sshd or the container's pid 1, so every such finding is one whose ancestry it could
+    not trust; until DAH-3278 hardens that on the verifier, all of them count as the platform's.
+    Everything else is the provider's."""
     if finding.get("kind") not in _DOCKER_EXEC_KINDS:
         return False
     if finding.get("host") is True:
         return False
-    tags = finding.get("tags") or []
-    return any(isinstance(tag, str) and tag.startswith(EXECUTOR_CONTAINER_TAG_PREFIX) for tag in tags)
+    return nested_from_executor(finding)
 
 
 def finding_class(finding: dict[str, Any]) -> str:
@@ -147,6 +176,14 @@ def _named_container(finding: dict[str, Any]) -> str | None:
     for name in (container, docker.get("resolved_name") if isinstance(docker, dict) else None):
         if isinstance(name, str) and name:
             return name
+    return None
+
+
+def pod_id_of(name: str) -> str | None:
+    """`pod_<id>` and `volume_<id>` both belong to pod `<id>`."""
+    for prefix in (POD_CONTAINER_PREFIX, VOLUME_CONTAINER_PREFIX):
+        if name.startswith(prefix) and len(name) > len(prefix):
+            return name[len(prefix) :]
     return None
 
 
@@ -181,10 +218,11 @@ def build_verdict(
     unnamed = False
     for finding in provider:
         name = _named_container(finding)
+        pod_id = pod_id_of(name) if name else None
         if name is None:
             unnamed = True
-        elif name.startswith(POD_CONTAINER_PREFIX) and name[len(POD_CONTAINER_PREFIX) :] in rented:
-            affected.add(name[len(POD_CONTAINER_PREFIX) :])
+        elif pod_id in rented:
+            affected.add(pod_id)
         else:
             # a pod that left or joined since the rented list was fetched, or not a pod at all:
             # recorded, but no renter is told about a container that was not theirs

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -10,10 +10,11 @@ all run from inside the executor container — the validator's SSH session lands
 sensor tags them `nested_from:executor-…` with `host=false`. On hosts where Tetragon lost the
 ancestry to sshd they surfaced as findings: 607 of the 632 MALICIOUS rounds on 8 Sep.
 
-Classification is by that ancestry, as `design/RENTER_DATA_PRIVACY.md` row 16 intends: a
-`DockerExec` from inside the executor container is *platform-origin* (the sensor itself already
-drops execs whose ancestry reaches sshd or pid 1, so these are the ones it could not trust); anything from the host, a
-`NamespaceEnter`, a memory read, an exec the sensor could not attribute is *provider-origin* and is
+Classification is by that ancestry, as `design/RENTER_DATA_PRIVACY.md` row 16 intends: a Docker
+control-plane action (`DockerExec`, and the `docker cp` / `docker rm` / … the executor runs on a
+pod's behalf) from inside the executor container is *platform-origin* (the sensor itself already
+drops docker-policy findings whose ancestry reaches sshd or pid 1, so these are the ones it could
+not trust); anything from the host, a `NamespaceEnter`, a memory read, an exec the sensor could not attribute is *provider-origin* and is
 what the check, the score gate and the renter event act on. The payloads are too many and too
 script-shaped for an exact allow-list to be honest, so the platform execs' payloads are recorded
 in the verdict (`platform_payloads`) for the daily digest instead of gating anything. What keeps
@@ -39,7 +40,20 @@ _EXEC_OPTIONS_WITH_VALUE = {"-u", "--user", "-e", "--env", "-w", "--workdir"}
 _EXEC_FLAGS = {"-i", "-t", "-it", "-ti", "-d", "--detach", "--privileged", "--interactive", "--tty"}
 _SHELL_WRAPPERS = {"sh", "/bin/sh", "bash", "/bin/bash", "/usr/bin/sh", "/usr/bin/bash"}
 _SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ec", "-lec"}
-_DOCKER_EXEC_KINDS = {"DockerExec"}
+# The kinds the sensor's two docker policies emit (`tamper-docker-cli`, `tamper-docker-sock-write`;
+# docker_cli.rs `finding_is_rental_interference`). The executor drives a pod's whole life through
+# the Docker API from inside its own container — create, start, `docker cp` for a restore, `docker
+# rm` when the rental ends — so any of these with the executor's ancestry is the platform's, not
+# only the exec. `DockerVolumeMount` is mount.rs (path-shaped), never the executor's.
+_DOCKER_CONTROL_PLANE_KINDS = frozenset(
+    {
+        "DockerExec", "DockerAttach", "DockerCp", "DockerRun", "DockerCreate", "DockerStart", "DockerStop",
+        "DockerKill", "DockerPause", "DockerRm", "DockerRestart", "DockerRename", "DockerUpdate", "DockerCommit",
+        "DockerExport", "DockerPrune", "DockerInspect", "DockerPull", "DockerPush", "DockerBuild", "DockerLoad",
+        "DockerImport", "DockerRmi", "DockerNetworkConnect", "DockerNetworkDisconnect", "DockerNetworkRm",
+        "DockerVolumeRm", "DockerSave", "DockerSocketWrite",
+    }
+)
 _PATH_SHAPED_KINDS = {"OverlayFsRead", "OverlayFsWrite", "DockerVolumeMount"}
 RENTAL_VOLUME_TAG = "rental_volume"
 # the renter's pod-log entry carries at most this many evidence hashes; the finding count is the
@@ -79,14 +93,18 @@ RENTER_EVENT = "provider_access_detected"
 class InspectorVerdict:
     provider_findings: list[dict[str, Any]]
     platform_findings: list[dict[str, Any]]
-    evidence: list[str]
+    evidence_sha256: list[str]
     report_sha256: str
     classes: list[str]
     affected_pod_ids: list[str]
     sensor: str
     enforce: bool
     action: str
-    extra: dict[str, Any] = field(default_factory=dict)
+    # the platform execs' payloads, deduplicated, for the daily digest (never gate on them)
+    platform_payloads: list[str] = field(default_factory=list)
+    # provider findings on a container that is not in the rented list: recorded, no renter told
+    unmatched_containers: list[str] = field(default_factory=list)
+    unmatched_containers_count: int = 0
 
     @property
     def provider_origin(self) -> bool:
@@ -98,13 +116,21 @@ class InspectorVerdict:
             "platform_findings": len(self.platform_findings),
             "classes": self.classes,
             "affected_pod_ids": self.affected_pod_ids,
-            "evidence_sha256": self.evidence,
+            "evidence_sha256": self.evidence_sha256,
             "report_sha256": self.report_sha256,
             "sensor": self.sensor,
             "enforce": self.enforce,
             "action": self.action,
             "ban_source": BAN_SOURCE if self.action == ACTION_QUARANTINE else None,
-            **self.extra,
+            "platform_payloads": self.platform_payloads,
+            **(
+                {
+                    "unmatched_containers": self.unmatched_containers,
+                    "unmatched_containers_count": self.unmatched_containers_count,
+                }
+                if self.unmatched_containers
+                else {}
+            ),
         }
 
 
@@ -172,12 +198,13 @@ def nested_from_executor(finding: dict[str, Any]) -> bool:
 
 
 def is_platform_origin(finding: dict[str, Any]) -> bool:
-    """A `docker exec` the sensor traced to inside the executor container (`host=false`, a
-    `nested_from:<executor-stack container>` tag). The sensor already drops execs whose ancestry
-    reaches sshd or the container's pid 1, so every such finding is one whose ancestry it could
-    not trust; until DAH-3278 hardens that on the verifier, all of them count as the platform's.
-    Everything else is the provider's."""
-    if _kind(finding) not in _DOCKER_EXEC_KINDS:
+    """A Docker control-plane action the sensor traced to inside the executor container
+    (`host=false`, a `nested_from:<executor-stack container>` tag). The sensor already drops
+    docker-policy findings whose ancestry reaches sshd or the container's pid 1, so every such
+    finding is one whose ancestry it could not trust; until DAH-3278 hardens that on the verifier,
+    all of them count as the platform's. Everything else — an nsenter, a memory or overlayfs read,
+    anything from the host — is the provider's."""
+    if _kind(finding) not in _DOCKER_CONTROL_PLANE_KINDS:
         return False
     if finding.get("host") is True:
         return False
@@ -276,22 +303,20 @@ def build_verdict(
         affected |= rented
     classes = sorted({finding_class(f) for f in provider})
     action = ACTION_QUARANTINE if (provider and enforce) else ACTION_NONE
-    extra: dict[str, Any] = {"platform_payloads": _platform_payloads(platform)}
-    if unmatched:
-        names = sorted(unmatched)
-        extra["unmatched_containers"] = [name[:_UNMATCHED_NAME_CHARS] for name in names[:_UNMATCHED_MAX]]
-        extra["unmatched_containers_count"] = len(names)
+    names = sorted(unmatched)
     return InspectorVerdict(
         provider_findings=provider,
         platform_findings=platform,
-        evidence=[canonical_sha256(f) for f in provider],
+        evidence_sha256=[canonical_sha256(f) for f in provider],
         report_sha256=canonical_sha256(report),
         classes=classes,
         affected_pod_ids=sorted(affected),
         sensor=SENSOR_ATTESTED if sensor_attested else SENSOR_UNATTESTED,
         enforce=enforce,
         action=action,
-        extra=extra,
+        platform_payloads=_platform_payloads(platform),
+        unmatched_containers=[name[:_UNMATCHED_NAME_CHARS] for name in names[:_UNMATCHED_MAX]],
+        unmatched_containers_count=len(names),
     )
 
 
@@ -318,8 +343,8 @@ def renter_access_event(
         "classes": verdict.classes,
         "provider_findings": len(verdict.provider_findings),
         "report_sha256": verdict.report_sha256,
-        "evidence_sha256": verdict.evidence[:_RENTER_EVIDENCE_MAX],
-        "evidence_sha256_truncated": len(verdict.evidence) > _RENTER_EVIDENCE_MAX,
+        "evidence_sha256": verdict.evidence_sha256[:_RENTER_EVIDENCE_MAX],
+        "evidence_sha256_truncated": len(verdict.evidence_sha256) > _RENTER_EVIDENCE_MAX,
         "sensor": verdict.sensor,
         "action": verdict.action,
     }

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -17,7 +17,12 @@ drops docker-policy findings whose ancestry reaches sshd or pid 1, so these are 
 not trust); anything from the host, a `NamespaceEnter`, a memory read, an exec the sensor could not attribute is *provider-origin* and is
 what the check, the score gate and the renter event act on when it names a rented pod (or names no
 container at all); a finding on any other container is recorded under `unmatched_containers` and
-acts on nobody. The payloads are too many and too
+acts on nobody. The executor's own backup and restore (`executor/src/storage/restic.py`) never
+reach this module: the sensor classifies the encrypted flow's `nsenter -t <pid> -U` as benign
+(nsenter.rs: a `CLONE_NEWUSER`-only `setns`, judged by nstype, never by a container name) and the
+unencrypted flow's `-v volume_<pod_id>:/workspace` bind as a runtime mount (mount.rs: runc /
+container-stack binaries), so neither is a finding — a name-based exemption here would only let a
+provider's `lium-storage-…`-named container borrow the platform's origin. The payloads are too many and too
 script-shaped for an exact allow-list to be honest, so the platform execs' payloads are recorded
 in the verdict (`platform_exec_commands`) for the daily digest instead of gating anything. What keeps
 the tag trustworthy — a provider `docker exec`-ing into the executor container to borrow its
@@ -112,6 +117,11 @@ class VerdictPayload(BaseModel):
     # no action
     unmatched_containers: list[str]
     unmatched_containers_count: int
+    # provider findings that named no container and no rental volume: each one marks every rented
+    # pod on the host (the fallback the flag decision has to measure)
+    unnamed_findings: int
+    # platform findings by kind, for the shadow numbers
+    platform_kind_counts: dict[str, int]
 
 
 class RenterAccessEvent(BaseModel):
@@ -149,6 +159,8 @@ class InspectorVerdict:
     # no action
     unmatched_containers: list[str] = field(default_factory=list)
     unmatched_containers_count: int = 0
+    # provider findings that named no container and no rental volume (every rented pod is marked)
+    unnamed_findings: int = 0
 
     @property
     def provider_origin(self) -> bool:
@@ -169,7 +181,14 @@ class InspectorVerdict:
             platform_exec_commands=self.platform_exec_commands,
             unmatched_containers=self.unmatched_containers,
             unmatched_containers_count=self.unmatched_containers_count,
+            unnamed_findings=self.unnamed_findings,
+            platform_kind_counts=_kind_counts(self.platform_findings),
         )
+
+    def findings_for_pod(self, pod_id: str) -> list[dict[str, Any]]:
+        """The provider findings that concern this pod: the ones naming its container or its volume,
+        and the ones naming nothing (those mark every rented pod on the host)."""
+        return [f for f in self.provider_findings if _concerns_pod(f, pod_id)]
 
 
 def canonical_sha256(value: Any) -> str:
@@ -241,7 +260,9 @@ def is_platform_origin(finding: dict[str, Any]) -> bool:
     docker-policy findings whose ancestry reaches sshd or the container's pid 1, so every such
     finding is one whose ancestry it could not trust; until DAH-3278 hardens that on the verifier,
     all of them count as the platform's. Everything else — an nsenter, a memory or overlayfs read,
-    anything from the host — is the provider's."""
+    anything from the host — is the provider's. The executor's own backup/restore nsenter and volume
+    bind (restic.py) are benign at the sensor (module docstring) and never arrive here; a
+    `NamespaceEnter` that does arrive is a real pid/mnt/net entry, whatever container it came from."""
     if _kind(finding) not in _DOCKER_CONTROL_PLANE_KINDS:
         return False
     if finding.get("host") is True:
@@ -298,15 +319,30 @@ def _named_resource(finding: dict[str, Any]) -> str | None:
 
 
 def _platform_exec_commands(platform: list[dict[str, Any]]) -> list[str]:
-    seen: list[str] = []
+    commands: list[str] = []
     for finding in platform:
         payload = docker_exec_command(str(finding.get("command") or "")) or "(not a docker exec argv)"
         payload = payload[:_PAYLOAD_PREVIEW_CHARS]
-        if payload not in seen:
-            seen.append(payload)
-        if len(seen) >= _PAYLOAD_PREVIEW_MAX:
+        if payload not in commands:
+            commands.append(payload)
+        if len(commands) >= _PAYLOAD_PREVIEW_MAX:
             break
-    return seen
+    return commands
+
+
+def _kind_counts(findings: list[dict[str, Any]]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for finding in findings:
+        kind = finding_kind(finding)
+        counts[kind] = counts.get(kind, 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def _concerns_pod(finding: dict[str, Any], pod_id: str) -> bool:
+    """A finding is about this pod when it names its container or volume, or names nothing at all
+    (those mark every rented pod); a foreign container — even one named like a pod id — is nobody's."""
+    name = _named_resource(finding)
+    return name is None or pod_id_of(name) == pod_id
 
 
 def build_verdict(
@@ -325,19 +361,19 @@ def build_verdict(
     rented = set(rented_pod_ids)
     affected: set[str] = set()
     unmatched: set[str] = set()
-    has_unnamed_finding = False
+    unnamed = 0
     for finding in provider:
         name = _named_resource(finding)
         pod_id = pod_id_of(name) if name else None
         if name is None:
-            has_unnamed_finding = True
+            unnamed += 1
         elif pod_id in rented:
             affected.add(pod_id)
         else:
             # a pod that left or joined since the rented list was fetched, or not a pod at all:
             # recorded, but no renter is told about a container that was not theirs
             unmatched.add(name)
-    if has_unnamed_finding:
+    if unnamed:
         # the sensor named no container at all: every renter on this host is told
         affected |= rented
     # Enforcement acts only for a rented pod: a provider inside their own container (a finding
@@ -357,6 +393,7 @@ def build_verdict(
         platform_exec_commands=_platform_exec_commands(platform),
         unmatched_containers=[name[:_UNMATCHED_NAME_CHARS] for name in names[:_UNMATCHED_MAX]],
         unmatched_containers_count=len(names),
+        unnamed_findings=unnamed,
     )
 
 
@@ -366,8 +403,12 @@ def renter_access_event(
     pod_id: str,
     when: str,
 ) -> RenterAccessEvent:
-    """One pod-log entry the renter sees in their pod's event stream."""
-    kinds = ", ".join(verdict.finding_kinds) or "access"
+    """One pod-log entry the renter sees in their pod's event stream: only the findings about this
+    pod (its container, its volume, or none named), never another renter's."""
+    findings = verdict.findings_for_pod(pod_id)
+    finding_kinds = sorted({finding_kind(f) for f in findings})
+    evidence = [canonical_sha256(f) for f in findings]
+    kinds = ", ".join(finding_kinds) or "access"
     sensor = "attested sensor" if verdict.sensor_attestation == SENSOR_ATTESTED else "unattested sensor"
     # `quarantine` only asks the backend to act; the ban itself is the backend's
     outcome = (
@@ -383,11 +424,11 @@ def renter_access_event(
         event=RENTER_EVENT,
         pod_id=pod_id,
         when=when,
-        finding_kinds=verdict.finding_kinds,
-        provider_findings=len(verdict.provider_findings),
+        finding_kinds=finding_kinds,
+        provider_findings=len(findings),
         report_sha256=verdict.report_sha256,
-        evidence_sha256=verdict.evidence_sha256[:_RENTER_EVIDENCE_MAX],
-        evidence_sha256_truncated=len(verdict.evidence_sha256) > _RENTER_EVIDENCE_MAX,
+        evidence_sha256=evidence[:_RENTER_EVIDENCE_MAX],
+        evidence_sha256_truncated=len(evidence) > _RENTER_EVIDENCE_MAX,
         sensor=verdict.sensor_attestation,
         action=verdict.action,
     )

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -30,6 +30,8 @@ import shlex
 from dataclasses import dataclass, field
 from typing import Any
 
+from pydantic import BaseModel
+
 NESTED_FROM_TAG_PREFIX = "nested_from:"
 POD_CONTAINER_PREFIX = "pod_"
 # the pod's volume is `volume_<pod_id>` (docker_service.py create flow; the sensor's
@@ -40,30 +42,11 @@ _EXEC_OPTIONS_WITH_VALUE = {"-u", "--user", "-e", "--env", "-w", "--workdir"}
 _EXEC_FLAGS = {"-i", "-t", "-it", "-ti", "-d", "--detach", "--privileged", "--interactive", "--tty"}
 _SHELL_WRAPPERS = {"sh", "/bin/sh", "bash", "/bin/bash", "/usr/bin/sh", "/usr/bin/bash"}
 _SHELL_COMMAND_FLAGS = {"-c", "-lc", "-ec", "-lec"}
-# The kinds the sensor's two docker policies emit (`tamper-docker-cli`, `tamper-docker-sock-write`;
-# docker_cli.rs `finding_is_rental_interference`). The executor drives a pod's whole life through
-# the Docker API from inside its own container — create, start, `docker cp` for a restore, `docker
-# rm` when the rental ends — so any of these with the executor's ancestry is the platform's, not
-# only the exec. `DockerVolumeMount` is mount.rs (path-shaped), never the executor's.
-_DOCKER_CONTROL_PLANE_KINDS = frozenset(
-    {
-        "DockerExec", "DockerAttach", "DockerCp", "DockerRun", "DockerCreate", "DockerStart", "DockerStop",
-        "DockerKill", "DockerPause", "DockerRm", "DockerRestart", "DockerRename", "DockerUpdate", "DockerCommit",
-        "DockerExport", "DockerPrune", "DockerInspect", "DockerPull", "DockerPush", "DockerBuild", "DockerLoad",
-        "DockerImport", "DockerRmi", "DockerNetworkConnect", "DockerNetworkDisconnect", "DockerNetworkRm",
-        "DockerVolumeRm", "DockerSave", "DockerSocketWrite",
-    }
-)
-_PATH_SHAPED_KINDS = {"OverlayFsRead", "OverlayFsWrite", "DockerVolumeMount"}
-RENTAL_VOLUME_TAG = "rental_volume"
-# the renter's pod-log entry carries at most this many evidence hashes; the finding count is the
-# sensor's to choose (21,694 OverlayFsRead in one day, 8 Sep), the full list stays in the
-# inspector event's `context.verdict`
-_RENTER_EVIDENCE_MAX = 20
 # The sensor's `RuntimeInterferenceKind` (celium-gpu-verifier inspector/src/collector/analysis/
-# types.rs, serde PascalCase) — the only strings a renter is shown as a class. Anything else — the
-# report is produced on the provider's root when the sensor is unattested — is shown as `unknown`
-# and kept raw only inside the evidence. Keep in step with types.rs and inspector_summary/sql.py.
+# types.rs, serde PascalCase) — the only strings a renter is shown as a finding kind. Anything else
+# — the report is produced on the provider's root when the sensor is unattested — is shown as
+# `unknown` and kept raw only inside the evidence. Keep in step with types.rs and
+# inspector_summary/sql.py.
 KNOWN_FINDING_KINDS = frozenset(
     {
         "DockerExec", "DockerAttach", "DockerCp", "DockerRun", "DockerCreate", "DockerStart", "DockerStop",
@@ -75,6 +58,21 @@ KNOWN_FINDING_KINDS = frozenset(
         "DockerVolumeMount",
     }
 )
+# fs.rs / mount.rs kinds: no container, the path is in `command`
+_PATH_SHAPED_KINDS = frozenset({"OverlayFsRead", "OverlayFsWrite", "DockerVolumeMount"})
+# The kinds the sensor's two docker policies emit (`tamper-docker-cli`, `tamper-docker-sock-write`;
+# docker_cli.rs `finding_is_rental_interference`): every `Docker*` kind except the path-shaped
+# `DockerVolumeMount`. The executor drives a pod's whole life through the Docker API from inside
+# its own container — create, start, `docker cp` for a restore, `docker rm` when the rental ends —
+# so any of these with the executor's ancestry is the platform's, not only the exec.
+_DOCKER_CONTROL_PLANE_KINDS = (
+    frozenset(kind for kind in KNOWN_FINDING_KINDS if kind.startswith("Docker")) - _PATH_SHAPED_KINDS
+)
+RENTAL_VOLUME_TAG = "rental_volume"
+# the renter's pod-log entry carries at most this many evidence hashes; the finding count is the
+# sensor's to choose (21,694 OverlayFsRead in one day, 8 Sep), the full list stays in the
+# inspector event's `context.verdict`
+_RENTER_EVIDENCE_MAX = 20
 UNKNOWN_KIND = "unknown"
 _PAYLOAD_PREVIEW_CHARS = 160
 _PAYLOAD_PREVIEW_MAX = 20
@@ -89,15 +87,57 @@ BAN_SOURCE = "inspector_auto"
 RENTER_EVENT = "provider_access_detected"
 
 
+class VerdictPayload(BaseModel):
+    """The verdict as the inspector event carries it to the backend (`context.verdict`).
+
+    Wire keys: `sensor` is the attestation state (`attested` / `unattested`), `finding_kinds` the
+    sensor's kinds (`KNOWN_FINDING_KINDS`, else `unknown`). `model_dump()` at the emit boundary.
+    """
+
+    provider_findings: int
+    platform_findings: int
+    finding_kinds: list[str]
+    affected_pod_ids: list[str]
+    evidence_sha256: list[str]
+    report_sha256: str
+    sensor: str
+    enforce: bool
+    action: str
+    ban_source: str | None
+    # the platform execs' payloads, deduplicated, for the daily digest (never gate on them)
+    platform_payloads: list[str]
+    # provider findings on a container that is not in the rented list: recorded, no renter told
+    unmatched_containers: list[str]
+    unmatched_containers_count: int
+
+
+class RenterAccessEvent(BaseModel):
+    """One pod-log entry the renter sees in their pod's event stream."""
+
+    log_text: str
+    log_status: str
+    log_tag: str
+    event: str
+    pod_id: str
+    when: str
+    finding_kinds: list[str]
+    provider_findings: int
+    report_sha256: str
+    evidence_sha256: list[str]
+    evidence_sha256_truncated: bool
+    sensor: str
+    action: str
+
+
 @dataclass(frozen=True)
 class InspectorVerdict:
     provider_findings: list[dict[str, Any]]
     platform_findings: list[dict[str, Any]]
     evidence_sha256: list[str]
     report_sha256: str
-    classes: list[str]
+    finding_kinds: list[str]
     affected_pod_ids: list[str]
-    sensor: str
+    sensor_attestation: str
     enforce: bool
     action: str
     # the platform execs' payloads, deduplicated, for the daily digest (never gate on them)
@@ -110,28 +150,22 @@ class InspectorVerdict:
     def provider_origin(self) -> bool:
         return bool(self.provider_findings)
 
-    def as_payload(self) -> dict[str, Any]:
-        return {
-            "provider_findings": len(self.provider_findings),
-            "platform_findings": len(self.platform_findings),
-            "classes": self.classes,
-            "affected_pod_ids": self.affected_pod_ids,
-            "evidence_sha256": self.evidence_sha256,
-            "report_sha256": self.report_sha256,
-            "sensor": self.sensor,
-            "enforce": self.enforce,
-            "action": self.action,
-            "ban_source": BAN_SOURCE if self.action == ACTION_QUARANTINE else None,
-            "platform_payloads": self.platform_payloads,
-            **(
-                {
-                    "unmatched_containers": self.unmatched_containers,
-                    "unmatched_containers_count": self.unmatched_containers_count,
-                }
-                if self.unmatched_containers
-                else {}
-            ),
-        }
+    def as_payload(self) -> VerdictPayload:
+        return VerdictPayload(
+            provider_findings=len(self.provider_findings),
+            platform_findings=len(self.platform_findings),
+            finding_kinds=self.finding_kinds,
+            affected_pod_ids=self.affected_pod_ids,
+            evidence_sha256=self.evidence_sha256,
+            report_sha256=self.report_sha256,
+            sensor=self.sensor_attestation,
+            enforce=self.enforce,
+            action=self.action,
+            ban_source=BAN_SOURCE if self.action == ACTION_QUARANTINE else None,
+            platform_payloads=self.platform_payloads,
+            unmatched_containers=self.unmatched_containers,
+            unmatched_containers_count=self.unmatched_containers_count,
+        )
 
 
 def canonical_sha256(value: Any) -> str:
@@ -211,7 +245,8 @@ def is_platform_origin(finding: dict[str, Any]) -> bool:
     return nested_from_executor(finding)
 
 
-def finding_class(finding: dict[str, Any]) -> str:
+def finding_kind(finding: dict[str, Any]) -> str:
+    """The sensor's kind, or `unknown` for anything outside its vocabulary."""
     kind = _kind(finding)
     return kind if kind in KNOWN_FINDING_KINDS else UNKNOWN_KIND
 
@@ -286,22 +321,21 @@ def build_verdict(
     rented = set(rented_pod_ids)
     affected: set[str] = set()
     unmatched: set[str] = set()
-    unnamed = False
+    has_unnamed_finding = False
     for finding in provider:
         name = _named_resource(finding)
         pod_id = pod_id_of(name) if name else None
         if name is None:
-            unnamed = True
+            has_unnamed_finding = True
         elif pod_id in rented:
             affected.add(pod_id)
         else:
             # a pod that left or joined since the rented list was fetched, or not a pod at all:
             # recorded, but no renter is told about a container that was not theirs
             unmatched.add(name)
-    if unnamed:
+    if has_unnamed_finding:
         # the sensor named no container at all: every renter on this host is told
         affected |= rented
-    classes = sorted({finding_class(f) for f in provider})
     action = ACTION_QUARANTINE if (provider and enforce) else ACTION_NONE
     names = sorted(unmatched)
     return InspectorVerdict(
@@ -309,9 +343,9 @@ def build_verdict(
         platform_findings=platform,
         evidence_sha256=[canonical_sha256(f) for f in provider],
         report_sha256=canonical_sha256(report),
-        classes=classes,
+        finding_kinds=sorted({finding_kind(f) for f in provider}),
         affected_pod_ids=sorted(affected),
-        sensor=SENSOR_ATTESTED if sensor_attested else SENSOR_UNATTESTED,
+        sensor_attestation=SENSOR_ATTESTED if sensor_attested else SENSOR_UNATTESTED,
         enforce=enforce,
         action=action,
         platform_payloads=_platform_payloads(platform),
@@ -325,26 +359,29 @@ def renter_access_event(
     *,
     pod_id: str,
     when: str,
-) -> dict[str, Any]:
+) -> RenterAccessEvent:
     """One pod-log entry the renter sees in their pod's event stream."""
-    classes = ", ".join(verdict.classes) or "access"
-    sensor = "attested sensor" if verdict.sensor == SENSOR_ATTESTED else "unattested sensor"
-    return {
-        "log_text": (
-            f"Provider-side access to this pod detected ({classes}; {sensor}). "
-            "Lium has recorded the evidence"
-            + (" and removed the host from the marketplace." if verdict.action == ACTION_QUARANTINE else ".")
+    kinds = ", ".join(verdict.finding_kinds) or "access"
+    sensor = "attested sensor" if verdict.sensor_attestation == SENSOR_ATTESTED else "unattested sensor"
+    # `quarantine` only asks the backend to act; the ban itself is the backend's
+    outcome = (
+        " and asked to take the host off the marketplace." if verdict.action == ACTION_QUARANTINE else "."
+    )
+    return RenterAccessEvent(
+        log_text=(
+            f"Provider-side access to this pod detected ({kinds}; {sensor}). "
+            f"Lium has recorded the evidence{outcome}"
         ),
-        "log_status": "error",
-        "log_tag": RENTER_EVENT,
-        "event": RENTER_EVENT,
-        "pod_id": pod_id,
-        "when": when,
-        "classes": verdict.classes,
-        "provider_findings": len(verdict.provider_findings),
-        "report_sha256": verdict.report_sha256,
-        "evidence_sha256": verdict.evidence_sha256[:_RENTER_EVIDENCE_MAX],
-        "evidence_sha256_truncated": len(verdict.evidence_sha256) > _RENTER_EVIDENCE_MAX,
-        "sensor": verdict.sensor,
-        "action": verdict.action,
-    }
+        log_status="error",
+        log_tag=RENTER_EVENT,
+        event=RENTER_EVENT,
+        pod_id=pod_id,
+        when=when,
+        finding_kinds=verdict.finding_kinds,
+        provider_findings=len(verdict.provider_findings),
+        report_sha256=verdict.report_sha256,
+        evidence_sha256=verdict.evidence_sha256[:_RENTER_EVIDENCE_MAX],
+        evidence_sha256_truncated=len(verdict.evidence_sha256) > _RENTER_EVIDENCE_MAX,
+        sensor=verdict.sensor_attestation,
+        action=verdict.action,
+    )

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -1,0 +1,210 @@
+"""Turn an Inspector report into a verdict the validator can act on (DAH-3275).
+
+The sensor reports every `docker exec` / `nsenter` / memory read against a rented pod. Some of
+those are ours: the validator's own liveness exec (`cat /root/.ssh/authorized_keys`), the
+executor's disk metric (`df -k`), the executor's legacy volume restore (`tar`). They run from
+inside the executor container (the SSH session lands there), so the sensor tags them
+`nested_from:executor-…` and `host=false`; on hosts where Tetragon loses the ancestry to sshd
+they still surface as findings — 607 of the 632 MALICIOUS rounds on 8 Sep were exactly that.
+
+A finding is *platform-origin* only when BOTH hold: it came from inside the executor container
+and its exec payload is one of the exact commands the platform runs. Everything else is
+*provider-origin* and is what the check, the score gate and the renter event act on.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shlex
+from dataclasses import dataclass, field
+from typing import Any
+
+EXECUTOR_CONTAINER_TAG_PREFIX = "nested_from:executor"
+POD_CONTAINER_PREFIX = "pod_"
+
+# Exact exec payloads the platform runs against a rented pod. Keep this list in step with the
+# code that runs them: rented_machine.py (_check_pod_running), the executor's
+# hardware_service.py (disk metric) — nothing else may be added without a matching caller.
+PLATFORM_EXEC_PAYLOADS = frozenset(
+    {
+        "cat /root/.ssh/authorized_keys",
+        "df -k /",
+        "df -k /lium-cipher",
+    }
+)
+# The executor's legacy tar restore streams an archive into one directory of the pod.
+PLATFORM_EXEC_PAYLOAD_PATTERNS = (
+    re.compile(r"^tar --xattrs --acls -xzpf - -C /[A-Za-z0-9._/-]+$"),
+)
+_EXEC_OPTIONS_WITH_VALUE = {"-u", "--user", "-e", "--env", "-w", "--workdir"}
+_EXEC_FLAGS = {"-i", "-t", "-it", "-ti", "-d", "--detach", "--privileged", "--interactive", "--tty"}
+_SHELL_WRAPPERS = {"sh", "/bin/sh", "bash", "/bin/bash", "/usr/bin/sh", "/usr/bin/bash"}
+_DOCKER_EXEC_KINDS = {"DockerExec"}
+
+SENSOR_ATTESTED = "attested"
+SENSOR_UNATTESTED = "unattested"
+ACTION_QUARANTINE = "quarantine"
+ACTION_NONE = "none"
+BAN_SOURCE = "inspector_auto"
+RENTER_EVENT = "provider_access_detected"
+
+
+@dataclass(frozen=True)
+class InspectorVerdict:
+    provider_findings: list[dict[str, Any]]
+    platform_findings: list[dict[str, Any]]
+    evidence: list[str]
+    report_sha256: str
+    classes: list[str]
+    affected_pod_ids: list[str]
+    sensor: str
+    enforce: bool
+    action: str
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def provider_origin(self) -> bool:
+        return bool(self.provider_findings)
+
+    def as_payload(self) -> dict[str, Any]:
+        return {
+            "provider_findings": len(self.provider_findings),
+            "platform_findings": len(self.platform_findings),
+            "classes": self.classes,
+            "affected_pod_ids": self.affected_pod_ids,
+            "evidence_sha256": self.evidence,
+            "report_sha256": self.report_sha256,
+            "sensor": self.sensor,
+            "enforce": self.enforce,
+            "action": self.action,
+            "ban_source": BAN_SOURCE if self.action == ACTION_QUARANTINE else None,
+            **self.extra,
+        }
+
+
+def canonical_sha256(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    ).hexdigest()
+
+
+def exec_payload(command: str) -> str | None:
+    """The command a `docker exec` ran inside the target container, or None if not an exec.
+
+    `docker exec -u 0 -i pod_x sh -c 'cat /root/.ssh/authorized_keys'` → the cat; a bare
+    `docker exec pod_x df -k /` → the df. Options and a `sh -c` wrapper are stripped; anything
+    that does not parse is not a platform exec.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    if "exec" not in tokens:
+        return None
+    index = tokens.index("exec") + 1
+    while index < len(tokens) and tokens[index].startswith("-"):
+        if tokens[index] in _EXEC_OPTIONS_WITH_VALUE:
+            index += 2
+        elif tokens[index] in _EXEC_FLAGS or "=" in tokens[index]:
+            index += 1
+        else:
+            return None
+    if index >= len(tokens) or not tokens[index].startswith(POD_CONTAINER_PREFIX):
+        return None
+    payload = tokens[index + 1 :]
+    if len(payload) >= 3 and payload[0] in _SHELL_WRAPPERS and payload[1] == "-c":
+        payload = payload[2:]
+        if len(payload) == 1:
+            # the shell's -c argument is one string; normalise its whitespace
+            return " ".join(payload[0].split())
+    return " ".join(payload) if payload else None
+
+
+def is_platform_origin(finding: dict[str, Any]) -> bool:
+    if finding.get("kind") not in _DOCKER_EXEC_KINDS:
+        return False
+    if finding.get("host") is True:
+        return False
+    tags = finding.get("tags") or []
+    if not any(isinstance(tag, str) and tag.startswith(EXECUTOR_CONTAINER_TAG_PREFIX) for tag in tags):
+        return False
+    payload = exec_payload(str(finding.get("command") or ""))
+    if payload is None:
+        return False
+    if payload in PLATFORM_EXEC_PAYLOADS:
+        return True
+    return any(pattern.match(payload) for pattern in PLATFORM_EXEC_PAYLOAD_PATTERNS)
+
+
+def _finding_pod_id(finding: dict[str, Any], rented_pod_ids: set[str]) -> str | None:
+    container = finding.get("container")
+    docker = finding.get("docker") or {}
+    candidates = [container, docker.get("resolved_name") if isinstance(docker, dict) else None]
+    for name in candidates:
+        if isinstance(name, str) and name.startswith(POD_CONTAINER_PREFIX):
+            pod_id = name[len(POD_CONTAINER_PREFIX) :]
+            if pod_id in rented_pod_ids:
+                return pod_id
+    return None
+
+
+def build_verdict(
+    report: dict[str, Any],
+    findings: list[dict[str, Any]],
+    *,
+    rented_pod_ids: list[str],
+    sensor_attested: bool,
+    enforce: bool,
+) -> InspectorVerdict:
+    provider: list[dict[str, Any]] = []
+    platform: list[dict[str, Any]] = []
+    for finding in findings:
+        (platform if is_platform_origin(finding) else provider).append(finding)
+
+    rented = set(rented_pod_ids)
+    affected = sorted({pod for pod in (_finding_pod_id(f, rented) for f in provider) if pod})
+    if provider and not affected:
+        # the sensor did not name the pod: every renter on this host is told
+        affected = sorted(rented)
+    classes = sorted({str(f.get("kind") or "unknown") for f in provider})
+    action = ACTION_QUARANTINE if (provider and enforce) else ACTION_NONE
+    return InspectorVerdict(
+        provider_findings=provider,
+        platform_findings=platform,
+        evidence=[canonical_sha256(f) for f in provider],
+        report_sha256=canonical_sha256(report),
+        classes=classes,
+        affected_pod_ids=affected,
+        sensor=SENSOR_ATTESTED if sensor_attested else SENSOR_UNATTESTED,
+        enforce=enforce,
+        action=action,
+    )
+
+
+def renter_access_event(
+    verdict: InspectorVerdict,
+    *,
+    pod_id: str,
+    when: str,
+) -> dict[str, Any]:
+    """One pod-log entry the renter sees in their pod's event stream."""
+    classes = ", ".join(verdict.classes) or "access"
+    sensor = "attested sensor" if verdict.sensor == SENSOR_ATTESTED else "unattested sensor"
+    return {
+        "log_text": (
+            f"Provider-side access to this pod detected ({classes}; {sensor}). "
+            "Lium has recorded the evidence"
+            + (" and removed the host from the marketplace." if verdict.action == ACTION_QUARANTINE else ".")
+        ),
+        "log_status": "error",
+        "log_tag": RENTER_EVENT,
+        "event": RENTER_EVENT,
+        "pod_id": pod_id,
+        "when": when,
+        "classes": verdict.classes,
+        "evidence_sha256": verdict.evidence,
+        "sensor": verdict.sensor,
+        "action": verdict.action,
+    }

--- a/neurons/validators/src/services/task/inspector_verdict.py
+++ b/neurons/validators/src/services/task/inspector_verdict.py
@@ -64,6 +64,8 @@ KNOWN_FINDING_KINDS = frozenset(
 UNKNOWN_KIND = "unknown"
 _PAYLOAD_PREVIEW_CHARS = 160
 _PAYLOAD_PREVIEW_MAX = 20
+_UNMATCHED_MAX = 20
+_UNMATCHED_NAME_CHARS = 128
 
 SENSOR_ATTESTED = "attested"
 SENSOR_UNATTESTED = "unattested"
@@ -277,7 +279,7 @@ def build_verdict(
     extra: dict[str, Any] = {"platform_payloads": _platform_payloads(platform)}
     if unmatched:
         names = sorted(unmatched)
-        extra["unmatched_containers"] = [name[:128] for name in names[:_PAYLOAD_PREVIEW_MAX]]
+        extra["unmatched_containers"] = [name[:_UNMATCHED_NAME_CHARS] for name in names[:_UNMATCHED_MAX]]
         extra["unmatched_containers_count"] = len(names)
     return InspectorVerdict(
         provider_findings=provider,

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -587,8 +587,15 @@ class InspectorMessages:
         reason="INSPECTOR_MALICIOUS_FINDINGS",
         severity="warning",
         category="runtime",
-        impact="Findings logged; score unchanged",
-        remediation="Review the libinspector report and tenant workload before taking action.",
+        impact="Provider-origin findings recorded; score unchanged",
+        remediation="Review the verdict's evidence and the renter's pod events; the backend acts on the requested quarantine.",
+    )
+    PLATFORM_ORIGIN_ONLY = MessageTemplate(
+        event="Inspector findings were the platform's own execs",
+        reason="INSPECTOR_PLATFORM_ORIGIN_ONLY",
+        severity="info",
+        category="runtime",
+        impact="Only validator/executor execs seen (sshd ancestry lost on this host); nothing provider-side",
     )
     VALIDATION_ERROR = MessageTemplate(
         event="Inspector validation error",

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -588,7 +588,7 @@ class InspectorMessages:
         severity="warning",
         category="runtime",
         impact="Provider-origin findings recorded; score unchanged",
-        remediation="Review the verdict's evidence; under INSPECTOR_ENFORCE_ENABLED the renters were told and the backend acts on the requested quarantine.",
+        remediation="Review the verdict's evidence; when the verdict's action is quarantine (INSPECTOR_ENFORCE_ENABLED and a rented pod affected) the renters were told and the backend acts on it.",
     )
     PLATFORM_ORIGIN_ONLY = MessageTemplate(
         event="Inspector findings were the platform's own execs",

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -588,7 +588,7 @@ class InspectorMessages:
         severity="warning",
         category="runtime",
         impact="Provider-origin findings recorded; score unchanged",
-        remediation="Review the verdict's evidence and the renter's pod events; the backend acts on the requested quarantine.",
+        remediation="Review the verdict's evidence; under INSPECTOR_ENFORCE_ENABLED the renters were told and the backend acts on the requested quarantine.",
     )
     PLATFORM_ORIGIN_ONLY = MessageTemplate(
         event="Inspector findings were the platform's own execs",

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -178,6 +178,9 @@ class Context(BaseModel):
     # False only once ProviderSideLoadCheck sees provider-side CPU/disk above the floors under
     # enforcement; the score gate lives in calculate_scores for the same reason as above.
     provider_side_load_passed: bool = True
+    # False only once InspectorRentedCheck sees a provider-origin finding on a rented pod under
+    # INSPECTOR_ENFORCE_ENABLED (DAH-3275); the score gate lives in calculate_scores.
+    inspector_passed: bool = True
     # G1 — NVIDIA CC GPU attestation outcome: True/False when verified, None when
     # not performed (non-CVM node, no evidence supplied, or NRAS undeterminable).
     gpu_attestation_passed: bool | None = None

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -85,6 +85,14 @@ def calculate_scores(
         job_score = 0.0
         warning_messages.append("Provider-side workload consumes the machine's CPU or disk")
 
+    # Inspector gate (DAH-3275): the host reached into a renter's pod (exec / nsenter / memory
+    # read not attributable to the platform). Non-fatal check, same mechanics as the two above;
+    # INSPECTOR_ENFORCE_ENABLED off leaves the flag True.
+    if not ctx.inspector_passed:
+        actual_score = 0.0
+        job_score = 0.0
+        warning_messages.append("Provider-side access to a rented pod detected by the Inspector")
+
     # EMA verifyx download speed check — threshold enforced upstream in VerifyXCheck
     ema_verifyx_download = ((ctx.state.specs or {}).get("network") or {}).get(
         "ema_verifyx_download_speed"

--- a/neurons/validators/tests/test_attestation_gaps_g1_g4.py
+++ b/neurons/validators/tests/test_attestation_gaps_g1_g4.py
@@ -527,6 +527,7 @@ def _score_ctx(tdx_quote, attestation_passed):
         tdx_attestation_passed=attestation_passed,
         cpu_truth_passed=True,
         provider_side_load_passed=True,
+        inspector_passed=True,
     )
 
 

--- a/neurons/validators/tests/test_inspector_check.py
+++ b/neurons/validators/tests/test_inspector_check.py
@@ -24,8 +24,9 @@ class DummyInspectorService:
         self.response = response
         self.called = False
 
-    async def validate_rented_executor(self, shell, ssh, executor, default_extra):
+    async def validate_rented_executor(self, shell, ssh, executor, default_extra, *, sensor_attested=False):
         self.called = True
+        self.sensor_attested = sensor_attested
         return self.response
 
 

--- a/neurons/validators/tests/test_inspector_validation_service.py
+++ b/neurons/validators/tests/test_inspector_validation_service.py
@@ -557,3 +557,39 @@ async def test_capture_stderr_does_not_wait_forever():
     captured = await service._capture_stderr(process)
 
     assert captured is None
+
+
+@pytest.mark.asyncio
+async def test_validate_rented_executor_on_an_attested_host_trusts_the_measured_image_not_the_shell():
+    # DAH-3275: on a dstack CVM the executor image is measured by the TDX quote; a sha256sum
+    # answered by the provider's shell adds nothing, so it is not asked for — and the
+    # diagnostics say which of the two vouched for the sensor.
+    service = InspectorValidationService()
+    ssh = FakeSSH()
+    shell = FakeShell(sha256="different")
+
+    result = await service.validate_rented_executor(
+        shell,
+        ssh,
+        SimpleNamespace(uuid="exec-1", python_path="/usr/bin/python3", root_dir="/root/app"),
+        {"executor_uuid": "exec-1"},
+        sensor_attested=True,
+    )
+
+    assert result.error is None
+    assert shell.remote_checksum_calls == 0
+    assert result.diagnostics["sensor_integrity"] == "tdx_measured_image"
+
+
+@pytest.mark.asyncio
+async def test_validate_rented_executor_marks_the_shell_checksum_unattested():
+    service = InspectorValidationService()
+    result = await service.validate_rented_executor(
+        FakeShell(),
+        FakeSSH(),
+        SimpleNamespace(uuid="exec-1", python_path="/usr/bin/python3", root_dir="/root/app"),
+        {"executor_uuid": "exec-1"},
+    )
+
+    assert result.error is None
+    assert result.diagnostics["sensor_integrity"] == "shell_sha256_unattested"

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -251,16 +251,36 @@ def test_a_pod_outside_the_rented_list_is_recorded_but_no_renter_is_told():
 
 
 @pytest.mark.parametrize("kind", [["DockerExec"], {"k": 1}, 7, None])
-@pytest.mark.parametrize("tags", [7, "nested_from:executor-executor-1", {"a": 1}, None, [1, None, "rental_volume"]])
-def test_any_json_type_in_kind_or_tags_classifies_without_raising(kind, tags):
+def test_any_json_type_in_kind_classifies_without_raising(kind):
     finding = _finding(VALIDATOR_LIVENESS)
     finding["kind"] = kind
-    finding["tags"] = tags
     verdict = build_verdict({}, [finding], rented_pod_ids=[POD], sensor_attested=False, enforce=True)
 
     assert is_platform_origin(finding) is False    # not a string kind → not an exec we can vouch for
     assert verdict.classes == ["unknown"]
     assert verdict.affected_pod_ids == [POD]       # `container` still names the pod
+
+
+@pytest.mark.parametrize(
+    ("tags", "platform"),
+    [
+        (7, False),
+        ("nested_from:executor-executor-1", False),      # a string is not a list of tags
+        ({"a": 1}, False),
+        (None, False),
+        ([1, None, "nested_from:executor-executor-1"], True),   # non-string entries are skipped
+    ],
+)
+def test_any_json_type_in_tags_reaches_the_ancestry_guard_without_raising(tags, platform):
+    finding = _finding(VALIDATOR_LIVENESS)      # kind DockerExec, host False: the tag decides
+    finding["tags"] = tags
+    assert is_platform_origin(finding) is platform
+
+    # the path-shaped branch reads tags too: no container, a rental-volume path, odd tags
+    path_finding = _path_finding("OverlayFsRead", f"/var/lib/docker/volumes/volume_{POD}/_data/x")
+    path_finding["tags"] = tags
+    verdict = build_verdict({}, [path_finding], rented_pod_ids=[POD, "other"], sensor_attested=False, enforce=False)
+    assert verdict.affected_pod_ids == [POD]    # the kind alone routes it to the path rule
 
 
 def test_unmatched_containers_are_capped_in_the_verdict():

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -189,8 +189,8 @@ def test_a_read_of_the_pods_volume_names_the_pod_and_only_that_pod(kind, path):
     verdict = build_verdict({}, [_path_finding(kind, path)], rented_pod_ids=[POD, "other"], sensor_attested=False, enforce=False)
 
     assert verdict.affected_pod_ids == [POD]
-    assert verdict.classes == [kind]
-    assert "unmatched_containers" not in verdict.as_payload()
+    assert verdict.finding_kinds == [kind]
+    assert verdict.as_payload().unmatched_containers == []
 
 
 def test_a_volume_named_in_the_container_field_names_the_pod_too():
@@ -208,10 +208,10 @@ def test_the_renter_event_caps_the_evidence_list():
     event = renter_access_event(verdict, pod_id=POD, when="2026-09-09T00:00:00Z")
 
     assert len(verdict.evidence_sha256) == 60
-    assert len(event["evidence_sha256"]) == 20
-    assert event["evidence_sha256_truncated"] is True
-    assert event["provider_findings"] == 60
-    assert event["report_sha256"] == verdict.report_sha256
+    assert len(event.evidence_sha256) == 20
+    assert event.evidence_sha256_truncated is True
+    assert event.provider_findings == 60
+    assert event.report_sha256 == verdict.report_sha256
 
 
 def test_platform_origin_is_the_executor_ancestry_not_the_payload():
@@ -241,7 +241,7 @@ def test_verdict_records_the_platform_payloads_for_the_digest():
     findings = [_finding(c) for c in execs.values()] + [_finding(HUMAN_SHELL, host=True, nested=False)]
     verdict = build_verdict({}, findings, rented_pod_ids=[POD], sensor_attested=False, enforce=False)
 
-    payloads = verdict.as_payload()["platform_payloads"]
+    payloads = verdict.as_payload().platform_payloads
     assert payloads == verdict.platform_payloads
     assert "cat /root/.ssh/authorized_keys" in payloads
     assert "df -k /root" in payloads
@@ -258,15 +258,16 @@ def test_a_pod_outside_the_rented_list_is_recorded_but_no_renter_is_told():
     assert verdict.affected_pod_ids == []
     assert verdict.unmatched_containers == ["pod_gone-since-the-list-was-fetched"]
     assert verdict.unmatched_containers_count == 1
-    assert verdict.as_payload()["unmatched_containers"] == ["pod_gone-since-the-list-was-fetched"]
+    assert verdict.as_payload().unmatched_containers == ["pod_gone-since-the-list-was-fetched"]
     assert len(verdict.provider_findings) == 1
 
 
-def test_a_verdict_with_every_pod_matched_carries_no_unmatched_keys():
+def test_a_verdict_with_every_pod_matched_carries_empty_unmatched_fields():
     verdict = build_verdict({}, [_finding(HUMAN_SHELL, host=True, nested=False)], rented_pod_ids=[POD], sensor_attested=False, enforce=False)
 
     assert verdict.unmatched_containers == [] and verdict.unmatched_containers_count == 0
-    assert "unmatched_containers" not in verdict.as_payload()
+    payload = verdict.as_payload().model_dump()
+    assert payload["unmatched_containers"] == [] and payload["unmatched_containers_count"] == 0
 
 
 @pytest.mark.parametrize("kind", [["DockerExec"], {"k": 1}, 7, None])
@@ -276,7 +277,7 @@ def test_any_json_type_in_kind_classifies_without_raising(kind):
     verdict = build_verdict({}, [finding], rented_pod_ids=[POD], sensor_attested=False, enforce=True)
 
     assert is_platform_origin(finding) is False    # not a string kind → not an exec we can vouch for
-    assert verdict.classes == ["unknown"]
+    assert verdict.finding_kinds == ["unknown"]
     assert verdict.affected_pod_ids == [POD]       # `container` still names the pod
 
 
@@ -309,7 +310,7 @@ def test_unmatched_containers_are_capped_in_the_verdict():
         f["container"] = f"pod_gone-{i:02d}-" + "x" * 300
         findings.append(f)
     verdict = build_verdict({}, findings, rented_pod_ids=[POD], sensor_attested=False, enforce=False)
-    payload = verdict.as_payload()
+    payload = verdict.as_payload().model_dump()
 
     assert len(payload["unmatched_containers"]) == 20
     assert all(len(name) <= 128 for name in payload["unmatched_containers"])
@@ -317,15 +318,16 @@ def test_unmatched_containers_are_capped_in_the_verdict():
     assert verdict.affected_pod_ids == []
 
 
-def test_renter_visible_classes_come_from_a_fixed_vocabulary():
+def test_renter_visible_finding_kinds_come_from_a_fixed_vocabulary():
     odd = _finding(HUMAN_SHELL, host=True, nested=False, kind="<script>alert(1)</script>" + "x" * 500)
     verdict = build_verdict({}, [odd, _finding(HUMAN_SHELL, host=True, nested=False, kind="NamespaceEnter")],
                             rented_pod_ids=[POD], sensor_attested=False, enforce=False)
 
-    assert verdict.classes == ["NamespaceEnter", "unknown"]
-    event = renter_access_event(verdict, pod_id=POD, when="2026-09-09T00:00:00Z")
+    assert verdict.finding_kinds == ["NamespaceEnter", "unknown"]
+    event = renter_access_event(verdict, pod_id=POD, when="2026-09-09T00:00:00Z").model_dump()
     assert "<script>" not in event["log_text"]
-    assert event["classes"] == ["NamespaceEnter", "unknown"]
+    assert event["finding_kinds"] == ["NamespaceEnter", "unknown"]
+    assert "classes" not in event
     # the raw kind survives only in the evidence
     assert verdict.evidence_sha256[0] == canonical_sha256(odd)
 
@@ -345,10 +347,12 @@ def test_verdict_hashes_only_the_provider_findings_and_names_the_pod():
     assert verdict.evidence_sha256 == [canonical_sha256(report["findings"][1])]
     assert verdict.report_sha256 == canonical_sha256(report)
     assert verdict.affected_pod_ids == [POD]
-    assert verdict.classes == ["DockerExec"]
-    assert verdict.sensor == SENSOR_UNATTESTED
+    assert verdict.finding_kinds == ["DockerExec"]
+    assert verdict.sensor_attestation == SENSOR_UNATTESTED
     assert verdict.action == ACTION_NONE
-    assert verdict.as_payload()["ban_source"] is None
+    payload = verdict.as_payload().model_dump()
+    assert payload["ban_source"] is None
+    assert payload["sensor"] == SENSOR_UNATTESTED and payload["finding_kinds"] == ["DockerExec"]
 
 
 def test_verdict_without_a_named_pod_tells_every_renter_on_the_host():
@@ -357,9 +361,9 @@ def test_verdict_without_a_named_pod_tells_every_renter_on_the_host():
     verdict = build_verdict({}, [finding], rented_pod_ids=["b", "a"], sensor_attested=True, enforce=True)
 
     assert verdict.affected_pod_ids == ["a", "b"]
-    assert verdict.sensor == SENSOR_ATTESTED
+    assert verdict.sensor_attestation == SENSOR_ATTESTED
     assert verdict.action == ACTION_QUARANTINE
-    assert verdict.as_payload()["ban_source"] == "inspector_auto"
+    assert verdict.as_payload().ban_source == "inspector_auto"
 
 
 # --- the check -----------------------------------------------------------------------------
@@ -421,9 +425,12 @@ async def test_platform_only_findings_are_clean_and_no_renter_is_told(context_fa
     assert result.passed is True
     assert result.event.reason_code == Msg.PLATFORM_ORIGIN_ONLY.reason
     assert result.event.severity == "info"
+    # the event carries the count; the findings themselves are in the report
+    assert result.event.what_we_saw["platform_findings"] == 2
     event = result.updates["state"].inspector_event
     assert event["outcome"] == "CLEAN"
     assert event["context"]["verdict"]["platform_findings"] == 2
+    assert event["context"]["verdict"]["finding_kinds"] == []
     assert event["context"]["verdict"]["provider_findings"] == 0
     assert "inspector_passed" not in result.updates
     redis.publish.assert_not_awaited()
@@ -485,7 +492,8 @@ async def test_provider_finding_under_enforcement_fails_the_check_and_requests_q
     assert log["log_tag"] == "provider_access_detected"
     assert log["log_status"] == "error"
     assert log["evidence_sha256"] == verdict["evidence_sha256"]
-    assert "removed the host from the marketplace" in log["log_text"]
+    assert log["finding_kinds"] == ["DockerExec"]
+    assert "asked to take the host off the marketplace" in log["log_text"]
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -250,6 +250,34 @@ def test_a_pod_outside_the_rented_list_is_recorded_but_no_renter_is_told():
     assert len(verdict.provider_findings) == 1
 
 
+@pytest.mark.parametrize("kind", [["DockerExec"], {"k": 1}, 7, None])
+@pytest.mark.parametrize("tags", [7, "nested_from:executor-executor-1", {"a": 1}, None, [1, None, "rental_volume"]])
+def test_any_json_type_in_kind_or_tags_classifies_without_raising(kind, tags):
+    finding = _finding(VALIDATOR_LIVENESS)
+    finding["kind"] = kind
+    finding["tags"] = tags
+    verdict = build_verdict({}, [finding], rented_pod_ids=[POD], sensor_attested=False, enforce=True)
+
+    assert is_platform_origin(finding) is False    # not a string kind → not an exec we can vouch for
+    assert verdict.classes == ["unknown"]
+    assert verdict.affected_pod_ids == [POD]       # `container` still names the pod
+
+
+def test_unmatched_containers_are_capped_in_the_verdict():
+    findings = []
+    for i in range(30):
+        f = _finding(HUMAN_SHELL, host=True, nested=False)
+        f["container"] = f"pod_gone-{i:02d}-" + "x" * 300
+        findings.append(f)
+    verdict = build_verdict({}, findings, rented_pod_ids=[POD], sensor_attested=False, enforce=False)
+    payload = verdict.as_payload()
+
+    assert len(payload["unmatched_containers"]) == 20
+    assert all(len(name) <= 128 for name in payload["unmatched_containers"])
+    assert payload["unmatched_containers_count"] == 30
+    assert verdict.affected_pod_ids == []
+
+
 def test_renter_visible_classes_come_from_a_fixed_vocabulary():
     odd = _finding(HUMAN_SHELL, host=True, nested=False, kind="<script>alert(1)</script>" + "x" * 500)
     verdict = build_verdict({}, [odd, _finding(HUMAN_SHELL, host=True, nested=False, kind="NamespaceEnter")],

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -236,6 +236,27 @@ def test_platform_origin_is_the_executor_ancestry_not_the_payload():
     assert not is_platform_origin(_finding(f"/var/lib/docker/volumes/volume_{POD}/_data", kind="DockerVolumeMount"))
 
 
+def test_a_container_named_like_the_storage_helper_cannot_borrow_the_platforms_origin():
+    # taiberium (11 Sep) asked to exempt the encrypted backup's nsenter (restic.py runs it from a
+    # `lium-storage-<id>` helper). The sensor already judges that `nsenter -t <pid> -U` benign by
+    # nstype (CLONE_NEWUSER only, nsenter.rs) and the unencrypted flow's volume bind as a runtime
+    # mount (mount.rs), so neither reaches the verdict; a NamespaceEnter or DockerVolumeMount that
+    # does arrive is real and a helper-shaped container name must not turn it into the platform's
+    nsenter = "nsenter -t 4242 -m -p -- /bin/sh"
+    mount = f"/var/lib/docker/volumes/volume_{POD}/_data"
+    for kind, command in (("NamespaceEnter", nsenter), ("DockerVolumeMount", mount)):
+        assert not is_platform_origin(_finding(command, kind=kind, nested_from="lium-storage-0123456789ab"))
+        assert not is_platform_origin(_finding(command, kind=kind))  # the executor container itself
+        assert not is_platform_origin(_finding(command, kind=kind, nested=False))
+    # the shadow digest still sees what the platform did produce, by kind
+    verdict = build_verdict(
+        {}, [_finding(VALIDATOR_LIVENESS), _finding(f"docker rm -f pod_{POD}", kind="DockerRm"), _finding(VALIDATOR_LIVENESS)],
+        rented_pod_ids=[POD], sensor_attested=False, enforce=False,
+    )
+    assert verdict.provider_findings == []
+    assert verdict.as_payload().platform_kind_counts == {"DockerExec": 2, "DockerRm": 1}
+
+
 def test_verdict_records_the_platform_exec_commands_for_the_digest():
     execs = _platform_execs()
     findings = [_finding(c) for c in execs.values()] + [_finding(HUMAN_SHELL, host=True, nested=False)]
@@ -387,6 +408,37 @@ def test_verdict_without_a_named_pod_tells_every_renter_on_the_host():
     assert verdict.sensor_attestation == SENSOR_ATTESTED
     assert verdict.action == ACTION_QUARANTINE
     assert verdict.as_payload().ban_source == "inspector_auto"
+    # the fallback is counted so the shadow digest can say how often it fires (an overlay2 path has
+    # no `volumes/` segment, so this may be common — taiberium, 11 Sep)
+    assert verdict.unnamed_findings == 1 and verdict.as_payload().unnamed_findings == 1
+    named = build_verdict({}, [_finding(HUMAN_SHELL, host=True, nested=False)], rented_pod_ids=[POD], sensor_attested=True, enforce=True)
+    assert named.unnamed_findings == 0
+
+
+def test_the_renter_event_carries_only_that_pods_findings():
+    # two renters on one host: A's event must not show B's kinds or evidence; a finding that names
+    # no container is about every pod and appears in both
+    on_a = _finding(HUMAN_KEY_READ, host=True, nested=False)
+    on_b = _finding("/proc/4242/mem", kind="ProcessMemoryRead", host=True, nested=False)
+    on_b["container"] = "pod_b"
+    # a provider container named exactly like a pod id is unmatched, never a pod's
+    foreign = _finding("docker exec b sh", host=True, nested=False)
+    foreign["container"] = "b"
+    unnamed = _finding("chroot /var/lib/docker/overlay2/abc/merged", kind="ContainerChroot", host=True, nested=False)
+    unnamed["container"] = None
+    verdict = build_verdict({}, [on_a, on_b, unnamed, foreign], rented_pod_ids=[POD, "b"], sensor_attested=True, enforce=True)
+    # host-wide, in the inspector event
+    assert verdict.finding_kinds == ["ContainerChroot", "DockerExec", "ProcessMemoryRead"]
+    assert verdict.unmatched_containers == ["b"]
+
+    event_a = renter_access_event(verdict, pod_id=POD, when="2026-09-11T00:00:00Z")
+    event_b = renter_access_event(verdict, pod_id="b", when="2026-09-11T00:00:00Z")
+    assert event_a.finding_kinds == ["ContainerChroot", "DockerExec"] and event_a.provider_findings == 2
+    assert event_a.evidence_sha256 == [canonical_sha256(on_a), canonical_sha256(unnamed)]
+    assert "ProcessMemoryRead" not in event_a.log_text
+    assert event_b.finding_kinds == ["ContainerChroot", "ProcessMemoryRead"] and event_b.provider_findings == 2
+    assert event_b.evidence_sha256 == [canonical_sha256(on_b), canonical_sha256(unnamed)]
+    assert "DockerExec" not in event_b.log_text
 
 
 # --- the check -----------------------------------------------------------------------------
@@ -547,6 +599,24 @@ async def test_finding_on_a_non_rented_container_under_enforcement_is_recorded_a
     assert verdict["affected_pod_ids"] == []
     assert verdict["unmatched_containers"] == ["my-own-jupyter"]
     redis.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_finding_on_a_non_rented_container_in_shadow_is_not_called_access_to_a_rented_pod(context_factory):
+    """Shadow mode, the provider in their own container: the impact text names what happened — a
+    container that is not a rented pod — so the shadow counts read from it are not wrong in the
+    enforcement direction (taiberium, 11 Sep). The flag is off here."""
+    finding = _finding(HUMAN_SHELL, host=True, nested=False)
+    finding["container"] = "my-own-jupyter"
+    ctx, _ = _ctx(context_factory, [finding])
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert result.passed is True
+    assert "not a rented pod" in result.event.impact
+    assert "access to a rented pod" not in result.event.impact
+    verdict = result.updates["state"].inspector_event["context"]["verdict"]
+    assert verdict["enforce"] is False and verdict["affected_pod_ids"] == []
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -20,7 +20,7 @@ from neurons.validators.src.services.task.inspector_verdict import (
     build_verdict,
     canonical_sha256,
     KNOWN_FINDING_KINDS,
-    exec_payload,
+    docker_exec_command,
     is_platform_origin,
     renter_access_event,
 )
@@ -109,8 +109,8 @@ def _platform_execs() -> dict[str, str]:
         ("/usr/bin/docker exec -u 0 -i executor-executor-1 sh -c 'cat x'", None),
     ],
 )
-def test_exec_payload_strips_options_and_shell_wrapper(command, payload):
-    assert exec_payload(command) == payload
+def test_docker_exec_command_strips_options_and_shell_wrapper(command, payload):
+    assert docker_exec_command(command) == payload
 
 
 def test_the_real_platform_execs_are_recognised_from_the_executor_container():
@@ -119,7 +119,7 @@ def test_the_real_platform_execs_are_recognised_from_the_executor_container():
     for name, command in execs.items():
         assert is_platform_origin(_finding(command)), name
         # the digest depends on the argv parsing as a docker exec — the drift the builders could cause
-        assert exec_payload(command) is not None, name
+        assert docker_exec_command(command) is not None, name
     # the very same commands from the host are a human at the keyboard
     for name, command in execs.items():
         assert not is_platform_origin(_finding(command, host=True, nested=False)), name
@@ -236,13 +236,13 @@ def test_platform_origin_is_the_executor_ancestry_not_the_payload():
     assert not is_platform_origin(_finding(f"/var/lib/docker/volumes/volume_{POD}/_data", kind="DockerVolumeMount"))
 
 
-def test_verdict_records_the_platform_payloads_for_the_digest():
+def test_verdict_records_the_platform_exec_commands_for_the_digest():
     execs = _platform_execs()
     findings = [_finding(c) for c in execs.values()] + [_finding(HUMAN_SHELL, host=True, nested=False)]
     verdict = build_verdict({}, findings, rented_pod_ids=[POD], sensor_attested=False, enforce=False)
 
-    payloads = verdict.as_payload().platform_payloads
-    assert payloads == verdict.platform_payloads
+    payloads = verdict.as_payload().platform_exec_commands
+    assert payloads == verdict.platform_exec_commands
     assert "cat /root/.ssh/authorized_keys" in payloads
     assert "df -k /root" in payloads
     assert "tar --xattrs --acls -xzpf - -C /root/restored --strip-components=1" in payloads
@@ -260,6 +260,29 @@ def test_a_pod_outside_the_rented_list_is_recorded_but_no_renter_is_told():
     assert verdict.unmatched_containers_count == 1
     assert verdict.as_payload().unmatched_containers == ["pod_gone-since-the-list-was-fetched"]
     assert len(verdict.provider_findings) == 1
+
+
+@pytest.mark.parametrize("container", ["my-own-jupyter", "pod_gone-since-the-list-was-fetched"])
+def test_a_finding_on_a_container_that_is_not_a_rented_pod_takes_no_action(container):
+    """A provider inside their own container is provider-origin but harms no renter: under
+    enforcement the verdict still says `none` (taiberium, #1342)."""
+    finding = _finding(HUMAN_SHELL, host=True, nested=False)
+    finding["container"] = container
+    verdict = build_verdict({}, [finding], rented_pod_ids=[POD], sensor_attested=True, enforce=True)
+
+    assert verdict.provider_origin is True
+    assert verdict.affected_pod_ids == []
+    assert verdict.action == ACTION_NONE
+    assert verdict.as_payload().ban_source is None
+    assert verdict.unmatched_containers == [container]
+
+
+def test_a_rented_pod_named_under_enforcement_is_quarantined():
+    verdict = build_verdict(
+        {}, [_finding(HUMAN_SHELL, host=True, nested=False)], rented_pod_ids=[POD], sensor_attested=True, enforce=True
+    )
+    assert verdict.affected_pod_ids == [POD]
+    assert verdict.action == ACTION_QUARANTINE
 
 
 def test_a_verdict_with_every_pod_matched_carries_empty_unmatched_fields():
@@ -494,6 +517,36 @@ async def test_provider_finding_under_enforcement_fails_the_check_and_requests_q
     assert log["evidence_sha256"] == verdict["evidence_sha256"]
     assert log["finding_kinds"] == ["DockerExec"]
     assert "asked to take the host off the marketplace" in log["log_text"]
+
+
+@pytest.mark.asyncio
+async def test_finding_on_a_non_rented_container_under_enforcement_is_recorded_and_acts_on_nobody(
+    context_factory, monkeypatch
+):
+    """The provider entered their own container: MALICIOUS is recorded with the container under
+    `unmatched_containers`, but the check passes, the score gate is not set and no renter is told."""
+    monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", True)
+    redis = AsyncMock()
+    finding = _finding(HUMAN_SHELL, host=True, nested=False)
+    finding["container"] = "my-own-jupyter"
+    ctx, _ = _ctx(context_factory, [finding], redis=redis)
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.MALICIOUS_FINDINGS.reason
+    assert result.event.severity == "warning"
+    assert "not a rented pod" in result.event.impact
+    assert "inspector_passed" not in result.updates
+    event = result.updates["state"].inspector_event
+    assert event["outcome"] == "MALICIOUS"
+    verdict = event["context"]["verdict"]
+    assert verdict["enforce"] is True
+    assert verdict["action"] == ACTION_NONE
+    assert verdict["ban_source"] is None
+    assert verdict["affected_pod_ids"] == []
+    assert verdict["unmatched_containers"] == ["my-own-jupyter"]
+    redis.publish.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import shlex
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -19,6 +21,7 @@ from neurons.validators.src.services.task.inspector_verdict import (
     canonical_sha256,
     exec_payload,
     is_platform_origin,
+    renter_access_event,
 )
 from neurons.validators.src.services.task.messages import InspectorMessages as Msg
 from neurons.validators.src.services.task.score_calculator import calculate_scores
@@ -53,11 +56,41 @@ def _finding(command: str, *, host: bool = False, kind: str = "DockerExec", nest
 
 
 VALIDATOR_LIVENESS = f'/usr/bin/docker exec -u 0 -i pod_{POD} sh -c "cat /root/.ssh/authorized_keys"'
-EXECUTOR_DF = f"/usr/bin/docker exec -u root pod_{POD} df -k /lium-cipher"
-EXECUTOR_TAR = f"/usr/bin/docker exec -u 0 -i pod_{POD} tar --xattrs --acls -xzpf - -C /root/restored"
 HUMAN_SHELL = f"/usr/bin/docker exec -it pod_{POD} bash"
 HUMAN_KEY_READ = f"/usr/bin/docker exec -u 0 -i pod_{POD} sh -c 'cat /root/.ssh/id_ed25519'"
 CHAINED = f"/usr/bin/docker exec -u 0 -i pod_{POD} sh -c 'cat /root/.ssh/authorized_keys; cat /root/.ssh/id_rsa'"
+
+
+def _platform_execs() -> dict[str, str]:
+    """The argv the platform really runs against a pod, built by the code that runs it."""
+    import sys
+
+    miner_jobs = str(Path(__file__).resolve().parents[1] / "src" / "miner_jobs")
+    if miner_jobs not in sys.path:
+        sys.path.insert(0, miner_jobs)
+    import backup_storage
+    import restore_storage
+    from workspace_mount import VolumeAccess
+
+    access = VolumeAccess(volume_name="v", volume_path="/root", encrypted=True, container_name=f"pod_{POD}")
+    return {
+        "liveness": VALIDATOR_LIVENESS,
+        # executor hardware_service._get_filesystem_usage: `docker exec -u root <pod> df -k <Destination>`
+        "df_root": f"/usr/bin/docker exec -u root pod_{POD} df -k /root",
+        "df_cipher": f"/usr/bin/docker exec -u root pod_{POD} df -k /lium-cipher",
+        "restore_mkdir": shlex.join(restore_storage.workspace_command(None, access, "mkdir") + ["-p", "/root/restored"]),
+        "restore_chown": shlex.join(restore_storage.workspace_command(None, access, "chown") + ["1000", "/root/restored"]),
+        "restore_tar": shlex.join(
+            restore_storage.workspace_command(None, access, "tar", interactive=True)
+            + ["--xattrs", "--acls", "-xzpf", "-", "-C", "/root/restored", "--strip-components=1"]
+        ),
+        "backup_du": shlex.join(backup_storage.workspace_command(None, access, "du") + ["-sb", "/root/data"]),
+        "backup_tar": shlex.join(
+            backup_storage.workspace_command(None, access, "tar") + ["--xattrs", "--acls", "-C", "/root", "-czf", "-", "data"]
+        ),
+        "gocryptfs_setup": f"/usr/bin/docker exec -u 0 pod_{POD} sh /dev/shm/.s-abc",
+        "sshd_probe": f"/usr/bin/docker exec -u 0 pod_{POD} sh -lc 'test -S /run/sshd.sock && echo ok'",
+    }
 
 
 @pytest.mark.parametrize(
@@ -65,30 +98,75 @@ CHAINED = f"/usr/bin/docker exec -u 0 -i pod_{POD} sh -c 'cat /root/.ssh/authori
     [
         (VALIDATOR_LIVENESS, "cat /root/.ssh/authorized_keys"),
         (f"/usr/bin/docker exec -u 0 -i pod_{POD} sh -c cat /root/.ssh/authorized_keys", "cat /root/.ssh/authorized_keys"),
-        (EXECUTOR_DF, "df -k /lium-cipher"),
-        (EXECUTOR_TAR, "tar --xattrs --acls -xzpf - -C /root/restored"),
+        (f"/usr/bin/docker exec -u root pod_{POD} df -k /root", "df -k /root"),
         (HUMAN_SHELL, "bash"),
         (f"/usr/bin/docker exec --user=root pod_{POD} df -k /", "df -k /"),
+        (f"/usr/bin/docker exec -u 0 pod_{POD} sh -lc 'test -S /run/sshd.sock'", "test -S /run/sshd.sock"),
         ("/usr/bin/docker ps", None),
-        (f"/usr/bin/docker exec -u 0 -i executor-executor-1 sh -c 'cat x'", None),
+        ("/usr/bin/docker exec -u 0 -i executor-executor-1 sh -c 'cat x'", None),
     ],
 )
 def test_exec_payload_strips_options_and_shell_wrapper(command, payload):
     assert exec_payload(command) == payload
 
 
-def test_platform_origin_needs_both_the_executor_source_and_a_known_payload():
-    assert is_platform_origin(_finding(VALIDATOR_LIVENESS))
-    assert is_platform_origin(_finding(EXECUTOR_DF))
-    assert is_platform_origin(_finding(EXECUTOR_TAR))
-    # the same command from the host is a human at the keyboard
-    assert not is_platform_origin(_finding(VALIDATOR_LIVENESS, host=True, nested=False))
-    # a chain that starts with our command is not our command
-    assert not is_platform_origin(_finding(CHAINED))
-    assert not is_platform_origin(_finding(HUMAN_KEY_READ))
-    assert not is_platform_origin(_finding(HUMAN_SHELL))
+def test_the_real_platform_execs_are_recognised_from_the_executor_container():
+    execs = _platform_execs()
+    assert execs["restore_tar"].endswith("--strip-components=1")
+    for name, command in execs.items():
+        assert is_platform_origin(_finding(command)), name
+    # the very same commands from the host are a human at the keyboard
+    for name, command in execs.items():
+        assert not is_platform_origin(_finding(command, host=True, nested=False)), name
+
+
+def test_platform_origin_is_the_executor_ancestry_not_the_payload():
+    # the classifier does not judge the payload: what the platform runs changes too often for an
+    # exact list (DAH-3278 hardens the tag on the verifier); a chained read from the executor
+    # container is recorded as a platform payload, not as a provider
+    assert is_platform_origin(_finding(CHAINED))
+    assert is_platform_origin(_finding(HUMAN_KEY_READ))
+    # …but without the executor tag, or from the host, it is the provider's
+    assert not is_platform_origin(_finding(HUMAN_KEY_READ, nested=False))
+    assert not is_platform_origin(_finding(HUMAN_SHELL, host=True))
     # only execs can be ours; an nsenter never is
     assert not is_platform_origin(_finding(VALIDATOR_LIVENESS, kind="NamespaceEnter"))
+
+
+def test_verdict_records_the_platform_payloads_for_the_digest():
+    execs = _platform_execs()
+    findings = [_finding(c) for c in execs.values()] + [_finding(HUMAN_SHELL, host=True, nested=False)]
+    verdict = build_verdict({}, findings, rented_pod_ids=[POD], sensor_attested=False, enforce=False)
+
+    payloads = verdict.as_payload()["platform_payloads"]
+    assert "cat /root/.ssh/authorized_keys" in payloads
+    assert "df -k /root" in payloads
+    assert "tar --xattrs --acls -xzpf - -C /root/restored --strip-components=1" in payloads
+    assert len(verdict.provider_findings) == 1
+    assert len(payloads) == len(set(payloads)) <= 20
+
+
+def test_a_pod_outside_the_rented_list_is_recorded_but_no_renter_is_told():
+    finding = _finding(HUMAN_SHELL, host=True, nested=False)
+    finding["container"] = "pod_gone-since-the-list-was-fetched"
+    verdict = build_verdict({}, [finding], rented_pod_ids=[POD], sensor_attested=False, enforce=False)
+
+    assert verdict.affected_pod_ids == []
+    assert verdict.as_payload()["unmatched_containers"] == ["pod_gone-since-the-list-was-fetched"]
+    assert len(verdict.provider_findings) == 1
+
+
+def test_renter_visible_classes_come_from_a_fixed_vocabulary():
+    odd = _finding(HUMAN_SHELL, host=True, nested=False, kind="<script>alert(1)</script>" + "x" * 500)
+    verdict = build_verdict({}, [odd, _finding(HUMAN_SHELL, host=True, nested=False, kind="NamespaceEnter")],
+                            rented_pod_ids=[POD], sensor_attested=False, enforce=False)
+
+    assert verdict.classes == ["NamespaceEnter", "unknown"]
+    event = renter_access_event(verdict, pod_id=POD, when="2026-09-09T00:00:00Z")
+    assert "<script>" not in event["log_text"]
+    assert event["classes"] == ["NamespaceEnter", "unknown"]
+    # the raw kind survives only in the evidence
+    assert verdict.evidence[0] == canonical_sha256(odd)
 
 
 def test_verdict_hashes_only_the_provider_findings_and_names_the_pod():
@@ -175,7 +253,7 @@ def _ctx(context_factory, findings: list[dict], *, redis=None, **overrides):
 async def test_platform_only_findings_are_clean_and_no_renter_is_told(context_factory, monkeypatch):
     monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", True)
     redis = AsyncMock()
-    ctx, _ = _ctx(context_factory, [_finding(VALIDATOR_LIVENESS), _finding(EXECUTOR_DF)], redis=redis)
+    ctx, _ = _ctx(context_factory, [_finding(VALIDATOR_LIVENESS), _finding(_platform_execs()["df_root"])], redis=redis)
 
     result = await InspectorRentedCheck().run(ctx)
 
@@ -245,6 +323,21 @@ async def test_provider_finding_under_enforcement_fails_the_check_and_requests_q
     assert verdict["ban_source"] == "inspector_auto"
     (log,) = redis.publish.await_args.args[1]["logs"]
     assert "removed the host from the marketplace" in log["log_text"]
+
+
+@pytest.mark.asyncio
+async def test_a_malformed_report_is_a_sensor_error_not_a_provider_finding(context_factory, monkeypatch):
+    monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", True)
+    redis = AsyncMock()
+    ctx, _ = _ctx(context_factory, ["not-a-finding", 42], redis=redis)  # type: ignore[list-item]
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.VALIDATION_ERROR.reason
+    assert "inspector_passed" not in result.updates
+    assert result.updates["state"].inspector_event["outcome"] == "ERROR"
+    redis.publish.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from helpers import build_context_config, build_services, build_state
+from neurons.validators.src.services.inspector_validation_service import (
+    InspectorValidationResponse,
+)
+from neurons.validators.src.services.redis_service import STREAMING_LOG_CHANNEL
+from neurons.validators.src.services.task.checks.inspector import InspectorRentedCheck
+from neurons.validators.src.services.task.inspector_verdict import (
+    ACTION_NONE,
+    ACTION_QUARANTINE,
+    SENSOR_ATTESTED,
+    SENSOR_UNATTESTED,
+    build_verdict,
+    canonical_sha256,
+    exec_payload,
+    is_platform_origin,
+)
+from neurons.validators.src.services.task.messages import InspectorMessages as Msg
+from neurons.validators.src.services.task.score_calculator import calculate_scores
+from protocol.vc_protocol.compute_requests import (
+    RentedExecutor,
+    RentedExecutorsResponse,
+    RentedPod,
+)
+
+from core.config import settings
+
+POD = "0f6a1c2e-1111-4222-8333-444455556666"
+
+
+def _finding(command: str, *, host: bool = False, kind: str = "DockerExec", nested: bool = True) -> dict:
+    return {
+        "category": "runtime_interference",
+        "kind": kind,
+        "severity": "high",
+        "time": "2026-09-08T00:11:00Z",
+        "command": command,
+        "binary": "/usr/bin/docker",
+        "pid": 4242,
+        "cwd": "/root",
+        "container": f"pod_{POD}",
+        "parent": {"pid": 4000, "binary": "/bin/bash"},
+        "host": host,
+        "policy": "tamper-docker-cli",
+        "tags": ["tamper:docker-cli", "severity:high"] + (["nested_from:executor-executor-1"] if nested else []),
+        "details": {},
+    }
+
+
+VALIDATOR_LIVENESS = f'/usr/bin/docker exec -u 0 -i pod_{POD} sh -c "cat /root/.ssh/authorized_keys"'
+EXECUTOR_DF = f"/usr/bin/docker exec -u root pod_{POD} df -k /lium-cipher"
+EXECUTOR_TAR = f"/usr/bin/docker exec -u 0 -i pod_{POD} tar --xattrs --acls -xzpf - -C /root/restored"
+HUMAN_SHELL = f"/usr/bin/docker exec -it pod_{POD} bash"
+HUMAN_KEY_READ = f"/usr/bin/docker exec -u 0 -i pod_{POD} sh -c 'cat /root/.ssh/id_ed25519'"
+CHAINED = f"/usr/bin/docker exec -u 0 -i pod_{POD} sh -c 'cat /root/.ssh/authorized_keys; cat /root/.ssh/id_rsa'"
+
+
+@pytest.mark.parametrize(
+    ("command", "payload"),
+    [
+        (VALIDATOR_LIVENESS, "cat /root/.ssh/authorized_keys"),
+        (f"/usr/bin/docker exec -u 0 -i pod_{POD} sh -c cat /root/.ssh/authorized_keys", "cat /root/.ssh/authorized_keys"),
+        (EXECUTOR_DF, "df -k /lium-cipher"),
+        (EXECUTOR_TAR, "tar --xattrs --acls -xzpf - -C /root/restored"),
+        (HUMAN_SHELL, "bash"),
+        (f"/usr/bin/docker exec --user=root pod_{POD} df -k /", "df -k /"),
+        ("/usr/bin/docker ps", None),
+        (f"/usr/bin/docker exec -u 0 -i executor-executor-1 sh -c 'cat x'", None),
+    ],
+)
+def test_exec_payload_strips_options_and_shell_wrapper(command, payload):
+    assert exec_payload(command) == payload
+
+
+def test_platform_origin_needs_both_the_executor_source_and_a_known_payload():
+    assert is_platform_origin(_finding(VALIDATOR_LIVENESS))
+    assert is_platform_origin(_finding(EXECUTOR_DF))
+    assert is_platform_origin(_finding(EXECUTOR_TAR))
+    # the same command from the host is a human at the keyboard
+    assert not is_platform_origin(_finding(VALIDATOR_LIVENESS, host=True, nested=False))
+    # a chain that starts with our command is not our command
+    assert not is_platform_origin(_finding(CHAINED))
+    assert not is_platform_origin(_finding(HUMAN_KEY_READ))
+    assert not is_platform_origin(_finding(HUMAN_SHELL))
+    # only execs can be ours; an nsenter never is
+    assert not is_platform_origin(_finding(VALIDATOR_LIVENESS, kind="NamespaceEnter"))
+
+
+def test_verdict_hashes_only_the_provider_findings_and_names_the_pod():
+    report = {"findings": [_finding(VALIDATOR_LIVENESS), _finding(HUMAN_KEY_READ, host=True, nested=False)]}
+    verdict = build_verdict(
+        report,
+        report["findings"],
+        rented_pod_ids=[POD, "other-pod"],
+        sensor_attested=False,
+        enforce=False,
+    )
+
+    assert len(verdict.platform_findings) == 1
+    assert len(verdict.provider_findings) == 1
+    assert verdict.evidence == [canonical_sha256(report["findings"][1])]
+    assert verdict.report_sha256 == canonical_sha256(report)
+    assert verdict.affected_pod_ids == [POD]
+    assert verdict.classes == ["DockerExec"]
+    assert verdict.sensor == SENSOR_UNATTESTED
+    assert verdict.action == ACTION_NONE
+    assert verdict.as_payload()["ban_source"] is None
+
+
+def test_verdict_without_a_named_pod_tells_every_renter_on_the_host():
+    finding = _finding(HUMAN_SHELL, host=True, nested=False)
+    finding["container"] = None
+    verdict = build_verdict({}, [finding], rented_pod_ids=["b", "a"], sensor_attested=True, enforce=True)
+
+    assert verdict.affected_pod_ids == ["a", "b"]
+    assert verdict.sensor == SENSOR_ATTESTED
+    assert verdict.action == ACTION_QUARANTINE
+    assert verdict.as_payload()["ban_source"] == "inspector_auto"
+
+
+# --- the check -----------------------------------------------------------------------------
+
+
+class DummyInspectorService:
+    def __init__(self, response: InspectorValidationResponse) -> None:
+        self.response = response
+        self.sensor_attested = None
+
+    async def validate_rented_executor(self, shell, ssh, executor, default_extra, *, sensor_attested=False):
+        self.sensor_attested = sensor_attested
+        return self.response
+
+
+def _rented(executor_uuid: str) -> RentedExecutorsResponse:
+    return RentedExecutorsResponse(
+        executors={
+            executor_uuid: RentedExecutor(
+                miner_hotkey="miner",
+                executor_ip_address="127.0.0.1",
+                executor_ip_port="22",
+                pods=[RentedPod(pod_id=POD, container_name=f"pod_{POD}")],
+            )
+        },
+        banned_guids=[],
+    )
+
+
+def _ctx(context_factory, findings: list[dict], *, redis=None, **overrides):
+    service = DummyInspectorService(
+        InspectorValidationResponse(
+            report={
+                "canary_ok": True,
+                "health": {"collector_started_unix": 1},
+                "findings": findings,
+                "summary": {"findings": len(findings)},
+            },
+            diagnostics={"sensor_integrity": "shell_sha256_unattested"},
+        )
+    )
+    ctx = context_factory(
+        config=build_context_config(inspector_enabled=True),
+        services=build_services(inspector=service, redis=redis),
+        state=build_state(rented_data=_rented("executor-123")),
+        **overrides,
+    )
+    return ctx, service
+
+
+@pytest.mark.asyncio
+async def test_platform_only_findings_are_clean_and_no_renter_is_told(context_factory, monkeypatch):
+    monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", True)
+    redis = AsyncMock()
+    ctx, _ = _ctx(context_factory, [_finding(VALIDATOR_LIVENESS), _finding(EXECUTOR_DF)], redis=redis)
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.PLATFORM_ORIGIN_ONLY.reason
+    assert result.event.severity == "info"
+    event = result.updates["state"].inspector_event
+    assert event["outcome"] == "CLEAN"
+    assert event["context"]["verdict"]["platform_findings"] == 2
+    assert event["context"]["verdict"]["provider_findings"] == 0
+    assert "inspector_passed" not in result.updates
+    redis.publish.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_provider_finding_in_shadow_records_the_verdict_and_tells_the_renter(context_factory, monkeypatch):
+    monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", False)
+    redis = AsyncMock()
+    provider = _finding(HUMAN_KEY_READ, host=True, nested=False)
+    ctx, _ = _ctx(context_factory, [_finding(VALIDATOR_LIVENESS), provider], redis=redis)
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert result.passed is True
+    assert result.event.reason_code == Msg.MALICIOUS_FINDINGS.reason
+    assert result.event.severity == "warning"
+    assert result.event.what_we_saw["findings"] == [provider]
+    assert result.event.what_we_saw["platform_findings"] == 1
+    assert "inspector_passed" not in result.updates
+    verdict = result.updates["state"].inspector_event["context"]["verdict"]
+    assert verdict["evidence_sha256"] == [canonical_sha256(provider)]
+    assert verdict["action"] == ACTION_NONE
+    assert verdict["enforce"] is False
+    assert verdict["sensor"] == SENSOR_UNATTESTED
+    assert verdict["affected_pod_ids"] == [POD]
+    # the sensor's own diagnostics stay next to the verdict
+    assert result.updates["state"].inspector_event["context"]["sensor_integrity"] == "shell_sha256_unattested"
+
+    redis.publish.assert_awaited_once()
+    channel, message = redis.publish.await_args.args
+    assert channel == STREAMING_LOG_CHANNEL
+    assert message["pod_id"] == POD
+    assert message["executor_uuid"] == ctx.executor.uuid
+    (log,) = message["logs"]
+    assert log["log_tag"] == "provider_access_detected"
+    assert log["log_status"] == "error"
+    assert log["evidence_sha256"] == verdict["evidence_sha256"]
+    assert "removed the host" not in log["log_text"]
+
+
+@pytest.mark.asyncio
+async def test_provider_finding_under_enforcement_fails_the_check_and_requests_quarantine(
+    context_factory, monkeypatch
+):
+    monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", True)
+    redis = AsyncMock()
+    ctx, _ = _ctx(context_factory, [_finding(HUMAN_SHELL, host=True, nested=False)], redis=redis)
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.halt is False  # non-fatal: the cycle finishes, the score gate does the rest
+    assert result.event.severity == "error"
+    assert result.updates["inspector_passed"] is False
+    verdict = result.updates["state"].inspector_event["context"]["verdict"]
+    assert verdict["action"] == ACTION_QUARANTINE
+    assert verdict["ban_source"] == "inspector_auto"
+    (log,) = redis.publish.await_args.args[1]["logs"]
+    assert "removed the host from the marketplace" in log["log_text"]
+
+
+@pytest.mark.asyncio
+async def test_tdx_attested_host_marks_the_sensor_attested_and_skips_the_shell_checksum(context_factory):
+    ctx, service = _ctx(context_factory, [], tdx_attestation_passed=True)
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert service.sensor_attested is True
+    assert result.updates["state"].inspector_event["context"]["verdict"]["sensor"] == SENSOR_ATTESTED
+
+
+@pytest.mark.asyncio
+async def test_renter_event_failure_does_not_lose_the_verdict(context_factory, monkeypatch):
+    monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", False)
+    redis = AsyncMock()
+    redis.publish.side_effect = ConnectionError("redis down")
+    ctx, _ = _ctx(context_factory, [_finding(HUMAN_SHELL, host=True, nested=False)], redis=redis)
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert result.event.reason_code == Msg.MALICIOUS_FINDINGS.reason
+    assert result.updates["state"].inspector_event["context"]["verdict"]["provider_findings"] == 1
+
+
+def test_score_gate_zeroes_on_a_failed_inspector_verdict():
+    def ctx(inspector_passed: bool):
+        return SimpleNamespace(
+            state=SimpleNamespace(gpu_model="", specs={"network": {"ema_verifyx_download_speed": 500.0}}),
+            collateral_deposited=True,
+            collateral_error_message=None,
+            contract_version=None,
+            executor=SimpleNamespace(price_per_gpu=None, tdx_quote=None),
+            tdx_attestation_passed=False,
+            cpu_truth_passed=True,
+            provider_side_load_passed=True,
+            inspector_passed=inspector_passed,
+        )
+
+    actual, job, warning = calculate_scores(ctx(False), rented=False)
+    assert (actual, job) == (0.0, 0.0)
+    assert "Inspector" in warning
+
+    actual, _, _ = calculate_scores(ctx(True), rented=False)
+    assert actual > 0.0

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -19,6 +19,7 @@ from neurons.validators.src.services.task.inspector_verdict import (
     SENSOR_UNATTESTED,
     build_verdict,
     canonical_sha256,
+    KNOWN_FINDING_KINDS,
     exec_payload,
     is_platform_origin,
     renter_access_event,
@@ -36,7 +37,9 @@ from core.config import settings
 POD = "0f6a1c2e-1111-4222-8333-444455556666"
 
 
-def _finding(command: str, *, host: bool = False, kind: str = "DockerExec", nested: bool = True) -> dict:
+def _finding(
+    command: str, *, host: bool = False, kind: str = "DockerExec", nested: bool = True, nested_from: str = "executor-executor-1"
+) -> dict:
     return {
         "category": "runtime_interference",
         "kind": kind,
@@ -50,7 +53,7 @@ def _finding(command: str, *, host: bool = False, kind: str = "DockerExec", nest
         "parent": {"pid": 4000, "binary": "/bin/bash"},
         "host": host,
         "policy": "tamper-docker-cli",
-        "tags": ["tamper:docker-cli", "severity:high"] + (["nested_from:executor-executor-1"] if nested else []),
+        "tags": ["tamper:docker-cli", "severity:high"] + ([f"nested_from:{nested_from}"] if nested else []),
         "details": {},
     }
 
@@ -115,9 +118,53 @@ def test_the_real_platform_execs_are_recognised_from_the_executor_container():
     assert execs["restore_tar"].endswith("--strip-components=1")
     for name, command in execs.items():
         assert is_platform_origin(_finding(command)), name
+        # the digest depends on the argv parsing as a docker exec — the drift the builders could cause
+        assert exec_payload(command) is not None, name
     # the very same commands from the host are a human at the keyboard
     for name, command in execs.items():
         assert not is_platform_origin(_finding(command, host=True, nested=False)), name
+
+
+@pytest.mark.parametrize(
+    ("container", "platform"),
+    [
+        ("executor", True),
+        ("executor-executor-1", True),
+        ("lium-executor-executor-1", True),   # a compose project not literally `executor`
+        ("pod_other", False),
+        ("nginx", False),
+        ("myexecutor", False),
+    ],
+)
+def test_the_executor_stack_rule_matches_the_sensors(container, platform):
+    assert is_platform_origin(_finding(VALIDATOR_LIVENESS, nested_from=container)) is platform
+
+
+def test_known_finding_kinds_are_the_sensors_runtime_interference_kinds():
+    # celium-gpu-verifier inspector/src/collector/analysis/types.rs, RuntimeInterferenceKind (PascalCase)
+    expected = {
+        "DockerExec", "DockerAttach", "DockerCp", "DockerRun", "DockerCreate", "DockerStart", "DockerStop",
+        "DockerKill", "DockerPause", "DockerRm", "DockerRestart", "DockerRename", "DockerUpdate", "DockerCommit",
+        "DockerExport", "DockerPrune", "DockerInspect", "DockerPull", "DockerPush", "DockerBuild", "DockerLoad",
+        "DockerImport", "DockerRmi", "DockerNetworkConnect", "DockerNetworkDisconnect", "DockerNetworkRm",
+        "DockerVolumeRm", "DockerSave", "NamespaceEnter", "DockerSocketWrite", "OverlayFsRead", "OverlayFsWrite",
+        "ProcFsRead", "ProcFsWrite", "ContainerChroot", "ProcessAttach", "ProcessMemoryRead", "ProcessMemoryWrite",
+        "DockerVolumeMount",
+    }
+    assert KNOWN_FINDING_KINDS == frozenset(expected)
+    assert len(expected) == 39
+
+
+def test_a_read_of_the_pods_volume_names_the_pod():
+    # the 8 Sep class-D shape: tamper-fs OverlayFsRead on /var/lib/docker/volumes/volume_<pod>/_data
+    finding = _finding("", host=True, nested=False, kind="OverlayFsRead")
+    finding["container"] = f"volume_{POD}"
+    finding["binary"] = "/usr/bin/cat"
+    verdict = build_verdict({}, [finding], rented_pod_ids=[POD, "other"], sensor_attested=False, enforce=False)
+
+    assert verdict.affected_pod_ids == [POD]
+    assert verdict.classes == ["OverlayFsRead"]
+    assert "unmatched_containers" not in verdict.as_payload()
 
 
 def test_platform_origin_is_the_executor_ancestry_not_the_payload():

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -155,16 +155,63 @@ def test_known_finding_kinds_are_the_sensors_runtime_interference_kinds():
     assert len(expected) == 39
 
 
-def test_a_read_of_the_pods_volume_names_the_pod():
-    # the 8 Sep class-D shape: tamper-fs OverlayFsRead on /var/lib/docker/volumes/volume_<pod>/_data
-    finding = _finding("", host=True, nested=False, kind="OverlayFsRead")
+def _path_finding(kind: str, path: str) -> dict:
+    """The shape fs.rs / mount.rs emit: no container, the path in `command`, tag `rental_volume`."""
+    return {
+        "category": "runtime_interference",
+        "kind": kind,
+        "severity": "high",
+        "time": "2026-09-08T00:11:00Z",
+        "command": path,
+        "binary": "/usr/bin/cat",
+        "pid": 4242,
+        "cwd": "/root",
+        "container": None,
+        "docker": None,
+        "parent": {"pid": 4000, "binary": "/bin/bash"},
+        "host": True,
+        "policy": "tamper-fs",
+        "tags": ["tamper:fs", "rental_volume", "severity:high"],
+        "details": {},
+    }
+
+
+@pytest.mark.parametrize(
+    ("kind", "path"),
+    [
+        ("OverlayFsRead", f"/var/lib/docker/volumes/volume_{POD}/_data/.ssh/id_ed25519"),
+        ("OverlayFsWrite", f"/var/lib/docker/volumes/volume_{POD}/_data/.bashrc"),
+        ("DockerVolumeMount", f"/var/lib/docker/plugins/<eight hex characters>/propagated-mount/volume_{POD}"),
+    ],
+)
+def test_a_read_of_the_pods_volume_names_the_pod_and_only_that_pod(kind, path):
+    # the 8 Sep class-D shape: tamper-fs on the pod's volume data, container unset
+    verdict = build_verdict({}, [_path_finding(kind, path)], rented_pod_ids=[POD, "other"], sensor_attested=False, enforce=False)
+
+    assert verdict.affected_pod_ids == [POD]
+    assert verdict.classes == [kind]
+    assert "unmatched_containers" not in verdict.as_payload()
+
+
+def test_a_volume_named_in_the_container_field_names_the_pod_too():
+    # DockerVolumeRm carries the volume as the container name
+    finding = _finding("/usr/bin/docker volume rm volume_x", host=True, nested=False, kind="DockerVolumeRm")
     finding["container"] = f"volume_{POD}"
-    finding["binary"] = "/usr/bin/cat"
     verdict = build_verdict({}, [finding], rented_pod_ids=[POD, "other"], sensor_attested=False, enforce=False)
 
     assert verdict.affected_pod_ids == [POD]
-    assert verdict.classes == ["OverlayFsRead"]
-    assert "unmatched_containers" not in verdict.as_payload()
+
+
+def test_the_renter_event_caps_the_evidence_list():
+    findings = [_finding(f"/usr/bin/docker exec -it pod_{POD} cat /root/f{i}", host=True, nested=False) for i in range(60)]
+    verdict = build_verdict({}, findings, rented_pod_ids=[POD], sensor_attested=False, enforce=False)
+    event = renter_access_event(verdict, pod_id=POD, when="2026-09-09T00:00:00Z")
+
+    assert len(verdict.evidence) == 60
+    assert len(event["evidence_sha256"]) == 20
+    assert event["evidence_sha256_truncated"] is True
+    assert event["provider_findings"] == 60
+    assert event["report_sha256"] == verdict.report_sha256
 
 
 def test_platform_origin_is_the_executor_ancestry_not_the_payload():
@@ -282,7 +329,7 @@ def _ctx(context_factory, findings: list[dict], *, redis=None, **overrides):
                 "canary_ok": True,
                 "health": {"collector_started_unix": 1},
                 "findings": findings,
-                "summary": {"findings": len(findings)},
+                "summary": {"findings": len(findings) if isinstance(findings, list) else 0},
             },
             diagnostics={"sensor_integrity": "shell_sha256_unattested"},
         )
@@ -385,6 +432,16 @@ async def test_a_malformed_report_is_a_sensor_error_not_a_provider_finding(conte
     assert "inspector_passed" not in result.updates
     assert result.updates["state"].inspector_event["outcome"] == "ERROR"
     redis.publish.assert_not_awaited()
+
+
+@pytest.mark.parametrize("findings", [{}, "", 0])
+@pytest.mark.asyncio
+async def test_a_falsy_non_list_findings_is_still_a_sensor_error(context_factory, findings):
+    ctx, _ = _ctx(context_factory, findings)  # type: ignore[arg-type]
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert result.event.reason_code == Msg.VALIDATION_ERROR.reason
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -411,7 +411,10 @@ async def test_platform_only_findings_are_clean_and_no_renter_is_told(context_fa
 
 
 @pytest.mark.asyncio
-async def test_provider_finding_in_shadow_records_the_verdict_and_tells_the_renter(context_factory, monkeypatch):
+async def test_provider_finding_in_shadow_records_the_verdict_and_does_not_tell_the_renter(
+    context_factory, monkeypatch
+):
+    """Shadow mode measures the classifier; the renter is told only when enforcement acts on it."""
     monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", False)
     redis = AsyncMock()
     provider = _finding(HUMAN_KEY_READ, host=True, nested=False)
@@ -434,16 +437,7 @@ async def test_provider_finding_in_shadow_records_the_verdict_and_tells_the_rent
     # the sensor's own diagnostics stay next to the verdict
     assert result.updates["state"].inspector_event["context"]["sensor_integrity"] == "shell_sha256_unattested"
 
-    redis.publish.assert_awaited_once()
-    channel, message = redis.publish.await_args.args
-    assert channel == STREAMING_LOG_CHANNEL
-    assert message["pod_id"] == POD
-    assert message["executor_uuid"] == ctx.executor.uuid
-    (log,) = message["logs"]
-    assert log["log_tag"] == "provider_access_detected"
-    assert log["log_status"] == "error"
-    assert log["evidence_sha256"] == verdict["evidence_sha256"]
-    assert "removed the host" not in log["log_text"]
+    redis.publish.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -463,7 +457,15 @@ async def test_provider_finding_under_enforcement_fails_the_check_and_requests_q
     verdict = result.updates["state"].inspector_event["context"]["verdict"]
     assert verdict["action"] == ACTION_QUARANTINE
     assert verdict["ban_source"] == "inspector_auto"
-    (log,) = redis.publish.await_args.args[1]["logs"]
+    redis.publish.assert_awaited_once()
+    channel, message = redis.publish.await_args.args
+    assert channel == STREAMING_LOG_CHANNEL
+    assert message["pod_id"] == POD
+    assert message["executor_uuid"] == ctx.executor.uuid
+    (log,) = message["logs"]
+    assert log["log_tag"] == "provider_access_detected"
+    assert log["log_status"] == "error"
+    assert log["evidence_sha256"] == verdict["evidence_sha256"]
     assert "removed the host from the marketplace" in log["log_text"]
 
 
@@ -504,14 +506,16 @@ async def test_tdx_attested_host_marks_the_sensor_attested_and_skips_the_shell_c
 
 @pytest.mark.asyncio
 async def test_renter_event_failure_does_not_lose_the_verdict(context_factory, monkeypatch):
-    monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", False)
+    monkeypatch.setattr(settings, "INSPECTOR_ENFORCE_ENABLED", True)  # the only mode that publishes
     redis = AsyncMock()
     redis.publish.side_effect = ConnectionError("redis down")
     ctx, _ = _ctx(context_factory, [_finding(HUMAN_SHELL, host=True, nested=False)], redis=redis)
 
     result = await InspectorRentedCheck().run(ctx)
 
+    redis.publish.assert_awaited_once()
     assert result.event.reason_code == Msg.MALICIOUS_FINDINGS.reason
+    assert result.updates["inspector_passed"] is False
     assert result.updates["state"].inspector_event["context"]["verdict"]["provider_findings"] == 1
 
 

--- a/neurons/validators/tests/test_inspector_verdict.py
+++ b/neurons/validators/tests/test_inspector_verdict.py
@@ -207,7 +207,7 @@ def test_the_renter_event_caps_the_evidence_list():
     verdict = build_verdict({}, findings, rented_pod_ids=[POD], sensor_attested=False, enforce=False)
     event = renter_access_event(verdict, pod_id=POD, when="2026-09-09T00:00:00Z")
 
-    assert len(verdict.evidence) == 60
+    assert len(verdict.evidence_sha256) == 60
     assert len(event["evidence_sha256"]) == 20
     assert event["evidence_sha256_truncated"] is True
     assert event["provider_findings"] == 60
@@ -223,8 +223,17 @@ def test_platform_origin_is_the_executor_ancestry_not_the_payload():
     # …but without the executor tag, or from the host, it is the provider's
     assert not is_platform_origin(_finding(HUMAN_KEY_READ, nested=False))
     assert not is_platform_origin(_finding(HUMAN_SHELL, host=True))
-    # only execs can be ours; an nsenter never is
+    # the executor runs a pod's whole life through the Docker API: a `docker cp` for a restore or the
+    # `docker rm` at the rental's end from inside its container is ours too — taiberium, 9 Sep
+    assert is_platform_origin(_finding(f"docker cp /tmp/restore.tar pod_{POD}:/root", kind="DockerCp"))
+    assert is_platform_origin(_finding(f"docker rm -f pod_{POD}", kind="DockerRm"))
+    assert is_platform_origin(_finding(f"docker stop pod_{POD}", kind="DockerStop"))
+    assert not is_platform_origin(_finding(f"docker rm -f pod_{POD}", kind="DockerRm", host=True))
+    # only Docker control-plane actions can be ours; an nsenter, a memory or overlayfs read never is
     assert not is_platform_origin(_finding(VALIDATOR_LIVENESS, kind="NamespaceEnter"))
+    assert not is_platform_origin(_finding("/proc/4242/mem", kind="ProcessMemoryRead"))
+    assert not is_platform_origin(_finding(f"/var/lib/docker/volumes/volume_{POD}/_data/x", kind="OverlayFsRead"))
+    assert not is_platform_origin(_finding(f"/var/lib/docker/volumes/volume_{POD}/_data", kind="DockerVolumeMount"))
 
 
 def test_verdict_records_the_platform_payloads_for_the_digest():
@@ -233,6 +242,7 @@ def test_verdict_records_the_platform_payloads_for_the_digest():
     verdict = build_verdict({}, findings, rented_pod_ids=[POD], sensor_attested=False, enforce=False)
 
     payloads = verdict.as_payload()["platform_payloads"]
+    assert payloads == verdict.platform_payloads
     assert "cat /root/.ssh/authorized_keys" in payloads
     assert "df -k /root" in payloads
     assert "tar --xattrs --acls -xzpf - -C /root/restored --strip-components=1" in payloads
@@ -246,8 +256,17 @@ def test_a_pod_outside_the_rented_list_is_recorded_but_no_renter_is_told():
     verdict = build_verdict({}, [finding], rented_pod_ids=[POD], sensor_attested=False, enforce=False)
 
     assert verdict.affected_pod_ids == []
+    assert verdict.unmatched_containers == ["pod_gone-since-the-list-was-fetched"]
+    assert verdict.unmatched_containers_count == 1
     assert verdict.as_payload()["unmatched_containers"] == ["pod_gone-since-the-list-was-fetched"]
     assert len(verdict.provider_findings) == 1
+
+
+def test_a_verdict_with_every_pod_matched_carries_no_unmatched_keys():
+    verdict = build_verdict({}, [_finding(HUMAN_SHELL, host=True, nested=False)], rented_pod_ids=[POD], sensor_attested=False, enforce=False)
+
+    assert verdict.unmatched_containers == [] and verdict.unmatched_containers_count == 0
+    assert "unmatched_containers" not in verdict.as_payload()
 
 
 @pytest.mark.parametrize("kind", [["DockerExec"], {"k": 1}, 7, None])
@@ -308,7 +327,7 @@ def test_renter_visible_classes_come_from_a_fixed_vocabulary():
     assert "<script>" not in event["log_text"]
     assert event["classes"] == ["NamespaceEnter", "unknown"]
     # the raw kind survives only in the evidence
-    assert verdict.evidence[0] == canonical_sha256(odd)
+    assert verdict.evidence_sha256[0] == canonical_sha256(odd)
 
 
 def test_verdict_hashes_only_the_provider_findings_and_names_the_pod():
@@ -323,7 +342,7 @@ def test_verdict_hashes_only_the_provider_findings_and_names_the_pod():
 
     assert len(verdict.platform_findings) == 1
     assert len(verdict.provider_findings) == 1
-    assert verdict.evidence == [canonical_sha256(report["findings"][1])]
+    assert verdict.evidence_sha256 == [canonical_sha256(report["findings"][1])]
     assert verdict.report_sha256 == canonical_sha256(report)
     assert verdict.affected_pod_ids == [POD]
     assert verdict.classes == ["DockerExec"]
@@ -495,13 +514,27 @@ async def test_a_falsy_non_list_findings_is_still_a_sensor_error(context_factory
 
 
 @pytest.mark.asyncio
-async def test_tdx_attested_host_marks_the_sensor_attested_and_skips_the_shell_checksum(context_factory):
+async def test_tdx_attested_host_marks_the_sensor_attested_and_skips_the_shell_checksum(context_factory, monkeypatch):
+    monkeypatch.setattr(settings, "ENABLE_ATTESTATION_WHITELIST", True)  # the image was compared to TDX_WHITELIST
     ctx, service = _ctx(context_factory, [], tdx_attestation_passed=True)
 
     result = await InspectorRentedCheck().run(ctx)
 
     assert service.sensor_attested is True
     assert result.updates["state"].inspector_event["context"]["verdict"]["sensor"] == SENSOR_ATTESTED
+
+
+@pytest.mark.asyncio
+async def test_a_passed_attestation_without_the_whitelist_leaves_the_sensor_unattested(context_factory, monkeypatch):
+    # prod runs ENABLE_ATTESTATION_WHITELIST=false: the quote is genuine but nothing compared the image
+    # against TDX_WHITELIST, so the sensor binary is not measured and the shell checksum must stay — taiberium, 9 Sep
+    monkeypatch.setattr(settings, "ENABLE_ATTESTATION_WHITELIST", False)
+    ctx, service = _ctx(context_factory, [], tdx_attestation_passed=True)
+
+    result = await InspectorRentedCheck().run(ctx)
+
+    assert service.sensor_attested is False
+    assert result.updates["state"].inspector_event["context"]["verdict"]["sensor"] == SENSOR_UNATTESTED
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3275](https://app.notion.com/p/3d6b8bfdbde9816ab645cf20764b09d1) · reviewer: @taiberium

**TL;DR** — Every Inspector outcome returned `passed=True` and the validator's own execs counted as attacks (607 of 632 MALICIOUS rounds on 8 Sep). The check now separates platform-origin from provider-origin findings, records a verdict (evidence hashes, sensor attestation, action) and, behind `INSPECTOR_ENFORCE_ENABLED` (default off) when a rented pod is affected, tells the renter, fails the check and requests an `inspector_auto` quarantine.

**What changed**
- `inspector_verdict.py`: platform-origin = a Docker control-plane action (`DockerExec`, `DockerCp`, `DockerRm`, …) from the executor container; sha256 per provider finding
- `InspectorRentedCheck`: provider-origin → `MALICIOUS` + verdict; check fails, score gate and renter event only when `verdict.action` is `quarantine` (`services/task/checks/inspector.py`)
- `INSPECTOR_ENFORCE_ENABLED` (default `False`) + `inspector_passed` score gate, like `cpu_truth_passed` (`core/config.py`, `task/pipeline.py`, `task/score_calculator.py`)
- Sensor integrity: TDX-attested host with `ENABLE_ATTESTATION_WHITELIST` on → measured image vouches for `libinspector.so`, shell `sha256sum` skipped; else `shell_sha256_unattested`

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_inspector_verdict.py tests/test_inspector_check.py tests/test_inspector_validation_service.py -q` → passes
- class-A exec (`cat /root/.ssh/authorized_keys`, tag `nested_from:executor-executor-1`) → platform-origin; `host: true` + enforce → `passed=False`, `action == "quarantine"`; on a non-rented container → `action == "none"`

**Verified by the loop:** Gate: PASS b836a23

**Ran it:** `tools/aws_verify.sh lium-io b836a23 --bundle` → validators 2057 passed, 2 box-only fails (sysfs, sshd adopt) · EC2 20260911T074251Z-uy86

**Self-review:** clean at b836a23 (15 checks, 3 low)

**Parts:** backend ✓ (validator; the platform consumer of `context.verdict` is arhangel66's PR) · migration n/a — existing jsonb · frontend n/a — existing pod log view · CLI/SDK n/a — validator only · docs n/a — flag off · tests ✓ 4 files, 34 new · dashboards n/a — digest follow-up

**Docs:** none changed in this PR — default off, nothing visible until the flag is on; renter/provider pages are B-147 (3).

**Cross-PR:** independent of #1341 — different files, either order lands.

<details><summary>Details</summary>

### Why

`design/RENTER_DATA_PRIVACY.md` §3–4 and `private/INSPECTOR_20260908.md`. Three things made "we log every time a provider views data" empty: (1) `checks/inspector.py` returned `passed=True` in every branch and nothing called `ProviderBanService` (`inspector_auto` had no caller); (2) the validator's own execs — `cat /root/.ssh/authorized_keys` from `rented_machine.py`, the executor's `df -k` metric, the executor's legacy `tar` restore — are `DockerExec` findings whenever the host's Tetragon loses the ancestry to sshd (10 hosts, 607 findings on 8 Sep); (3) the renter saw nothing.

### Classification

A finding is platform-origin when **all** hold: `kind` is one of the sensor's Docker control-plane kinds (the `tamper-docker-cli` and `tamper-docker-sock-write` policies: `DockerExec`, `DockerCp`, `DockerRm`, `DockerStop`, … — the executor creates, copies into, stops and removes a pod's containers through the Docker API from inside its own container, so any of them can be ours; round 3, taiberium); `host` is not `true`; a `nested_from:<name>` tag names an executor-stack container by the sensor's own rule (`executor`, `executor-*`, `*-executor-*` — so `lium-executor-executor-1` too). The sensor itself already drops docker-policy findings whose ancestry reaches sshd or the container's pid 1, so every such finding is one whose ancestry it could not trust; until DAH-3278 hardens that on the verifier, all of them count as the platform's. Everything else — the same command from the host, an `nsenter`, a memory or overlayfs read, an exec the sensor could not attribute — is provider-origin. The executor's own backup and restore (`executor/src/storage/restic.py`) never reach the verdict: the sensor judges the encrypted flow's `nsenter -t <pid> -U` benign by nstype (`CLONE_NEWUSER` only, nsenter.rs, never by a container name) and the unencrypted flow's `volume_<pod_id>` bind a runtime mount (mount.rs, runc / container-stack binaries), so neither is a finding; a name-based exemption here would let a `lium-storage-…`-named provider container borrow the platform's origin (round 6, taiberium).

The first cut also matched the payload against an exact allow-list; round 1 of the review showed it rejected what the platform really runs (`hardware_service.py` `df -k /root` on every unencrypted rental, `restore_storage.py` `tar … --strip-components=1` + `mkdir -p` + `chown`, `backup_storage.py` `du -sb` + `tar -czf`, the key-injection / sshd / gocryptfs `sh -c '<script>'` execs), i.e. it would have told renters about provider access every metrics cycle and, under enforcement, quarantined the host. The platform's exec payloads are too many and too script-shaped for an exact list to stay honest, so the classifier is the ancestry alone — what `design/RENTER_DATA_PRIVACY.md` row 16 asks for — and the payloads seen from the executor container are recorded in the verdict (`platform_exec_commands`, deduped, ≤ 20 × 160 chars) so the daily digest shows what runs. `test_the_real_platform_execs_are_recognised_from_the_executor_container` builds the argv from `restore_storage.workspace_command` / `backup_storage.workspace_command` / `VolumeAccess.docker_exec_args`, so the test and the jobs cannot drift apart silently. What keeps the tag trustworthy — a provider `docker exec`-ing into the executor container to borrow its ancestry — is the verifier's half (DAH-3278: stack-binary ancestry gating, sysbox-fs exemption); on an unattested host that is the residual risk and the verdict says `sensor: unattested`.

The verdict names the pod from `finding.container` / `docker.resolved_name` (`pod_<id>`, or `volume_<id>` as `DockerVolumeRm` carries it); the path-shaped kinds the sensor emits with `container: None` — `OverlayFsRead`/`OverlayFsWrite` (fs.rs) and `DockerVolumeMount` (mount.rs), the path in `command`, tag `rental_volume`, the 8 Sep class-D shape — name the pod through the volume in that path (`/var/lib/docker/volumes/volume_<id>/…` or `…/propagated-mount/volume_<id>`, the sensor's own `volume_name_from_path` rule). A `pod_*` that is not in the rented list (left or joined since the list was fetched) is recorded as `unmatched_containers` (≤ 20 × 128 chars + a count) and no renter is told about a container that was not theirs; only when a provider finding names neither a container nor a rental-volume path does every rented pod on the host get the event. `kind` and `tags` of any JSON type classify without raising (non-string kind → `unknown`, never platform-origin). Renter-visible `finding_kinds` come from a fixed vocabulary — the sensor's 39 `RuntimeInterferenceKind` names (celium-gpu-verifier `inspector/src/collector/analysis/types.rs`, pinned by `test_known_finding_kinds_are_the_sensors_runtime_interference_kinds`), else `unknown` — the report is produced on the provider's root when the sensor is unattested, so no raw string from it reaches a pod log; the raw finding stays in the evidence. A report whose `findings` is not a list of objects is an `ERROR` outcome (broken sensor), never a provider finding.

### What the backend receives

`InspectorEventRequest.context.verdict`:

```json
{"provider_findings": 1, "platform_findings": 1, "finding_kinds": ["DockerExec"], "affected_pod_ids": ["<pod>"], "platform_exec_commands": ["cat /root/.ssh/authorized_keys"],
 "evidence_sha256": ["<sha256 of the canonical finding JSON>"], "report_sha256": "…",
 "sensor": "unattested", "enforce": false, "action": "none", "ban_source": null, "unmatched_containers": [], "unmatched_containers_count": 0,
 "unnamed_findings": 0, "platform_kind_counts": {"DockerExec": 1}}
```

`unnamed_findings` counts the provider findings that named no container and no rental volume — each one marks every rented pod on the host (an overlay2 path has no `volumes/` segment), so the shadow digest can say how often that fallback fires; `platform_kind_counts` is the platform findings by kind, for the same shadow numbers (round 6, taiberium).

With `INSPECTOR_ENFORCE_ENABLED=true` and a provider-origin finding that names a rented pod (`affected_pod_ids` non-empty; a finding naming no container at all counts as every rented pod): `action: "quarantine"`, `ban_source: "inspector_auto"`. A provider-origin finding on a container that is not a rented pod — the provider inside their own container — is recorded under `unmatched_containers` with `action: "none"`, whatever the flag (round 5, taiberium). The backend half — `save_inspector_event` calling `ProviderBanService.ban_provider(source=inspector_auto)` (which already removes the executors from the marketplace and notifies renters; it does not delete pods) when `action == "quarantine"` — is lium-platform work for arhangel66; until it lands the validator's consequence is the score gate.

### Renter event

Published only with `INSPECTOR_ENFORCE_ENABLED=true` (round 2, taiberium: in shadow mode the classifier is still being measured — 607 of 632 rounds were the sensor's false positives on 8 Sep — and a wrong "the provider read your pod" cannot be taken back) on `STREAMING_LOG_CHANNEL` (the backend's `handle_log_stream` → `save_pod_status(pod_id, logs=…)`, the same stream the create flow uses), one entry per affected pod: `log_tag: provider_access_detected`, `log_status: error`, text "Provider-side access to this pod detected (DockerExec; unattested sensor). Lium has recorded the evidence[ and asked to take the host off the marketplace]." plus `finding_kinds`, `provider_findings` (count), `report_sha256`, at most 20 `evidence_sha256` — all from that pod's findings only (its container, its volume, or a finding that names nothing), never another renter's (round 6) — (`evidence_sha256_truncated: true` when cut — the finding count is the sensor's to choose; the full list is in the inspector event), `sensor`, `action`. A publish failure is logged and does not lose the verdict (it is in the inspector event).

### Sensor integrity

`validate_rented_executor(…, sensor_attested=ctx.tdx_attestation_passed and settings.ENABLE_ATTESTATION_WHITELIST)`. On a dstack CVM the executor image — and `libinspector.so` in it — is part of the stack `attestation_service` measures against `TDX_WHITELIST` — but only when `ENABLE_ATTESTATION_WHITELIST` is on; prod runs it off today, so a passed attestation alone says the quote is genuine, not that the image is ours, and the shell checksum stays (round 3, taiberium); a `sha256sum` answered by the provider's shell adds nothing there and is skipped (`diagnostics.sensor_integrity = tdx_measured_image`). On every other host the shell checksum still runs (it catches an outdated image) and the verdict says `sensor: unattested` / `shell_sha256_unattested`, which is the honest statement: the sensor runs on the provider's root. NVIDIA GPU attestation (`gpu_attestation_passed`) does not measure the executor image, so it does not count.

### Flag semantics

`INSPECTOR_ENFORCE_ENABLED=false` (default): the verdict and evidence are recorded in the inspector event, no renter event, `passed=True`, score untouched — shadow. `true` and a rented pod affected: `passed=False` (check stays non-fatal, the cycle finishes), `inspector_passed=False` → `calculate_scores` zeroes the score with the warning "Provider-side access to a rented pod detected by the Inspector", `action=quarantine` requested, the affected renters told. `true` and no rented pod affected (the finding names a container that is not a rented pod): `MALICIOUS` recorded with the container under `unmatched_containers`, `passed=True`, score untouched, no renter event, `action=none`. `CLEAN`, `ERROR`, `COLLECTOR_NOT_RUNNING`, `CANARY_FAILED`, `COLLECTOR_RECENTLY_STARTED` are unchanged in this PR (the ≥ 4-cycles-dark signal is §4.3's second half).

### Ran it

`tools/aws_verify.sh lium-io e22b8d5 --bundle …` (EC2 warm lium-io box, run `20260910T094523Z-cjpb`; earlier heads 3477a6f, 10f53d8, 22ae818, e2cc27c, 518b653, 7218c8d, e3bd0bd, 693a416 ran the same way with the same two failures):

```
validators pytest tests/: rc=1 in 111 s — 2 failed, 2050 passed, 15 skipped
FAILED tests/test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices
FAILED tests/test_sshd_bootstrap_script.py::test_adopt_path_hardens_config_for_key_only_auth
```

The two failures are the warm box's (root can read an unreadable sysfs tree; an sshd is already running on the box) and appear in every lium-io run on it today, including main.

### Self-review

Verdict `findings` at `b836a23` · 15 checks · by subagent-r91-1342 · 2026-09-11 07:51Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `PR body:36` | Being fixed in the body override per the author: the Classification paragraph should state, with the sensor citations now in the module docstring, why the backup's `nsenter -U` and the runc-driven volume bind never reach the validator (the answer to NITs 1–2); the code at b836a23 already matches the body's existing 'an nsenter … is provider-origin' sentence. | Add the one-sentence sensor citation to Classification before push; nothing to change in code. |
| low | PROSE-VS-CODE | `PR body:46` | Being fixed in the body override per the author: the `context.verdict` example lacks `unnamed_findings` and `platform_kind_counts`, and the Renter-event paragraph should say the kinds, count and ≤ 20 hashes are of the findings about that pod (`findings_for_pod`), never another renter's. | Add both keys to the example and the per-pod sentence, citing `test_the_renter_event_carries_only_that_pods_findings`. |
| low | STALE-BODY | `PR body:21` | Being fixed in the body override per the author: Parts ('31 new' tests), Verified, Ran-it and Self-review lines are rendered from 9bee804; b836a23 adds four tests (`…cannot_borrow_the_platforms_origin`, `…carries_only_that_pods_findings`, `…in_shadow_is_not_called_access_to_a_rented_pod`) and extends `…tells_every_renter_on_the_host`. | Re-render at the pushed head (the tooling records gate and verdict lines; update the test count by hand). |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/src/services/task/inspector_verdict.py:49` `--privileged` is a member of `_EXEC_FLAGS`, the set `docker_exec_command` skips while parsing a docker-exec argv the sensor reported; nothing in the diff runs or configures a container. · `neurons/validators/tests/test_inspector_verdict.py:51` `"cwd": "/root"` is a value in the `_finding()` fixture dict (the sensor's reported cwd), not a mount. · `neurons/validators/tests/test_inspector_verdict.py:78` `VolumeAccess(volume_path="/root")` is the argument the real restore/backup job builders take to produce the argv strings under test; nothing is mounted. · `neurons/validators/tests/test_inspector_verdict.py:92` `-C /root` is part of the tar argv string built by `backup_storage.workspace_command` for the `docker_exec_command` test; a string fixture, no mount. · `neurons/validators/tests/test_inspector_verdict.py:168` `"cwd": "/root"` in the `_path_finding()` fixture dict; a dict value, not a mount. · `neurons/validators/tests/test_inspector_verdict.py:1` ruff I001 (import block unsorted) on this file is pre-existing at the reviewed head 9bee804 (same result on `git show 9bee8048:…`), not introduced by b836a23.

### Verified

Gate: PASS (b836a23) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1342)

</details>
