### PR TITLE
DAH-3365 - [P2] README: accurate and current (lium-io)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ For more details, visit the [Validator Setup Guide](neurons/validators/README.md
 
 ## Repository Layout
 
-Three neurons, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files; `watchtower/`, its own pdm project with a Dockerfile; one shared pdm package (`datura/`, a `pyproject.toml` only); and `packages/lium-core/`, the library published to PyPI. The root `pyproject.toml` (`compute-subnet`, Python 3.11) holds only the repo-wide dev tools (`ruff`, `pre-commit`):
+Three neurons, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files; `watchtower/`, its own pdm project with a Dockerfile; one shared pdm package (`datura/`, a `pyproject.toml` only); and `packages/lium-core/`, the library published to PyPI. The root `pyproject.toml` (`compute-subnet`, Python 3.11) holds the shared `[tool.ruff]` config and the repo-wide dev tools (`ruff`, `pre-commit`), plus one declared runtime dependency (`aiohttp`):
 
 - `neurons/validators/` — the validator: scores miners, verifies executors over SSH, creates and manages rental containers on them (`src/services/docker_service.py`), sets weights. `src/miner_jobs/` holds the scripts the validator uploads to an executor and runs there (`machine_scrape.py` hardware scrape, `backup_storage.py` / `restore_storage.py`, `workspace_mount.py`); `machine_scrape.py` is obfuscated per job by `src/services/file_encrypt_service.py` before upload, so its key order is load-bearing (see the comment at the top of that file).
 - `neurons/miners/` — the miner: registers executors with the network and answers validator requests; its database schema is Alembic migrations under `migrations/`.
@@ -91,11 +91,11 @@ Python 3.11 and [pdm](https://pdm-project.org). Each service is its own pdm proj
 (cd neurons/miners && pdm install && pdm run pytest tests/ -v --tb=short)
 ```
 
-These are the commands `.github/workflows/test.yml` (**Tests**) runs on every pull request, every push to `main` and every merge-queue run. The workflow has no path filter: a `route` job reads the changed files and each neuron's job runs only when that neuron, `datura/` or `.github/` changed; `ruff-check` (`ruff check --select F,ASYNC210,ASYNC251` over `neurons datura watchtower`) always runs and is part of `tests-ok`; `lint` (`ruff format --check`, report-only, not required) runs per changed neuron; `e2e-gate` (`cd e2e && ./gate.sh`) runs when a neuron, `datura/`, `.github/` or `e2e/` changed; `tests-ok` is the one status check to require and reports on every PR. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
+These are the commands `.github/workflows/test.yml` (**Tests**) runs on every pull request, every push to `main` and every merge-queue run. The workflow has no path filter: a `route` job reads the changed files and each neuron's job runs only when that neuron, `datura/` or `.github/` changed; `ruff-check` (`ruff check --select F,ASYNC210,ASYNC251 --ignore F541 --extend-exclude migrations neurons datura watchtower`) always runs and is part of `tests-ok`; `lint` (`ruff format --check`, report-only, not required) runs per changed neuron; `e2e-gate` (`cd e2e && ./gate.sh`) runs when a neuron, `datura/`, `.github/` or `e2e/` changed; `tests-ok` is the one status check to require and reports on every PR. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
 
 ## Releases
 
-Images are built and pushed to Docker Hub by the `*_cd_*` workflows from each neuron's `docker_build.sh` / `docker_publish.sh` (and the `*_runner_*` pair for the auto-updating runner image):
+Images are built and pushed to Docker Hub by the `*_cd_prod` and `*_cd_dev` workflows from each neuron's `docker_build.sh` / `docker_publish.sh` (and the `*_runner_*` pair for the auto-updating runner image):
 
 | Tag pushed | Workflow | Images |
 |---|---|---|
@@ -103,7 +103,7 @@ Images are built and pushed to Docker Hub by the `*_cd_*` workflows from each ne
 | `validator-v*` | `validator_cd_prod.yml` | `daturaai/compute-subnet-validator`, `daturaai/compute-subnet-validator-runner` |
 | `miner-v*` | `miner_cd_prod.yml` | `daturaai/compute-subnet-miner`, `daturaai/compute-subnet-miner-runner` |
 
-The `*_cd_dev.yml` and `*_cd_staging.yml` workflows are started by hand (`workflow_dispatch`); `validator_cd_staging.yml` publishes `ghcr.io/datura-ai/lium-validator:staging`. The deploy of the validator and central miner lives in the private `lium-io-deployment` repository.
+The `*_cd_dev.yml` and `*_cd_staging.yml` workflows are started by hand (`workflow_dispatch`); the two `*_cd_staging.yml` use `docker/build-push-action` to publish `ghcr.io/datura-ai/lium-validator:staging` and `ghcr.io/datura-ai/lium-miner:staging`. The deploy of the validator and central miner lives in the private `lium-io-deployment` repository.
 
 ## Contact and Support
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,16 @@ Python 3.11 and [pdm](https://pdm-project.org). Each service is its own pdm proj
 (cd neurons/miners && pdm install && pdm run pytest tests/ -v --tb=short)
 ```
 
-These are the commands `.github/workflows/test.yml` (**Tests**) runs on every pull request, every push to `main` and every merge-queue run. The workflow has no path filter: a `route` job reads the changed files and each neuron's job runs only when that neuron, `datura/` or `.github/` changed; `ruff-check` (`ruff check --select F,ASYNC210,ASYNC251 --ignore F541 --extend-exclude migrations neurons datura watchtower`) always runs and is part of `tests-ok`; `lint` (`ruff format --check`, report-only, not required) runs per changed neuron; `e2e-gate` (`cd e2e && ./gate.sh`) runs when a neuron, `datura/`, `.github/` or `e2e/` changed; `tests-ok` is the one status check to require and reports on every PR. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
+These are the commands `.github/workflows/test.yml` (**Tests**) runs on every pull request, every push to `main` and every merge-queue run. The workflow has no path filter; its jobs decide for themselves:
+
+- `route` reads the changed files (`.github/actions/changed-packages`), after dropping `*.md`, `.gitignore` and the root `docs/` tree — a README-only PR runs no neuron job.
+- Each neuron's test job runs only when that neuron, `datura/` or `.github/` changed.
+- `ruff-check` (`ruff check --select F,ASYNC210,ASYNC251 --ignore F541 --extend-exclude migrations neurons datura watchtower`) always runs and is part of `tests-ok`.
+- `lint` (`ruff format --check`, report-only, not required) runs per changed neuron.
+- `e2e-gate` (`cd e2e && ./gate.sh`) runs when a neuron, `datura/`, `.github/` or `e2e/` changed.
+- `tests-ok` is the one status check to require; it reports on every PR.
+
+Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
 
 ## Releases
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lium.io
 
-**[Lium Subnet Documentation](https://docs.lium.io/bittensor-subnet/overview)**
+**[Lium Documentation](https://docs.lium.io)** — providers: <https://docs.lium.io/providers>, validators: <https://docs.lium.io/validators>
 
 <img width="469" height="468" alt="image" src="https://github.com/user-attachments/assets/69550b83-91a9-492a-bd7a-09d35c6106d3" />
 
@@ -16,6 +16,7 @@ Welcome to **Lium.io powered by Bittensor Subnet 51**! This project enables a de
   - [For Validators](#for-validators)
 - [Repository Layout](#repository-layout)
 - [Running the Tests](#running-the-tests)
+- [Releases](#releases)
 - [Contact and Support](#contact-and-support)
 
 ## Introduction
@@ -64,13 +65,15 @@ For more details, visit the [Validator Setup Guide](neurons/validators/README.md
 
 ## Repository Layout
 
-Three neurons, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files; `watchtower/`, its own pdm project with a Dockerfile; and one shared pdm package (`datura/`, a `pyproject.toml` only):
+Three neurons, each with its own `pyproject.toml` / `pdm.lock`, Dockerfile and compose files; `watchtower/`, its own pdm project with a Dockerfile; one shared pdm package (`datura/`, a `pyproject.toml` only); and `packages/lium-core/`, the library published to PyPI. The root `pyproject.toml` (`compute-subnet`, Python 3.11) holds only the repo-wide dev tools (`ruff`, `pre-commit`):
 
 - `neurons/validators/` — the validator: scores miners, verifies executors over SSH, creates and manages rental containers on them (`src/services/docker_service.py`), sets weights. `src/miner_jobs/` holds the scripts the validator uploads to an executor and runs there (`machine_scrape.py` hardware scrape, `backup_storage.py` / `restore_storage.py`, `workspace_mount.py`); `machine_scrape.py` is obfuscated per job by `src/services/file_encrypt_service.py` before upload, so its key order is load-bearing (see the comment at the top of that file).
 - `neurons/miners/` — the miner: registers executors with the network and answers validator requests; its database schema is Alembic migrations under `migrations/`.
 - `neurons/executor/` — the agent installed on a GPU machine: exposes the machine to its miner's validators, runs the containers. `dstacktee/` runs it inside an Intel TDX confidential VM with attestation (its own README).
 - `datura/` — the protocol shared by the three: request/response models (`datura/requests`), consumers, errors.
+- `packages/lium-core/` — `lium_core.shared_config`, the shared-config client the validator and the miner install from PyPI as `lium-core` (its own README; CI `lium-core-ci.yml`, release by hand through `lium-core-release.yml`).
 - `watchtower/` — pulls validator-signed image updates and restarts containers (its own README).
+- `e2e/` — the whole loop on one machine without the chain: a real executor on its own dockerd, a real miner, the validator's services as the tester (`e2e/README.md`; `./gate.sh` is what CI runs).
 - `scripts/` — the `install_*_on_ubuntu.sh` installers referenced by the setup guides; `docs/` — operator notes; `contrib/` — contribution and style guides.
 
 ## Running the Tests
@@ -88,7 +91,19 @@ Python 3.11 and [pdm](https://pdm-project.org). Each service is its own pdm proj
 (cd neurons/miners && pdm install && pdm run pytest tests/ -v --tb=short)
 ```
 
-These are the commands `.github/workflows/test.yml` runs on every pull request against `main` or `dev`. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
+These are the commands `.github/workflows/test.yml` (**Tests**) runs on every pull request, every push to `main` and every merge-queue run. The workflow has no path filter: a `route` job reads the changed files and each neuron's job runs only when that neuron, `datura/` or `.github/` changed; `ruff-check` (`ruff check --select F,ASYNC210,ASYNC251` over `neurons datura watchtower`) always runs and is part of `tests-ok`; `lint` (`ruff format --check`, report-only, not required) runs per changed neuron; `e2e-gate` (`cd e2e && ./gate.sh`) runs when a neuron, `datura/`, `.github/` or `e2e/` changed; `tests-ok` is the one status check to require and reports on every PR. Tests follow Arrange-Act-Assert, one behaviour per function; `ruff format` (pre-commit hook in `.pre-commit-config.yaml`) is the formatter.
+
+## Releases
+
+Images are built and pushed to Docker Hub by the `*_cd_*` workflows from each neuron's `docker_build.sh` / `docker_publish.sh` (and the `*_runner_*` pair for the auto-updating runner image):
+
+| Tag pushed | Workflow | Images |
+|---|---|---|
+| `executor-v*` | `executor_cd_prod.yml` | `daturaai/compute-subnet-executor`, `daturaai/compute-subnet-executor-runner` |
+| `validator-v*` | `validator_cd_prod.yml` | `daturaai/compute-subnet-validator`, `daturaai/compute-subnet-validator-runner` |
+| `miner-v*` | `miner_cd_prod.yml` | `daturaai/compute-subnet-miner`, `daturaai/compute-subnet-miner-runner` |
+
+The `*_cd_dev.yml` and `*_cd_staging.yml` workflows are started by hand (`workflow_dispatch`); `validator_cd_staging.yml` publishes `ghcr.io/datura-ai/lium-validator:staging`. The deploy of the validator and central miner lives in the private `lium-io-deployment` repository.
 
 ## Contact and Support
 

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -158,7 +158,9 @@ Go to `/etc/docker/daemon.json` and add `"exec-opts": ["native.cgroupdriver=cgro
 | OS          | Version |
 |-------------|---------|
 | Ubuntu      | 22.04+  |
-| Kernel      | 5.19+ (6.x recommended) — overlayfs on ID-mapped mounts, which Sysbox needs for GPUs, landed in 5.19; `nvidia_docker_sysbox_setup.sh` checks it |
+| Kernel      | 5.19+ (6.x recommended) |
+
+Why 5.19: overlayfs on ID-mapped mounts, which Sysbox needs for GPUs, landed in 5.19; `nvidia_docker_sysbox_setup.sh` checks it.
 
 Checking OS and Kernel version
 ```shell

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -9,7 +9,7 @@ Before the first command, the machine needs:
 - **Ubuntu 22.04 on x86_64**, kernel 5.19 or newer (6.x recommended; `hostnamectl` shows both), and root or passwordless `sudo`;
 - **the NVIDIA driver loaded** — `nvidia-smi` lists the GPUs;
 - **Docker Engine installed and running** — `docker ps` works. The Sysbox installer below refuses to run without it (`lium mine` runs the Docker install script too, but only after this step, and it is a no-op on a machine that already has Docker);
-- **a public IP** with the service port (`8080`) and the node SSH port (`2200`) reachable, and the SS58 hotkey of a provider registered on subnet 51.
+- **a public IP** with the service port (`8080`) and the node SSH port (`2200`) reachable, and the hotkey (SS58 address) of your registered provider account — see the [Provider Quickstart](https://docs.lium.io/providers/quickstart).
 
 RAM, disk (including the 1.5× VRAM rule for the idle incentive) and the recommended XFS storage setup are in the [Node Quickstart requirements](https://docs.lium.io/providers/nodes/quickstart#requirements).
 
@@ -19,10 +19,10 @@ Install [Sysbox](https://docs.lium.io/providers/nodes/sysbox) first — validato
 curl -fsSL https://raw.githubusercontent.com/Datura-ai/lium-io/main/neurons/executor/nvidia_docker_sysbox_setup.sh | sudo bash
 ```
 
-Then run the node in one command, with your miner hotkey:
+Then run the node in one command, with your provider hotkey:
 
 ```shell
-curl -fsSL https://lium.io/mine.sh | bash -s -- -k <your_miner_hotkey_ss58>
+curl -fsSL https://lium.io/mine.sh | bash -s -- -k <your_provider_hotkey_ss58>
 ```
 
 The script installs the [`lium`](https://github.com/Datura-ai/lium) CLI and runs `lium mine`, which:
@@ -80,27 +80,34 @@ cd neurons/executor
 cp .env.template .env
 ```
 
-* Install Required Tools 
+* Install Sysbox and the NVIDIA Container Toolkit (root is required)
 ```shell
-./nvidia_docker_sysbox_setup.sh
+sudo ./nvidia_docker_sysbox_setup.sh
 ```
 
-Add the correct miner wallet hotkey for `MINER_HOTKEY_SS58_ADDRESS`.
-You can change the ports for `INTERNAL_PORT`, `EXTERNAL_PORT`, `SSH_PORT` based on your need.
+Put your provider hotkey (SS58 address) in `MINER_HOTKEY_SS58_ADDRESS` — the variable keeps its historical name.
+You can change the ports for `INTERNAL_PORT`, `EXTERNAL_PORT`, `SSH_PORT` based on your need; the template's
+defaults are `8001` / `8001` / `2200` (`lium mine` proposes `8080` for the service port instead).
 
 - **INTERNAL_PORT**: internal port of your executor docker container
 - **EXTERNAL_PORT**: external expose port of your executor docker container
 - **SSH_PORT**: ssh port map into 22 of your executor docker container
 - **SSH_PUBLIC_PORT**: [Optional] ssh public access port of your executor docker container. If `SSH_PUBLIC_PORT` is equal to `SSH_PORT` then you don't have to specify this port.
-- **MINER_HOTKEY_SS58_ADDRESS**: the miner hotkey address
+- **MINER_HOTKEY_SS58_ADDRESS**: your provider hotkey (SS58 address)
 - **RENTING_PORT_RANGE**: The port range that are publicly accessible. This can be empty if all ports are open. Available formats are: 
-  - Range Specification(`from-to`): Miners can specify a range of ports, such as 2000-2005. This means ports from 2000 to 2005 will be open for the validator to select.
-  - Specific Ports(`port1,port2,port3`): Miners can specify individual ports, such as 2000,2001,2002. This means only ports 2000, 2001, and 2002 will be available for the validator.
+  - Range Specification(`from-to`): a range of ports, such as 2000-2005. This means ports from 2000 to 2005 will be open for the validator to select.
+  - Specific Ports(`port1,port2,port3`): individual ports, such as 2000,2001,2002. This means only ports 2000, 2001, and 2002 will be available for the validator.
   - Default Behavior: If no ports are specified, the validator will assume that all ports on the executor are available.
 - **RENTING_PORT_MAPPINGS**: Internal, external port mappings. Use this env when you are using proxy in front of your executors and the internal port and external port can't be the same. You can ignore this env, if all ports are open or the internal and external ports are the same. example:
   - if internal port 46681 is mapped to 56681 external port and internal port 46682 is mapped to 56682 external port, then RENTING_PORT_MAPPINGS="[[46681, 56681], [46682, 56682]]"
 
 Note: Please use either **RENTING_PORT_RANGE** or **RENTING_PORT_MAPPINGS** and DO NOT use both of them if you have specific ports are available.
+
+Optional, commented out in the template (`src/core/config.py` has the defaults):
+
+- **COMPUTE_REST_API_URL**: the Lium backend the executor pre-pulls its GPU's cache template image from (default `https://lium.io/api`; empty disables the pre-pull)
+- **CACHE_TEMPLATE_REFRESH_SECONDS**: how often the template digest is re-checked (default `900`)
+- **CONTAINER_SIGNATURE_MAX_AGE_SECONDS**: maximum clock skew accepted on signed pod-metrics and pod-log requests (default `300`; keep the host on NTP rather than widening this)
 
 
 * Run project
@@ -150,24 +157,24 @@ Go to `/etc/docker/daemon.json` and add `"exec-opts": ["native.cgroupdriver=cgro
 #### System Requirments
 | OS          | Version |
 |-------------|---------|
-| Ubuntu      | 22+     |
-| Kernel      | 6.5+    |
+| Ubuntu      | 22.04+  |
+| Kernel      | 5.19+ (6.x recommended) — overlayfs on ID-mapped mounts, which Sysbox needs for GPUs, landed in 5.19; `nvidia_docker_sysbox_setup.sh` checks it |
 
 Checking OS and Kernel version
 ```shell
 hostnamectl
 ```
 
-Get the latest kernel version on ubuntu 22.04 if the kernel version is less than 6.5
+Get the HWE kernel on Ubuntu 22.04 if the kernel version is older than 5.19
 ```shell
 sudo apt update
 sudo apt install --install-recommends linux-generic-hwe-22.04
 sudo reboot
 ```
 
-Installation of sysbox
+Installation of sysbox (as root; `sudo ./nvidia_docker_sysbox_setup.sh --check` only runs the host checks)
 ```shell
-./nvidia_docker_sysbox_setup.sh
+sudo ./nvidia_docker_sysbox_setup.sh
 ```
 
 Verify sysbox is working correctly with gpu

--- a/neurons/executor/dstacktee/README.md
+++ b/neurons/executor/dstacktee/README.md
@@ -52,7 +52,7 @@ cp .env.example .env
 
 `lium-cvm.sh` subcommands: `check`, `download`, `new <name> [--env local|staging|prod] [--enable-logs] [--enable-sysinfo]`
 (`--env` picks `app/docker-compose.local.yml`, `app/docker-compose.staging.yml` or `app/docker-compose.yml`; default `prod`),
-`run <name>`, `stop <name>`, `list`, `lsgpu`, `help`.
+`run <name> [--dry-run]`, `stop <name> [--timeout N] [--force]`, `list`, `lsgpu`, `help`.
 
 ## Architecture
 

--- a/neurons/executor/dstacktee/README.md
+++ b/neurons/executor/dstacktee/README.md
@@ -50,6 +50,10 @@ cp .env.example .env
 ./lium-cvm.sh run my-executor
 ```
 
+`lium-cvm.sh` subcommands: `check`, `download`, `new <name> [--env local|staging|prod] [--enable-logs] [--enable-sysinfo]`
+(`--env` picks `app/docker-compose.local.yml`, `app/docker-compose.staging.yml` or `app/docker-compose.yml`; default `prod`),
+`run <name>`, `stop <name>`, `list`, `lsgpu`, `help`.
+
 ## Architecture
 
 ```mermaid
@@ -97,8 +101,10 @@ SSH_PORT=2200
 RENTING_PORT_RANGE="19001,19002,19003"
 
 # Identity
-MINER_HOTKEY_SS58_ADDRESS=your_hotkey_here
+MINER_HOTKEY_SS58_ADDRESS=your_hotkey_here   # your provider hotkey (SS58)
+VALIDATOR_HOTKEY_SS58_ADDRESS=...            # measured into the CVM attestation (RTMR) by app/init_script.sh; the executor's trusted validator is fixed in src/core/config.py
 ENABLE_TDX_ATTESTATION=true
+ENABLE_GPU_ATTESTATION=false                 # optional; GPU_ATTESTATION_ARCH=HOPPER | BLACKWELL when on
 
 # Measured executor-runner release (from the release notes) — required
 EXECUTOR_RUNNER_IMAGE_DIGEST=sha256:...

--- a/neurons/executor/dstacktee/README.md
+++ b/neurons/executor/dstacktee/README.md
@@ -102,7 +102,7 @@ RENTING_PORT_RANGE="19001,19002,19003"
 
 # Identity
 MINER_HOTKEY_SS58_ADDRESS=your_hotkey_here   # your provider hotkey (SS58)
-VALIDATOR_HOTKEY_SS58_ADDRESS=...            # measured into the CVM attestation (RTMR) by app/init_script.sh; the executor's trusted validator is fixed in src/core/config.py
+VALIDATOR_HOTKEY_SS58_ADDRESS=...            # measured into the CVM attestation (RTMR) by app/init_script.sh; the executor's trusted validator is fixed per image: docker_build.sh writes src/core/config_override.py from VALIDATOR_HOTKEY_SS58 at build time (src/core/config.py holds the default)
 ENABLE_TDX_ATTESTATION=true
 ENABLE_GPU_ATTESTATION=false                 # optional; GPU_ATTESTATION_ARCH=HOPPER | BLACKWELL when on
 

--- a/neurons/miners/README.md
+++ b/neurons/miners/README.md
@@ -74,6 +74,8 @@ Fill in your information for:
 
 `INTERNAL_PORT` and `EXTERNAL_PORT`: Optionally customize these ports. Make sure the `EXTERNAL PORT` is open for external connections to connect to the validators.
 
+`COMPUTE_REST_API_URL`: The Lium backend the miner talks to (template default `https://lium.io/api`).
+
 
 #### Step 4: Start the Miner
 
@@ -271,6 +273,15 @@ docker exec -it <container-id or name> pdm run /root/app/src/cli.py get-reclaim-
 ```
 
 This will print a JSON list of all reclaim requests made by the miner, including their status and details.
+
+### Contract versions
+
+```bash
+docker exec -it <container-id or name> pdm run /root/app/src/cli.py show-contract-versions
+docker exec -it <container-id or name> pdm run /root/app/src/cli.py current-contract-version
+```
+
+`show-contract-versions` lists the collateral contract versions with their addresses; `current-contract-version` prints the one this miner uses. (`migrate-validator-hotkey` is a one-off data migration for a past validator hotkey change and is not part of normal operation.)
 
 ### Finalizing a Reclaim Request
 


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3365](https://app.notion.com/p/README-accurate-and-current-lium-io-3d7b8bfdbde9814c8dc8e4ddda2a4341) · reviewer: @taiberium

**TL;DR** — Root: a dead docs link, a layout without `packages/lium-core` and `e2e`, a `dev` trigger `test.yml` does not have, no release process. Executor (provider-facing): kernel 6.5+ vs the installer's 5.19 check, "miner hotkey" wording, missing variables. READMEs only.

**What changed**
- Root: resolving docs links; `packages/lium-core/`, `e2e/` in the layout; the real `test.yml` jobs and triggers; a Releases table for the `*-v*` tags and images (`README.md`)
- Executor: "provider hotkey"; Sysbox kernel 5.19+ (what the installer checks); `sudo` and `--check` on the installer; 8001 vs 8080 port defaults; three missing `.env.template` variables (`neurons/executor/README.md`)
- Miners: `COMPUTE_REST_API_URL`; `show-contract-versions`, `current-contract-version`, `migrate-validator-hotkey` (`neurons/miners/README.md`)
- dstacktee: every `lium-cvm.sh` subcommand with its flags; three `.env.example` variables the config block omitted (`neurons/executor/dstacktee/README.md`)

**How to verify**
- `curl -sL -o /dev/null -w '%{http_code} %{url_effective}' https://docs.lium.io/bittensor-subnet/overview` → `200 https://docs.lium.io/intro` (the old link redirects to the intro)
- `rg -n '^  [a-z0-9-]+:$' .github/workflows/test.yml` → 3 triggers + route, validators, executor, miners, lint, ruff-check, e2e, tests-ok; `rg -n branches .github/workflows/test.yml` → `[main]` only
- `rg -o 'daturaai/[a-z-]+' neurons/*/docker_*build.sh | sort -u` → the six images; `rg -n 'IMAGE_NAME:' .github/workflows/*_cd_staging.yml` → `lium-validator`, `lium-miner`
- `rg -n 5.19 neurons/executor/nvidia_docker_sysbox_setup.sh` → the check; `rg -c '^@cli.command' neurons/miners/src/cli.py` → 19; `rg -n '^"[a-z]+"' neurons/executor/dstacktee/lium-cvm.sh` → the 8 subcommands

**Verified by the loop:** Gate: PASS b24d42f

**Ran it:** the `curl` above → `200 https://docs.lium.io/intro` · macOS; nothing else in the diff runs

**Self-review:** clean at b24d42f (19 checks, 1 low)

**Parts:** backend n/a — text · migration n/a — text · frontend n/a — text · CLI/SDK n/a — text · docs ✓ four READMEs · tests n/a — README-only; tests-ok reports · dashboards n/a — text

**Docs:** the four READMEs are the change; docs.lium.io already agrees (Node Quickstart).

<details><summary>Details</summary>

### What was wrong (quoted from `main`)

Root `README.md`:
- "**[Lium Subnet Documentation](https://docs.lium.io/bittensor-subnet/overview)**" — 308 → `/intro`; the docs are organised by audience now (`/providers`, `/validators`).
- "Three neurons … `watchtower/` … and one shared pdm package (`datura/`)" — `packages/lium-core/` (published to PyPI, its own CI and release workflow) and `e2e/` (the CI gate) were not in the layout.
- "These are the commands `.github/workflows/test.yml` runs on every pull request against `main` or `dev`" — `test.yml` has `pull_request` (no branch filter), `push: branches: [main]`, `merge_group`; no `dev`. The route/lint/ruff-check/e2e-gate/tests-ok jobs were undocumented.
- No release process: `executor_cd_prod.yml` (`executor-v*`), `validator_cd_prod.yml` (`validator-v*`), `miner_cd_prod.yml` (`miner-v*`) run each neuron's `docker_build.sh`/`docker_publish.sh` and the runner pair; images `daturaai/compute-subnet-{executor,validator,miner}[-runner]`; `*_cd_dev`/`*_cd_staging` are `workflow_dispatch`; `validator_cd_staging.yml` → `ghcr.io/datura-ai/lium-validator:staging`.

`neurons/executor/README.md` (addresses providers):
- "| Kernel | 6.5+ |" vs. the top of the same file "kernel 5.19 or newer" — `nvidia_docker_sysbox_setup.sh:54`: "overlayfs over ID-mapped mounts landed in 5.19"; docs.lium.io Sysbox page: "Kernel 5.19+ is mandatory for GPUs". Table now 5.19+ (6.x recommended).
- "the SS58 hotkey of a provider registered on subnet 51" / "with your miner hotkey" / "Add the correct miner wallet hotkey" / "Miners can specify a range of ports" — reworded to "provider hotkey" and "you", the wording of docs.lium.io's Node Quickstart (`-k <your_provider_hotkey_ss58>`); the env var `MINER_HOTKEY_SS58_ADDRESS` keeps its name and the README says so. Per L-271 no subnet/mining words remain in the provider-facing prose; the hotkey stays because the command needs it.
- "`./nvidia_docker_sysbox_setup.sh`" (twice, no sudo) — the script's own header: `sudo bash nvidia_docker_sysbox_setup.sh [--check]`; the quick-setup section already piped it to `sudo bash`.
- The manual-setup variable list stopped at `RENTING_PORT_MAPPINGS`; `.env.template` also carries `COMPUTE_REST_API_URL`, `CACHE_TEMPLATE_REFRESH_SECONDS`, `CONTAINER_SIGNATURE_MAX_AGE_SECONDS` (defaults in `src/core/config.py`). Template port defaults are `8001`/`8001`/`2200` while the quick-setup text says `8080` (`lium mine`'s default, `lium/cli/commands/mine.py:163`); both now stated.

`neurons/miners/README.md`: `cli.py` has 19 commands; `show-contract-versions`, `current-contract-version`, `migrate-validator-hotkey` were undocumented; `COMPUTE_REST_API_URL` is in `.env.template` but not in the variable list.

`neurons/executor/dstacktee/README.md`: `lium-cvm.sh` dispatches `check download new run stop list lsgpu help` and `new` takes `--env local|staging|prod`, `--enable-logs`, `--enable-sysinfo`; the README showed `check download new run` only. `.env.example` has `VALIDATOR_HOTKEY_SS58_ADDRESS`, `ENABLE_GPU_ATTESTATION` (default false), `GPU_ATTESTATION_ARCH` (HOPPER | BLACKWELL) that the config block omitted.

`neurons/validators/README.md`: read against `.env.template` and `docker-compose.yml`; nothing found wrong, not changed.

### Cross-PR

`git merge-tree` of this branch against every open PR that edits one of the four READMEs: #1331 (DAH-3247, lium_protocol) conflicts on the root `README.md`: its layout paragraph vs. this one's, and it also edits `test.yml` / `.github/actions/changed-packages` (a `protocol` job; `lium_protocol/` routes to `validators`) while keeping the "`main` or `dev`" sentence this PR removes — whichever lands second re-applies the tests paragraph (add the `protocol` job and the routing here if #1331 merges first; drop the `main`/`dev` sentence there if this one does); #946, #903, #745 (the older dstacktee/CVM branches) conflict on three of the four READMEs (root, executor, miners) because they rewrite them wholesale and are far behind `main`; #1220 and #1216 touch other README files only.

lium-io#745 (dstacktee epic, open since long) and #1220 (CVM v2) touch `neurons/executor/dstacktee/`; #1301 (DAH-3114) touches executor config. 

Ticket: split from DAH-3360 into DAH-3365 on 10 Sep 17:40Z so the ticket assignee is this PR's reviewer (PR_PROCESS §12, L-292).

### Self-review

Verdict `clean` at `b24d42f` · 19 checks · by subagent-fresh-r90 · 2026-09-11 07:52Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | PROSE-VS-CODE | `README.md:97` | "Each neuron's test job runs only when that neuron, `datura/` or `.github/` changed" holds for pull_request and merge_group runs; on the `push` to `main` the paragraph also lists, `.github/actions/changed-packages/action.yml` has no diff (`files = null`) and selects every package, so all three neuron jobs and e2e-gate run regardless. | Append "(a push to `main` has no file list and runs every job)" to the bullet, or scope the bullets with "On a PR or merge-queue run:". |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/executor/README.md:25` Mechanical note (curl | bash): the line is untouched in this round and pre-exists on origin/main; it is the documented Node Quickstart path on docs.lium.io, only the placeholder name changed in the PR. · `README.md:95` isDoc rule confirmed: `action.yml:43` is /\.md$|(^|\/)\.gitignore$|^docs\//, applied to both the PR file list (line 54) and the merge-group diff (line 63) before routing; `*.md` and `.gitignore` anywhere, `docs/` at the root only — exactly what the bullet says; a README-only PR sets every output false, so no neuron job and no e2e-gate run while tests-ok (if: always()) still reports. · `README.md:98` `ruff-check` bullet: `test.yml:190` is the quoted command verbatim; the job has no `if`/`needs` (always runs) and is in `tests-ok.needs` (line 198). · `README.md:99` `lint` bullet: job id `lint` (name `ruff format (<pkg>)`), `args: format --check`, `continue-on-error: true`, step-level `if` on `needs.route.outputs[matrix.package]`, absent from `tests-ok.needs` — report-only, not required, per changed neuron. · `README.md:100` `e2e-gate` bullet: job id `e2e`, `name: e2e-gate`, `if: needs.route.outputs.e2e == 'true'`, `working-directory: e2e`, `run: ./gate.sh`; the action sets e2e = anyPackage || touches(files, 'e2e/') and `touches` includes the SHARED prefixes `datura/` and `.github/`. · `README.md:101` `tests-ok` bullet: `if: always()`, needs [route, validators, executor, miners, ruff-check, e2e], fails on any failure/cancelled result — the one check to require, reports on every PR. Triggers: `pull_request` (no filter), `push: branches: [main]`, `merge_group: branches: [main]` match the lead sentence; the body's `rg` verify commands reproduce (3 triggers + 8 jobs; `branches` → `[main]` twice). · `neurons/executor/README.md:161` Kernel row is a plain two-column cell again; the table (header, separator, two rows) is followed by a blank line and the reason paragraph, so it renders. `nvidia_docker_sysbox_setup.sh:53-54` (`kernel_supports_idmapped`: "overlayfs over ID-mapped mounts landed in 5.19") and `check_kernel` (lines 197-217, "sysbox cannot pass GPUs through without ID-mapped mounts") are the check the paragraph names. · `neurons/executor/dstacktee/README.md:105` `docker_build.sh:61` sets CONFIG_OVERRIDE_FILE to src/core/config_override.py and lines 92-94 write `_VALIDATOR_HOTKEY_SS58 = "..."` into it when VALIDATOR_HOTKEY_SS58 is set, before `docker build`; the Dockerfile's `COPY . .` includes it (`.dockerignore` does not exclude it, `.gitignore:169` keeps it out of git only); `src/core/config.py:8-13` holds the default and imports the override; `executor_cd_prod.yml`/`executor_cd_dev.yml` build through `source ./docker_build.sh` (dev sets the variable) — fixed per image. VALIDATOR_HOTKEY_SS58_ADDRESS is read by no file under `neurons/executor/src` (Settings has extra="ignore"); `app/init_script.sh:11,28` whitelists it and extends the RTMR with it.

### Verified

Gate: PASS (b24d42f) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1353)

</details>
