### PR TITLE
DAH-3376 - [P2] standard stack passes the host's docker login to Watchtower and the…

### DIFF
--- a/neurons/executor/docker-compose.dev.yml
+++ b/neurons/executor/docker-compose.dev.yml
@@ -1,5 +1,6 @@
 version: '3.7'
 
+# Same host docker-config mounts as docker-compose.yml (DAH-3376); see the comment there.
 services:
   executor-runner:
     image: daturaai/compute-subnet-executor-runner:dev
@@ -7,7 +8,10 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "$HOME/.bittensor/wallets:/root/.bittensor/wallets"
+      - "$HOME/.docker:/root/.docker:ro"
       - ./.env:/root/executor/.env
+    environment:
+      - DOCKER_HOST=unix:///var/run/docker.sock
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 
@@ -16,4 +20,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - "$HOME/.docker:/config:ro"
+    environment:
+      - DOCKER_CONFIG=/config
     command: --interval 60 --cleanup --label-enable

--- a/neurons/executor/docker-compose.yml
+++ b/neurons/executor/docker-compose.yml
@@ -1,5 +1,10 @@
 version: '3.7'
 
+# The host's Docker config directory ($HOME/.docker, written by `docker login`) is mounted
+# read-only into both containers so the update chain can authenticate against Docker Hub:
+# anonymous pulls are counted per source IP, and hosts behind a shared egress exhaust that
+# quota together (DAH-3376). An empty or missing directory changes nothing — the pulls stay
+# anonymous, as before.
 services:
   executor-runner:
     image: daturaai/compute-subnet-executor-runner:latest
@@ -7,6 +12,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - "$HOME/.bittensor/wallets:/root/.bittensor/wallets"
+      - "$HOME/.docker:/root/.docker:ro"
       - ./.env:/root/executor/.env
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
@@ -16,4 +22,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+      - "$HOME/.docker:/config:ro"
+    environment:
+      - DOCKER_CONFIG=/config
     command: --interval 60 --cleanup --label-enable

--- a/neurons/executor/docker-compose.yml
+++ b/neurons/executor/docker-compose.yml
@@ -9,8 +9,9 @@ version: '3.7'
 # by that user cannot write config.json. The runner pins DOCKER_HOST so a `currentContext`
 # in the host's config.json cannot redirect its docker CLI. The credentials must be inline
 # (`auths`): Watchtower has no credential helper, and a `credsStore` in config.json makes it
-# skip every container, public images included (the runner's CLI still pulls anonymously) —
-# `grep credsStore ~/.docker/config.json` must print nothing (remove the key, log in again).
+# skip every container, public images included (a `credHelpers` entry for Docker Hub routes
+# through a helper the same way) — `grep -E 'credsStore|credHelpers' ~/.docker/config.json`
+# should print nothing; remove the key and log in again otherwise.
 services:
   executor-runner:
     image: daturaai/compute-subnet-executor-runner:latest

--- a/neurons/executor/docker-compose.yml
+++ b/neurons/executor/docker-compose.yml
@@ -7,7 +7,10 @@ version: '3.7'
 # Create it as the user who runs the stack (`mkdir -p ~/.docker`; the installer does) before
 # the first `docker compose up`, or the daemon creates it as root and a later `docker login`
 # by that user cannot write config.json. The runner pins DOCKER_HOST so a `currentContext`
-# in the host's config.json cannot redirect its docker CLI.
+# in the host's config.json cannot redirect its docker CLI. The credentials must be inline
+# (`auths`): Watchtower has no credential helper, and a `credsStore` in config.json makes it
+# skip every container, public images included (the runner's CLI still pulls anonymously) —
+# `grep credsStore ~/.docker/config.json` must print nothing (remove the key, log in again).
 services:
   executor-runner:
     image: daturaai/compute-subnet-executor-runner:latest

--- a/neurons/executor/docker-compose.yml
+++ b/neurons/executor/docker-compose.yml
@@ -3,8 +3,11 @@ version: '3.7'
 # The host's Docker config directory ($HOME/.docker, written by `docker login`) is mounted
 # read-only into both containers so the update chain can authenticate against Docker Hub:
 # anonymous pulls are counted per source IP, and hosts behind a shared egress exhaust that
