### PR TITLE
DAH-3319 - [P0] sysbox installer preflight: PASS/FIX lines with the fix, --check mode

### DIFF
--- a/neurons/executor/nvidia_docker_sysbox_setup.sh
+++ b/neurons/executor/nvidia_docker_sysbox_setup.sh
@@ -9,6 +9,7 @@ set -e
 # Env:
 #   SYSBOX_SKIP_KERNEL_CHECK=1  install even when the ID-mapped mounts check rejects the host
 #   EXECUTOR_PORT / SSH_PORT    the ports the preflight checks (else neurons/executor/.env next to this script, else 8080 / 2200)
+#   SYSBOX_SETUP_HOST_ROOT      test-only: prefix for the host files the preflight reads (/proc/modules, /etc/os-release, ...)
 
 SYSBOX_VERSION="0.6.6"
 SYSBOX_DEB_URL="https://github.com/nestybox/sysbox/releases/download/v${SYSBOX_VERSION}/sysbox-ce_${SYSBOX_VERSION}-0.linux_amd64.deb"
@@ -124,9 +125,11 @@ fail_no_idmapped() {
 
 # ── Preflight ───────────────────────────────────────────
 # One PASS / FIX line per requirement, each FIX with the command that fixes it. The host checks
-# run before anything is installed (a FIX there ends the run with nothing changed); `--check`
-# runs them plus the checks on what this script installs. Paths under HOST_ROOT so tests can
-# point them at a fixture tree; commands are stubbed on PATH.
+# run before anything is installed: a FIX in what sysbox itself needs (root, x86_64, kernel,
+# Docker) ends the run with nothing changed; the rest (driver, iptables modules, disk, ports)
+# print the fix and the install goes on, because the node cannot be listed at all without
+# sysbox. `--check` runs them all plus the checks on what this script installs. Paths under
+# SYSBOX_SETUP_HOST_ROOT so tests can point them at a fixture tree; commands are stubbed on PATH.
 
 MIN_NVIDIA_DRIVER="580.65.06"   # validators' MIN_NVIDIA_DRIVER_VERSION: an idle node below it earns nothing after the cutoff
 MIN_DISK_TO_VRAM_RATE="1.5"     # validators' MIN_DISK_TO_VRAM_RATE (rental_price.py): idle pay needs total disk >= 1.5x total VRAM
@@ -144,7 +147,7 @@ pf_fix() {
     return 1
 }
 
-host_path() { echo "${HOST_ROOT:-}$1"; }
+host_path() { echo "${SYSBOX_SETUP_HOST_ROOT:-}$1"; }
 
 self_cmd() {
     # how to run this script again: the file when there is one, else the one-liner (curl | bash). A leading VAR=VALUE
@@ -315,7 +318,7 @@ check_iptables_modules() {
         "printf 'ip_tables\\niptable_nat\\niptable_filter\\n' | sudo tee /etc/modules-load.d/lium-iptables.conf >/dev/null   # survives reboots"
 }
 
-check_disk_for_vram() {
+check_total_disk_for_vram() {
     # The validators compare the TOTAL size of the filesystem the executor sees as / (its
     # rootfs lives under Docker's data-root) with total GPU VRAM; free space is not the rule.
     local vram_mib vram_gb data_root total_kb total_gb needed_gb
@@ -339,7 +342,7 @@ check_disk_for_vram() {
         "Add disk, or move Docker's data-root to a filesystem of at least ${needed_gb} GB (\"data-root\" in /etc/docker/daemon.json, then sudo systemctl restart docker)."
 }
 
-preflight_ports() {
+resolve_preflight_ports() {
     # EXECUTOR_PORT / SSH_PORT from the environment, else the executor .env next to this script, else the defaults
     local env_file=""
     [ -f "$0" ] && env_file="$(dirname "$0")/.env"   # piped from curl there is no file next to the script
@@ -363,13 +366,14 @@ port_container() {
 }
 
 ufw_blocks_port() {
-    # true when ufw is active and no ALLOW rule covers TCP $1 (single port or lo:hi range)
+    # true when ufw is active and no inbound ALLOW rule covers TCP $1 (single port or lo:hi range)
     local status
     status=$(ufw status 2>/dev/null) || return 1
     echo "$status" | grep -q '^Status: active' || return 1
     ! echo "$status" | awk -v p="$1" '
         {
-            allow = 0; for (i = 2; i <= NF; i++) if ($i == "ALLOW") allow = 1   # "ALLOW", "ALLOW IN", "… on eth0 ALLOW"
+            # "ALLOW", "ALLOW IN", "… on eth0 ALLOW" open the port; "ALLOW OUT" / "ALLOW FWD" (ufw route) do not
+            allow = 0; for (i = 2; i <= NF; i++) if ($i == "ALLOW") { if ($(i+1) == "OUT" || $(i+1) == "FWD") next; allow = 1 }
             if (!allow) next
             split($1, spec, "/"); if (spec[2] != "" && spec[2] != "tcp") next
             n = split(spec[1], range, ":")
@@ -379,8 +383,8 @@ ufw_blocks_port() {
 }
 
 check_ports() {
-    local ports p listener container label fixed=0
-    read -r -a ports <<< "$(preflight_ports)"
+    local ports p listener container label has_fix=0
+    read -r -a ports <<< "$(resolve_preflight_ports)"
     command -v ss &>/dev/null || { pf_skip "Ports — 'ss' (iproute2) is missing, cannot tell what listens."; return 0; }
     for p in "${ports[0]}:executor" "${ports[1]}:SSH"; do
         label=${p#*:} p=${p%%:*}
@@ -392,18 +396,18 @@ check_ports() {
                 executor-*|executor_*) ;;   # the executor itself, from an earlier install
                 *) pf_fix "TCP $p ($label port) is published by container ${container:-unknown} — the executor cannot bind it." \
                        "docker stop ${container:-<name>}, or choose another port (EXTERNAL_PORT / SSH_PORT in neurons/executor/.env) and open it instead."
-                   fixed=1
+                   has_fix=1
                    continue ;;
             esac
         elif [ -n "$listener" ]; then
             pf_fix "TCP $p ($label port) is already in use by $listener — the executor cannot bind it." \
                 "Stop that process, or choose another port (EXTERNAL_PORT / SSH_PORT in neurons/executor/.env) and open it instead."
-            fixed=1
+            has_fix=1
             continue
         fi
         if ufw_blocks_port "$p"; then
-            pf_fix "TCP $p ($label port) is blocked by ufw — validators cannot reach the node." "sudo ufw allow $p/tcp"
-            fixed=1
+            pf_fix "TCP $p ($label port) has no inbound allow rule in the active ufw — open it for the validators." "sudo ufw allow $p/tcp"
+            has_fix=1
             continue
         fi
         if [ -n "$container" ]; then
@@ -414,7 +418,7 @@ check_ports() {
     done
     echo "         Cloud firewalls and routers are outside this host: after 'docker compose up', from ANY other machine run"
     echo "           nc -vz <this host's public IP> ${ports[0]} ${ports[1]}    # both must say 'succeeded'"
-    return $fixed
+    return $has_fix
 }
 
 check_sysbox() {
@@ -433,7 +437,8 @@ check_sysbox() {
             "$(self_cmd)   # re-applies the Docker 29 settings and re-verifies; then: journalctl -u sysbox-mgr --no-pager -n 20"
         return 1
     fi
-    pf_pass "sysbox-runc $(sysbox-runc --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo installed) runs a container."
+    # `sysbox-runc --version` prints its name on the first line and "version: 0.6.6" on the second
+    pf_pass "sysbox-runc $(sysbox-runc --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | grep . || echo installed) runs a container."
 }
 
 preflight_summary() {
@@ -442,17 +447,30 @@ preflight_summary() {
     [ "$PREFLIGHT_FIX" -eq 0 ]
 }
 
-preflight_host() {
-    # what this script cannot install for you; a FIX here stops the run before anything changes.
-    # Returns 1 without root: every other check reads Docker's socket or the process table.
-    check_root || return 1
+preflight_blocking() {
+    # what sysbox itself needs before it can go on this host: x86_64 (the .deb is amd64 only), a kernel with
+    # ID-mapped mounts (or the override), Docker installed and running (the runtime is registered in its
+    # daemon.json and it is restarted). Returns 1 when any of them is a FIX; install mode stops there.
+    local fixes_before=$PREFLIGHT_FIX
     check_arch || true
     check_kernel || true
     check_docker || true
+    [ "$PREFLIGHT_FIX" -eq "$fixes_before" ]
+}
+
+preflight_advisory() {
+    # what the validators need once the node runs; sysbox installs without any of it and the node cannot be
+    # listed at all without sysbox, so a FIX here prints the fix and install mode goes on
     check_nvidia_driver || true
     check_iptables_modules || true
-    check_disk_for_vram || true
+    check_total_disk_for_vram || true
     check_ports || true
+}
+
+preflight_reminder() {
+    # after a successful install: the advisory FIX lines are far up the screen by now
+    [ "$PREFLIGHT_FIX" -gt 0 ] || return 0
+    warn "The preflight printed $PREFLIGHT_FIX FIX line(s) at the top. Run those commands, then: $(self_cmd --check)"
 }
 
 preflight_stack() {
@@ -474,7 +492,8 @@ case "${1:-}" in
     --check) PREFLIGHT_MODE_FLAG="--check" ;;
     -h|--help)
         echo "Usage: sudo bash nvidia_docker_sysbox_setup.sh [--check]"
-        echo "  (no option)  preflight the host, then install sysbox + NVIDIA container toolkit, configure Docker, verify"
+        echo "  (no option)  preflight the host, then install sysbox + NVIDIA container toolkit, configure Docker, verify;"
+        echo "               a FIX on root, x86_64, kernel or Docker stops the install, any other FIX is printed and the install goes on"
         echo "  --check      preflight only: host requirements and what this script installs, PASS/FIX per line, exit 1 on any FIX"
         echo "Env: SYSBOX_SKIP_KERNEL_CHECK=1, EXECUTOR_PORT, SSH_PORT (see the header of this script)"
         exit 0
@@ -486,7 +505,12 @@ esac
 
 if [ -n "$PREFLIGHT_MODE_FLAG" ]; then
     echo -e "\n${B}Preflight${N} — host requirements, then what this script installs"
-    if preflight_host; then preflight_stack; fi
+    # without root nothing else is checked: every other check reads Docker's socket or the process table
+    if check_root; then
+        preflight_blocking || true
+        preflight_advisory
+        preflight_stack
+    fi
     preflight_summary && exit 0
     echo "  Fix the lines above, then run: $(self_cmd)"
     exit 1
@@ -494,8 +518,13 @@ fi
 
 step 1 7 "Pre-flight checks"
 
-preflight_host || true
-preflight_summary || { echo "  Fix the lines above and re-run. Nothing was installed."; exit 1; }
+if ! check_root || ! preflight_blocking; then
+    preflight_summary || true
+    echo "  Fix the lines above and re-run. Nothing was installed."
+    exit 1
+fi
+preflight_advisory
+preflight_summary || echo "  The FIX lines above do not stop the install: the node is not listed at all without sysbox. Run those commands afterwards."
 
 echo -e "\n  This will install sysbox, configure Docker, restart Docker, and verify."
 if [ -t 0 ]; then
@@ -513,6 +542,7 @@ if command -v sysbox-runc &>/dev/null && docker info 2>/dev/null | grep -q sysbo
     fi
     if docker run --rm --runtime=sysbox-runc --gpus all "$VERIFY_IMAGE" nvidia-smi &>/dev/null; then
         ok "Sysbox is already working. Nothing to do."
+        preflight_reminder
         exit 0
     fi
 fi
@@ -695,6 +725,7 @@ if docker run --rm --runtime=sysbox-runc --gpus all "$VERIFY_IMAGE" nvidia-smi &
     echo -e "  ${G}╚══════════════════════════════════════════╝${N}"
     echo ""
     ok "Your executor now supports Docker-in-Docker."
+    preflight_reminder
 
     # ── 8. Restart executor ──────────────────────────────
     if [ -n "$EXECUTOR_COMPOSE_DIR" ]; then

--- a/neurons/executor/nvidia_docker_sysbox_setup.sh
+++ b/neurons/executor/nvidia_docker_sysbox_setup.sh
@@ -5,8 +5,10 @@ set -e
 # Usage:
 #   curl -fsSL https://raw.githubusercontent.com/Datura-ai/compute-subnet/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash
 #   or: cd compute-subnet/neurons/executor && sudo bash nvidia_docker_sysbox_setup.sh
+#   sudo bash nvidia_docker_sysbox_setup.sh --check   only the preflight, one PASS/FIX line per requirement; exit 1 on any FIX
 # Env:
 #   SYSBOX_SKIP_KERNEL_CHECK=1  install even when the ID-mapped mounts check rejects the host
+#   EXECUTOR_PORT / SSH_PORT    the ports the preflight checks (else neurons/executor/.env next to this script, else 8080 / 2200)
 
 SYSBOX_VERSION="0.6.6"
 SYSBOX_DEB_URL="https://github.com/nestybox/sysbox/releases/download/v${SYSBOX_VERSION}/sysbox-ce_${SYSBOX_VERSION}-0.linux_amd64.deb"
@@ -20,7 +22,9 @@ warn() { echo -e "  ${Y}!${N} $1"; }
 fail() { echo -e "  ${R}✗${N} $1"; }
 step() { echo -e "\n${B}[$1/$2]${N} $3"; }
 
-cleanup() { [ -n "$DOWNLOADED_DEB" ] && rm -f "$DOWNLOADED_DEB"; }
+# an `if`, not `[ … ] && rm`: under `set -e` the failing test made the EXIT trap end every run
+# with status 1, including "Nothing to do." and SUCCESS
+cleanup() { if [ -n "$DOWNLOADED_DEB" ]; then rm -f "$DOWNLOADED_DEB"; fi; }
 trap cleanup EXIT
 
 version_ge() {
@@ -99,16 +103,6 @@ nvidia_hook_symptom() {
     fail "  nvidia-container-cli: mount error: .../merged/proc/driver/nvidia: no such file or directory"
 }
 
-fail_old_kernel() {
-    fail "Kernel $(uname -r) is too old for sysbox with GPUs — overlayfs gained ID-mapped mounts in 5.19 (6.x recommended)."
-    nvidia_hook_symptom
-    fail "Fix on Ubuntu 22.04: sudo apt-get install -y linux-generic-hwe-22.04 && sudo reboot"
-    fail "  Ubuntu 20.04 tops out at 5.15 even with HWE — upgrade the distro instead."
-    fail "Before rebooting: stop any rentals, and confirm the NVIDIA driver is DKMS-managed ('dkms status'),"
-    fail "otherwise a .run-installed driver will not load on the new kernel and the node comes back without GPUs."
-    fail "If this kernel is known to carry the backport, override with: sudo SYSBOX_SKIP_KERNEL_CHECK=1 bash $0"
-}
-
 fail_no_idmapped() {
     fail "Sysbox reports it cannot use ID-mapped mounts, although kernel $(uname -r) supports them."
     nvidia_hook_symptom
@@ -118,18 +112,358 @@ fail_no_idmapped() {
     fail "  journalctl -u sysbox-mgr -b | grep -i id-mapped"
 }
 
+# ── Preflight ───────────────────────────────────────────
+# One PASS / FIX line per requirement, each FIX with the command that fixes it. The host checks
+# run before anything is installed (a FIX there ends the run with nothing changed); `--check`
+# runs them plus the checks on what this script installs. Paths under HOST_ROOT so tests can
+# point them at a fixture tree; commands are stubbed on PATH.
+
+MIN_NVIDIA_DRIVER="580.65.06"   # validators' MIN_NVIDIA_DRIVER_VERSION: an idle node below it earns nothing after the cutoff
+MIN_DISK_TO_VRAM_RATE="1.5"     # validators' MIN_DISK_TO_VRAM_RATE (rental_price.py): idle pay needs total disk >= 1.5x total VRAM
+PREFLIGHT_PASS=0 PREFLIGHT_FIX=0 PREFLIGHT_SKIP=0
+
+pf_pass() { PREFLIGHT_PASS=$((PREFLIGHT_PASS + 1)); echo -e "  ${G}PASS${N} $1"; }
+pf_skip() { PREFLIGHT_SKIP=$((PREFLIGHT_SKIP + 1)); echo -e "  ${Y}SKIP${N} $1"; }
+pf_fix() {
+    # $1 what is wrong; every further argument is one line of the fix
+    PREFLIGHT_FIX=$((PREFLIGHT_FIX + 1))
+    echo -e "  ${R}FIX${N}  $1"
+    shift
+    local line
+    for line in "$@"; do echo "         $line"; done
+    return 1
+}
+
+host_path() { echo "${HOST_ROOT:-}$1"; }
+
+self_cmd() {
+    # how to run this script again, with $@ as its options: the file when there is one, else the one-liner (curl | bash)
+    if [ -f "$0" ]; then
+        echo "sudo bash $0${1:+ $*}"
+    else
+        echo "curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash${1:+ -s -- $*}"
+    fi
+}
+
+os_release_field() {
+    # VERSION_ID / ID from /etc/os-release, empty when the file or the key is missing
+    local file
+    file=$(host_path /etc/os-release)
+    [ -r "$file" ] && sed -n "s/^$1=\"\{0,1\}\([^\"]*\)\"\{0,1\}$/\1/p" "$file" | head -1
+}
+
+docker_server_version() {
+    docker version --format '{{.Server.Version}}' 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
+}
+
+daemon_feature_off() {
+    # true when /etc/docker/daemon.json sets features.<$1> to false (jq when present; jq itself
+    # is one of the packages this script installs, so fall back to grep before it exists)
+    local file
+    file=$(host_path /etc/docker/daemon.json)
+    [ -r "$file" ] || return 1
+    if command -v jq &>/dev/null; then
+        [ "$(jq -r --arg k "$1" '.features[$k]' "$file" 2>/dev/null)" = "false" ]
+    else
+        grep -Eq "\"$1\"[[:space:]]*:[[:space:]]*false" "$file"
+    fi
+}
+
+check_root() {
+    [ "$(id -u)" -eq 0 ] && { pf_pass "Running as root."; return 0; }
+    pf_fix "Not running as root — the checks read Docker's socket and the kernel modules." \
+        "$(self_cmd "${PREFLIGHT_MODE_FLAG:-}")"
+}
+
+check_arch() {
+    local arch
+    arch=$(uname -m)
+    [ "$arch" = "x86_64" ] && { pf_pass "Architecture $arch."; return 0; }
+    pf_fix "Architecture $arch — sysbox ships for x86_64 only." "Use an x86_64 host."
+}
+
+check_kernel() {
+    local kernel version_id
+    kernel=$(uname -r)
+    if kernel_supports_idmapped; then
+        pf_pass "Kernel $kernel (>= 5.19, ID-mapped mounts available)."
+        return 0
+    fi
+    if [ "${SYSBOX_SKIP_KERNEL_CHECK:-0}" = "1" ]; then
+        pf_pass "Kernel $kernel accepted because SYSBOX_SKIP_KERNEL_CHECK=1 is set."
+        return 0
+    fi
+    version_id=$(os_release_field VERSION_ID)
+    case "$version_id" in
+        22.04) pf_fix "Kernel $kernel is below 5.19 — sysbox cannot pass GPUs through without ID-mapped mounts." \
+                   "sudo apt-get install -y linux-generic-hwe-22.04 && sudo reboot" \
+                   "Before rebooting: stop any rentals; 'dkms status' must list the nvidia module or the driver will not load on the new kernel." \
+                   "If this kernel is known to carry the ID-mapped mounts backport: SYSBOX_SKIP_KERNEL_CHECK=1 $(self_cmd)" ;;
+        20.04) pf_fix "Kernel $kernel is below 5.19 and Ubuntu 20.04 tops out at 5.15 even with HWE." \
+                   "Upgrade the host to Ubuntu 22.04 or newer (sudo do-release-upgrade), then re-run this script." ;;
+        *)     pf_fix "Kernel $kernel is below 5.19 — sysbox cannot pass GPUs through without ID-mapped mounts." \
+                   "Install a 5.19+ kernel for your distribution and reboot, then re-run this script." ;;
+    esac
+}
+
+check_docker() {
+    local version
+    if ! command -v docker &>/dev/null; then
+        pf_fix "Docker is not installed." "curl -fsSL https://get.docker.com | sudo sh"
+        return 1
+    fi
+    if ! docker ps &>/dev/null; then
+        pf_fix "Docker daemon is not running (docker ps failed)." "sudo systemctl enable --now docker"
+        return 1
+    fi
+    version=$(docker_server_version)
+    if [ -z "$version" ]; then
+        pf_fix "Docker is running but reported no server version." "docker version   # then sudo systemctl restart docker"
+        return 1
+    fi
+    if docker_version_ge 29 0 && ! docker_version_ge 29 2; then
+        pf_pass "Docker $version (29.0–29.1 is untested with sysbox; 28.x and 29.2+ are)."
+    else
+        pf_pass "Docker $version."
+    fi
+}
+
+check_docker_features() {
+    # Docker 29.2 routes --gpus through CDI and 29.5 gives containers a time namespace; sysbox
+    # accepts neither. The install step writes both keys; this reports whether they are set.
+    local version missing=""
+    version=$(docker_server_version)
+    [ -n "$version" ] || { pf_skip "Docker 29 settings — Docker is not running."; return 0; }
+    if ! docker_version_ge 29 2; then
+        pf_pass "Docker $version needs no daemon.json features (cdi / time-namespaces appear in 29.2 / 29.5)."
+        return 0
+    fi
+    daemon_feature_off cdi || missing="cdi"
+    if docker_version_ge 29 5 && ! daemon_feature_off time-namespaces; then
+        missing="${missing:+$missing, }time-namespaces"
+    fi
+    if [ -z "$missing" ]; then
+        pf_pass "Docker $version has the sysbox settings in /etc/docker/daemon.json (features.cdi$(docker_version_ge 29 5 && echo ' and features.time-namespaces') = false)."
+        return 0
+    fi
+    pf_fix "Docker $version without features.$missing = false in /etc/docker/daemon.json — sysbox rejects its containers." \
+        "$(self_cmd)   # writes the features block and restarts Docker; stop rentals first" \
+        "or by hand: add {\"features\":{\"cdi\":false,\"time-namespaces\":false}} to /etc/docker/daemon.json && sudo systemctl restart docker"
+}
+
+check_nvidia_driver() {
+    local driver
+    if ! command -v nvidia-smi &>/dev/null; then
+        pf_fix "nvidia-smi not found — no NVIDIA driver installed." \
+            "sudo apt-get install -y nvidia-driver-580-server && sudo reboot   # Ubuntu; or your vendor's driver package"
+        return 1
+    fi
+    driver=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1)
+    if [ -z "$driver" ] || ! ls "$(host_path /proc/driver/nvidia)" &>/dev/null; then
+        pf_fix "NVIDIA driver is installed but not loaded (nvidia-smi gives no driver version or /proc/driver/nvidia is missing)." \
+            "sudo reboot   # then check 'nvidia-smi'; if it still fails: sudo dkms autoinstall && sudo reboot"
+        return 1
+    fi
+    if version_ge "$driver" "${MIN_NVIDIA_DRIVER%%.*}" "$(echo "$MIN_NVIDIA_DRIVER" | cut -d. -f2)"; then
+        pf_pass "NVIDIA driver $driver ($(nvidia-smi --list-gpus 2>/dev/null | grep -c '^GPU') GPU(s))."
+        return 0
+    fi
+    pf_fix "NVIDIA driver $driver is below $MIN_NVIDIA_DRIVER, the validators' minimum — an idle node below it earns nothing." \
+        "sudo apt-get install -y nvidia-driver-580-server && sudo reboot   # stop rentals first"
+}
+
+check_nvidia_toolkit() {
+    local version
+    version=$(nvidia-container-cli --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    if [ -n "$version" ]; then
+        pf_pass "NVIDIA container toolkit (nvidia-container-cli $version)."
+        return 0
+    fi
+    pf_fix "NVIDIA container toolkit is not installed — Docker cannot pass GPUs into containers." \
+        "$(self_cmd)   # adds NVIDIA's apt repository and installs nvidia-container-toolkit"
+}
+
+check_iptables_modules() {
+    # The validators' Docker-in-Docker probe runs legacy iptables inside the pod; on an nftables
+    # host without these modules its dockerd fails with "can't initialize iptables table 'nat'",
+    # sshd never starts and the node is scored as having no sysbox (ticket-0309: three reinstalls).
+    local mod missing=""
+    for mod in ip_tables iptable_nat iptable_filter; do
+        grep -q "^$mod " "$(host_path /proc/modules)" 2>/dev/null && continue
+        [ -d "$(host_path "/sys/module/$mod")" ] && continue
+        missing="${missing:+$missing }$mod"
+    done
+    if [ -z "$missing" ]; then
+        pf_pass "Legacy iptables modules loaded (ip_tables iptable_nat iptable_filter) for the validators' Docker-in-Docker probe."
+        return 0
+    fi
+    pf_fix "Kernel modules $missing are not loaded — the validators' Docker-in-Docker probe needs legacy iptables and reports sysbox missing without them." \
+        "sudo modprobe -a ip_tables iptable_nat iptable_filter   # -a: without it modprobe reads the 2nd and 3rd name as parameters of the 1st" \
+        "printf 'ip_tables\\niptable_nat\\niptable_filter\\n' | sudo tee /etc/modules-load.d/lium-iptables.conf >/dev/null   # survives reboots"
+}
+
+check_disk_for_vram() {
+    # The validators compare the TOTAL size of the filesystem the executor sees as / (its
+    # rootfs lives under Docker's data-root) with total GPU VRAM; free space is not the rule.
+    local vram_mib vram_gb data_root total_kb total_gb needed_gb
+    command -v nvidia-smi &>/dev/null || { pf_skip "Disk >= ${MIN_DISK_TO_VRAM_RATE}x VRAM — no NVIDIA driver, VRAM unknown."; return 0; }
+    vram_mib=$(nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | awk '{s += $1} END {print s + 0}')
+    [ "${vram_mib:-0}" -gt 0 ] 2>/dev/null || { pf_skip "Disk >= ${MIN_DISK_TO_VRAM_RATE}x VRAM — nvidia-smi reports no GPU memory."; return 0; }
+    data_root=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null)
+    if [ -z "$data_root" ] || [ ! -d "$data_root" ]; then data_root=/var/lib/docker; fi
+    [ -d "$data_root" ] || data_root=/
+    total_kb=$(df -Pk "$data_root" 2>/dev/null | awk 'NR == 2 {print $2}')
+    [ "${total_kb:-0}" -gt 0 ] 2>/dev/null || { pf_skip "Disk >= ${MIN_DISK_TO_VRAM_RATE}x VRAM — cannot read the filesystem size of $data_root."; return 0; }
+    vram_gb=$(awk -v m="$vram_mib" 'BEGIN {printf "%.1f", m / 1024}')
+    total_gb=$(awk -v k="$total_kb" 'BEGIN {printf "%.1f", k / 1024 / 1024}')
+    needed_gb=$(awk -v v="$vram_gb" -v r="$MIN_DISK_TO_VRAM_RATE" 'BEGIN {printf "%.1f", v * r}')
+    if awk -v t="$total_gb" -v n="$needed_gb" 'BEGIN {exit !(t >= n)}'; then
+        pf_pass "Disk ${total_gb} GB on $data_root >= ${needed_gb} GB (${MIN_DISK_TO_VRAM_RATE}x of ${vram_gb} GB VRAM) — idle pay eligible."
+        return 0
+    fi
+    pf_fix "Disk ${total_gb} GB on $data_root is below ${needed_gb} GB (${MIN_DISK_TO_VRAM_RATE}x of ${vram_gb} GB VRAM) — the node is listed but earns nothing while idle." \
+        "Add disk, or move Docker's data-root to a filesystem of at least ${needed_gb} GB (\"data-root\" in /etc/docker/daemon.json, then sudo systemctl restart docker)."
+}
+
+preflight_ports() {
+    # EXECUTOR_PORT / SSH_PORT from the environment, else the executor .env next to this script, else the defaults
+    local env_file
+    env_file="$(dirname "$0")/.env"
+    if [ -z "${EXECUTOR_PORT:-}" ] && [ -r "$env_file" ]; then
+        EXECUTOR_PORT=$(sed -n 's/^EXTERNAL_PORT=\([0-9]*\).*/\1/p' "$env_file" | head -1)
+    fi
+    if [ -z "${SSH_PORT:-}" ] && [ -r "$env_file" ]; then
+        SSH_PORT=$(sed -n 's/^SSH_PORT=\([0-9]*\).*/\1/p' "$env_file" | head -1)
+    fi
+    echo "${EXECUTOR_PORT:-8080} ${SSH_PORT:-2200}"
+}
+
+port_listener() {
+    # the process listening on TCP $1, e.g. 'users:(("sshd",pid=812,fd=3))'; empty when the port is free
+    ss -Hltnp "sport = :$1" 2>/dev/null | awk '{print $NF}' | head -1
+}
+
+ufw_blocks_port() {
+    # true when ufw is active and no ALLOW rule covers TCP $1 (single port or lo:hi range)
+    local status
+    status=$(ufw status 2>/dev/null) || return 1
+    echo "$status" | grep -q '^Status: active' || return 1
+    ! echo "$status" | awk -v p="$1" '
+        $2 == "ALLOW" || $3 == "ALLOW" {
+            split($1, spec, "/"); if (spec[2] != "" && spec[2] != "tcp") next
+            n = split(spec[1], range, ":")
+            if ((n == 1 && range[1] == p) || (n == 2 && range[1] + 0 <= p + 0 && p + 0 <= range[2] + 0)) found = 1
+        }
+        END { exit !found }'
+}
+
+check_ports() {
+    local ports p listener label fixed=0
+    read -r -a ports <<< "$(preflight_ports)"
+    for p in "${ports[0]}:executor" "${ports[1]}:SSH"; do
+        label=${p#*:} p=${p%%:*}
+        listener=$(port_listener "$p")
+        if [ -n "$listener" ] && ! echo "$listener" | grep -Eq 'docker-proxy|dockerd'; then
+            pf_fix "TCP $p ($label port) is already in use by $listener — the executor cannot bind it." \
+                "Stop that process, or choose another port (EXTERNAL_PORT / SSH_PORT in neurons/executor/.env) and open it instead."
+            fixed=1
+            continue
+        fi
+        if ufw_blocks_port "$p"; then
+            pf_fix "TCP $p ($label port) is blocked by ufw — validators cannot reach the node." "sudo ufw allow $p/tcp"
+            fixed=1
+            continue
+        fi
+        if [ -n "$listener" ]; then
+            pf_pass "TCP $p ($label port) is served by Docker and not blocked by ufw."
+        else
+            pf_pass "TCP $p ($label port) is free and not blocked by ufw."
+        fi
+    done
+    echo "         Cloud firewalls and routers are outside this host: after 'docker compose up', from ANY other machine run"
+    echo "           nc -vz <this host's public IP> ${ports[0]} ${ports[1]}    # both must say 'succeeded'"
+    return $fixed
+}
+
+check_sysbox() {
+    # installed, registered as a Docker runtime, and a container starts under it (the docs' probe)
+    if ! command -v sysbox-runc &>/dev/null; then
+        pf_fix "sysbox-runc is not installed — validators reject a node without it." "$(self_cmd)"
+        return 1
+    fi
+    if ! docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q sysbox-runc; then
+        pf_fix "sysbox-runc is installed but not registered in Docker's runtimes." \
+            "$(self_cmd)   # writes the runtime into /etc/docker/daemon.json and restarts Docker"
+        return 1
+    fi
+    if ! docker run --rm --runtime=sysbox-runc alpine echo ok &>/dev/null; then
+        pf_fix "sysbox-runc is registered but 'docker run --rm --runtime=sysbox-runc alpine echo ok' fails." \
+            "$(self_cmd)   # re-applies the Docker 29 settings and re-verifies; then: journalctl -u sysbox-mgr --no-pager -n 20"
+        return 1
+    fi
+    pf_pass "sysbox-runc $(sysbox-runc --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo installed) runs a container."
+}
+
+preflight_summary() {
+    echo ""
+    echo "  Preflight: $PREFLIGHT_PASS PASS, $PREFLIGHT_FIX FIX, $PREFLIGHT_SKIP SKIP."
+    [ "$PREFLIGHT_FIX" -eq 0 ]
+}
+
+preflight_host() {
+    # what this script cannot install for you; a FIX here stops the run before anything changes
+    check_root || true
+    check_arch || true
+    check_kernel || true
+    check_docker || true
+    check_nvidia_driver || true
+    check_iptables_modules || true
+    check_disk_for_vram || true
+    check_ports || true
+}
+
+preflight_stack() {
+    # what this script installs: reported in --check mode, done in install mode
+    check_nvidia_toolkit || true
+    check_docker_features || true
+    check_sysbox || true
+}
+
+
+# sourced by the tests: functions only, nothing below runs
+if [ -n "${SYSBOX_SETUP_LIB:-}" ]; then
+    return 0
+fi
+
+PREFLIGHT_MODE_FLAG=""
+case "${1:-}" in
+    "") ;;
+    --check) PREFLIGHT_MODE_FLAG="--check" ;;
+    -h|--help)
+        echo "Usage: sudo bash nvidia_docker_sysbox_setup.sh [--check]"
+        echo "  (no option)  preflight the host, then install sysbox + NVIDIA container toolkit, configure Docker, verify"
+        echo "  --check      preflight only: host requirements and what this script installs, PASS/FIX per line, exit 1 on any FIX"
+        echo "Env: SYSBOX_SKIP_KERNEL_CHECK=1, EXECUTOR_PORT, SSH_PORT (see the header of this script)"
+        exit 0
+        ;;
+    *)  fail "Unknown option: $1 (use --check or --help)"; exit 2 ;;
+esac
+
 # ── 1. Pre-flight ────────────────────────────────────────
+
+if [ -n "$PREFLIGHT_MODE_FLAG" ]; then
+    echo -e "\n${B}Preflight${N} — host requirements, then what this script installs"
+    preflight_host
+    preflight_stack
+    preflight_summary && exit 0
+    echo "  Fix the lines above, then run: $(self_cmd)"
+    exit 1
+fi
 
 step 1 7 "Pre-flight checks"
 
-[ "$(id -u)" -eq 0 ]                         || { fail "Run as root (use sudo)."; exit 1; }
-[ "$(uname -m)" = "x86_64" ]                 || { fail "Sysbox requires x86_64."; exit 1; }
-command -v docker &>/dev/null                 || { fail "Docker not installed."; exit 1; }
-docker ps &>/dev/null                         || { fail "Docker daemon not running."; exit 1; }
-command -v nvidia-smi &>/dev/null             || { fail "nvidia-smi not found. Install NVIDIA drivers first."; exit 1; }
-ls /proc/driver/nvidia &>/dev/null            || { fail "NVIDIA driver not loaded. Try: nvidia-smi"; exit 1; }
-
-ok "All checks passed."
+preflight_host
+preflight_summary || { echo "  Fix the lines above and re-run. Nothing was installed."; exit 1; }
 
 echo -e "\n  This will install sysbox, configure Docker, restart Docker, and verify."
 if [ -t 0 ]; then
@@ -152,23 +486,13 @@ if command -v sysbox-runc &>/dev/null && docker info 2>/dev/null | grep -q sysbo
 fi
 
 # Reached only when the real GPU test above did not pass, so a working host is never rejected here.
+# The preflight already settled the kernel version, so a "no" from sysbox-mgr points at the
+# filesystem under Docker's data-root or at sysbox-mgr's own configuration.
 if [ "${SYSBOX_SKIP_KERNEL_CHECK:-0}" = "1" ]; then
     warn "SYSBOX_SKIP_KERNEL_CHECK=1 — installing without the ID-mapped mounts check."
-else
-    IDMAPPED=$(sysbox_idmapped_report)
-    case "$IDMAPPED" in
-        yes) ;;
-        no)
-            if kernel_supports_idmapped; then fail_no_idmapped; else fail_old_kernel; fi
-            exit 1
-            ;;
-        *)  # sysbox-mgr reported nothing this boot — fall back to the kernel version
-            if ! kernel_supports_idmapped; then
-                fail_old_kernel
-                exit 1
-            fi
-            ;;
-    esac
+elif [ "$(sysbox_idmapped_report)" = "no" ]; then
+    fail_no_idmapped
+    exit 1
 fi
 
 SKIP_INSTALL=false
@@ -238,7 +562,9 @@ if [ "$has_executor" = true ]; then
         # Compose file missing — stop and remove executor containers directly
         executor_ids=$(docker ps --filter "name=executor" -q 2>/dev/null || true)
         if [ -n "$executor_ids" ]; then
+            # shellcheck disable=SC2086  # one id per word
             docker stop $executor_ids > /dev/null 2>&1
+            # shellcheck disable=SC2086
             docker rm $executor_ids > /dev/null 2>&1
         fi
         ok "Executor containers stopped (compose file not found — restart manually after setup)."
@@ -250,6 +576,7 @@ fi
 stopped=$(docker ps -a -q 2>/dev/null || true)
 if [ -n "$stopped" ]; then
     warn "Removing stopped containers (sysbox requires none)..."
+    # shellcheck disable=SC2086  # one id per word
     docker rm -f $stopped > /dev/null 2>&1
     ok "Stopped containers removed."
 fi
@@ -340,9 +667,11 @@ if docker run --rm --runtime=sysbox-runc --gpus all "$VERIFY_IMAGE" nvidia-smi &
     # ── 8. Restart executor ──────────────────────────────
     if [ -n "$EXECUTOR_COMPOSE_DIR" ]; then
         step 7 7 "Restarting executor"
-        docker compose -f "$EXECUTOR_COMPOSE_DIR/docker-compose.yml" up -d 2>/dev/null \
-            && ok "Executor restarted ($EXECUTOR_COMPOSE_DIR)." \
-            || warn "Failed to restart executor. Run manually: cd $EXECUTOR_COMPOSE_DIR && docker compose up -d"
+        if docker compose -f "$EXECUTOR_COMPOSE_DIR/docker-compose.yml" up -d 2>/dev/null; then
+            ok "Executor restarted ($EXECUTOR_COMPOSE_DIR)."
+        else
+            warn "Failed to restart executor. Run manually: cd $EXECUTOR_COMPOSE_DIR && docker compose up -d"
+        fi
     fi
 else
     echo ""

--- a/neurons/executor/nvidia_docker_sysbox_setup.sh
+++ b/neurons/executor/nvidia_docker_sysbox_setup.sh
@@ -427,6 +427,7 @@ check_sysbox() {
         pf_fix "sysbox-runc is not installed — validators reject a node without it." "$(self_cmd)"
         return 1
     fi
+    docker ps &>/dev/null || { pf_skip "sysbox-runc — Docker is not running."; return 0; }
     if ! docker info --format '{{json .Runtimes}}' 2>/dev/null | grep -q sysbox-runc; then
         pf_fix "sysbox-runc is installed but not registered in Docker's runtimes." \
             "$(self_cmd)   # writes the runtime into /etc/docker/daemon.json and restarts Docker"
@@ -512,7 +513,8 @@ if [ -n "$CHECK_MODE_OPTION" ]; then
         preflight_stack
     fi
     preflight_summary && exit 0
-    echo "  Fix the lines above, then run: $(self_cmd)"
+    # every FIX line above carries its own command; the installer is one of them, never all of them
+    echo "  Fix the lines above, then re-run: $(self_cmd "$CHECK_MODE_OPTION")"
     exit 1
 fi
 

--- a/neurons/executor/nvidia_docker_sysbox_setup.sh
+++ b/neurons/executor/nvidia_docker_sysbox_setup.sh
@@ -3,8 +3,8 @@ set -e
 
 # Lium Executor — Sysbox Setup
 # Usage:
-#   curl -fsSL https://raw.githubusercontent.com/Datura-ai/compute-subnet/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash
-#   or: cd compute-subnet/neurons/executor && sudo bash nvidia_docker_sysbox_setup.sh
+#   curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash
+#   or: cd lium-io/neurons/executor && sudo bash nvidia_docker_sysbox_setup.sh
 #   sudo bash nvidia_docker_sysbox_setup.sh --check   only the preflight, one PASS/FIX line per requirement; exit 1 on any FIX
 # Env:
 #   SYSBOX_SKIP_KERNEL_CHECK=1  install even when the ID-mapped mounts check rejects the host
@@ -34,9 +34,19 @@ version_ge() {
     [ "$major" -gt "$2" ] 2>/dev/null || { [ "$major" -eq "$2" ] && [ "$minor" -ge "$3" ]; } 2>/dev/null
 }
 
-docker_version_ge() {
+docker_server_version() {
     # the DAEMON version — it writes the OCI spec sysbox has to accept, and it can differ from the client
-    version_ge "$(docker version --format '{{.Server.Version}}' 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)" "$1" "$2"
+    docker version --format '{{.Server.Version}}' 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
+}
+
+docker_version_ge() { version_ge "$(docker_server_version)" "$1" "$2"; }
+
+version3_ge() {
+    # "a.b.c" >= "x.y.z", all three components numeric (driver versions: 580.65.06 vs the validators' minimum)
+    awk -v a="$1" -v b="$2" 'BEGIN {
+        n = split(a, x, "."); split(b, y, ".")
+        for (i = 1; i <= 3; i++) { if (x[i] + 0 > y[i] + 0) exit 0; if (x[i] + 0 < y[i] + 0) exit 1 }
+        exit 0 }'
 }
 
 kernel_supports_idmapped() {
@@ -137,11 +147,14 @@ pf_fix() {
 host_path() { echo "${HOST_ROOT:-}$1"; }
 
 self_cmd() {
-    # how to run this script again, with $@ as its options: the file when there is one, else the one-liner (curl | bash)
+    # how to run this script again: the file when there is one, else the one-liner (curl | bash). A leading VAR=VALUE
+    # argument goes after sudo (sudo's env_reset drops variables set before it); the rest are the script's options.
+    local env=""
+    case "${1:-}" in *=*) env="$1 "; shift ;; esac
     if [ -f "$0" ]; then
-        echo "sudo bash $0${1:+ $*}"
+        echo "sudo ${env}bash $0${1:+ $*}"
     else
-        echo "curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash${1:+ -s -- $*}"
+        echo "curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo ${env}bash${1:+ -s -- $*}"
     fi
 }
 
@@ -150,10 +163,6 @@ os_release_field() {
     local file
     file=$(host_path /etc/os-release)
     [ -r "$file" ] && sed -n "s/^$1=\"\{0,1\}\([^\"]*\)\"\{0,1\}$/\1/p" "$file" | head -1
-}
-
-docker_server_version() {
-    docker version --format '{{.Server.Version}}' 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1
 }
 
 daemon_feature_off() {
@@ -198,7 +207,7 @@ check_kernel() {
         22.04) pf_fix "Kernel $kernel is below 5.19 — sysbox cannot pass GPUs through without ID-mapped mounts." \
                    "sudo apt-get install -y linux-generic-hwe-22.04 && sudo reboot" \
                    "Before rebooting: stop any rentals; 'dkms status' must list the nvidia module or the driver will not load on the new kernel." \
-                   "If this kernel is known to carry the ID-mapped mounts backport: SYSBOX_SKIP_KERNEL_CHECK=1 $(self_cmd)" ;;
+                   "If this kernel is known to carry the ID-mapped mounts backport: $(self_cmd SYSBOX_SKIP_KERNEL_CHECK=1)" ;;
         20.04) pf_fix "Kernel $kernel is below 5.19 and Ubuntu 20.04 tops out at 5.15 even with HWE." \
                    "Upgrade the host to Ubuntu 22.04 or newer (sudo do-release-upgrade), then re-run this script." ;;
         *)     pf_fix "Kernel $kernel is below 5.19 — sysbox cannot pass GPUs through without ID-mapped mounts." \
@@ -246,9 +255,11 @@ check_docker_features() {
         pf_pass "Docker $version has the sysbox settings in /etc/docker/daemon.json (features.cdi$(docker_version_ge 29 5 && echo ' and features.time-namespaces') = false)."
         return 0
     fi
+    local block='{"features":{"cdi":false}}'
+    docker_version_ge 29 5 && block='{"features":{"cdi":false,"time-namespaces":false}}'
     pf_fix "Docker $version without features.$missing = false in /etc/docker/daemon.json — sysbox rejects its containers." \
         "$(self_cmd)   # writes the features block and restarts Docker; stop rentals first" \
-        "or by hand: add {\"features\":{\"cdi\":false,\"time-namespaces\":false}} to /etc/docker/daemon.json && sudo systemctl restart docker"
+        "or by hand: add $block to /etc/docker/daemon.json && sudo systemctl restart docker"
 }
 
 check_nvidia_driver() {
@@ -264,7 +275,7 @@ check_nvidia_driver() {
             "sudo reboot   # then check 'nvidia-smi'; if it still fails: sudo dkms autoinstall && sudo reboot"
         return 1
     fi
-    if version_ge "$driver" "${MIN_NVIDIA_DRIVER%%.*}" "$(echo "$MIN_NVIDIA_DRIVER" | cut -d. -f2)"; then
+    if version3_ge "$driver" "$MIN_NVIDIA_DRIVER"; then
         pf_pass "NVIDIA driver $driver ($(nvidia-smi --list-gpus 2>/dev/null | grep -c '^GPU') GPU(s))."
         return 0
     fi
@@ -317,7 +328,8 @@ check_disk_for_vram() {
     vram_gb=$(awk -v m="$vram_mib" 'BEGIN {printf "%.1f", m / 1024}')
     total_gb=$(awk -v k="$total_kb" 'BEGIN {printf "%.1f", k / 1024 / 1024}')
     needed_gb=$(awk -v v="$vram_gb" -v r="$MIN_DISK_TO_VRAM_RATE" 'BEGIN {printf "%.1f", v * r}')
-    if awk -v t="$total_gb" -v n="$needed_gb" 'BEGIN {exit !(t >= n)}'; then
+    # the validator rounds VRAM and disk to 0.1 GB, then compares VRAM x 1.5 unrounded with the disk
+    if awk -v t="$total_gb" -v v="$vram_gb" -v r="$MIN_DISK_TO_VRAM_RATE" 'BEGIN {exit !(t >= v * r)}'; then
         pf_pass "Disk ${total_gb} GB on $data_root >= ${needed_gb} GB (${MIN_DISK_TO_VRAM_RATE}x of ${vram_gb} GB VRAM) — idle pay eligible."
         return 0
     fi
@@ -327,12 +339,12 @@ check_disk_for_vram() {
 
 preflight_ports() {
     # EXECUTOR_PORT / SSH_PORT from the environment, else the executor .env next to this script, else the defaults
-    local env_file
-    env_file="$(dirname "$0")/.env"
-    if [ -z "${EXECUTOR_PORT:-}" ] && [ -r "$env_file" ]; then
+    local env_file=""
+    [ -f "$0" ] && env_file="$(dirname "$0")/.env"   # piped from curl there is no file next to the script
+    if [ -z "${EXECUTOR_PORT:-}" ] && [ -n "$env_file" ] && [ -r "$env_file" ]; then
         EXECUTOR_PORT=$(sed -n 's/^EXTERNAL_PORT=\([0-9]*\).*/\1/p' "$env_file" | head -1)
     fi
-    if [ -z "${SSH_PORT:-}" ] && [ -r "$env_file" ]; then
+    if [ -z "${SSH_PORT:-}" ] && [ -n "$env_file" ] && [ -r "$env_file" ]; then
         SSH_PORT=$(sed -n 's/^SSH_PORT=\([0-9]*\).*/\1/p' "$env_file" | head -1)
     fi
     echo "${EXECUTOR_PORT:-8080} ${SSH_PORT:-2200}"

--- a/neurons/executor/nvidia_docker_sysbox_setup.sh
+++ b/neurons/executor/nvidia_docker_sysbox_setup.sh
@@ -44,7 +44,7 @@ docker_version_ge() { version_ge "$(docker_server_version)" "$1" "$2"; }
 version3_ge() {
     # "a.b.c" >= "x.y.z", all three components numeric (driver versions: 580.65.06 vs the validators' minimum)
     awk -v a="$1" -v b="$2" 'BEGIN {
-        n = split(a, x, "."); split(b, y, ".")
+        split(a, x, "."); split(b, y, ".")
         for (i = 1; i <= 3; i++) { if (x[i] + 0 > y[i] + 0) exit 0; if (x[i] + 0 < y[i] + 0) exit 1 }
         exit 0 }'
 }
@@ -269,9 +269,11 @@ check_nvidia_driver() {
             "sudo apt-get install -y nvidia-driver-580-server && sudo reboot   # Ubuntu; or your vendor's driver package"
         return 1
     fi
+    # nvidia-smi prints its errors on stdout ("Failed to initialize NVML: Driver/library version mismatch"), so only a
+    # dotted number counts as a version
     driver=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1)
-    if [ -z "$driver" ] || ! ls "$(host_path /proc/driver/nvidia)" &>/dev/null; then
-        pf_fix "NVIDIA driver is installed but not loaded (nvidia-smi gives no driver version or /proc/driver/nvidia is missing)." \
+    if ! echo "$driver" | grep -Eq '^[0-9]+(\.[0-9]+)+$' || ! ls "$(host_path /proc/driver/nvidia)" &>/dev/null; then
+        pf_fix "NVIDIA driver is installed but not loaded (nvidia-smi: ${driver:-no output}; /proc/driver/nvidia $(ls "$(host_path /proc/driver/nvidia)" &>/dev/null && echo present || echo missing))." \
             "sudo reboot   # then check 'nvidia-smi'; if it still fails: sudo dkms autoinstall && sudo reboot"
         return 1
     fi
@@ -355,13 +357,20 @@ port_listener() {
     ss -Hltnp "sport = :$1" 2>/dev/null | awk '{print $NF}' | head -1
 }
 
+port_container() {
+    # the container that publishes TCP $1 (a docker-proxy listener belongs to one); empty when none does
+    docker ps --filter "publish=$1" --format '{{.Names}}' 2>/dev/null | head -1
+}
+
 ufw_blocks_port() {
     # true when ufw is active and no ALLOW rule covers TCP $1 (single port or lo:hi range)
     local status
     status=$(ufw status 2>/dev/null) || return 1
     echo "$status" | grep -q '^Status: active' || return 1
     ! echo "$status" | awk -v p="$1" '
-        $2 == "ALLOW" || $3 == "ALLOW" {
+        {
+            allow = 0; for (i = 2; i <= NF; i++) if ($i == "ALLOW") allow = 1   # "ALLOW", "ALLOW IN", "… on eth0 ALLOW"
+            if (!allow) next
             split($1, spec, "/"); if (spec[2] != "" && spec[2] != "tcp") next
             n = split(spec[1], range, ":")
             if ((n == 1 && range[1] == p) || (n == 2 && range[1] + 0 <= p + 0 && p + 0 <= range[2] + 0)) found = 1
@@ -370,12 +379,23 @@ ufw_blocks_port() {
 }
 
 check_ports() {
-    local ports p listener label fixed=0
+    local ports p listener container label fixed=0
     read -r -a ports <<< "$(preflight_ports)"
+    command -v ss &>/dev/null || { pf_skip "Ports — 'ss' (iproute2) is missing, cannot tell what listens."; return 0; }
     for p in "${ports[0]}:executor" "${ports[1]}:SSH"; do
         label=${p#*:} p=${p%%:*}
         listener=$(port_listener "$p")
-        if [ -n "$listener" ] && ! echo "$listener" | grep -Eq 'docker-proxy|dockerd'; then
+        container=""
+        if [ -n "$listener" ] && echo "$listener" | grep -Eq 'docker-proxy|dockerd'; then
+            container=$(port_container "$p")
+            case "$container" in
+                executor-*|executor_*) ;;   # the executor itself, from an earlier install
+                *) pf_fix "TCP $p ($label port) is published by container ${container:-unknown} — the executor cannot bind it." \
+                       "docker stop ${container:-<name>}, or choose another port (EXTERNAL_PORT / SSH_PORT in neurons/executor/.env) and open it instead."
+                   fixed=1
+                   continue ;;
+            esac
+        elif [ -n "$listener" ]; then
             pf_fix "TCP $p ($label port) is already in use by $listener — the executor cannot bind it." \
                 "Stop that process, or choose another port (EXTERNAL_PORT / SSH_PORT in neurons/executor/.env) and open it instead."
             fixed=1
@@ -386,8 +406,8 @@ check_ports() {
             fixed=1
             continue
         fi
-        if [ -n "$listener" ]; then
-            pf_pass "TCP $p ($label port) is served by Docker and not blocked by ufw."
+        if [ -n "$container" ]; then
+            pf_pass "TCP $p ($label port) is served by the executor ($container) and not blocked by ufw."
         else
             pf_pass "TCP $p ($label port) is free and not blocked by ufw."
         fi
@@ -423,8 +443,9 @@ preflight_summary() {
 }
 
 preflight_host() {
-    # what this script cannot install for you; a FIX here stops the run before anything changes
-    check_root || true
+    # what this script cannot install for you; a FIX here stops the run before anything changes.
+    # Returns 1 without root: every other check reads Docker's socket or the process table.
+    check_root || return 1
     check_arch || true
     check_kernel || true
     check_docker || true
@@ -465,8 +486,7 @@ esac
 
 if [ -n "$PREFLIGHT_MODE_FLAG" ]; then
     echo -e "\n${B}Preflight${N} — host requirements, then what this script installs"
-    preflight_host
-    preflight_stack
+    if preflight_host; then preflight_stack; fi
     preflight_summary && exit 0
     echo "  Fix the lines above, then run: $(self_cmd)"
     exit 1
@@ -474,7 +494,7 @@ fi
 
 step 1 7 "Pre-flight checks"
 
-preflight_host
+preflight_host || true
 preflight_summary || { echo "  Fix the lines above and re-run. Nothing was installed."; exit 1; }
 
 echo -e "\n  This will install sysbox, configure Docker, restart Docker, and verify."

--- a/neurons/executor/nvidia_docker_sysbox_setup.sh
+++ b/neurons/executor/nvidia_docker_sysbox_setup.sh
@@ -184,7 +184,7 @@ daemon_feature_off() {
 check_root() {
     [ "$(id -u)" -eq 0 ] && { pf_pass "Running as root."; return 0; }
     pf_fix "Not running as root — the checks read Docker's socket and the kernel modules." \
-        "$(self_cmd "${PREFLIGHT_MODE_FLAG:-}")"
+        "$(self_cmd "${CHECK_MODE_OPTION:-}")"
 }
 
 check_arch() {
@@ -258,11 +258,11 @@ check_docker_features() {
         pf_pass "Docker $version has the sysbox settings in /etc/docker/daemon.json (features.cdi$(docker_version_ge 29 5 && echo ' and features.time-namespaces') = false)."
         return 0
     fi
-    local block='{"features":{"cdi":false}}'
-    docker_version_ge 29 5 && block='{"features":{"cdi":false,"time-namespaces":false}}'
+    local daemon_features_block='{"features":{"cdi":false}}'
+    docker_version_ge 29 5 && daemon_features_block='{"features":{"cdi":false,"time-namespaces":false}}'
     pf_fix "Docker $version without features.$missing = false in /etc/docker/daemon.json — sysbox rejects its containers." \
         "$(self_cmd)   # writes the features block and restarts Docker; stop rentals first" \
-        "or by hand: add $block to /etc/docker/daemon.json && sudo systemctl restart docker"
+        "or by hand: add $daemon_features_block to /etc/docker/daemon.json && sudo systemctl restart docker"
 }
 
 check_nvidia_driver() {
@@ -486,10 +486,10 @@ if [ -n "${SYSBOX_SETUP_LIB:-}" ]; then
     return 0
 fi
 
-PREFLIGHT_MODE_FLAG=""
+CHECK_MODE_OPTION=""
 case "${1:-}" in
     "") ;;
-    --check) PREFLIGHT_MODE_FLAG="--check" ;;
+    --check) CHECK_MODE_OPTION="--check" ;;
     -h|--help)
         echo "Usage: sudo bash nvidia_docker_sysbox_setup.sh [--check]"
         echo "  (no option)  preflight the host, then install sysbox + NVIDIA container toolkit, configure Docker, verify;"
@@ -503,7 +503,7 @@ esac
 
 # ── 1. Pre-flight ────────────────────────────────────────
 
-if [ -n "$PREFLIGHT_MODE_FLAG" ]; then
+if [ -n "$CHECK_MODE_OPTION" ]; then
     echo -e "\n${B}Preflight${N} — host requirements, then what this script installs"
     # without root nothing else is checked: every other check reads Docker's socket or the process table
     if check_root; then

--- a/neurons/executor/tests/test_sysbox_setup_preflight.py
+++ b/neurons/executor/tests/test_sysbox_setup_preflight.py
@@ -39,6 +39,7 @@ STUBS = {
         case "$1 $2" in
             "version --format") echo "${STUB_DOCKER_VERSION:-28.5.2}" ;;
             "ps ") exit 0 ;;
+            "ps --filter") echo "${STUB_PORT_CONTAINER:-executor-1}" ;;
             "info --format")
                 case "$3" in
                     *DockerRootDir*) echo "${STUB_DOCKER_ROOT:-$HOST_ROOT/var/lib/docker}" ;;
@@ -235,7 +236,14 @@ def test_docker_29_1_passes_but_says_untested(tmp_path):
 
 @pytest.mark.parametrize("with_jq", [False, True])
 def test_docker_29_7_without_the_two_settings_names_both(tmp_path, with_jq):
-    rc, out, _ = run_check(tmp_path, "check_docker_features", env={"STUB_DOCKER_VERSION": "29.7.0"}, with_jq=with_jq)
+    # a daemon.json that exists but carries neither key, so the jq path is the one that decides
+    rc, out, _ = run_check(
+        tmp_path,
+        "check_docker_features",
+        env={"STUB_DOCKER_VERSION": "29.7.0"},
+        files={"etc/docker/daemon.json": '{"runtimes": {"sysbox-runc": {"path": "/usr/bin/sysbox-runc"}}}\n'},
+        with_jq=with_jq,
+    )
     assert rc == 1
     assert "FIX  Docker 29.7.0 without features.cdi, time-namespaces = false" in out
     assert 'add {"features":{"cdi":false,"time-namespaces":false}} to /etc/docker/daemon.json' in out
@@ -266,13 +274,15 @@ def test_docker_29_3_needs_only_cdi(tmp_path):
     assert "time-namespaces" not in out.split("PASS")[1]
 
 
-def test_docker_29_3_with_cdi_still_on_is_a_fix(tmp_path):
-    # a daemon.json that mentions cdi but leaves it true is the negative control for the grep path
+@pytest.mark.parametrize("with_jq", [False, True])
+def test_docker_29_3_with_cdi_still_on_is_a_fix(tmp_path, with_jq):
+    # a daemon.json that mentions cdi but leaves it true is the negative control for both read paths
     rc, out, _ = run_check(
         tmp_path,
         "check_docker_features",
         env={"STUB_DOCKER_VERSION": "29.3.0"},
         files={"etc/docker/daemon.json": '{"features": {"cdi": true}}\n'},
+        with_jq=with_jq,
     )
     assert rc == 1
     assert "FIX  Docker 29.3.0 without features.cdi = false" in out
@@ -305,7 +315,17 @@ def test_nvidia_smi_missing_is_a_fix(tmp_path):
 def test_nvidia_driver_not_loaded_is_a_fix(tmp_path):
     rc, out, _ = run_check(tmp_path, "check_nvidia_driver", files={"proc/driver/nvidia/version": None})
     assert rc == 1
-    assert "FIX  NVIDIA driver is installed but not loaded" in out
+    assert "FIX  NVIDIA driver is installed but not loaded" in out and "/proc/driver/nvidia missing" in out
+
+
+def test_nvidia_smi_error_text_is_not_read_as_a_version(tmp_path):
+    # nvidia-smi prints this on stdout; it must land in the "not loaded" line with the reboot fix, not in "below 580.65.06"
+    rc, out, _ = run_check(
+        tmp_path, "check_nvidia_driver", env={"STUB_NV_DRIVER": "Failed to initialize NVML: Driver/library version mismatch"}
+    )
+    assert rc == 1
+    assert "FIX  NVIDIA driver is installed but not loaded (nvidia-smi: Failed to initialize NVML" in out
+    assert "sudo reboot" in out and "below 580.65.06" not in out
 
 
 @pytest.mark.parametrize("driver", ["575.57.08", "580.65.05", "580.64.99"])
@@ -407,10 +427,28 @@ def test_port_held_by_another_process_is_a_fix(tmp_path):
     assert "PASS TCP 2200 (SSH port)" in out
 
 
-def test_port_served_by_docker_passes(tmp_path):
+def test_port_served_by_the_executor_container_passes(tmp_path):
     rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_BUSY_PORT": "2200", "STUB_BUSY_PROC": "docker-proxy"})
     assert rc == 0
-    assert "PASS TCP 2200 (SSH port) is served by Docker" in out
+    assert "PASS TCP 2200 (SSH port) is served by the executor (executor-1)" in out
+
+
+def test_port_published_by_another_container_is_a_fix(tmp_path):
+    # a docker-proxy listener is not the executor's by definition: ask Docker whose it is
+    rc, out, _ = run_check(
+        tmp_path,
+        "check_ports",
+        env={"STUB_BUSY_PORT": "8080", "STUB_BUSY_PROC": "docker-proxy", "STUB_PORT_CONTAINER": "nginx-proxy"},
+    )
+    assert rc == 1
+    assert "FIX  TCP 8080 (executor port) is published by container nginx-proxy" in out
+    assert "docker stop nginx-proxy" in out
+
+
+def test_ports_are_skipped_without_ss(tmp_path):
+    rc, out, fix = run_check(tmp_path, "check_ports", without=("ss",))
+    assert rc == 0 and fix == 0
+    assert "SKIP Ports — 'ss' (iproute2) is missing" in out
 
 
 def test_ufw_active_without_a_rule_names_ufw_allow(tmp_path):
@@ -424,6 +462,13 @@ def test_ufw_active_without_a_rule_names_ufw_allow(tmp_path):
 
 def test_ufw_range_rule_covers_the_port(tmp_path):
     ufw = "Status: active\\n2000:9000/tcp   ALLOW   Anywhere"
+    rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_UFW_STATUS": ufw})
+    assert rc == 0, out
+
+
+def test_ufw_verbose_and_interface_rows_are_read(tmp_path):
+    # `ufw status verbose` prints "ALLOW IN"; an interface rule prints "8080/tcp on eth0"; v6 rows carry "(v6)"
+    ufw = "Status: active\\n8080/tcp on eth0   ALLOW IN   Anywhere\\n2200/tcp (v6)   ALLOW IN   Anywhere (v6)\\n2200   ALLOW IN   Anywhere"
     rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_UFW_STATUS": ufw})
     assert rc == 0, out
 
@@ -532,6 +577,8 @@ def test_not_root_is_a_fix_that_names_sudo(tmp_path):
     assert proc.returncode == 1
     assert "FIX  Not running as root" in proc.stdout
     assert f"sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'} --check" in proc.stdout
+    # nothing else runs without root: the other checks would read the process table and Docker's socket as a user
+    assert "Preflight: 0 PASS, 1 FIX, 0 SKIP." in proc.stdout
 
 
 def test_unknown_option_is_refused(tmp_path):

--- a/neurons/executor/tests/test_sysbox_setup_preflight.py
+++ b/neurons/executor/tests/test_sysbox_setup_preflight.py
@@ -561,6 +561,14 @@ def test_sysbox_not_registered_in_docker_is_a_fix(tmp_path):
     assert "FIX  sysbox-runc is installed but not registered" in out
 
 
+def test_sysbox_is_skipped_when_docker_is_not_running(tmp_path):
+    # a failed `docker info` says nothing about the runtime registration
+    rc, out, _ = run_check(tmp_path, "check_sysbox", env={"STUB_NO_DOCKER_DAEMON": "1"})
+    assert rc == 0
+    assert "SKIP sysbox-runc — Docker is not running." in out
+    assert "not registered" not in out
+
+
 def test_sysbox_container_start_failure_is_a_fix(tmp_path):
     rc, out, _ = run_check(tmp_path, "check_sysbox", env={"STUB_SYSBOX_RUN_FAILS": "1"})
     assert rc == 1
@@ -586,7 +594,7 @@ def test_check_mode_without_a_gpu_reports_the_nvidia_fixes_and_exits_one(tmp_pat
     assert "SKIP Disk >= 1.5x VRAM" in proc.stdout
     assert "PASS Kernel 6.8.0-45-generic" in proc.stdout
     assert "Preflight: 9 PASS, 2 FIX, 1 SKIP." in proc.stdout
-    assert f"Fix the lines above, then run: sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'}" in proc.stdout
+    assert f"Fix the lines above, then re-run: sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'} --check" in proc.stdout
 
 
 @pytest.mark.parametrize(
@@ -656,6 +664,9 @@ def test_check_mode_still_exits_one_on_an_advisory_fix(tmp_path):
     assert "FIX  NVIDIA driver 575.57.08 is below 580.65.06" in proc.stdout
     assert "Preflight: 11 PASS, 1 FIX, 0 SKIP." in proc.stdout
     assert "do not stop the install" not in proc.stdout
+    # the installer never installs a driver: pointing at it is the reinstall loop of ticket-0309
+    script = tmp_path / "executor" / "nvidia_docker_sysbox_setup.sh"
+    assert f"Fix the lines above, then re-run: sudo bash {script} --check" in proc.stdout
 
 
 @pytest.mark.parametrize("args", [("--check",), ()])

--- a/neurons/executor/tests/test_sysbox_setup_preflight.py
+++ b/neurons/executor/tests/test_sysbox_setup_preflight.py
@@ -1,0 +1,523 @@
+"""DAH-3319: the preflight in nvidia_docker_sysbox_setup.sh — one PASS / FIX line per host
+requirement with the command that fixes it, run before anything is installed and standalone as
+`--check` (ticket-0309: a provider reinstalled sysbox three times; the cause was a host setting
+nobody had checked).
+
+Same harness as test_sysbox_setup_apt_repo.py: the script is run under bash with stub commands
+on PATH and the files it reads (/proc/modules, /etc/os-release, /etc/docker/daemon.json, ...)
+under a fixture HOST_ROOT. The check functions are sourced with SYSBOX_SETUP_LIB=1.
+"""
+
+import os
+import re
+import shutil
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+SCRIPT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "nvidia_docker_sysbox_setup.sh"))
+
+# the real tools the check functions call, so PATH can be built without the host's jq
+REAL_TOOLS = ["bash", "grep", "sed", "awk", "head", "tail", "cut", "ls", "dirname", "cat", "seq", "rm"]
+
+STUBS = {
+    "id": '#!/bin/bash\necho "${STUB_UID:-0}"\n',
+    "uname": textwrap.dedent(
+        """\
+        #!/bin/bash
+        case "$1" in -r) echo "${STUB_KERNEL:-6.8.0-45-generic}" ;; -m) echo "${STUB_ARCH:-x86_64}" ;; esac
+        """
+    ),
+    "docker": textwrap.dedent(
+        """\
+        #!/bin/bash
+        [ -z "${STUB_NO_DOCKER_DAEMON:-}" ] || { echo "Cannot connect to the Docker daemon" >&2; exit 1; }
+        case "$1 $2" in
+            "version --format") echo "${STUB_DOCKER_VERSION:-28.5.2}" ;;
+            "ps ") exit 0 ;;
+            "info --format")
+                case "$3" in
+                    *DockerRootDir*) echo "${STUB_DOCKER_ROOT:-$HOST_ROOT/var/lib/docker}" ;;
+                    *Runtimes*) echo "${STUB_DOCKER_RUNTIMES:-\\"runc\\", \\"sysbox-runc\\"}" ;;
+                esac ;;
+            "run --rm") [ -z "${STUB_SYSBOX_RUN_FAILS:-}" ] && echo ok || { echo "OCI runtime create failed" >&2; exit 125; } ;;
+        esac
+        """
+    ),
+    "nvidia-smi": textwrap.dedent(
+        """\
+        #!/bin/bash
+        case "$1" in
+            --query-gpu=driver_version) echo "${STUB_NV_DRIVER:-580.65.06}" ;;
+            --query-gpu=memory.total) for _ in $(seq "${STUB_NV_GPUS:-8}"); do echo "${STUB_NV_MEM_MIB:-81559}"; done ;;
+            --list-gpus) for i in $(seq "${STUB_NV_GPUS:-8}"); do echo "GPU $((i - 1)): NVIDIA H100 80GB HBM3"; done ;;
+        esac
+        """
+    ),
+    "nvidia-container-cli": '#!/bin/bash\nprintf "cli-version: 1.17.8\\nlib-version: 1.17.8\\n"\n',
+    "sysbox-runc": '#!/bin/bash\necho "sysbox-runc\\n\\tversion:\\t0.6.6"\n',
+    "ss": textwrap.dedent(
+        """\
+        #!/bin/bash
+        # ss -Hltnp "sport = :PORT": one line when STUB_BUSY_PORT is that port
+        port=${!#}; port=${port##*:}
+        [ "${STUB_BUSY_PORT:-}" = "$port" ] && echo "LISTEN 0 128 0.0.0.0:$port 0.0.0.0:* users:((\\"${STUB_BUSY_PROC:-sshd}\\",pid=812,fd=3))"
+        exit 0
+        """
+    ),
+    "ufw": '#!/bin/bash\nprintf "%b\\n" "${STUB_UFW_STATUS:-Status: inactive}"\n',
+    "df": textwrap.dedent(
+        """\
+        #!/bin/bash
+        echo "Filesystem 1024-blocks Used Available Capacity Mounted on"
+        echo "/dev/nvme0n1p1 ${STUB_DF_TOTAL_KB:-1048576000} 1 1 1% /"
+        """
+    ),
+}
+
+GOOD_FILES = {
+    "etc/os-release": 'NAME="Ubuntu"\nVERSION_ID="22.04"\nID=ubuntu\n',
+    "proc/modules": "ip_tables 32768 3 iptable_nat,iptable_filter\niptable_nat 16384 1\niptable_filter 16384 1\n",
+    "proc/driver/nvidia/version": "NVRM version: 580.65.06\n",
+    "var/lib/docker/.keep": "",
+}
+
+
+def _bin_dir(tmp_path, *, with_jq: bool, without: tuple[str, ...] = ()):
+    """Stubs first, then the real tools the checks need — never the host's jq unless asked."""
+    stubs = tmp_path / "bin"
+    stubs.mkdir(exist_ok=True)
+    for name, body in STUBS.items():
+        if name in without:
+            (stubs / name).unlink(missing_ok=True)
+            continue
+        path = stubs / name
+        path.write_text(body)
+        path.chmod(0o755)
+    tools = REAL_TOOLS + (["jq"] if with_jq else [])
+    for tool in tools:
+        real = shutil.which(tool)
+        if real is None:
+            if tool == "jq":
+                pytest.skip("jq not installed")
+            raise RuntimeError(f"{tool} not on PATH")
+        link = stubs / tool
+        if not link.exists():
+            link.symlink_to(real)
+    return stubs
+
+
+def _host_root(tmp_path, files=None):
+    root = tmp_path / "root"
+    for rel, content in {**GOOD_FILES, **(files or {})}.items():
+        if content is None:
+            continue
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return root
+
+
+def run_check(tmp_path, function, *, env=None, files=None, with_jq=False, without=()):
+    """Source the installer's functions and run one check; returns (rc, output, fix_count)."""
+    stubs = _bin_dir(tmp_path, with_jq=with_jq, without=without)
+    root = _host_root(tmp_path, files)
+    program = (
+        f"SYSBOX_SETUP_LIB=1 . {SCRIPT}\nset +e\n{function}\nrc=$?\necho \"RC=$rc FIX=$PREFLIGHT_FIX PASS=$PREFLIGHT_PASS SKIP=$PREFLIGHT_SKIP\"\n"
+    )
+    proc = subprocess.run(
+        ["bash", "-c", program],
+        capture_output=True,
+        text=True,
+        env={"PATH": str(stubs), "HOST_ROOT": str(root), **(env or {})},
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    out = ANSI.sub("", proc.stdout)
+    counts = dict(kv.split("=") for kv in out.strip().splitlines()[-1].split())
+    return int(counts["RC"]), out, int(counts["FIX"])
+
+
+def run_script(tmp_path, *args, env=None, files=None, without=()):
+    """The installer itself, as a provider runs it, with the same stubs and fixture tree; stdout without colour."""
+    stubs = _bin_dir(tmp_path, with_jq=False, without=without)
+    root = _host_root(tmp_path, files)
+    proc = subprocess.run(
+        ["bash", SCRIPT, *args],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        env={"PATH": str(stubs), "HOST_ROOT": str(root), **(env or {})},
+    )
+    proc.stdout = ANSI.sub("", proc.stdout)
+    return proc
+
+
+pytestmark = pytest.mark.skipif(sys.platform == "win32", reason="bash installer")
+
+
+# ── kernel ───────────────────────────────────────────────────────────────────
+
+
+def test_kernel_6_8_passes(tmp_path):
+    rc, out, fix = run_check(tmp_path, "check_kernel")
+    assert rc == 0 and fix == 0
+    assert "PASS Kernel 6.8.0-45-generic" in out
+
+
+def test_kernel_5_15_on_22_04_names_the_hwe_kernel(tmp_path):
+    rc, out, fix = run_check(tmp_path, "check_kernel", env={"STUB_KERNEL": "5.15.0-91-generic"})
+    assert rc == 1 and fix == 1
+    assert "FIX  Kernel 5.15.0-91-generic is below 5.19" in out
+    assert "sudo apt-get install -y linux-generic-hwe-22.04 && sudo reboot" in out
+    assert "SYSBOX_SKIP_KERNEL_CHECK=1" in out
+
+
+def test_kernel_5_15_on_20_04_says_upgrade_the_distro(tmp_path):
+    rc, out, _ = run_check(
+        tmp_path, "check_kernel", env={"STUB_KERNEL": "5.15.0-91-generic"}, files={"etc/os-release": 'VERSION_ID="20.04"\n'}
+    )
+    assert rc == 1
+    assert "Ubuntu 20.04 tops out at 5.15" in out
+    assert "do-release-upgrade" in out
+    assert "hwe-22.04" not in out
+
+
+def test_kernel_override_is_honoured(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_kernel", env={"STUB_KERNEL": "5.15.0-91-generic", "SYSBOX_SKIP_KERNEL_CHECK": "1"})
+    assert rc == 0
+    assert "PASS Kernel 5.15.0-91-generic accepted because SYSBOX_SKIP_KERNEL_CHECK=1" in out
+
+
+# ── docker ───────────────────────────────────────────────────────────────────
+
+
+def test_docker_28_passes_with_its_version(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_docker")
+    assert rc == 0
+    assert "PASS Docker 28.5.2." in out
+
+
+def test_docker_missing_names_the_install_command(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_docker", without=("docker",))
+    assert rc == 1
+    assert "FIX  Docker is not installed." in out
+    assert "curl -fsSL https://get.docker.com | sudo sh" in out
+
+
+def test_docker_daemon_down_names_systemctl(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_docker", env={"STUB_NO_DOCKER_DAEMON": "1"})
+    assert rc == 1
+    assert "FIX  Docker daemon is not running" in out
+    assert "sudo systemctl enable --now docker" in out
+
+
+def test_docker_29_1_passes_but_says_untested(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_docker", env={"STUB_DOCKER_VERSION": "29.1.0"})
+    assert rc == 0
+    assert "PASS Docker 29.1.0 (29.0–29.1 is untested with sysbox" in out
+
+
+@pytest.mark.parametrize("with_jq", [False, True])
+def test_docker_29_7_without_the_two_settings_names_both(tmp_path, with_jq):
+    rc, out, _ = run_check(tmp_path, "check_docker_features", env={"STUB_DOCKER_VERSION": "29.7.0"}, with_jq=with_jq)
+    assert rc == 1
+    assert "FIX  Docker 29.7.0 without features.cdi, time-namespaces = false" in out
+    assert '{"features":{"cdi":false,"time-namespaces":false}}' in out
+
+
+@pytest.mark.parametrize("with_jq", [False, True])
+def test_docker_29_7_with_both_settings_passes(tmp_path, with_jq):
+    rc, out, _ = run_check(
+        tmp_path,
+        "check_docker_features",
+        env={"STUB_DOCKER_VERSION": "29.7.0"},
+        files={"etc/docker/daemon.json": '{"runtimes": {}, "features": {"cdi": false, "time-namespaces": false}}\n'},
+        with_jq=with_jq,
+    )
+    assert rc == 0, out
+    assert "PASS Docker 29.7.0 has the sysbox settings" in out
+    assert "features.cdi and features.time-namespaces = false" in out
+
+
+def test_docker_29_3_needs_only_cdi(tmp_path):
+    rc, out, _ = run_check(
+        tmp_path,
+        "check_docker_features",
+        env={"STUB_DOCKER_VERSION": "29.3.0"},
+        files={"etc/docker/daemon.json": '{"features": {"cdi": false}}\n'},
+    )
+    assert rc == 0, out
+    assert "time-namespaces" not in out.split("PASS")[1]
+
+
+def test_docker_29_3_with_cdi_still_on_is_a_fix(tmp_path):
+    # a daemon.json that mentions cdi but leaves it true is the negative control for the grep path
+    rc, out, _ = run_check(
+        tmp_path,
+        "check_docker_features",
+        env={"STUB_DOCKER_VERSION": "29.3.0"},
+        files={"etc/docker/daemon.json": '{"features": {"cdi": true}}\n'},
+    )
+    assert rc == 1
+    assert "FIX  Docker 29.3.0 without features.cdi = false" in out
+
+
+def test_docker_28_needs_no_features(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_docker_features")
+    assert rc == 0
+    assert "PASS Docker 28.5.2 needs no daemon.json features" in out
+
+
+# ── nvidia ───────────────────────────────────────────────────────────────────
+
+
+def test_nvidia_driver_580_with_8_gpus_passes(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_nvidia_driver")
+    assert rc == 0
+    assert "PASS NVIDIA driver 580.65.06 (8 GPU(s))." in out
+
+
+def test_nvidia_smi_missing_is_a_fix(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_nvidia_driver", without=("nvidia-smi",))
+    assert rc == 1
+    assert "FIX  nvidia-smi not found" in out
+    assert "sudo apt-get install -y nvidia-driver-580-server && sudo reboot" in out
+
+
+def test_nvidia_driver_not_loaded_is_a_fix(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_nvidia_driver", files={"proc/driver/nvidia/version": None})
+    assert rc == 1
+    assert "FIX  NVIDIA driver is installed but not loaded" in out
+
+
+def test_nvidia_driver_below_validator_minimum_is_a_fix(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_nvidia_driver", env={"STUB_NV_DRIVER": "575.57.08"})
+    assert rc == 1
+    assert "FIX  NVIDIA driver 575.57.08 is below 580.65.06" in out
+
+
+def test_nvidia_toolkit_present_and_missing(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_nvidia_toolkit")
+    assert rc == 0 and "PASS NVIDIA container toolkit (nvidia-container-cli 1.17.8)." in out
+    rc, out, _ = run_check(tmp_path, "check_nvidia_toolkit", without=("nvidia-container-cli",))
+    assert rc == 1 and "FIX  NVIDIA container toolkit is not installed" in out
+
+
+# ── iptables modules (ticket-0309) ───────────────────────────────────────────
+
+
+def test_iptables_modules_loaded_pass(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_iptables_modules")
+    assert rc == 0
+    assert "PASS Legacy iptables modules loaded" in out
+
+
+def test_iptables_modules_missing_name_modprobe_and_the_persistent_file(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_iptables_modules", files={"proc/modules": "nf_tables 311296 0\n"})
+    assert rc == 1
+    assert "FIX  Kernel modules ip_tables iptable_nat iptable_filter are not loaded" in out
+    assert "sudo modprobe -a ip_tables iptable_nat iptable_filter" in out
+    assert "/etc/modules-load.d/lium-iptables.conf" in out
+
+
+def test_iptables_built_in_modules_count_as_loaded(tmp_path):
+    files = {"proc/modules": "nf_tables 311296 0\n"}
+    for mod in ("ip_tables", "iptable_nat", "iptable_filter"):
+        files[f"sys/module/{mod}/.keep"] = ""
+    rc, out, _ = run_check(tmp_path, "check_iptables_modules", files=files)
+    assert rc == 0, out
+
+
+# ── disk >= 1.5x VRAM (validators' MIN_DISK_TO_VRAM_RATE) ────────────────────
+
+
+def test_disk_rule_uses_total_size_of_dockers_filesystem(tmp_path):
+    # 8 x 81559 MiB = 637.2 GB VRAM -> needs 955.8 GB; the fixture filesystem is 1000.0 GB
+    rc, out, _ = run_check(tmp_path, "check_disk_for_vram")
+    assert rc == 0
+    assert "PASS Disk 1000.0 GB on " in out
+    assert ">= 955.8 GB (1.5x of 637.2 GB VRAM)" in out
+
+
+def test_disk_below_the_rule_is_a_fix_with_the_numbers(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_disk_for_vram", env={"STUB_DF_TOTAL_KB": str(500 * 1024 * 1024)})
+    assert rc == 1
+    assert "FIX  Disk 500.0 GB on " in out
+    assert "is below 955.8 GB (1.5x of 637.2 GB VRAM)" in out
+    assert "earns nothing while idle" in out
+
+
+def test_disk_rule_is_skipped_without_a_gpu(tmp_path):
+    rc, out, fix = run_check(tmp_path, "check_disk_for_vram", without=("nvidia-smi",))
+    assert rc == 0 and fix == 0
+    assert "SKIP Disk >= 1.5x VRAM — no NVIDIA driver" in out
+
+
+# ── ports ────────────────────────────────────────────────────────────────────
+
+
+def test_ports_free_and_no_ufw_pass_with_the_outside_probe_hint(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_ports")
+    assert rc == 0
+    assert "PASS TCP 8080 (executor port) is free" in out
+    assert "PASS TCP 2200 (SSH port) is free" in out
+    assert "nc -vz <this host's public IP> 8080 2200" in out
+
+
+def test_port_held_by_another_process_is_a_fix(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_BUSY_PORT": "8080", "STUB_BUSY_PROC": "nginx"})
+    assert rc == 1
+    assert "FIX  TCP 8080 (executor port) is already in use by " in out and "nginx" in out
+    assert "PASS TCP 2200 (SSH port)" in out
+
+
+def test_port_served_by_docker_passes(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_BUSY_PORT": "2200", "STUB_BUSY_PROC": "docker-proxy"})
+    assert rc == 0
+    assert "PASS TCP 2200 (SSH port) is served by Docker" in out
+
+
+def test_ufw_active_without_a_rule_names_ufw_allow(tmp_path):
+    ufw = "Status: active\\n\\nTo   Action   From\\n--   ------   ----\\n22/tcp   ALLOW   Anywhere\\n8080/tcp   ALLOW   Anywhere"
+    rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_UFW_STATUS": ufw})
+    assert rc == 1
+    assert "PASS TCP 8080 (executor port)" in out
+    assert "FIX  TCP 2200 (SSH port) is blocked by ufw" in out
+    assert "sudo ufw allow 2200/tcp" in out
+
+
+def test_ufw_range_rule_covers_the_port(tmp_path):
+    ufw = "Status: active\\n2000:9000/tcp   ALLOW   Anywhere"
+    rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_UFW_STATUS": ufw})
+    assert rc == 0, out
+
+
+def test_ports_come_from_env_then_the_env_file(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_ports", env={"EXECUTOR_PORT": "8001", "SSH_PORT": "2201"})
+    assert rc == 0
+    assert "TCP 8001 (executor port)" in out and "TCP 2201 (SSH port)" in out
+
+
+def test_env_file_next_to_the_script_is_read(tmp_path):
+    # $0 is the script under test when sourced via a copy next to a .env
+    copy_dir = tmp_path / "executor"
+    copy_dir.mkdir()
+    shutil.copy(SCRIPT, copy_dir / "nvidia_docker_sysbox_setup.sh")
+    (copy_dir / ".env").write_text("INTERNAL_PORT=8001\nEXTERNAL_PORT=8123 # external\nSSH_PORT=2299\n")
+    stubs = _bin_dir(tmp_path, with_jq=False)
+    root = _host_root(tmp_path)
+    proc = subprocess.run(
+        ["bash", str(copy_dir / "nvidia_docker_sysbox_setup.sh"), "--check"],
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        env={"PATH": str(stubs), "HOST_ROOT": str(root)},
+    )
+    assert "TCP 8123 (executor port)" in proc.stdout and "TCP 2299 (SSH port)" in proc.stdout
+
+
+# ── sysbox probe ─────────────────────────────────────────────────────────────
+
+
+def test_sysbox_installed_registered_and_running_passes(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_sysbox")
+    assert rc == 0
+    assert "PASS sysbox-runc 0.6.6 runs a container." in out
+
+
+def test_sysbox_missing_points_at_the_installer(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_sysbox", without=("sysbox-runc",))
+    assert rc == 1
+    assert "FIX  sysbox-runc is not installed" in out
+
+
+def test_sysbox_not_registered_in_docker_is_a_fix(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_sysbox", env={"STUB_DOCKER_RUNTIMES": '{"runc":{}}'})
+    assert rc == 1
+    assert "FIX  sysbox-runc is installed but not registered" in out
+
+
+def test_sysbox_container_start_failure_is_a_fix(tmp_path):
+    rc, out, _ = run_check(tmp_path, "check_sysbox", env={"STUB_SYSBOX_RUN_FAILS": "1"})
+    assert rc == 1
+    assert "docker run --rm --runtime=sysbox-runc alpine echo ok' fails" in out
+
+
+# ── the script as a provider runs it ─────────────────────────────────────────
+
+
+def test_check_mode_on_a_good_host_exits_zero_with_a_summary(tmp_path):
+    proc = run_script(tmp_path, "--check")
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "FIX  " not in proc.stdout
+    assert "Preflight: 12 PASS, 0 FIX, 0 SKIP." in proc.stdout
+
+
+def test_check_mode_without_a_gpu_reports_the_nvidia_fixes_and_exits_one(tmp_path):
+    # the EC2 shape: kernel, docker, disk and ports fine, no NVIDIA driver
+    proc = run_script(tmp_path, "--check", without=("nvidia-smi", "nvidia-container-cli"))
+    assert proc.returncode == 1
+    assert "FIX  nvidia-smi not found" in proc.stdout
+    assert "FIX  NVIDIA container toolkit is not installed" in proc.stdout
+    assert "SKIP Disk >= 1.5x VRAM" in proc.stdout
+    assert "PASS Kernel 6.8.0-45-generic" in proc.stdout
+    assert "Preflight: 9 PASS, 2 FIX, 1 SKIP." in proc.stdout
+    assert f"Fix the lines above, then run: sudo bash {SCRIPT}" in proc.stdout
+
+
+def test_install_mode_stops_before_installing_on_a_fix(tmp_path):
+    apt = tmp_path / "bin" / "apt-get"
+    apt.parent.mkdir()
+    apt.write_text('#!/bin/bash\necho "apt-get $*" >> "$HOST_ROOT/apt.log"\n')
+    apt.chmod(0o755)
+    proc = run_script(tmp_path, env={"STUB_KERNEL": "5.15.0-91-generic"})
+    root = tmp_path / "root"
+    assert proc.returncode == 1
+    assert "FIX  Kernel 5.15.0-91-generic is below 5.19" in proc.stdout
+    assert "Nothing was installed." in proc.stdout
+    assert not (root / "apt.log").exists(), "apt must not run after a FIX"
+    assert "Installing packages" not in proc.stdout
+
+
+def test_not_root_is_a_fix_that_names_sudo(tmp_path):
+    proc = run_script(tmp_path, "--check", env={"STUB_UID": "1000"})
+    assert proc.returncode == 1
+    assert "FIX  Not running as root" in proc.stdout
+    assert "sudo bash" in proc.stdout and "--check" in proc.stdout
+
+
+def test_unknown_option_is_refused(tmp_path):
+    proc = run_script(tmp_path, "--bogus")
+    assert proc.returncode == 2
+    assert "Unknown option: --bogus" in proc.stdout
+
+
+def test_fix_lines_name_the_curl_one_liner_when_piped_from_curl(tmp_path):
+    # `curl … | sudo bash -s -- --check` has no script file behind $0
+    stubs = _bin_dir(tmp_path, with_jq=False, without=("sysbox-runc",))
+    root = _host_root(tmp_path)
+    with open(SCRIPT) as fh:
+        script = fh.read()
+    proc = subprocess.run(
+        ["bash", "-s", "--", "--check"],
+        input=script,
+        capture_output=True,
+        text=True,
+        env={"PATH": str(stubs), "HOST_ROOT": str(root)},
+    )
+    out = ANSI.sub("", proc.stdout)
+    assert proc.returncode == 1
+    assert "FIX  sysbox-runc is not installed" in out
+    assert "curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash" in out
+    assert "sudo bash bash" not in out
+
+
+def test_help_lists_check_and_exits_zero(tmp_path):
+    # exit 0 is also the regression test for the EXIT trap that used to turn every clean exit into status 1
+    proc = run_script(tmp_path, "--help")
+    assert proc.returncode == 0
+    assert "--check" in proc.stdout

--- a/neurons/executor/tests/test_sysbox_setup_preflight.py
+++ b/neurons/executor/tests/test_sysbox_setup_preflight.py
@@ -5,7 +5,7 @@ nobody had checked).
 
 Same harness as test_sysbox_setup_apt_repo.py: the script is run under bash with stub commands
 on PATH and the files it reads (/proc/modules, /etc/os-release, /etc/docker/daemon.json, ...)
-under a fixture HOST_ROOT. The check functions are sourced with SYSBOX_SETUP_LIB=1.
+under a fixture SYSBOX_SETUP_HOST_ROOT. The check functions are sourced with SYSBOX_SETUP_LIB=1.
 """
 
 import os
@@ -14,6 +14,8 @@ import shutil
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -40,9 +42,10 @@ STUBS = {
             "version --format") echo "${STUB_DOCKER_VERSION:-28.5.2}" ;;
             "ps ") exit 0 ;;
             "ps --filter") echo "${STUB_PORT_CONTAINER:-executor-1}" ;;
+            "info ") echo " Runtimes: io.containerd.runc.v2 nvidia runc sysbox-runc" ;;   # the "already working?" probe of install mode
             "info --format")
                 case "$3" in
-                    *DockerRootDir*) echo "${STUB_DOCKER_ROOT:-$HOST_ROOT/var/lib/docker}" ;;
+                    *DockerRootDir*) echo "${STUB_DOCKER_ROOT:-$SYSBOX_SETUP_HOST_ROOT/var/lib/docker}" ;;
                     *Runtimes*) echo "${STUB_DOCKER_RUNTIMES:-\\"runc\\", \\"sysbox-runc\\"}" ;;
                 esac ;;
             "run --rm") [ -z "${STUB_SYSBOX_RUN_FAILS:-}" ] && echo ok || { echo "OCI runtime create failed" >&2; exit 125; } ;;
@@ -60,7 +63,8 @@ STUBS = {
         """
     ),
     "nvidia-container-cli": '#!/bin/bash\nprintf "cli-version: 1.17.8\\nlib-version: 1.17.8\\n"\n',
-    "sysbox-runc": '#!/bin/bash\necho "sysbox-runc\\n\\tversion:\\t0.6.6"\n',
+    # the real `sysbox-runc --version`: the name alone on line 1, the version on line 2
+    "sysbox-runc": '#!/bin/bash\nprintf "sysbox-runc\\n\\tversion:\\t0.6.6\\n\\tcommit:\\tabc123\\n"\n',
     "ss": textwrap.dedent(
         """\
         #!/bin/bash
@@ -88,7 +92,7 @@ GOOD_FILES = {
 }
 
 
-def _bin_dir(tmp_path, *, with_jq: bool, without: tuple[str, ...] = ()):
+def _bin_dir(tmp_path: Path, *, with_jq: bool, without: tuple[str, ...] = ()) -> Path:
     """Stubs first, then the real tools the checks need — never the host's jq unless asked."""
     stubs = tmp_path / "bin"
     stubs.mkdir(exist_ok=True)
@@ -112,7 +116,8 @@ def _bin_dir(tmp_path, *, with_jq: bool, without: tuple[str, ...] = ()):
     return stubs
 
 
-def _host_root(tmp_path, files=None):
+def _host_root(tmp_path: Path, files: dict[str, str | None] | None = None) -> Path:
+    """The fixture tree the script reads through SYSBOX_SETUP_HOST_ROOT; a None value leaves that file out."""
     root = tmp_path / "root"
     for rel, content in {**GOOD_FILES, **(files or {})}.items():
         if content is None:
@@ -123,7 +128,7 @@ def _host_root(tmp_path, files=None):
     return root
 
 
-def _script_copy(tmp_path):
+def _script_copy(tmp_path: Path) -> Path:
     """The script in its own directory, so the `.env` it may read next to itself is the test's, never the checkout's."""
     copy_dir = tmp_path / "executor"
     copy_dir.mkdir(exist_ok=True)
@@ -132,27 +137,47 @@ def _script_copy(tmp_path):
     return copy
 
 
-def run_check(tmp_path, function, *, env=None, files=None, with_jq=False, without=()):
-    """Source the installer's functions and run one check; returns (rc, output, fix_count)."""
+class CheckResult(NamedTuple):
+    rc: int
+    output: str
+    fix_count: int
+
+
+def run_check(
+    tmp_path: Path,
+    function: str,
+    *,
+    env: dict[str, str] | None = None,
+    files: dict[str, str | None] | None = None,
+    with_jq: bool = False,
+    without: tuple[str, ...] = (),
+) -> CheckResult:
+    """Source the installer's functions and run one check."""
     stubs = _bin_dir(tmp_path, with_jq=with_jq, without=without)
     root = _host_root(tmp_path, files)
-    program = (
+    bash_snippet = (
         f"SYSBOX_SETUP_LIB=1 . {SCRIPT}\nset +e\n{function}\nrc=$?\necho \"RC=$rc FIX=$PREFLIGHT_FIX PASS=$PREFLIGHT_PASS SKIP=$PREFLIGHT_SKIP\"\n"
     )
     proc = subprocess.run(
-        ["bash", "-c", program],
+        ["bash", "-c", bash_snippet],
         capture_output=True,
         text=True,
         cwd=tmp_path,
-        env={"PATH": str(stubs), "HOST_ROOT": str(root), **(env or {})},
+        env={"PATH": str(stubs), "SYSBOX_SETUP_HOST_ROOT": str(root), **(env or {})},
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
     out = ANSI.sub("", proc.stdout)
-    counts = dict(kv.split("=") for kv in out.strip().splitlines()[-1].split())
-    return int(counts["RC"]), out, int(counts["FIX"])
+    summary_counters = dict(kv.split("=") for kv in out.strip().splitlines()[-1].split())
+    return CheckResult(int(summary_counters["RC"]), out, int(summary_counters["FIX"]))
 
 
-def run_script(tmp_path, *args, env=None, files=None, without=()):
+def run_script(
+    tmp_path: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+    files: dict[str, str | None] | None = None,
+    without: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
     """The installer itself, as a provider runs it, with the same stubs and fixture tree; stdout without colour."""
     stubs = _bin_dir(tmp_path, with_jq=False, without=without)
     root = _host_root(tmp_path, files)
@@ -162,7 +187,7 @@ def run_script(tmp_path, *args, env=None, files=None, without=()):
         text=True,
         stdin=subprocess.DEVNULL,
         cwd=tmp_path,
-        env={"PATH": str(stubs), "HOST_ROOT": str(root), **(env or {})},
+        env={"PATH": str(stubs), "SYSBOX_SETUP_HOST_ROOT": str(root), **(env or {})},
     )
     proc.stdout = ANSI.sub("", proc.stdout)
     return proc
@@ -378,14 +403,14 @@ def test_iptables_built_in_modules_count_as_loaded(tmp_path):
 
 def test_disk_rule_uses_total_size_of_dockers_filesystem(tmp_path):
     # 8 x 81559 MiB = 637.2 GB VRAM -> needs 955.8 GB; the fixture filesystem is 1000.0 GB
-    rc, out, _ = run_check(tmp_path, "check_disk_for_vram")
+    rc, out, _ = run_check(tmp_path, "check_total_disk_for_vram")
     assert rc == 0
     assert "PASS Disk 1000.0 GB on " in out
     assert ">= 955.8 GB (1.5x of 637.2 GB VRAM)" in out
 
 
 def test_disk_below_the_rule_is_a_fix_with_the_numbers(tmp_path):
-    rc, out, _ = run_check(tmp_path, "check_disk_for_vram", env={"STUB_DF_TOTAL_KB": str(500 * 1024 * 1024)})
+    rc, out, _ = run_check(tmp_path, "check_total_disk_for_vram", env={"STUB_DF_TOTAL_KB": str(500 * 1024 * 1024)})
     assert rc == 1
     assert "FIX  Disk 500.0 GB on " in out
     assert "is below 955.8 GB (1.5x of 637.2 GB VRAM)" in out
@@ -396,15 +421,15 @@ def test_disk_rule_compares_like_the_validator_at_the_boundary(tmp_path):
     # 1x 81613 MiB = 79.7 GB VRAM -> 119.55 GB needed. The validator compares 79.7 * 1.5 unrounded with the rounded
     # disk, so 119.5 GB fails; a compare against the displayed (rounded) 119.5 would have passed it.
     env = {"STUB_NV_GPUS": "1", "STUB_NV_MEM_MIB": "81613"}
-    rc, out, _ = run_check(tmp_path, "check_disk_for_vram", env={**env, "STUB_DF_TOTAL_KB": str(int(119.5 * 1024 * 1024))})
+    rc, out, _ = run_check(tmp_path, "check_total_disk_for_vram", env={**env, "STUB_DF_TOTAL_KB": str(int(119.5 * 1024 * 1024))})
     assert rc == 1, out
     assert "FIX  Disk 119.5 GB" in out and "(1.5x of 79.7 GB VRAM)" in out
-    rc, out, _ = run_check(tmp_path, "check_disk_for_vram", env={**env, "STUB_DF_TOTAL_KB": str(int(119.6 * 1024 * 1024))})
+    rc, out, _ = run_check(tmp_path, "check_total_disk_for_vram", env={**env, "STUB_DF_TOTAL_KB": str(int(119.6 * 1024 * 1024))})
     assert rc == 0, out
 
 
 def test_disk_rule_is_skipped_without_a_gpu(tmp_path):
-    rc, out, fix = run_check(tmp_path, "check_disk_for_vram", without=("nvidia-smi",))
+    rc, out, fix = run_check(tmp_path, "check_total_disk_for_vram", without=("nvidia-smi",))
     assert rc == 0 and fix == 0
     assert "SKIP Disk >= 1.5x VRAM — no NVIDIA driver" in out
 
@@ -456,7 +481,7 @@ def test_ufw_active_without_a_rule_names_ufw_allow(tmp_path):
     rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_UFW_STATUS": ufw})
     assert rc == 1
     assert "PASS TCP 8080 (executor port)" in out
-    assert "FIX  TCP 2200 (SSH port) is blocked by ufw" in out
+    assert "FIX  TCP 2200 (SSH port) has no inbound allow rule in the active ufw" in out
     assert "sudo ufw allow 2200/tcp" in out
 
 
@@ -471,6 +496,15 @@ def test_ufw_verbose_and_interface_rows_are_read(tmp_path):
     ufw = "Status: active\\n8080/tcp on eth0   ALLOW IN   Anywhere\\n2200/tcp (v6)   ALLOW IN   Anywhere (v6)\\n2200   ALLOW IN   Anywhere"
     rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_UFW_STATUS": ufw})
     assert rc == 0, out
+
+
+def test_ufw_allow_out_row_does_not_open_an_inbound_port(tmp_path):
+    # an outbound rule (or a `ufw route` FWD rule) on the port is not a rule that lets validators in; only 2200 has an inbound ALLOW
+    ufw = "Status: active\\n8080/tcp   ALLOW OUT   Anywhere\\n8080/tcp   ALLOW FWD   Anywhere\\n2200/tcp   ALLOW IN   Anywhere"
+    rc, out, _ = run_check(tmp_path, "check_ports", env={"STUB_UFW_STATUS": ufw})
+    assert rc == 1
+    assert "FIX  TCP 8080 (executor port) has no inbound allow rule in the active ufw" in out
+    assert "PASS TCP 2200 (SSH port)" in out
 
 
 def test_ports_come_from_env_then_the_env_file(tmp_path):
@@ -499,7 +533,7 @@ def test_env_file_in_the_working_directory_is_ignored_when_piped_from_curl(tmp_p
         capture_output=True,
         text=True,
         cwd=tmp_path,
-        env={"PATH": str(stubs), "HOST_ROOT": str(root)},
+        env={"PATH": str(stubs), "SYSBOX_SETUP_HOST_ROOT": str(root)},
     )
     out = ANSI.sub("", proc.stdout)
     assert "TCP 8080 (executor port)" in out and "TCP 2200 (SSH port)" in out
@@ -555,30 +589,85 @@ def test_check_mode_without_a_gpu_reports_the_nvidia_fixes_and_exits_one(tmp_pat
     assert f"Fix the lines above, then run: sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'}" in proc.stdout
 
 
-def test_install_mode_stops_before_installing_on_a_fix(tmp_path):
-    proc = run_script(tmp_path, env={"STUB_KERNEL": "5.15.0-91-generic"})
+@pytest.mark.parametrize(
+    "env, fix_line",
+    [
+        ({"STUB_KERNEL": "5.15.0-91-generic"}, "FIX  Kernel 5.15.0-91-generic is below 5.19"),
+        ({"STUB_NO_DOCKER_DAEMON": "1"}, "FIX  Docker daemon is not running"),
+        ({"STUB_ARCH": "aarch64"}, "FIX  Architecture aarch64"),
+    ],
+)
+def test_install_mode_stops_before_installing_on_a_blocking_fix(tmp_path, env, fix_line):
+    # sysbox itself cannot go on this host without these; nothing after the preflight runs
+    proc = run_script(tmp_path, env=env)
     assert proc.returncode == 1
-    assert "FIX  Kernel 5.15.0-91-generic is below 5.19" in proc.stdout
+    assert fix_line in proc.stdout
     assert "Nothing was installed." in proc.stdout
-    # step 2 is the first thing after the preflight; on a good host the same stubs reach it (next test)
-    assert "Checking running containers" not in proc.stdout
+    assert "Sysbox is already working" not in proc.stdout and "Checking running containers" not in proc.stdout
 
 
 def test_install_mode_on_a_good_host_reaches_the_install_steps(tmp_path):
-    # the negative control for the test above: same stubs, kernel fine -> the preflight passes and the script goes on
+    # the negative control for the test above: same stubs, host fine -> the preflight passes and the script goes on
+    # (the stubbed Docker already knows sysbox-runc and runs the GPU probe, so the script ends at "Nothing to do.")
     proc = run_script(tmp_path)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
     assert "Preflight: 9 PASS, 0 FIX, 0 SKIP." in proc.stdout
     assert "Nothing was installed." not in proc.stdout
-    assert "Checking running containers" in proc.stdout or "Sysbox is already working" in proc.stdout
+    assert "Sysbox is already working. Nothing to do." in proc.stdout
+    assert "FIX line(s) at the top" not in proc.stdout
 
 
-def test_not_root_is_a_fix_that_names_sudo(tmp_path):
-    proc = run_script(tmp_path, "--check", env={"STUB_UID": "1000"})
+@pytest.mark.parametrize(
+    "env, without, fix_line",
+    [
+        ({"STUB_NV_DRIVER": "575.57.08"}, (), "FIX  NVIDIA driver 575.57.08 is below 580.65.06"),
+        ({}, ("nvidia-smi",), "FIX  nvidia-smi not found"),
+        ({"STUB_DF_TOTAL_KB": str(500 * 1024 * 1024)}, (), "FIX  Disk 500.0 GB on "),
+        ({"STUB_BUSY_PORT": "8080", "STUB_BUSY_PROC": "nginx"}, (), "FIX  TCP 8080 (executor port) is already in use by "),
+        ({"STUB_UFW_STATUS": "Status: active"}, (), "FIX  TCP 2200 (SSH port) has no inbound allow rule in the active ufw"),
+    ],
+)
+def test_install_mode_goes_on_after_an_advisory_fix(tmp_path, env, without, fix_line):
+    # driver, disk and ports are what the validators want once the node runs; without sysbox the node is not
+    # listed at all, so the FIX is printed with its command and the install continues to a clean exit
+    proc = run_script(tmp_path, env=env, without=without)
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert fix_line in proc.stdout
+    assert "The FIX lines above do not stop the install" in proc.stdout
+    assert "Nothing was installed." not in proc.stdout
+    assert "Sysbox is already working. Nothing to do." in proc.stdout
+    assert f"Run those commands, then: sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'} --check" in proc.stdout
+
+
+def test_install_mode_goes_on_without_the_iptables_modules(tmp_path):
+    # the ticket-0309 cause: the FIX names the modprobe, and the install no longer waits for it
+    proc = run_script(tmp_path, files={"proc/modules": "nf_tables 311296 0\n"})
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "FIX  Kernel modules ip_tables iptable_nat iptable_filter are not loaded" in proc.stdout
+    assert "sudo modprobe -a ip_tables iptable_nat iptable_filter" in proc.stdout
+    assert "Sysbox is already working. Nothing to do." in proc.stdout
+    assert "The preflight printed 1 FIX line(s) at the top." in proc.stdout
+
+
+def test_check_mode_still_exits_one_on_an_advisory_fix(tmp_path):
+    # --check reports; the advisory / blocking split is install mode's
+    proc = run_script(tmp_path, "--check", env={"STUB_NV_DRIVER": "575.57.08"})
+    assert proc.returncode == 1
+    assert "FIX  NVIDIA driver 575.57.08 is below 580.65.06" in proc.stdout
+    assert "Preflight: 11 PASS, 1 FIX, 0 SKIP." in proc.stdout
+    assert "do not stop the install" not in proc.stdout
+
+
+@pytest.mark.parametrize("args", [("--check",), ()])
+def test_not_root_is_a_fix_that_names_sudo(tmp_path, args):
+    proc = run_script(tmp_path, *args, env={"STUB_UID": "1000"})
     assert proc.returncode == 1
     assert "FIX  Not running as root" in proc.stdout
-    assert f"sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'} --check" in proc.stdout
+    assert f"sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'}{' --check' if args else ''}\n" in proc.stdout
     # nothing else runs without root: the other checks would read the process table and Docker's socket as a user
     assert "Preflight: 0 PASS, 1 FIX, 0 SKIP." in proc.stdout
+    if not args:
+        assert "Nothing was installed." in proc.stdout
 
 
 def test_unknown_option_is_refused(tmp_path):
@@ -598,7 +687,7 @@ def test_fix_lines_name_the_curl_one_liner_when_piped_from_curl(tmp_path):
         input=script,
         capture_output=True,
         text=True,
-        env={"PATH": str(stubs), "HOST_ROOT": str(root)},
+        env={"PATH": str(stubs), "SYSBOX_SETUP_HOST_ROOT": str(root)},
     )
     out = ANSI.sub("", proc.stdout)
     assert proc.returncode == 1

--- a/neurons/executor/tests/test_sysbox_setup_preflight.py
+++ b/neurons/executor/tests/test_sysbox_setup_preflight.py
@@ -122,6 +122,15 @@ def _host_root(tmp_path, files=None):
     return root
 
 
+def _script_copy(tmp_path):
+    """The script in its own directory, so the `.env` it may read next to itself is the test's, never the checkout's."""
+    copy_dir = tmp_path / "executor"
+    copy_dir.mkdir(exist_ok=True)
+    copy = copy_dir / "nvidia_docker_sysbox_setup.sh"
+    shutil.copy(SCRIPT, copy)
+    return copy
+
+
 def run_check(tmp_path, function, *, env=None, files=None, with_jq=False, without=()):
     """Source the installer's functions and run one check; returns (rc, output, fix_count)."""
     stubs = _bin_dir(tmp_path, with_jq=with_jq, without=without)
@@ -133,6 +142,7 @@ def run_check(tmp_path, function, *, env=None, files=None, with_jq=False, withou
         ["bash", "-c", program],
         capture_output=True,
         text=True,
+        cwd=tmp_path,
         env={"PATH": str(stubs), "HOST_ROOT": str(root), **(env or {})},
     )
     assert proc.returncode == 0, proc.stdout + proc.stderr
@@ -146,10 +156,11 @@ def run_script(tmp_path, *args, env=None, files=None, without=()):
     stubs = _bin_dir(tmp_path, with_jq=False, without=without)
     root = _host_root(tmp_path, files)
     proc = subprocess.run(
-        ["bash", SCRIPT, *args],
+        ["bash", str(_script_copy(tmp_path)), *args],
         capture_output=True,
         text=True,
         stdin=subprocess.DEVNULL,
+        cwd=tmp_path,
         env={"PATH": str(stubs), "HOST_ROOT": str(root), **(env or {})},
     )
     proc.stdout = ANSI.sub("", proc.stdout)
@@ -173,7 +184,8 @@ def test_kernel_5_15_on_22_04_names_the_hwe_kernel(tmp_path):
     assert rc == 1 and fix == 1
     assert "FIX  Kernel 5.15.0-91-generic is below 5.19" in out
     assert "sudo apt-get install -y linux-generic-hwe-22.04 && sudo reboot" in out
-    assert "SYSBOX_SKIP_KERNEL_CHECK=1" in out
+    # the override goes after sudo: sudo's env_reset drops a variable set in front of it (sourced here, so the curl form)
+    assert "backport: curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo SYSBOX_SKIP_KERNEL_CHECK=1 bash" in out
 
 
 def test_kernel_5_15_on_20_04_says_upgrade_the_distro(tmp_path):
@@ -226,7 +238,7 @@ def test_docker_29_7_without_the_two_settings_names_both(tmp_path, with_jq):
     rc, out, _ = run_check(tmp_path, "check_docker_features", env={"STUB_DOCKER_VERSION": "29.7.0"}, with_jq=with_jq)
     assert rc == 1
     assert "FIX  Docker 29.7.0 without features.cdi, time-namespaces = false" in out
-    assert '{"features":{"cdi":false,"time-namespaces":false}}' in out
+    assert 'add {"features":{"cdi":false,"time-namespaces":false}} to /etc/docker/daemon.json' in out
 
 
 @pytest.mark.parametrize("with_jq", [False, True])
@@ -264,6 +276,8 @@ def test_docker_29_3_with_cdi_still_on_is_a_fix(tmp_path):
     )
     assert rc == 1
     assert "FIX  Docker 29.3.0 without features.cdi = false" in out
+    # below 29.5 the by-hand block names cdi only, like the install step
+    assert 'add {"features":{"cdi":false}} to /etc/docker/daemon.json' in out
 
 
 def test_docker_28_needs_no_features(tmp_path):
@@ -294,10 +308,17 @@ def test_nvidia_driver_not_loaded_is_a_fix(tmp_path):
     assert "FIX  NVIDIA driver is installed but not loaded" in out
 
 
-def test_nvidia_driver_below_validator_minimum_is_a_fix(tmp_path):
-    rc, out, _ = run_check(tmp_path, "check_nvidia_driver", env={"STUB_NV_DRIVER": "575.57.08"})
+@pytest.mark.parametrize("driver", ["575.57.08", "580.65.05", "580.64.99"])
+def test_nvidia_driver_below_validator_minimum_is_a_fix(tmp_path, driver):
+    rc, out, _ = run_check(tmp_path, "check_nvidia_driver", env={"STUB_NV_DRIVER": driver})
     assert rc == 1
-    assert "FIX  NVIDIA driver 575.57.08 is below 580.65.06" in out
+    assert f"FIX  NVIDIA driver {driver} is below 580.65.06" in out
+
+
+@pytest.mark.parametrize("driver", ["580.65.06", "580.65.10", "581.0.0"])
+def test_nvidia_driver_at_or_above_the_minimum_passes(tmp_path, driver):
+    rc, out, _ = run_check(tmp_path, "check_nvidia_driver", env={"STUB_NV_DRIVER": driver})
+    assert rc == 0, out
 
 
 def test_nvidia_toolkit_present_and_missing(tmp_path):
@@ -349,6 +370,17 @@ def test_disk_below_the_rule_is_a_fix_with_the_numbers(tmp_path):
     assert "FIX  Disk 500.0 GB on " in out
     assert "is below 955.8 GB (1.5x of 637.2 GB VRAM)" in out
     assert "earns nothing while idle" in out
+
+
+def test_disk_rule_compares_like_the_validator_at_the_boundary(tmp_path):
+    # 1x 81613 MiB = 79.7 GB VRAM -> 119.55 GB needed. The validator compares 79.7 * 1.5 unrounded with the rounded
+    # disk, so 119.5 GB fails; a compare against the displayed (rounded) 119.5 would have passed it.
+    env = {"STUB_NV_GPUS": "1", "STUB_NV_MEM_MIB": "81613"}
+    rc, out, _ = run_check(tmp_path, "check_disk_for_vram", env={**env, "STUB_DF_TOTAL_KB": str(int(119.5 * 1024 * 1024))})
+    assert rc == 1, out
+    assert "FIX  Disk 119.5 GB" in out and "(1.5x of 79.7 GB VRAM)" in out
+    rc, out, _ = run_check(tmp_path, "check_disk_for_vram", env={**env, "STUB_DF_TOTAL_KB": str(int(119.6 * 1024 * 1024))})
+    assert rc == 0, out
 
 
 def test_disk_rule_is_skipped_without_a_gpu(tmp_path):
@@ -403,21 +435,30 @@ def test_ports_come_from_env_then_the_env_file(tmp_path):
 
 
 def test_env_file_next_to_the_script_is_read(tmp_path):
-    # $0 is the script under test when sourced via a copy next to a .env
-    copy_dir = tmp_path / "executor"
-    copy_dir.mkdir()
-    shutil.copy(SCRIPT, copy_dir / "nvidia_docker_sysbox_setup.sh")
-    (copy_dir / ".env").write_text("INTERNAL_PORT=8001\nEXTERNAL_PORT=8123 # external\nSSH_PORT=2299\n")
+    copy = _script_copy(tmp_path)
+    (copy.parent / ".env").write_text("INTERNAL_PORT=8001\nEXTERNAL_PORT=8123 # external\nSSH_PORT=2299\n")
+    proc = run_script(tmp_path, "--check")
+    assert "TCP 8123 (executor port)" in proc.stdout and "TCP 2299 (SSH port)" in proc.stdout
+
+
+def test_env_file_in_the_working_directory_is_ignored_when_piped_from_curl(tmp_path):
+    # piped from curl $0 is `bash`; a `.env` in the provider's cwd must not steer the port check
+    (tmp_path / ".env").write_text("EXTERNAL_PORT=8123\nSSH_PORT=22\n")
     stubs = _bin_dir(tmp_path, with_jq=False)
     root = _host_root(tmp_path)
+    with open(SCRIPT) as fh:
+        script = fh.read()
     proc = subprocess.run(
-        ["bash", str(copy_dir / "nvidia_docker_sysbox_setup.sh"), "--check"],
+        ["bash", "-s", "--", "--check"],
+        input=script,
         capture_output=True,
         text=True,
-        stdin=subprocess.DEVNULL,
+        cwd=tmp_path,
         env={"PATH": str(stubs), "HOST_ROOT": str(root)},
     )
-    assert "TCP 8123 (executor port)" in proc.stdout and "TCP 2299 (SSH port)" in proc.stdout
+    out = ANSI.sub("", proc.stdout)
+    assert "TCP 8080 (executor port)" in out and "TCP 2200 (SSH port)" in out
+    assert "TCP 22 " not in out
 
 
 # ── sysbox probe ─────────────────────────────────────────────────────────────
@@ -466,28 +507,31 @@ def test_check_mode_without_a_gpu_reports_the_nvidia_fixes_and_exits_one(tmp_pat
     assert "SKIP Disk >= 1.5x VRAM" in proc.stdout
     assert "PASS Kernel 6.8.0-45-generic" in proc.stdout
     assert "Preflight: 9 PASS, 2 FIX, 1 SKIP." in proc.stdout
-    assert f"Fix the lines above, then run: sudo bash {SCRIPT}" in proc.stdout
+    assert f"Fix the lines above, then run: sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'}" in proc.stdout
 
 
 def test_install_mode_stops_before_installing_on_a_fix(tmp_path):
-    apt = tmp_path / "bin" / "apt-get"
-    apt.parent.mkdir()
-    apt.write_text('#!/bin/bash\necho "apt-get $*" >> "$HOST_ROOT/apt.log"\n')
-    apt.chmod(0o755)
     proc = run_script(tmp_path, env={"STUB_KERNEL": "5.15.0-91-generic"})
-    root = tmp_path / "root"
     assert proc.returncode == 1
     assert "FIX  Kernel 5.15.0-91-generic is below 5.19" in proc.stdout
     assert "Nothing was installed." in proc.stdout
-    assert not (root / "apt.log").exists(), "apt must not run after a FIX"
-    assert "Installing packages" not in proc.stdout
+    # step 2 is the first thing after the preflight; on a good host the same stubs reach it (next test)
+    assert "Checking running containers" not in proc.stdout
+
+
+def test_install_mode_on_a_good_host_reaches_the_install_steps(tmp_path):
+    # the negative control for the test above: same stubs, kernel fine -> the preflight passes and the script goes on
+    proc = run_script(tmp_path)
+    assert "Preflight: 9 PASS, 0 FIX, 0 SKIP." in proc.stdout
+    assert "Nothing was installed." not in proc.stdout
+    assert "Checking running containers" in proc.stdout or "Sysbox is already working" in proc.stdout
 
 
 def test_not_root_is_a_fix_that_names_sudo(tmp_path):
     proc = run_script(tmp_path, "--check", env={"STUB_UID": "1000"})
     assert proc.returncode == 1
     assert "FIX  Not running as root" in proc.stdout
-    assert "sudo bash" in proc.stdout and "--check" in proc.stdout
+    assert f"sudo bash {tmp_path / 'executor' / 'nvidia_docker_sysbox_setup.sh'} --check" in proc.stdout
 
 
 def test_unknown_option_is_refused(tmp_path):


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3319](https://app.notion.com/p/Sysbox-installer-preflight-PASS-FIX-lines-with-the-exact-fix-before-anything-is-installed-check-3d7b8bfdbde9819faef4ed3ae8ff05a7) · reviewer: @taiberium

**TL;DR** — ticket-0309: a provider reinstalled Sysbox three times; the cause (iptables modules the validators' probe needs) surfaced only after staff logged in. The installer now checks the host first, one PASS / FIX line per requirement with its fix; `--check` adds what the script installs. Risk: a kernel below 5.19 now stops the install (main let sysbox-mgr decide); a driver, iptables, disk or port FIX is printed and the install goes on (round 1).

**What changed**
- Preflight in `nvidia_docker_sysbox_setup.sh`: root, x86_64, kernel ≥ 5.19, Docker up — a FIX stops the install
- Driver ≥ 580.65.06, iptables modules, disk ≥ 1.5× VRAM, ports — a FIX is printed and the install goes on (`preflight_advisory`)
- `--check`: those plus NVIDIA toolkit, Docker 29 `features.cdi` / `time-namespaces`, sysbox-runc probe; exit 1 on a FIX
- Ports from `EXECUTOR_PORT` / `SSH_PORT`, else the `.env` next to the script, else 8080 / 2200
- `cleanup()` EXIT trap no longer turns clean exits into status 1
- 68 tests, stub commands on PATH + fixture tree (`tests/test_sysbox_setup_preflight.py`)

**How to verify**
- `cd neurons/executor && pdm run pytest tests/test_sysbox_setup_preflight.py -q` → 68 passed
- `sudo bash nvidia_docker_sysbox_setup.sh --check` → PASS/FIX per line, `Preflight: N PASS, M FIX, K SKIP.`, exit 1 if M > 0
- `bash nvidia_docker_sysbox_setup.sh </dev/null`: Docker stopped → `Nothing was installed.`, exit 1; no GPU → driver FIX, `do not stop the install`, step 2 onwards
- `shellcheck -S style nvidia_docker_sysbox_setup.sh` → no output

**Verified by the loop:** Gate: pending at 379c9c8

**Ran it:** Ubuntu 22.04, no GPU (EC2 20260910T094640Z-mqjz): Docker stopped → `Nothing was installed.` rc=1; no GPU → driver + iptables FIX, sysbox 0.6.6 installed; ufw `ALLOW OUT` → FIX · executor 200 passed -kmrp

**Self-review:** clean at 379c9c8 (15 checks, 4 low)

**Parts:** backend n/a — host script · migration n/a — no schema · frontend n/a — host script · CLI/SDK n/a — PR-1 · docs ✓ lium-docs#268 · tests ✓ 68 · dashboards n/a — nothing emitted

**Docs:** [lium-docs#268](https://github.com/Datura-ai/lium-docs/pull/268) — `docs/providers/nodes/sysbox.md` "Check the host first" (merge after this PR is on main).

<details><summary>Details</summary>

### Evidence (SO §25 origin)

- **ticket-0309** (Discord support, 3–4 Sep 2026): the provider had installed Sysbox, the documented verify command printed `nvidia-smi` output, the ports were open — and the validator scored the node 0 with `sysbox_runtime: false` for six hours across three reinstalls ("Honestly, I don't know what to do anymore"). Root cause after staff logged in: the host runs nftables and the legacy `iptable_nat` / `iptable_filter` modules were not loaded; the validators' Docker-in-Docker probe image runs legacy iptables, so its inner `dockerd` failed with `can't initialize iptables table 'nat'`, sshd never started, and the probe reported sysbox missing. The fix was one `modprobe`. Nothing on the host said so.
- **DAH-2768** (#1304, merged 8 Sep): the installer failed silently without NVIDIA's apt repository. **DAH-2919**: stale preflight image in `lium mine`. **VerifyX first-pass failures 11.6 %** (`speed/SWEEP_provider_verify.md`: 1,314 of 11,330 idle runs, 747 `VERIFYX_FAILED` + 563 `NETWORK_SPEED_TOO_SLOW`).
- Program: design/PROVIDER_BARRIER_PROGRAM.md §B.1 / §C PR-0 (owner P105.4, 10 Sep 2026: "faster GPU add, fully tested"). Metric: reinstall tickets → 0.
- Search first (L-261): #1304 already introduced the pattern of testing this script's functions under bash with stubs on PATH (`tests/test_sysbox_setup_apt_repo.py`); this PR follows it. No open lium-io PR touches `nvidia_docker_sysbox_setup.sh` (#1266 / #1274 touch the CVM scripts under `dstacktee/`).

### Design

- **Three groups of checks.** `preflight_blocking` is what sysbox itself needs on this host (x86_64 — the .deb is amd64 only; a kernel with ID-mapped mounts, or the override; Docker installed and running — the runtime goes into its daemon.json and it is restarted): a FIX there, or no root, ends install mode with `Nothing was installed.`, exit 1. `preflight_advisory` is what the validators need once the node runs (NVIDIA driver, iptables modules, disk, ports): sysbox installs without any of it and the node cannot be listed at all without sysbox, so a FIX is printed with its command, install mode says `The FIX lines above do not stop the install` and goes on; after `SUCCESS` / `Nothing to do.` a reminder names the count and the `--check` re-run (round 1, taiberium). `preflight_stack` is what the script installs (NVIDIA container toolkit, Docker 29 features, sysbox-runc); `--check` runs both and its FIX lines point at running the installer (or the manual daemon.json edit). Install mode does not run `preflight_stack` — it is about to do those things.
- **Exit codes.** `--check`: 0 when no FIX, 1 otherwise — advisory or blocking, it reports. Install mode: 1 on a blocking FIX before anything changes (the previous script also exited 1 on its one-line checks for root, Docker and the kernel); an advisory FIX does not change the exit code, which is the install's. `--help` 0, unknown option 2. The `cleanup` EXIT trap used `[ -n "$DOWNLOADED_DEB" ] && rm`, which under `set -e` made **every** exit report status 1 when nothing had been downloaded — `sudo bash nvidia_docker_sysbox_setup.sh; echo $?` printed 1 after SUCCESS and after "Sysbox is already working. Nothing to do." on `main`. It is an `if` now; `test_help_lists_check_and_exits_zero` covers it.
- **Kernel.** `kernel_supports_idmapped` (5.19+) as before; the FIX text depends on `/etc/os-release` (`22.04` → HWE kernel, plus the `SYSBOX_SKIP_KERNEL_CHECK=1` override line for a kernel known to carry the backport; `20.04` → upgrade the release; else generic). `SYSBOX_SKIP_KERNEL_CHECK=1` still passes an older kernel. Because the preflight settles the kernel first, the later `fail_old_kernel` branch after the sysbox-mgr report could no longer be reached and is removed; a `no` from sysbox-mgr on a 5.19+ kernel keeps `fail_no_idmapped` (filesystem / sysbox-mgr config).
- **Docker 29.** `check_docker_features` reads `/etc/docker/daemon.json` with `jq` when present and a grep fallback before jq is installed (jq is one of the packages this script installs). ≥ 29.2 needs `features.cdi = false`; ≥ 29.5 also `features["time-namespaces"] = false` — the same two settings the install step writes and lium-docs `docs/providers/nodes/sysbox.md` documents; the by-hand block in the FIX names only the keys that daemon needs. 29.0–29.1 passes with "untested" in the line (the docs say untested).
- **NVIDIA.** `nvidia-smi` present, a dotted version reported (nvidia-smi prints its errors on stdout — "Failed to initialize NVML: Driver/library version mismatch" lands in the "not loaded" line with the reboot fix, `test_nvidia_smi_error_text_is_not_read_as_a_version`), `/proc/driver/nvidia` present; then the version against `MIN_NVIDIA_DRIVER = 580.65.06` — `settings.MIN_NVIDIA_DRIVER_VERSION` in `neurons/validators/src/core/config.py`; `incentive/default.py::get_min_driver_multiplier` returns 0.0 for an idle node below it since `MIN_DRIVER_CUTOFF` (30 Jun 2026). A provider adding a node today with a 575 driver would be listed and paid nothing while idle; the FIX names the Ubuntu package (`nvidia-driver-580-server`, present in the 22.04 and 24.04 archives — Ran it, section K).
- **iptables modules (ticket-0309).** `ip_tables`, `iptable_nat`, `iptable_filter` loaded (`/proc/modules`) or built in (`/sys/module/<m>`). On both EC2 boxes Docker from get.docker.com (iptables-nft) had loaded `ip_tables` only. The FIX is `modprobe -a` — without `-a` modprobe reads the second and third names as parameters of the first and loads only `ip_tables` (the first proof run showed exactly that; section E) — plus a `modules-load.d` file so it survives a reboot.
- **Disk ≥ 1.5× VRAM.** The rule is `MIN_DISK_TO_VRAM_RATE = 1.5` in `neurons/validators/src/incentive/rental_price.py` (DAH-2520): `_insufficient_disk` compares `hard_disk.total` of the scrape — the **total** size of the filesystem the executor container sees as `/` (`miner_jobs/machine_scrape.py`: `shutil.disk_usage("/")`), which lives under Docker's data-root — against the sum of `gpu.details[].capacity` (MiB / 1024); free space is not the rule ("free is distorted by preallocated volumes"). The check does the same arithmetic on `df -Pk $(docker info --format '{{.DockerRootDir}}')` and the sum of `nvidia-smi --query-gpu=memory.total`, in the same order (VRAM and disk rounded to 0.1 GB, then VRAM × 1.5 unrounded against the disk — `test_disk_rule_compares_like_the_validator_at_the_boundary`). The gate is behind `ENABLE_UNRENTED_VRAM_OVER_DISK_LIMIT` (default False in `config.py`); production runs it on — `lium-io-deployment/infrastructure/Pulumi.prod.yaml:52` sets `"true"` — so the line is a FIX, not a note. Without a GPU the line is SKIP (not FIX) — the rule cannot be sized.
- **Ports.** Executor and SSH port: not held by a foreign process (`ss -Hltnp`); a `docker-proxy` listener is resolved to its container with `docker ps --filter publish=<port>` and passes only when that container is `executor-*` / `executor_*` (the names step 2 of this script already treats as the executor) — any other container is a FIX naming it; and not blocked by an active ufw (an inbound `ALLOW` in any column: plain, `ALLOW IN`, `on eth0`, `(v6)` rows; single-port and `lo:hi` range rules, tcp or any; an `ALLOW OUT` or `ALLOW FWD` row never counts — `test_ufw_allow_out_row_does_not_open_an_inbound_port`). The FIX line says the port has no inbound allow rule in the active ufw (Docker-published ports may bypass ufw's INPUT chain, so it does not claim the port is unreachable). Without `ss` the line is SKIP. Without root the preflight stops after the root FIX — the other checks read the process table and Docker's socket. Cloud firewalls and routers are outside the host, so the check prints the documented probe to run from another machine (`nc -vz <public IP> 8080 2200`) rather than a PASS it cannot prove. A probe from the host to its own public IP was tried on EC2 (section L: blocked by the security group, so it does detect a closed cloud firewall there) but a bare-metal host with the public IP on its NIC answers itself regardless of the upstream firewall, and a NAT without hairpin fails even when the forward is right — a PASS/FIX line from it would be wrong in both common provider shapes. The values come from `EXECUTOR_PORT` / `SSH_PORT`, else `EXTERNAL_PORT` / `SSH_PORT` in the `.env` next to the script, else the `lium mine` defaults 8080 / 2200 (lium-docs `docs/providers/nodes/quickstart.md`).
- **sysbox probe (`--check` only).** `sysbox-runc` on PATH, registered in `docker info` runtimes, and `docker run --rm --runtime=sysbox-runc alpine echo ok` — the probe lium-docs `docs/providers/nodes/sysbox.md` uses for the time-namespaces case. The GPU probe (`--gpus all … nvidia-smi`) stays where it was: the install path's step 6.
- **Idempotent.** `--check` writes nothing on the host (the sysbox probe pulls `alpine` once when the image is missing, as the docs' probe does); the second run prints the same lines (Ran it, section C2). Install mode's later steps are unchanged.
- **Re-run line.** `self_cmd` prints `sudo bash <path> [--check]` when `$0` is a file and the documented `curl … | sudo bash [-s -- --check]` one-liner when the script is piped from curl (Ran it, section I). The kernel override is printed after `sudo` (`sudo SYSBOX_SKIP_KERNEL_CHECK=1 bash …`) because sudo's `env_reset` drops a variable set in front of it. Piped from curl there is no file next to `$0`, so no `.env` is read (a `.env` in the provider's working directory must not steer the port check).
- **Driver compare** is on all three components (`version3_ge`): 580.65.05 is below 580.65.06. The kernel and Docker compares stay major/minor (`version_ge`) as before.
- **Not in this PR.** `lium mine` calling `--check` and the rewrite of Step 1 into one command (PR-1, design §C); a from-outside port probe (needs a Lium-side service); Ansible / fleet mode (DAH-2257). Docs for `--check`: lium-docs#268 (reviewer arhangel66 — the docs default `pr_ready.py` applies).

### Tests

`neurons/executor/tests/test_sysbox_setup_preflight.py` — 68, same harness as `test_sysbox_setup_apt_repo.py` (#1304): the script is sourced with `SYSBOX_SETUP_LIB=1` (or run from a copy in `tmp_path`, cwd there, so a developer's `neurons/executor/.env` cannot steer a test), commands are stubs on a PATH that also carries the real coreutils but not the host's `jq` unless the test asks, files under `SYSBOX_SETUP_HOST_ROOT` (test-only, named in the script header). `run_check` returns a `CheckResult` NamedTuple. Negative controls per check:

- kernel: 6.8 PASS · 5.15 on 22.04 FIX with the HWE command and the override after `sudo` · 5.15 on 20.04 FIX "upgrade the release" (and no HWE line) · 5.15 with `SYSBOX_SKIP_KERNEL_CHECK=1` PASS
- docker: 28.5.2 PASS · missing FIX `get.docker.com` · daemon down FIX `systemctl` · 29.1 PASS "untested" · 29.7 without settings FIX naming both keys and the two-key block (jq path and grep path) · 29.7 with both PASS (both paths) · 29.3 needs only cdi · 29.3 with `"cdi": true` FIX with the cdi-only block (jq path and grep path) · 28 needs nothing
- nvidia: 580.65.06 with 8 GPUs PASS · no nvidia-smi FIX · installed but `/proc/driver/nvidia` missing FIX · NVML error text FIX "not loaded" with the reboot fix · 575.57.08 / 580.65.05 / 580.64.99 FIX below minimum · 580.65.06 / 580.65.10 / 581.0.0 PASS · toolkit present PASS / missing FIX
- iptables: all loaded PASS · none loaded FIX with `modprobe -a` and the modules-load.d file · built-in (`/sys/module`) PASS
- disk: 8× 81559 MiB = 637.2 GB VRAM vs 1000.0 GB PASS · 500.0 GB FIX "below 955.8 GB" · the boundary the validator draws (79.7 GB VRAM: 119.5 GB FIX, 119.6 GB PASS) · no GPU SKIP
- ports: free PASS with the nc hint · 8080 held by nginx FIX · 2200 published by `executor-1` PASS · 8080 published by `nginx-proxy` FIX `docker stop nginx-proxy` · no `ss` SKIP · ufw verbose / `on eth0` / `(v6)` rows PASS · ufw active without a rule FIX `ufw allow 2200/tcp` · ufw `ALLOW OUT` and `ALLOW FWD` rows on 8080 FIX, `ALLOW IN` on 2200 PASS · ufw `2000:9000/tcp` range covers PASS · env override · `.env` next to the script · a `.env` in the working directory is ignored when piped from curl
- sysbox: installed + registered + runs PASS · missing / not registered / container fails FIX
- the script itself: `--check` good host → 12 PASS exit 0 · no GPU → 9 PASS 2 FIX 1 SKIP exit 1 · `--check` with a 575 driver → 11 PASS 1 FIX exit 1 · install mode on 5.15 / Docker down / aarch64 stops with `Nothing was installed.`, exit 1, step 2 never printed · its control: the same stubs on a good host → `Nothing to do.`, exit 0 · install mode with a 575 driver / no nvidia-smi / 500 GB disk / port held / ufw without rules → the FIX line, `do not stop the install`, `Nothing to do.`, the reminder, exit 0 · no iptables modules → the modprobe FIX and exit 0 · non-root in `--check` and in install mode: one FIX naming `sudo bash …` (`--check` kept), nothing else runs, install mode adds `Nothing was installed.` · piped from curl the FIX names the one-liner, never `sudo bash bash` · `--bogus` exit 2 · `--help` exit 0

### Ran it

EC2 sandbox, plain Canonical Ubuntu AMIs, t3.medium, no GPU — `20260910T022251Z-r0et` (Ubuntu 22.04.5, kernel 6.8.0-1063-aws) and `20260910T022251Z-lv2r` (Ubuntu 24.04.4, kernel 7.0.0-1012-aws), the script at `40c778c`; both logs read the same apart from the kernel line. Job: one script that runs each mode, then runs each FIX command and re-runs `--check`.

```
$ sudo -u ubuntu bash nvidia_docker_sysbox_setup.sh --check        # A. as a user, before Docker
  FIX  Not running as root — the checks read Docker's socket and the kernel modules.
         sudo bash /job/in/nvidia_docker_sysbox_setup.sh --check
  Preflight: 0 PASS, 1 FIX, 0 SKIP.                                 rc=1
$ curl -fsSL https://get.docker.com | sh                            # B. the Docker FIX line's command → server 29.8.0
$ bash nvidia_docker_sysbox_setup.sh --check                        # C. root, Docker up, no GPU
  PASS Running as root.
  PASS Architecture x86_64.
  PASS Kernel 6.8.0-1063-aws (>= 5.19, ID-mapped mounts available).
  PASS Docker 29.8.0.
  FIX  nvidia-smi not found — no NVIDIA driver installed.
         sudo apt-get install -y nvidia-driver-580-server && sudo reboot   # Ubuntu; or your vendor's driver package
  FIX  Kernel modules iptable_nat iptable_filter are not loaded — the validators' Docker-in-Docker probe needs legacy iptables …
         sudo modprobe -a ip_tables iptable_nat iptable_filter   # -a: without it modprobe reads the 2nd and 3rd name as parameters of the 1st
         printf 'ip_tables\niptable_nat\niptable_filter\n' | sudo tee /etc/modules-load.d/lium-iptables.conf >/dev/null   # survives reboots
  SKIP Disk >= 1.5x VRAM — no NVIDIA driver, VRAM unknown.
  PASS TCP 8080 (executor port) is free and not blocked by ufw.
  PASS TCP 2200 (SSH port) is free and not blocked by ufw.
         Cloud firewalls and routers are outside this host: after 'docker compose up', from ANY other machine run
           nc -vz <this host's public IP> 8080 2200    # both must say 'succeeded'
  FIX  NVIDIA container toolkit is not installed — Docker cannot pass GPUs into containers.
         sudo bash /job/in/nvidia_docker_sysbox_setup.sh   # adds NVIDIA's apt repository and installs nvidia-container-toolkit
  FIX  Docker 29.8.0 without features.cdi, time-namespaces = false in /etc/docker/daemon.json — sysbox rejects its containers.
         sudo bash /job/in/nvidia_docker_sysbox_setup.sh   # writes the features block and restarts Docker; stop rentals first
         or by hand: add {"features":{"cdi":false,"time-namespaces":false}} to /etc/docker/daemon.json && sudo systemctl restart docker
  FIX  sysbox-runc is not installed — validators reject a node without it.
         sudo bash /job/in/nvidia_docker_sysbox_setup.sh
  Preflight: 6 PASS, 5 FIX, 1 SKIP.                                 rc=1
$ bash … --check > c2; bash … --check > c3; diff c2 c3             # C2. idempotent → identical output on the second run
$ bash nvidia_docker_sysbox_setup.sh </dev/null                     # D. install mode — SUPERSEDED at the earlier head: since round 1 the same host
  …                                                                 #    goes on past the preflight; see "Round 1" below
$ sudo modprobe -a ip_tables iptable_nat iptable_filter && … tee /etc/modules-load.d/lium-iptables.conf   # E. the iptables FIX
  PASS Legacy iptables modules loaded (ip_tables iptable_nat iptable_filter) for the validators' Docker-in-Docker probe.
$ ufw --force enable; bash … --check | grep TCP                     # F. ufw without rules (wording at this head: "has no inbound allow rule in the active ufw")
  FIX  TCP 8080 (executor port) is blocked by ufw — validators cannot reach the node.
  FIX  TCP 2200 (SSH port) is blocked by ufw — validators cannot reach the node.
$ ufw allow 8080/tcp; ufw allow 2200/tcp; bash … --check | grep TCP   # the FIX lines' commands
  PASS TCP 8080 (executor port) is free and not blocked by ufw.
  PASS TCP 2200 (SSH port) is free and not blocked by ufw.
$ python3 -m http.server 8080 & bash … --check | grep 'TCP 8080'    # G. port held
  FIX  TCP 8080 (executor port) is already in use by users:(("python3",pid=4669,fd=3)) — the executor cannot bind it.
$ EXECUTOR_PORT=8001 SSH_PORT=2201 bash … --check | grep TCP        # H. env → TCP 8001 / TCP 2201; a .env next to a copy → TCP 8123 / TCP 2299
$ cat nvidia_docker_sysbox_setup.sh | bash -s -- --check | grep curl   # I. piped: the FIX re-run line is the one-liner
         curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash   # adds NVIDIA's apt repository …
$ apt-cache show nvidia-driver-580-server | grep -E '^(Package|Version)'   # K. the driver FIX's package exists
Package: nvidia-driver-580-server
Version: 580.178.04-0ubuntu0.22.04.1                                # 24.04: 580.178.04-0ubuntu0.24.04.1
$ shellcheck -S style nvidia_docker_sysbox_setup.sh                 # M. → shellcheck clean (version: 0.8.0)
$ bash nvidia_docker_sysbox_setup.sh --help                         # N. → usage, rc=0
```

Also on the box (section L, not pasted — it prints the box's public IP): a listener on 8080 and `curl http://<own public IP>:8080/` from the same host timed out with the security group closed, so a self-probe through the public IP does see a closed cloud firewall on EC2; it is not a PASS/FIX line for the reasons in Design → Ports.

First proof run at the earlier head (`20260910T014638Z-agau`) is what found two wrong FIX commands: `modprobe ip_tables iptable_nat iptable_filter` loaded only `ip_tables` (fixed with `-a`), and `ubuntu-drivers` is not on the minimal Ubuntu images (the FIX names the package now).

**Suite.** `tools/aws_verify.sh lium-io 40c778c` (warm box, `20260910T022251Z-iyfa`): `executor pytest tests/: rc=0 — 189 passed` (132 on `main` + 57 here); the validators and miners trees are untouched. The tests also pass without the executor `conftest.py` (`--noconftest`) and on macOS bash 3.2.

### Round 1 (taiberium, 10 Sep 09:29Z) — Ran it

EC2 sandbox, plain Canonical Ubuntu 22.04.5 (kernel 6.8.0-1063-aws), t3.medium, no GPU — `20260910T094640Z-mqjz`, the script at the round-1 head.

```
$ systemctl stop docker; bash nvidia_docker_sysbox_setup.sh </dev/null   # B. a blocking FIX still stops the install
  PASS Running as root.  PASS Architecture x86_64.  PASS Kernel 6.8.0-1063-aws (>= 5.19, ID-mapped mounts available).
  FIX  Docker daemon is not running (docker ps failed).
         sudo systemctl enable --now docker
  Preflight: 3 PASS, 1 FIX, 0 SKIP.
  Fix the lines above and re-run. Nothing was installed.            rc=1; sysbox-runc not installed
$ ufw allow out 8080/tcp; ufw allow 2200/tcp; bash … --check | grep TCP   # C. an ALLOW OUT row does not open the port
  FIX  TCP 8080 (executor port) is blocked by ufw — validators cannot reach the node.      # wording at this head: "has no inbound allow rule in the active ufw"
  PASS TCP 2200 (SSH port) is free and not blocked by ufw.
$ ufw allow 8080/tcp; bash … --check | grep 'TCP 8080'                → PASS TCP 8080 (executor port) is free and not blocked by ufw.
$ bash nvidia_docker_sysbox_setup.sh --check                        # D. --check still exits 1 on any FIX
  Preflight: 6 PASS, 5 FIX, 1 SKIP.                                 rc=1
$ bash nvidia_docker_sysbox_setup.sh </dev/null                     # E. advisory FIXes: the install goes on
  FIX  nvidia-smi not found — no NVIDIA driver installed.
         sudo apt-get install -y nvidia-driver-580-server && sudo reboot   # Ubuntu; or your vendor's driver package
  FIX  Kernel modules iptable_nat iptable_filter are not loaded — …
  Preflight: 6 PASS, 2 FIX, 1 SKIP.
  The FIX lines above do not stop the install: the node is not listed at all without sysbox. Run those commands afterwards.
[2/7] Checking running containers
[3/7] Installing packages
  ✓ Sysbox v0.6.6 installed.
[4/7] Configuring Docker … [5/7] Restarting Docker … ✓ Docker is running.
[6/7] Verifying sysbox + GPU
  ✗ Verification FAILED. Diagnostics: … NVIDIA driver: FAILED             rc=1 — expected on a box without a GPU; sysbox-runc is installed and
                                                                            registered in daemon.json (printed after the run)
$ shellcheck -S style nvidia_docker_sysbox_setup.sh                 # F. → shellcheck clean (version: 0.8.0)
```

Section C ran at the commit before the fresh review's wording fix; the awk logic is the same. **Suite, round 1.** `tools/aws_verify.sh lium-io 483e1a9 --app io-all` (warm box, `20260910T095859Z-kmrp`): `executor pytest tests/: rc=0 — 200 passed` (132 on `main` + 68 here), `miners: 27 passed`; `validators: 2 failed, 1999 passed` — the same two (`test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices`, `test_adopt_path_hardens_config_for_key_only_auth`) fail on every lium-io run on the warm box since 9 Sep (it runs as root with a live sshd); this PR does not touch the validators tree. **Round 2 (two rename NITs, 379c9c8):** `tools/aws_verify.sh lium-io 379c9c8` (warm box, `20260910T105551Z-k7ez`): `executor pytest tests/` → 200 passed, 0 skipped; `git diff 483e1a9 379c9c8 -w` is a pure rename, so the Ubuntu proof runs above stand.


### Self-review

Verdict `findings` at `379c9c8` · 15 checks · by subagent-fresh-r59m · 2026-09-10 11:02Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `neurons/executor/nvidia_docker_sysbox_setup.sh:489` | GitHub already shows head 379c9c8 while the live body's `Verified by the loop: Gate: PASS 483e1a9`, `Self-review: clean at 483e1a9` and the `Suite, round 1 … 483e1a9 … -kmrp` line all name the previous head; the 379c9c8 run (EC2 20260910T105551Z-k7ez, executor 200 passed) is not in the body yet. | Record this verdict and the k7ez suite line at 379c9c8 with tools/pr_self_review.py --record --apply and let the gate re-stamp `Verified` at this head; no code change. |
| low | CORRECTNESS | `neurons/executor/nvidia_docker_sysbox_setup.sh:430` | Known low from the 483e1a9 review, unchanged by the rename: in `--check` with Docker installed but down, check_sysbox reports `installed but not registered in Docker's runtimes` although `docker info` merely failed, while check_docker_features handles the same state with a SKIP. | Before the runtimes grep, `docker ps &>/dev/null // { pf_skip "sysbox-runc — Docker is not running."; return 0; }`. |
| low | TEST-GAP | `neurons/executor/tests/test_sysbox_setup_preflight.py:111` | Known low, unchanged: the `with_jq=True` variants skip silently where jq is absent; the k7ez run shows `200 passed` with no skips, so jq was present there, but a `-q` summary on a box without jq would hide the jq path. | Have tools/aws_verify.sh (and CI) install or assert jq before the executor suite and quote the skipped count in the Suite line. |
| low | STALE-BODY | `RECOVERY/workers/sysbox-preflight-1349-fix/body.md:107` | Known low, unchanged: the first Ran-it block's section F still quotes the pre-change FIX text `is blocked by ufw — validators cannot reach the node` without the `wording at this head` note that section C of the round-1 block carries. | Add the same one-line `# wording at this head: …` note after F's two FIX lines, or replace them with the head's text. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/executor/nvidia_docker_sysbox_setup.sh:6` A `#` header comment stating the script's documented distribution one-liner; nothing on this line executes, and it is unchanged by 379c9c8. · `neurons/executor/nvidia_docker_sysbox_setup.sh:153` A comment on self_cmd; the one-liner at line 160 is only `echo`ed as the re-run text of a FIX line, never run by the script. · `neurons/executor/nvidia_docker_sysbox_setup.sh:224` `curl -fsSL https://get.docker.com | sudo sh` is a string argument to pf_fix, printed as the fix text for a missing Docker (Docker's documented convenience install); the script does not execute it. · `neurons/executor/tests/test_sysbox_setup_preflight.py:246` An `assert … in out` on the printed FIX text of check_docker with the docker stub removed; no command is run. · `neurons/executor/tests/test_sysbox_setup_preflight.py:680` A comment; the test reads the local checkout's script and feeds it to `bash -s -- --check` over stdin with PATH set to the stub dir, to reproduce `$0 == bash`; no network access. · `neurons/executor/tests/test_sysbox_setup_preflight.py:695` An assertion that the FIX line names the curl one-liner when the script is piped; nothing is fetched or run. · `neurons/executor/tests/test_sysbox_setup_preflight.py:111` An environment `pytest.skip('jq not installed')` for the with_jq=True variants only; the grep variant of every case still runs, jq was present on the k7ez box (200 passed, 0 skipped), and it is recorded above as the known low TEST-GAP rather than a medium.

### Verified

Gate: pending at 379c9c8

</details>