-# quota together (DAH-3376). An empty or missing directory changes nothing — the pulls stay
-# anonymous, as before.
+# quota together (DAH-3376). An empty directory changes nothing — the pulls stay anonymous.
+# Create it as the user who runs the stack (`mkdir -p ~/.docker`; the installer does) before
+# the first `docker compose up`, or the daemon creates it as root and a later `docker login`
+# by that user cannot write config.json. The runner pins DOCKER_HOST so a `currentContext`
+# in the host's config.json cannot redirect its docker CLI.
 services:
   executor-runner:
     image: daturaai/compute-subnet-executor-runner:latest
@@ -14,6 +17,8 @@ services:
       - "$HOME/.bittensor/wallets:/root/.bittensor/wallets"
       - "$HOME/.docker:/root/.docker:ro"
       - ./.env:/root/executor/.env
+    environment:
+      - DOCKER_HOST=unix:///var/run/docker.sock
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
 

--- a/neurons/executor/docker-compose.yml
+++ b/neurons/executor/docker-compose.yml
@@ -9,9 +9,9 @@ version: '3.7'
 # by that user cannot write config.json. The runner pins DOCKER_HOST so a `currentContext`
 # in the host's config.json cannot redirect its docker CLI. The credentials must be inline
 # (`auths`): Watchtower has no credential helper, and a `credsStore` in config.json makes it
-# skip every container, public images included (a `credHelpers` entry for Docker Hub routes
-# through a helper the same way) — `grep -E 'credsStore|credHelpers' ~/.docker/config.json`
-# should print nothing; remove the key and log in again otherwise.
+# skip every container, public images included. The login must sit in `auths`, not in a
+# helper: `grep -E 'credsStore|credHelpers' ~/.docker/config.json` should print nothing;
+# remove the key and log in again otherwise.
 services:
   executor-runner:
     image: daturaai/compute-subnet-executor-runner:latest

--- a/neurons/executor/tests/test_installer_docker_config_dir.py
+++ b/neurons/executor/tests/test_installer_docker_config_dir.py
@@ -7,7 +7,7 @@ daemon creates the bind source as root and the operator's later ``docker login``
 ``install_docker`` returns early.
 
 Same harness as test_sysbox_setup_preflight.py: the script runs under bash with stub commands
-(apt-get, sudo, docker, id) ahead of the real PATH and a fixture ``$HOME``.
+(apt-get, sudo, docker) ahead of the real PATH and a fixture ``$HOME``.
 """
 
 import os
@@ -33,8 +33,6 @@ STUBS = {
         esac
         """
     ),
-    # the operator is already in the docker group: no usermod, no `sg` re-exec at the end
-    "id": '#!/bin/bash\n[ "$1" = "-nG" ] && { echo "docker"; exit 0; }\nexec /usr/bin/id "$@"\n',
 }
 
 
@@ -84,4 +82,5 @@ def test_installer_leaves_an_existing_docker_config_dir_alone(host):
     result = _run_installer(stubs, home)
 
     assert result.returncode == 0, result.stdout + result.stderr
+    assert f"Docker config directory ready: {home}/.docker" in result.stdout
     assert config.read_text() == '{"auths": {}}\n'

--- a/neurons/executor/tests/test_installer_docker_config_dir.py
+++ b/neurons/executor/tests/test_installer_docker_config_dir.py
@@ -1,0 +1,87 @@
+"""DAH-3376: scripts/install_executor_on_ubuntu.sh creates ``$HOME/.docker`` on every run.
+
+The stack bind-mounts ``$HOME/.docker`` (docker-compose.yml); when the directory is missing the
+daemon creates the bind source as root and the operator's later ``docker login`` cannot write
+``config.json``. The installer therefore creates it as the user running the script — the user
+``lium mine`` starts the stack as — including on a host where Docker is already installed and
+``install_docker`` returns early.
+
+Same harness as test_sysbox_setup_preflight.py: the script runs under bash with stub commands
+(apt-get, sudo, docker, id) ahead of the real PATH and a fixture ``$HOME``.
+"""
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[3] / "scripts" / "install_executor_on_ubuntu.sh"
+
+STUBS = {
+    "apt-get": "#!/bin/bash\nexit 0\n",
+    # `sudo -n <cmd>`: run <cmd> as-is
+    "sudo": '#!/bin/bash\n[ "$1" = "-n" ] && shift\nexec "$@"\n',
+    "docker": textwrap.dedent(
+        """\
+        #!/bin/bash
+        case "$1" in
+            --version) echo "Docker version 28.5.2, build stub" ;;
+            info|compose) exit 0 ;;
+            *) echo "unexpected docker $*" >&2; exit 1 ;;
+        esac
+        """
+    ),
+    # the operator is already in the docker group: no usermod, no `sg` re-exec at the end
+    "id": '#!/bin/bash\n[ "$1" = "-nG" ] && { echo "docker"; exit 0; }\nexec /usr/bin/id "$@"\n',
+}
+
+
+@pytest.fixture
+def host(tmp_path):
+    stubs = tmp_path / "bin"
+    stubs.mkdir()
+    for name, body in STUBS.items():
+        p = stubs / name
+        p.write_text(body)
+        p.chmod(0o755)
+    home = tmp_path / "home"
+    home.mkdir()
+    return stubs, home
+
+
+def _run_installer(stubs: Path, home: Path) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "PATH": f"{stubs}:{os.environ['PATH']}",
+        "HOME": str(home),
+        "USER": os.environ.get("USER", "op"),
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT)], env=env, capture_output=True, text=True, timeout=60
+    )
+
+
+def test_installer_creates_docker_config_dir_when_docker_is_already_installed(host):
+    stubs, home = host
+    assert not (home / ".docker").exists()
+
+    result = _run_installer(stubs, home)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Docker already installed" in result.stdout  # install_docker returned early
+    assert (home / ".docker").is_dir()
+    assert f"Docker config directory ready: {home}/.docker" in result.stdout
+
+
+def test_installer_leaves_an_existing_docker_config_dir_alone(host):
+    stubs, home = host
+    (home / ".docker").mkdir()
+    config = home / ".docker" / "config.json"
+    config.write_text('{"auths": {}}\n')
+
+    result = _run_installer(stubs, home)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert config.read_text() == '{"auths": {}}\n'

--- a/neurons/executor/tests/test_stack_registry_login.py
+++ b/neurons/executor/tests/test_stack_registry_login.py
@@ -8,9 +8,11 @@ containers therefore mount the host's Docker config directory read-only: Watchto
 
 from pathlib import Path
 
+import pytest
 import yaml
 
-COMPOSE_PATH = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+EXECUTOR_DIR = Path(__file__).resolve().parents[1]
+COMPOSE_PATHS = [EXECUTOR_DIR / "docker-compose.yml", EXECUTOR_DIR / "docker-compose.dev.yml"]
 HOST_DOCKER_CONFIG = "$HOME/.docker"
 
 
@@ -23,8 +25,9 @@ def _volumes(service: dict) -> dict[str, str]:
     return mapping
 
 
-def test_watchtower_reads_host_docker_config_read_only():
-    compose = yaml.safe_load(COMPOSE_PATH.read_text())
+@pytest.mark.parametrize("compose_path", COMPOSE_PATHS, ids=lambda p: p.name)
+def test_watchtower_reads_host_docker_config_read_only(compose_path):
+    compose = yaml.safe_load(compose_path.read_text())
     watchtower = compose["services"]["watchtower"]
 
     volumes = _volumes(watchtower)
@@ -32,13 +35,17 @@ def test_watchtower_reads_host_docker_config_read_only():
     assert "DOCKER_CONFIG=/config" in watchtower["environment"]
 
 
-def test_runner_reads_host_docker_config_read_only():
-    compose = yaml.safe_load(COMPOSE_PATH.read_text())
+@pytest.mark.parametrize("compose_path", COMPOSE_PATHS, ids=lambda p: p.name)
+def test_runner_reads_host_docker_config_read_only(compose_path):
+    compose = yaml.safe_load(compose_path.read_text())
     runner = compose["services"]["executor-runner"]
 
     volumes = _volumes(runner)
     assert volumes[HOST_DOCKER_CONFIG] == "/root/.docker:ro"
+    # a `currentContext` in the host's config.json must not redirect the runner's CLI
+    assert "DOCKER_HOST=unix:///var/run/docker.sock" in runner["environment"]
     # the runner's own pieces are untouched: socket, wallets, .env, watchtower label
     assert volumes["/var/run/docker.sock"] == "/var/run/docker.sock"
+    assert volumes["$HOME/.bittensor/wallets"] == "/root/.bittensor/wallets"
     assert volumes["./.env"] == "/root/executor/.env"
     assert "com.centurylinklabs.watchtower.enable=true" in runner["labels"]

--- a/neurons/executor/tests/test_stack_registry_login.py
+++ b/neurons/executor/tests/test_stack_registry_login.py
@@ -1,0 +1,44 @@
+"""DAH-3376: the standard stack passes the host's `docker login` to Watchtower and the runner.
+
+Anonymous Docker Hub pulls are counted per source IP; on a site where many nodes share one
+egress the quota is exhausted and Watchtower's pull of the runner never succeeds. Both
+containers therefore mount the host's Docker config directory read-only: Watchtower reads
+``$DOCKER_CONFIG/config.json``, the runner's docker CLI reads ``/root/.docker/config.json``.
+"""
+
+from pathlib import Path
+
+import yaml
+
+COMPOSE_PATH = Path(__file__).resolve().parents[1] / "docker-compose.yml"
+HOST_DOCKER_CONFIG = "$HOME/.docker"
+
+
+def _volumes(service: dict) -> dict[str, str]:
+    """Map host path -> '<container path>:<mode>' for the service's short-syntax volumes."""
+    mapping: dict[str, str] = {}
+    for entry in service["volumes"]:
+        host, _, rest = entry.partition(":")
+        mapping[host] = rest
+    return mapping
+
+
+def test_watchtower_reads_host_docker_config_read_only():
+    compose = yaml.safe_load(COMPOSE_PATH.read_text())
+    watchtower = compose["services"]["watchtower"]
+
+    volumes = _volumes(watchtower)
+    assert volumes[HOST_DOCKER_CONFIG] == "/config:ro"
+    assert "DOCKER_CONFIG=/config" in watchtower["environment"]
+
+
+def test_runner_reads_host_docker_config_read_only():
+    compose = yaml.safe_load(COMPOSE_PATH.read_text())
+    runner = compose["services"]["executor-runner"]
+
+    volumes = _volumes(runner)
+    assert volumes[HOST_DOCKER_CONFIG] == "/root/.docker:ro"
+    # the runner's own pieces are untouched: socket, wallets, .env, watchtower label
+    assert volumes["/var/run/docker.sock"] == "/var/run/docker.sock"
+    assert volumes["./.env"] == "/root/executor/.env"
+    assert "com.centurylinklabs.watchtower.enable=true" in runner["labels"]

--- a/neurons/executor/tests/test_stack_registry_login.py
+++ b/neurons/executor/tests/test_stack_registry_login.py
@@ -13,7 +13,6 @@ import yaml
 
 EXECUTOR_DIR = Path(__file__).resolve().parents[1]
 COMPOSE_PATHS = [EXECUTOR_DIR / "docker-compose.yml", EXECUTOR_DIR / "docker-compose.dev.yml"]
-HOST_DOCKER_CONFIG = "$HOME/.docker"
 
 
 def _volumes(service: dict) -> dict[str, str]:
@@ -25,27 +24,43 @@ def _volumes(service: dict) -> dict[str, str]:
     return mapping
 
 
-@pytest.mark.parametrize("compose_path", COMPOSE_PATHS, ids=lambda p: p.name)
-def test_watchtower_reads_host_docker_config_read_only(compose_path):
-    compose = yaml.safe_load(compose_path.read_text())
-    watchtower = compose["services"]["watchtower"]
-
-    volumes = _volumes(watchtower)
-    assert volumes[HOST_DOCKER_CONFIG] == "/config:ro"
-    assert "DOCKER_CONFIG=/config" in watchtower["environment"]
+def _env(service: dict) -> dict[str, str]:
+    """Map NAME -> value for the service's environment, list or map syntax."""
+    env = service.get("environment", {})
+    if isinstance(env, dict):
+        return {key: str(value) for key, value in env.items()}
+    return dict(entry.partition("=")[::2] for entry in env)
 
 
 @pytest.mark.parametrize("compose_path", COMPOSE_PATHS, ids=lambda p: p.name)
-def test_runner_reads_host_docker_config_read_only(compose_path):
+def test_both_services_read_the_same_host_docker_login_read_only(compose_path):
+    """Regression: one of the two services stops mounting the host's Docker config (Watchtower pulls
+    anonymously again and the shared-egress quota bites), the mount goes read-write (a container can rewrite
+    the host's credentials), or the mount lands where the process does not read its config — Watchtower
+    reads `$DOCKER_CONFIG/config.json`, the runner's CLI reads `/root/.docker/config.json` unless
+    DOCKER_CONFIG says otherwise — so the login is mounted but never used. Every assertion is a relation
+    between two parts of the file, not the value of one."""
     compose = yaml.safe_load(compose_path.read_text())
-    runner = compose["services"]["executor-runner"]
+    watchtower, runner = compose["services"]["watchtower"], compose["services"]["executor-runner"]
 
-    volumes = _volumes(runner)
-    assert volumes[HOST_DOCKER_CONFIG] == "/root/.docker:ro"
-    # a `currentContext` in the host's config.json must not redirect the runner's CLI
-    assert "DOCKER_HOST=unix:///var/run/docker.sock" in runner["environment"]
-    # the runner's own pieces are untouched: socket, wallets, .env, watchtower label
-    assert volumes["/var/run/docker.sock"] == "/var/run/docker.sock"
-    assert volumes["$HOME/.bittensor/wallets"] == "/root/.bittensor/wallets"
-    assert volumes["./.env"] == "/root/executor/.env"
-    assert "com.centurylinklabs.watchtower.enable=true" in runner["labels"]
+    login_mounts = {}
+    for name, service in (("watchtower", watchtower), ("executor-runner", runner)):
+        docker_config = [
+            (host, rest) for host, rest in _volumes(service).items() if host.endswith("/.docker")
+        ]
+        assert len(docker_config) == 1, f"{name} mounts {len(docker_config)} docker-config dirs"
+        ((host, rest),) = docker_config
+        target, _, mode = rest.rpartition(":")
+        assert mode == "ro", f"{name} could rewrite the host's credentials ({host} -> {rest})"
+        login_mounts[name] = (host, target)
+
+    assert login_mounts["watchtower"][0] == login_mounts["executor-runner"][0], (
+        "the two services read different logins"
+    )
+    # each process must find the file where it looks for it
+    assert _env(watchtower)["DOCKER_CONFIG"] == login_mounts["watchtower"][1]
+    assert _env(runner).get("DOCKER_CONFIG", "/root/.docker") == login_mounts["executor-runner"][1]
+    # a `currentContext` in the host's config.json must not redirect the runner's CLI away from the daemon
+    # whose socket is mounted
+    socket_target = _volumes(runner)["/var/run/docker.sock"].partition(":")[0]
+    assert _env(runner).get("DOCKER_HOST") == f"unix://{socket_target}"

--- a/scripts/install_executor_on_ubuntu.sh
+++ b/scripts/install_executor_on_ubuntu.sh
@@ -132,7 +132,8 @@ install_docker() {
 # The executor stack bind-mounts $HOME/.docker (DAH-3376). Create it as the user running this
 # script — the same user `lium mine` starts the stack as — on every run, Docker pre-installed or
 # not: if the daemon creates a missing bind source it is root-owned and a later `docker login`
-# by this user cannot write config.json.
+# by this user cannot write config.json. Run the script as the operator (as `lium mine` does),
+# not through `sudo bash`: under sudo $HOME is root's and the directory lands in /root.
 prepare_docker_config_dir() {
   mkdir -p "$HOME/.docker"
   ok "Docker config directory ready: $HOME/.docker"

--- a/scripts/install_executor_on_ubuntu.sh
+++ b/scripts/install_executor_on_ubuntu.sh
@@ -126,6 +126,10 @@ install_docker() {
       ok "Added ${SUDO_USER:-$USER} to docker group (activating for this session)"
     fi
   fi
+  # The executor stack bind-mounts $HOME/.docker (DAH-3376). Create it as the operator now:
+  # if the daemon creates a missing bind source it is root-owned and a later `docker login`
+  # by this user cannot write config.json.
+  mkdir -p "$HOME/.docker"
   ok "Docker installed"
 }
 

--- a/scripts/install_executor_on_ubuntu.sh
+++ b/scripts/install_executor_on_ubuntu.sh
@@ -126,11 +126,16 @@ install_docker() {
       ok "Added ${SUDO_USER:-$USER} to docker group (activating for this session)"
     fi
   fi
-  # The executor stack bind-mounts $HOME/.docker (DAH-3376). Create it as the operator now:
-  # if the daemon creates a missing bind source it is root-owned and a later `docker login`
-  # by this user cannot write config.json.
-  mkdir -p "$HOME/.docker"
   ok "Docker installed"
+}
+
+# The executor stack bind-mounts $HOME/.docker (DAH-3376). Create it as the user running this
+# script — the same user `lium mine` starts the stack as — on every run, Docker pre-installed or
+# not: if the daemon creates a missing bind source it is root-owned and a later `docker login`
+# by this user cannot write config.json.
+prepare_docker_config_dir() {
+  mkdir -p "$HOME/.docker"
+  ok "Docker config directory ready: $HOME/.docker"
 }
 
 verify_docker() {
@@ -161,6 +166,8 @@ pause_if_needed
 
 install_docker
 pause_if_needed
+
+prepare_docker_config_dir
 
 verify_docker
 pause_if_needed


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements DAH-3376 · reviewer: @taiberium

**TL;DR** — 116 of 468 executors sit on v1.123 with Watchtower running: all still carry the 19 Aug runner image — Watchtower's Docker Hub pull never succeeds, deterministic per network block (anonymous pulls are counted per source IP). Both containers now mount `$HOME/.docker` read-only: one host `docker login` authenticates the chain; empty dir = unchanged; dev compose not run on macOS.

**What changed**
- `watchtower`: `$HOME/.docker` → `/config:ro` + `DOCKER_CONFIG=/config` (both compose files); the executor's own template/pod pulls are unchanged
- `executor-runner`: `$HOME/.docker` → `/root/.docker:ro`, so its `docker compose up --pull always` pulls with the same login
- runner `DOCKER_HOST=unix:///var/run/docker.sock` pins the socket against a host `currentContext`; a host `credsStore` makes Watchtower skip every container (comment: the check)
- `scripts/install_executor_on_ubuntu.sh`: step `prepare_docker_config_dir` creates `$HOME/.docker` as the operator on every run, Docker pre-installed or not
- 4 tests: one compose relation test — same host login in both services, read-only, mounted where each process reads it (SO §52); installer creates/keeps `~/.docker` (`tests/test_installer_docker_config_dir.py`)

**Risks**
- None beyond the diff: no migration, no pod restart, no config change, no data rewrite.

**How to verify**
- `cd neurons/executor && pytest tests/test_stack_registry_login.py tests/test_installer_docker_config_dir.py -q --noconftest` → 4 passed
- htpasswd `registry:2` + `docker login`: runner CLI and Watchtower pull through the mounted login; empty dir → runner `no basic auth credentials`, Watchtower `skipped`; anonymous public pull OK (Details → Ran it)

**Verified by the loop:** Gate: PASS 4b599ea

**Ran it:** `cd neurons/executor && pytest tests -q` → 221 passed @ 4b599ea · EC2 warm box 20260910T224911Z-p9us · … +5 under Details

**Self-review:** clean at 4b599ea (15 checks, 5 low)

**Parts:** backend n/a — node stack only · migration n/a — no schema · frontend n/a — node stack only · CLI/SDK n/a — no command change · docs ✓ lium-platform#376 (after this PR) · tests ✓ 4 · dashboards n/a — no metric

**Docs:** docs: https://github.com/Datura-ai/lium-platform/pull/376 (moved from lium-docs#282; docs live under apps/docs) — `apps/docs/docs/providers/nodes/gpu-power-cap.md` § The standard stack, which stopped updating: diagnosis, Public Repo Read-only token, `docker login` as the stack's user, `git pull`, `compose pull/up`

<details><summary>Details</summary>

DAH-3376 · reviewer taiberium — body rendered by tools/pr_body_render.py

Made with [Cursor](https://cursor.com)

### Ran it

EC2 sandbox `20260910T194435Z-2u41` (AL2023, Docker 25.0.14, compose v2.29.7, Watchtower 1.22.1) at `2e0cfae5`; round 2 at `45adfde7`: EC2 `20260910T200932Z-hvxs`, same setup, lines marked r2; verified at the head `07f35918`: pytest on warm EC2 `20260910T203348Z-reqd` → 6 passed; commits after `45adfde7` change only the compose comment (`git diff 45adfde7 07f35918`), so the compose/registry runs stand for the head. `docker-compose.dev.yml` not run on macOS — needs a Mac run before merge (developer stack; the node stack is Linux-only).; job log under `RECOVERY/aws_run/20260910T194435Z-2u41/`.

```
$ pytest tests/test_stack_registry_login.py tests/test_installer_docker_config_dir.py -q --noconftest
6 passed in 0.06s
$ docker compose config | grep -nE 'source|target|read_only|DOCKER_CONFIG|DOCKER_HOST'
5:      DOCKER_HOST: unix:///var/run/docker.sock
24:        source: /root/.docker  25:        target: /root/.docker  26:        read_only: true
41:      DOCKER_CONFIG: /config
53:        source: /root/.docker  54:        target: /config        55:        read_only: true
$ su op -c 'docker compose up -d watchtower'   # docker-group user, no ~/.docker
 Container executor-watchtower-1  Started
$ ls -ld /home/op/.docker → drwxr-xr-x. 2 root root   $ su op -c 'touch ~/.docker/config.json' → Permission denied   (chown -R op → writable)
$ PATH=/tmp/stub:$PATH bash scripts/install_executor_on_ubuntu.sh    # Docker present, stub apt-get
✓ Docker already installed: Docker version 25.0.14   ✓ Docker config directory ready: /root/.docker
$ echo <password> | docker login <registry-ip>:5000 -u tester --password-stdin → Login Succeeded; -rw------- root root config.json ({"auths":{"<registry-ip>:5000":{"auth":"…"}}})
$ docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /root/.docker:/root/.docker:ro -e DOCKER_HOST=unix:///var/run/docker.sock --entrypoint docker $RUNNER pull <registry-ip>:5000/dummy:1 → <registry-ip>:5000/dummy:1
  … same with -v /tmp/empty:/root/.docker:ro → Error response from daemon: Head "…/v2/dummy/manifests/1": no basic auth credentials;  pull alpine:3.19 → Downloaded newer image
  … -v /tmp/ctx:/root/.docker:ro ({"currentContext":"nope"}) with DOCKER_HOST → server 25.0.16;  without → unable to resolve docker endpoint: context "nope": context not found
  … compose up --pull always --detach --wait (the entrypoint's command) → victim Pulled · Container app-victim-1 Healthy
$ docker run --rm … -v /root/.docker:/config:ro -e DOCKER_CONFIG=/config nickfedor/watchtower --run-once --label-enable --debug
msg="Loaded auth credentials from config" config_file=/config/config.json has_password=true … msg="Found new image" container=victim new_id=83b2b6703a62
  … with -v /tmp/empty:/config:ro → msg="No credentials found in config" config_file=/config/config.json (r2: `Failed to pull image … no basic auth credentials` → `Added container as skipped`; `docker inspect -f {{.Created}} victim` equal before/after — not recreated; with the login the same run reports `updated=1` and Created moves)
$ config.json = {"credsStore":"pass"} mounted read-only (r2): runner CLI `docker pull alpine:3.19` → Downloaded newer image (the entrypoint's `compose up --pull always` was NOT run with this config — not claimed);
  Watchtower → msg="Failed to get registry credentials" error="exec: docker-credential-pass: executable file not found" → both containers Skipped, the public alpine:3.20 one included
```

Not exercised: a real Docker Hub login (the loop holds none; the private registry stands in for the authenticated path); the runner's `compose up --pull always` with a `credsStore` config; a `credHelpers` config in either container.

### Self-review

Verdict `clean` at `4b599ea` · 15 checks · by subagent-tqa-reviewer · 2026-09-10 23:04Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `PR body — How to verify (review-wave/readability/overrides/lium-io-1354.json verify[0]):72` | `pytest tests/test_stack_registry_login.py tests/test_installer_docker_config_dir.py -q --noconftest → 6 passed` is still the count from the head before the test rewrite; at 4b599ea the two files collect 2 + 2 items (run locally against the worktree: `4 passed in 2.02s`). The round-1 low on this line was not applied, while `What` (`4 tests`), `Parts` (`tests ✓ 4`) and the Ran-it line (`the 4 of this PR`) already say 4. | Change `→ 6 passed` to `→ 4 passed` in the override's verify[0]. |
| low | STALE-BODY | `PR body — Ran it fold line (override ran_it):77` | `negative controls … each 1 failed (20260910T224225Z-goo0)` sits after `@ 4b599ea` but goo0 started 22:42Z on a tarball of the earlier head's test (its `tests/test_stack_registry_login.py` still has `HOST_DOCKER_CONFIG` and `startswith("unix://")`; 4b599ea was committed 22:48Z). The claim holds at 4b599ea — the three mutated assertions (lines 51, 54, 61) are byte-identical in the amend and re-running the same three sed controls against the 4b599ea test gives `1 failed, 1 passed` each — but the body attributes them to a run that did not see this head, and the new DOCKER_HOST relation (line 66) has no cited control. | Either re-run the controls on the warm box at 4b599ea and add a fourth (`DOCKER_HOST` dropped / `tcp://` / socket target moved with DOCKER_HOST unchanged → each `1 failed`), or write `(goo0, earlier head; those three assertions are unchanged at 4b599ea)`. |
| low | STALE-BODY | `PR body — Details › Ran it, first paragraph:94` | `verified at the head 07f35918 … commits after 45adfde7 change only the compose comment (git diff 45adfde7 07f35918), so the compose/registry runs stand for the head` — at 4b599ea 07f35918 is not the head and `git diff 45adfde7 4b599ea` touches docker-compose.yml (comment) and the rewritten test; the conclusion still holds because `git diff 07f35918 4b599ea` touches only the test, but the sentence no longer says why. | Reword to `compose files and installer unchanged since 07f35918 (git diff 07f35918 4b599ea touches only tests/test_stack_registry_login.py), so the compose/registry runs stand for the head; pytest at the head: 221 passed on p9us`. |
| low | TEST-GAP | `neurons/executor/tests/test_stack_registry_login.py:29` | `service.get("environment", {})` returns None when an `environment:` key is left with no items (YAML null), so `for entry in env` raises TypeError at line 32 instead of reaching the DOCKER_HOST/DOCKER_CONFIG assertion; verified by deleting the runner's only `- DOCKER_HOST=…` line: `1 failed` with `TypeError`, not the line-66 AssertionError. Loud, no false pass — same class as the round-1 helper-traceback note. Removing the whole `environment:` block fails at line 66 as intended. | `env = service.get("environment") or {}`. |
| low | CODE-QUALITY | `neurons/executor/tests/test_stack_registry_login.py:57` | The CI `ruff format` job (report-only, pinned like .pre-commit-config.yaml to ruff v0.5.1) lists this new file under `Would reformat` (p9us io-executor-ruff.log line 29): 0.5.x moves the assert message out of the parentheses at lines 57-59, while ruff 0.14.11 (root pyproject pin) reports the file as formatted. The other new test file passes both. | Bind the two host paths to names and assert on one line (`wt_host, runner_host = login_mounts["watchtower"][0], login_mounts["executor-runner"][0]` / `assert wt_host == runner_host, "the two services read different logins"`), which both ruff versions leave alone; or accept as-is, since 30/51 executor files already show under the report-only job. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `:` Line 65 is a dict lookup `_volumes(runner)["/var/run/docker.sock"]` that reads the executor-runner's socket bind — present on origin/main before this PR — to relate it to DOCKER_HOST; the test mounts nothing and the diff adds no docker.sock mount. · `:` All three are applied at 4b599ea: line 65-66 asserts `DOCKER_HOST == f"unix://{socket_target}"` (verified: DOCKER_HOST removed, `tcp://`, and the runner's socket target moved to /run/docker.sock with DOCKER_HOST unchanged each give `1 failed`; the socket mounted `:ro` still passes); `_env` accepts map syntax and list entries without `=` (verified: map-syntax compose and a `- HOME` pass-through both `2 passed`); `git diff 8719b94 4b599ea` removes the constant and grep finds no reader. · `:` Regenerated by `tools/pr_self_review.py --record` and the post-push gate at the pushed head; not a body edit the author makes by hand. Check that `--record` replaces rather than appends the old dismissal block. · `:` `ro` is the read-only property, not a value copied from the yaml, and `/root/.docker` is the docker CLI's default config dir for the `docker:26-cli` image (runs as root, HOME=/root), so neither restates the file under SO §52; the sentence is slightly generous but no assertion compares a yaml value to a copy of itself. · `:` p9us job.log checked out HEAD 4b599ead63… tree d7a92d7a, which equals `git rev-parse 4b599ea^{tree}`, ran `neurons/executor/tests` → `221 passed, 19 warnings`, failed.txt empty; the 4 items of this PR are in that tree by construction.

### Verified

Gate: PASS (4b599ea) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1354)

</details>
