### PR TITLE
DAH-3386 - [P1] the reset that flips a rented node names its check and carries diagnostics

### DIFF
--- a/neurons/validators/src/clients/compute_client.py
+++ b/neurons/validators/src/clients/compute_client.py
@@ -388,7 +388,10 @@ class ComputeClient:
                             miner_hotkey=data["miner_hotkey"],
                             validator_hotkey=validator_hotkey,
                             executor_uuid=data["executor_uuid"],
-                            reason=data["reason"]
+                            reason=data["reason"],
+                            reason_code=data.get("reason_code"),
+                            check_id=data.get("check_id"),
+                            evidence=data.get("evidence"),
                         )
 
                         async with self.lock:

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -146,6 +146,12 @@ class ResetVerifiedJobRequest(BaseValidatorRequest):
     miner_hotkey: str
     executor_uuid: str
     reason: ResetVerifiedJobReason = ResetVerifiedJobReason.DEFAULT
+    # DAH-3386: the check that cleared the verified job (its event reason_code and check_id) and what it saw —
+    # for POD_NOT_RUNNING the container's status, exit code, OOM flag and finish time. The backend writes them
+    # into the penalty it raises (lium-platform DAH-3385 details.evidence.validator). Optional both ways.
+    reason_code: str | None = None
+    check_id: str | None = None
+    evidence: dict | None = None
 
 
 class DuplicateExecutorsRequest(BaseValidatorRequest):

--- a/neurons/validators/src/protocol/vc_protocol/validator_requests.py
+++ b/neurons/validators/src/protocol/vc_protocol/validator_requests.py
@@ -140,6 +140,42 @@ class ResetVerifiedJobReason(int, enum.Enum):
     POD_NOT_RUNNING = 1         # container for pod is not running
 
 
+class _AbsentWhenNone(pydantic.BaseModel):
+    """A field the host did not answer stays absent on the wire (as the redis payload had it), instead of a
+    `null` the backend's JSONB row would keep; `None` set on purpose (`container_finished_at: None`) is dropped
+    too — the row reads the same either way."""
+
+    model_config = pydantic.ConfigDict(extra="allow")
+
+    @pydantic.model_serializer(mode="wrap")
+    def _drop_none(self, handler: pydantic.SerializerFunctionWrapHandler) -> dict[str, Any]:
+        return {key: value for key, value in handler(self).items() if value is not None}
+
+
+class ResetVerifiedJobContainerEvidence(_AbsentWhenNone):
+    """What the rented-machine check saw of the pod's container (`docker inspect`, typed and bounded on the
+    validator: rented_machine.py `_penalty_evidence_from_diagnostics`). Every field is optional."""
+
+    container_status: str | None = None
+    container_exit_code: int | None = None
+    container_oom_killed: bool | None = None
+    container_error: str | None = None
+    container_started_at: str | None = None
+    container_finished_at: str | None = None
+    container_missing: bool | None = None
+    diagnostics_capture_error: str | None = None
+
+
+class ResetVerifiedJobEvidence(_AbsentWhenNone):
+    """DAH-3386: what the check that cleared the verified job saw. The backend copies it into the penalty row
+    (lium-platform DAH-3385 `details.evidence.validator`), so the keys are named here and on that side alike;
+    `extra="allow"` keeps a key a newer check adds on the wire instead of dropping the reset."""
+
+    pod_id: str | None = None
+    container_name: str | None = None
+    container: ResetVerifiedJobContainerEvidence | None = None
+
+
 class ResetVerifiedJobRequest(BaseValidatorRequest):
     message_type: RequestType = RequestType.ResetVerifiedJobRequest
     validator_hotkey: str
@@ -151,7 +187,7 @@ class ResetVerifiedJobRequest(BaseValidatorRequest):
     # into the penalty it raises (lium-platform DAH-3385 details.evidence.validator). Optional both ways.
     reason_code: str | None = None
     check_id: str | None = None
-    evidence: dict | None = None
+    evidence: ResetVerifiedJobEvidence | None = None
 
 
 class DuplicateExecutorsRequest(BaseValidatorRequest):

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -436,14 +436,16 @@ class RedisService:
         # DAH-3386: the check that cleared the job and what it saw ride along; the backend puts them on the
         # penalty row (lium-platform DAH-3385). Optional on the wire: an older backend ignores the keys.
         evidence = dict(evidence or {})
+        reason_code = evidence.pop("reason_code", None)
+        check_id = evidence.pop("check_id", None)
         await self.publish(
             RESET_VERIFIED_JOB_CHANNEL,
             {
                 "miner_hotkey": miner_hotkey,
                 "executor_uuid": executor_id,
                 "reason": reason.value,
-                "reason_code": evidence.pop("reason_code", None),
-                "check_id": evidence.pop("check_id", None),
+                "reason_code": reason_code,
+                "check_id": check_id,
                 "evidence": evidence or None,
             },
         )

--- a/neurons/validators/src/services/redis_service.py
+++ b/neurons/validators/src/services/redis_service.py
@@ -419,7 +419,8 @@ class RedisService:
         miner_hotkey: str,
         executor_id,
         prev_info: dict = {},
-        reason: ResetVerifiedJobReason = ResetVerifiedJobReason.DEFAULT
+        reason: ResetVerifiedJobReason = ResetVerifiedJobReason.DEFAULT,
+        evidence: dict | None = None,
     ):
         spec = prev_info.get('spec', '')
         uuids = prev_info.get('uuids', '')
@@ -432,12 +433,18 @@ class RedisService:
         }
         await self.hset(VERIFIED_JOB_COUNT_KEY, executor_id, json.dumps(data))
 
+        # DAH-3386: the check that cleared the job and what it saw ride along; the backend puts them on the
+        # penalty row (lium-platform DAH-3385). Optional on the wire: an older backend ignores the keys.
+        evidence = dict(evidence or {})
         await self.publish(
             RESET_VERIFIED_JOB_CHANNEL,
             {
                 "miner_hotkey": miner_hotkey,
                 "executor_uuid": executor_id,
                 "reason": reason.value,
+                "reason_code": evidence.pop("reason_code", None),
+                "check_id": evidence.pop("check_id", None),
+                "evidence": evidence or None,
             },
         )
 

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -347,6 +347,15 @@ class TenantEnforcementCheck:
                     "default_extra": extra,
                     "clear_verified_job_info": True,
                     "clear_verified_job_reason": ResetVerifiedJobReason.POD_NOT_RUNNING.value,
+                    # DAH-3386: the backend's penalty row shows why the container was not running — a renter's
+                    # entrypoint exiting with its own code and a host that lost the container look different here.
+                    "clear_verified_job_evidence": {
+                        "reason_code": event.reason_code,
+                        "check_id": self.check_id,
+                        "pod_id": pod_id,
+                        "container_name": container_name,
+                        "container": _penalty_evidence_from_diagnostics(diagnostics),
+                    },
                 },
             ),
             ssh_pub_keys=[],
@@ -473,6 +482,26 @@ async def _check_pod_running(ssh_client, container_name: str) -> tuple[bool, lis
         ssh_keys = []
 
     return pod_running, ssh_keys
+
+
+# The diagnostics fields that decide whether a not-running container is the provider's fault (host lost the
+# container or it never came back after a reboot) or the workload's own exit (the renter's entrypoint returned,
+# the process was OOM-killed inside the tenant's ceiling). Logs and host context stay in Loki.
+_PENALTY_EVIDENCE_FIELDS = (
+    "container_status",
+    "container_exit_code",
+    "container_oom_killed",
+    "container_error",
+    "container_started_at",
+    "container_finished_at",
+    "container_missing",
+    "diagnostics_capture_error",
+)
+
+
+def _penalty_evidence_from_diagnostics(diagnostics: dict[str, object]) -> dict[str, object]:
+    """The subset of a pod's death diagnostics that travels with the reset to the backend (DAH-3386)."""
+    return {key: diagnostics.get(key) for key in _PENALTY_EVIDENCE_FIELDS if key in diagnostics}
 
 
 async def _collect_pod_diagnostics(

--- a/neurons/validators/src/services/task/checks/rented_machine.py
+++ b/neurons/validators/src/services/task/checks/rented_machine.py
@@ -499,9 +499,33 @@ _PENALTY_EVIDENCE_FIELDS = (
 )
 
 
+# Every value came from the provider's host (`docker inspect` stdout/stderr); the backend writes the dict into a
+# JSONB row and a log line, so each one is typed and bounded here (PR_PROCESS §5 bounded input).
+_PENALTY_EVIDENCE_STR_MAX = 256
+
+
 def _penalty_evidence_from_diagnostics(diagnostics: dict[str, object]) -> dict[str, object]:
-    """The subset of a pod's death diagnostics that travels with the reset to the backend (DAH-3386)."""
-    return {key: diagnostics.get(key) for key in _PENALTY_EVIDENCE_FIELDS if key in diagnostics}
+    """The subset of a pod's death diagnostics that travels with the reset to the backend (DAH-3386).
+
+    Strings are cut to _PENALTY_EVIDENCE_STR_MAX, `container_exit_code` is kept only as an int, the two flags only
+    as bools; anything else the host answered is dropped rather than forwarded.
+    """
+    evidence: dict[str, object] = {}
+    for key in _PENALTY_EVIDENCE_FIELDS:
+        if key not in diagnostics:
+            continue
+        value = diagnostics[key]
+        if key == "container_exit_code":
+            if isinstance(value, int) and not isinstance(value, bool):
+                evidence[key] = value
+        elif key in ("container_oom_killed", "container_missing"):
+            if isinstance(value, bool):
+                evidence[key] = value
+        elif isinstance(value, str):
+            evidence[key] = value[:_PENALTY_EVIDENCE_STR_MAX]
+        elif value is None:
+            evidence[key] = None
+    return evidence
 
 
 async def _collect_pod_diagnostics(

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -208,7 +208,7 @@ class LoggerSink:
         getattr(self.logger, level)(_m(event.event, extra=event.model_dump(mode="json")))
 
 
-def clear_evidence_for(res: "CheckResult", check_id: str) -> dict[str, Any]:
+def clear_evidence_for(res: CheckResult, check_id: str) -> dict[str, Any]:
     """The check's updates, with ``clear_verified_job_evidence`` filled when the check clears the verified job.
 
     DAH-3386: every check that sets ``clear_verified_job_info`` names itself to the backend — its event's

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -208,7 +208,7 @@ class LoggerSink:
         getattr(self.logger, level)(_m(event.event, extra=event.model_dump(mode="json")))
 
 
-def clear_evidence_for(res: CheckResult, check_id: str) -> dict[str, Any]:
+def updates_with_clear_verified_job_evidence(res: CheckResult, check_id: str) -> dict[str, Any]:
     """The check's updates, with ``clear_verified_job_evidence`` filled when the check clears the verified job.
 
     DAH-3386: every check that sets ``clear_verified_job_info`` names itself to the backend — its event's
@@ -287,7 +287,7 @@ class Pipeline:
             events.append(res.event)
 
             if res.updates:
-                current_ctx = current_ctx.model_copy(update=clear_evidence_for(res, chk.check_id))
+                current_ctx = current_ctx.model_copy(update=updates_with_clear_verified_job_evidence(res, chk.check_id))
 
             if failed:
                 return False, events, current_ctx

--- a/neurons/validators/src/services/task/pipeline.py
+++ b/neurons/validators/src/services/task/pipeline.py
@@ -156,6 +156,11 @@ class Context(BaseModel):
     state: ContextState = Field(default_factory=ContextState)
     clear_verified_job_info: bool = False
     clear_verified_job_reason: str | None = None
+    # DAH-3386: what the check that cleared the verified job saw — reason_code, check_id and, for a pod found not
+    # running, the container's death diagnostics. Sent to the backend with the reset so the penalty it raises
+    # carries the evidence (lium-platform DAH-3385). The pipeline fills reason_code/check_id from the event when
+    # the check did not set it itself.
+    clear_verified_job_evidence: dict[str, Any] | None = None
     collateral_deposited: bool = False
     collateral_error_message: str | None = None
     contract_version: str | None = None
@@ -201,6 +206,24 @@ class LoggerSink:
     async def emit(self, event: ValidationEvent) -> None:
         level = {"info": "info", "warning": "warning", "error": "error"}[event.severity]
         getattr(self.logger, level)(_m(event.event, extra=event.model_dump(mode="json")))
+
+
+def clear_evidence_for(res: "CheckResult", check_id: str) -> dict[str, Any]:
+    """The check's updates, with ``clear_verified_job_evidence`` filled when the check clears the verified job.
+
+    DAH-3386: every check that sets ``clear_verified_job_info`` names itself to the backend — its event's
+    reason_code and its check_id — so an EXECUTOR_INACTIVE_MID_RENTAL raised from the reset says which check
+    fired instead of the bare DEFAULT/POD_NOT_RUNNING enum. A check that already attached richer evidence (the
+    rented-machine check adds the container's death diagnostics) keeps it; only the two names are filled in.
+    """
+    updates = dict(res.updates)
+    if not updates.get("clear_verified_job_info"):
+        return updates
+    evidence = dict(updates.get("clear_verified_job_evidence") or {})
+    evidence.setdefault("reason_code", res.event.reason_code)
+    evidence.setdefault("check_id", res.event.check_id or check_id)
+    updates["clear_verified_job_evidence"] = evidence
+    return updates
 
 
 def summarize_steps(
@@ -264,7 +287,7 @@ class Pipeline:
             events.append(res.event)
 
             if res.updates:
-                current_ctx = current_ctx.model_copy(update=res.updates)
+                current_ctx = current_ctx.model_copy(update=clear_evidence_for(res, chk.check_id))
 
             if failed:
                 return False, events, current_ctx

--- a/neurons/validators/src/services/task/result_handler.py
+++ b/neurons/validators/src/services/task/result_handler.py
@@ -306,6 +306,7 @@ class ResultHandler:
                     executor_id=executor_id,
                     prev_info=verified_job_info,
                     reason=reason,
+                    evidence=context.clear_verified_job_evidence,
                 )
             else:
                 await self.redis_service.set_verified_job_info(

--- a/neurons/validators/tests/test_reset_verified_job_evidence.py
+++ b/neurons/validators/tests/test_reset_verified_job_evidence.py
@@ -17,14 +17,19 @@ guards against, from the 90-day penalty-reversal pass (lium-ads reports/PENALTY_
   4 test_the_publish_splits_names_from_evidence_and_an_empty_evidence_is_none
         the wire shape the backend's ResetVerifiedJobRequest expects; an older validator's publish (no keys) is
         still valid because every new field is optional.
+  5 test_the_published_reset_reaches_the_backend_queue_with_its_names_and_evidence
+        compute_client.py reads the three new keys off the redis payload; drop them and every reset reaches the
+        backend unnamed while every other test stays green.
 """
 
+import asyncio
 import json
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from neurons.validators.src.services.redis_service import RedisService
+from clients.compute_client import ComputeClient
+from neurons.validators.src.services.redis_service import RESET_VERIFIED_JOB_CHANNEL, RedisService
 from neurons.validators.src.services.task.checks.rented_machine import (
     _PENALTY_EVIDENCE_STR_MAX,
     TenantEnforcementCheck,
@@ -32,7 +37,7 @@ from neurons.validators.src.services.task.checks.rented_machine import (
 )
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
 from neurons.validators.src.services.task.models import ValidationEvent
-from neurons.validators.src.services.task.pipeline import CheckResult, clear_evidence_for
+from neurons.validators.src.services.task.pipeline import CheckResult, updates_with_clear_verified_job_evidence
 from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason, ResetVerifiedJobRequest
 from test_rented_machine_check import (
     DummyBackendClient,
@@ -119,7 +124,7 @@ def test_host_answers_to_docker_inspect_are_typed_and_bounded_before_they_travel
 def test_a_check_that_clears_the_job_without_naming_itself_is_named_by_the_pipeline():
     result = CheckResult(passed=False, event=_event("SPEC_CHANGED", None), updates={"clear_verified_job_info": True})
 
-    updates = clear_evidence_for(result, "gpu.validate.spec_change")
+    updates = updates_with_clear_verified_job_evidence(result, "gpu.validate.spec_change")
 
     assert updates["clear_verified_job_info"] is True
     assert updates["clear_verified_job_evidence"] == {"reason_code": "SPEC_CHANGED", "check_id": "gpu.validate.spec_change"}
@@ -136,7 +141,7 @@ def test_a_check_that_clears_the_job_without_naming_itself_is_named_by_the_pipel
             },
         },
     )
-    assert clear_evidence_for(rich, "pipeline.says.otherwise")["clear_verified_job_evidence"] == {
+    assert updates_with_clear_verified_job_evidence(rich, "pipeline.says.otherwise")["clear_verified_job_evidence"] == {
         "reason_code": "POD_NOT_RUNNING",
         "check_id": "executor.validate.rented_state",
         "container": {"container_exit_code": 2},
@@ -148,7 +153,7 @@ def test_a_check_that_does_not_clear_the_job_adds_no_evidence():
         passed=False, event=_event("EXECUTOR_TRANSPORT_UNREACHABLE", "executor.validate.rented_state"),
         updates={"default_extra": {"rented": True}},
     )
-    assert clear_evidence_for(result, "executor.validate.rented_state") == {"default_extra": {"rented": True}}
+    assert updates_with_clear_verified_job_evidence(result, "executor.validate.rented_state") == {"default_extra": {"rented": True}}
 
 
 @pytest.mark.asyncio
@@ -167,15 +172,81 @@ async def test_the_publish_splits_names_from_evidence_and_an_empty_evidence_is_n
     assert payload["reason_code"] == "POD_NOT_RUNNING"
     assert payload["check_id"] == "executor.validate.rented_state"
     assert payload["evidence"] == {"container": {"container_exit_code": 2, "container_oom_killed": False}}
-    # compute_client.py builds ResetVerifiedJobRequest from this payload with data.get(...) for the three new keys;
-    # the same construction here proves the payload parses, and the backend's copy of the model has the same three
-    # optional fields (lium-platform#325).
-    request = ResetVerifiedJobRequest(validator_hotkey="vk", **{k: v for k, v in payload.items()})
-    assert request.evidence == payload["evidence"] and request.reason_code == "POD_NOT_RUNNING"
-    assert json.loads(request.model_dump_json())["check_id"] == "executor.validate.rented_state"
 
     await service.clear_verified_job_info(miner_hotkey="hk", executor_id="ex-2", prev_info={})
     _, bare = service.publish.await_args.args
     assert bare["reason"] == ResetVerifiedJobReason.DEFAULT.value
     assert bare["reason_code"] is None and bare["check_id"] is None and bare["evidence"] is None
-    assert ResetVerifiedJobRequest(validator_hotkey="vk", **bare).evidence is None
+
+
+class _OneMessagePubsub:
+    """A pubsub that delivers one redis message and then stops the client's forever-loop."""
+
+    def __init__(self, channel: str, payload: dict) -> None:
+        self.message = {"channel": channel.encode(), "data": json.dumps(payload).encode()}
+        self.closed = False
+
+    async def listen(self):
+        yield self.message
+        raise asyncio.CancelledError  # the only way out of `while True`; not caught by `except Exception`
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+async def _queued_reset_request(payload: dict) -> ResetVerifiedJobRequest:
+    """Feed one RESET_VERIFIED_JOB_CHANNEL message through compute_client's redis loop; the queued request."""
+    client = ComputeClient.__new__(ComputeClient)
+    client.lock = asyncio.Lock()
+    client.message_queue = []
+    client.logging_extra = {}
+    client.my_hotkey = lambda: "vk"
+    pubsub = _OneMessagePubsub(RESET_VERIFIED_JOB_CHANNEL, payload)
+    client.miner_service = MagicMock()
+    client.miner_service.redis_service = AsyncMock()
+    client.miner_service.redis_service.subscribe = AsyncMock(return_value=pubsub)
+    with pytest.raises(asyncio.CancelledError):
+        await client.subscribe_mesages_from_redis()
+    assert pubsub.closed
+    (request,) = client.message_queue
+    assert isinstance(request, ResetVerifiedJobRequest)
+    return request
+
+
+@pytest.mark.asyncio
+async def test_the_published_reset_reaches_the_backend_queue_with_its_names_and_evidence():
+    """compute_client.py builds the ResetVerifiedJobRequest from the redis payload; if it stopped reading the
+    three new keys every reset would reach the backend unnamed again while every other test stayed green
+    (taiberium, 11 Sep). The payload is the one `clear_verified_job_info` publishes, not a hand-written copy."""
+    service = RedisService.__new__(RedisService)
+    service.hset = AsyncMock()
+    service.publish = AsyncMock()
+    await service.clear_verified_job_info(
+        miner_hotkey="hk", executor_id="ex-1", prev_info={}, reason=ResetVerifiedJobReason.POD_NOT_RUNNING,
+        evidence={"reason_code": "POD_NOT_RUNNING", "check_id": "executor.validate.rented_state", "pod_id": "pod-1",
+                  "container_name": "tenant-123", "container": {"container_exit_code": 2, "container_oom_killed": False}},
+    )
+    _, payload = service.publish.await_args.args
+
+    request = await _queued_reset_request(payload)
+
+    assert request.validator_hotkey == "vk" and request.miner_hotkey == "hk" and request.executor_uuid == "ex-1"
+    assert request.reason == ResetVerifiedJobReason.POD_NOT_RUNNING
+    assert request.reason_code == "POD_NOT_RUNNING" and request.check_id == "executor.validate.rented_state"
+    assert request.evidence.pod_id == "pod-1" and request.evidence.container_name == "tenant-123"
+    assert request.evidence.container.container_exit_code == 2 and request.evidence.container.container_oom_killed is False
+    assert request.evidence.container.container_status is None
+    # what send_model puts on the wire (model_dump_json, nothing excluded) is the redis payload's evidence
+    # unchanged: the six container fields the host did not answer are absent, not null — the backend's JSONB
+    # row (lium-platform#325) must not fill up with nulls the validator never saw
+    wire = json.loads(request.model_dump_json())
+    assert wire["evidence"] == payload["evidence"] == {
+        "pod_id": "pod-1", "container_name": "tenant-123",
+        "container": {"container_exit_code": 2, "container_oom_killed": False},
+    }
+
+    await service.clear_verified_job_info(miner_hotkey="hk", executor_id="ex-2", prev_info={})
+    _, bare = service.publish.await_args.args
+    plain = await _queued_reset_request(bare)
+    assert plain.reason == ResetVerifiedJobReason.DEFAULT
+    assert plain.reason_code is None and plain.check_id is None and plain.evidence is None

--- a/neurons/validators/tests/test_reset_verified_job_evidence.py
+++ b/neurons/validators/tests/test_reset_verified_job_evidence.py
@@ -4,8 +4,11 @@ Backend side (lium-platform DAH-3385) writes these fields into the penalty it ra
 guards against, from the 90-day penalty-reversal pass (lium-ads reports/PENALTY_ACCURACY_20260910.md):
 
   1 test_pod_not_running_reset_carries_the_containers_death_diagnostics
-        a renter's own entrypoint exiting (exit 2, no OOM, container present) was penalised as "executor inactive";
-        the penalty row said nothing about the container — the reviewer had to SSH to the host to find out.
+        a renter's own entrypoint exiting (container present, its own exit code, not OOM-killed) was penalised as
+        "executor inactive"; the row said nothing about the container — the reviewer had to SSH to the host.
+  1b test_host_answers_to_docker_inspect_are_typed_and_bounded_before_they_travel
+        the values come from the provider's host; an oversize or mistyped inspect state must not reach the backend's
+        JSONB row and log line as sent (PR_PROCESS §5 bounded input).
   2 test_a_check_that_clears_the_job_without_naming_itself_is_named_by_the_pipeline
         spec change, GPU fingerprint, duplicate executor, banned GPU and NVML spoof all reach the backend as
         reason DEFAULT (0); the pipeline fills reason_code/check_id so they are told apart on the row.
@@ -22,7 +25,11 @@ from unittest.mock import AsyncMock
 
 import pytest
 from neurons.validators.src.services.redis_service import RedisService
-from neurons.validators.src.services.task.checks.rented_machine import TenantEnforcementCheck
+from neurons.validators.src.services.task.checks.rented_machine import (
+    _PENALTY_EVIDENCE_STR_MAX,
+    TenantEnforcementCheck,
+    _penalty_evidence_from_diagnostics,
+)
 from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
 from neurons.validators.src.services.task.models import ValidationEvent
 from neurons.validators.src.services.task.pipeline import CheckResult, clear_evidence_for
@@ -87,6 +94,28 @@ async def test_pod_not_running_reset_carries_the_containers_death_diagnostics(co
     assert "container_host_context" not in evidence["container"]
 
 
+def test_host_answers_to_docker_inspect_are_typed_and_bounded_before_they_travel():
+    """A host that answers `docker inspect` with a 10 kB error string, a string exit code, a non-bool OOM flag and a
+    nested object for a field must not get any of that onto the penalty row: strings are cut, wrong types dropped."""
+    hostile = {
+        "container_status": "x" * 5000,
+        "container_exit_code": "137",
+        "container_oom_killed": "yes",
+        "container_missing": 0,
+        "container_error": {"nested": ["a" * 5000]},
+        "container_finished_at": None,
+        "container_logs_tail": "must not travel",
+        "diagnostics_capture_error": ["inspect: " + "e" * 5000],
+    }
+    evidence = _penalty_evidence_from_diagnostics(hostile)
+    assert evidence == {"container_status": "x" * _PENALTY_EVIDENCE_STR_MAX, "container_finished_at": None}
+    assert len(json.dumps(evidence)) < 2 * _PENALTY_EVIDENCE_STR_MAX
+    # And the honest shape passes through with its types intact.
+    honest = {"container_status": "exited", "container_exit_code": 2, "container_oom_killed": False,
+              "container_missing": False, "container_finished_at": "2026-09-10T13:45:00Z"}
+    assert _penalty_evidence_from_diagnostics(honest) == honest
+
+
 def test_a_check_that_clears_the_job_without_naming_itself_is_named_by_the_pipeline():
     result = CheckResult(passed=False, event=_event("SPEC_CHANGED", None), updates={"clear_verified_job_info": True})
 
@@ -94,16 +123,23 @@ def test_a_check_that_clears_the_job_without_naming_itself_is_named_by_the_pipel
 
     assert updates["clear_verified_job_info"] is True
     assert updates["clear_verified_job_evidence"] == {"reason_code": "SPEC_CHANGED", "check_id": "gpu.validate.spec_change"}
-    # A check that attached richer evidence keeps it; the pipeline only fills the two names it can know.
+    # A check that attached its own evidence keeps every key of it — the names it chose win over the event's.
     rich = CheckResult(
         passed=False,
-        event=_event("POD_NOT_RUNNING", "executor.validate.rented_state"),
-        updates={"clear_verified_job_info": True, "clear_verified_job_evidence": {"container": {"container_exit_code": 2}}},
+        event=_event("EVENT_SAYS_OTHERWISE", "event.says.otherwise"),
+        updates={
+            "clear_verified_job_info": True,
+            "clear_verified_job_evidence": {
+                "reason_code": "POD_NOT_RUNNING",
+                "check_id": "executor.validate.rented_state",
+                "container": {"container_exit_code": 2},
+            },
+        },
     )
-    assert clear_evidence_for(rich, "executor.validate.rented_state")["clear_verified_job_evidence"] == {
-        "container": {"container_exit_code": 2},
+    assert clear_evidence_for(rich, "pipeline.says.otherwise")["clear_verified_job_evidence"] == {
         "reason_code": "POD_NOT_RUNNING",
         "check_id": "executor.validate.rented_state",
+        "container": {"container_exit_code": 2},
     }
 
 
@@ -131,8 +167,9 @@ async def test_the_publish_splits_names_from_evidence_and_an_empty_evidence_is_n
     assert payload["reason_code"] == "POD_NOT_RUNNING"
     assert payload["check_id"] == "executor.validate.rented_state"
     assert payload["evidence"] == {"container": {"container_exit_code": 2, "container_oom_killed": False}}
-    # The compute client rebuilds the request from exactly this payload; the backend's copy of the model has the
-    # same three optional fields, so both directions of a rolling deploy parse.
+    # compute_client.py builds ResetVerifiedJobRequest from this payload with data.get(...) for the three new keys;
+    # the same construction here proves the payload parses, and the backend's copy of the model has the same three
+    # optional fields (lium-platform#325).
     request = ResetVerifiedJobRequest(validator_hotkey="vk", **{k: v for k, v in payload.items()})
     assert request.evidence == payload["evidence"] and request.reason_code == "POD_NOT_RUNNING"
     assert json.loads(request.model_dump_json())["check_id"] == "executor.validate.rented_state"

--- a/neurons/validators/tests/test_reset_verified_job_evidence.py
+++ b/neurons/validators/tests/test_reset_verified_job_evidence.py
@@ -1,0 +1,144 @@
+"""DAH-3386: the reset that flips a rented node inactive names the check that fired and what it saw.
+
+Backend side (lium-platform DAH-3385) writes these fields into the penalty it raises. The regressions each test
+guards against, from the 90-day penalty-reversal pass (lium-ads reports/PENALTY_ACCURACY_20260910.md):
+
+  1 test_pod_not_running_reset_carries_the_containers_death_diagnostics
+        a renter's own entrypoint exiting (exit 2, no OOM, container present) was penalised as "executor inactive";
+        the penalty row said nothing about the container — the reviewer had to SSH to the host to find out.
+  2 test_a_check_that_clears_the_job_without_naming_itself_is_named_by_the_pipeline
+        spec change, GPU fingerprint, duplicate executor, banned GPU and NVML spoof all reach the backend as
+        reason DEFAULT (0); the pipeline fills reason_code/check_id so they are told apart on the row.
+  3 test_a_check_that_does_not_clear_the_job_adds_no_evidence
+        the transport-unreachable result must not start carrying clear-evidence (it deliberately does not flip).
+  4 test_the_publish_splits_names_from_evidence_and_an_empty_evidence_is_none
+        the wire shape the backend's ResetVerifiedJobRequest expects; an older validator's publish (no keys) is
+        still valid because every new field is optional.
+"""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+from neurons.validators.src.services.redis_service import RedisService
+from neurons.validators.src.services.task.checks.rented_machine import TenantEnforcementCheck
+from neurons.validators.src.services.task.messages import TenantEnforcementMessages as Msg
+from neurons.validators.src.services.task.models import ValidationEvent
+from neurons.validators.src.services.task.pipeline import CheckResult, clear_evidence_for
+from protocol.vc_protocol.validator_requests import ResetVerifiedJobReason, ResetVerifiedJobRequest
+from test_rented_machine_check import (
+    DummyBackendClient,
+    DummyScoreCalculator,
+    DummySSHClient,
+    MockContainerCleanup,
+    build_rented_data,
+)
+
+from helpers import build_context_config, build_services, build_state
+
+
+def _event(reason_code: str, check_id: str | None) -> ValidationEvent:
+    return ValidationEvent(
+        event="x", reason_code=reason_code, severity="warning", impact="none", check_id=check_id,
+        when=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_pod_not_running_reset_carries_the_containers_death_diagnostics(context_factory):
+    ssh = DummySSHClient(pod_running=False)
+    backend = DummyBackendClient(active=True)
+    ctx = context_factory(
+        services=build_services(
+            score_calculator=DummyScoreCalculator(actual_score=1.0, job_score=1.0, warning=""),
+            container_cleanup=MockContainerCleanup(),
+            backend=backend,
+        ),
+        config=build_context_config(),
+        state=build_state(
+            gpu_processes=[], gpu_details=[], gpu_model="NVIDIA RTX 4090",
+            rented_data=build_rented_data(
+                "executor-123", {"containers": [{"name": "tenant-123", "pod_id": "pod-1"}], "owner_flag": False}
+            ),
+        ),
+        ssh=ssh,
+        collateral_deposited=True,
+        is_rental_succeed=True,
+        contract_version="v1.0.0",
+    )
+
+    result = await TenantEnforcementCheck().run(ctx)
+
+    assert result.passed is False
+    assert result.updates["clear_verified_job_reason"] == ResetVerifiedJobReason.POD_NOT_RUNNING.value
+    evidence = result.updates["clear_verified_job_evidence"]
+    assert evidence["reason_code"] == Msg.POD_NOT_RUNNING.reason
+    assert evidence["check_id"] == TenantEnforcementCheck().check_id
+    assert evidence["pod_id"] == "pod-1" and evidence["container_name"] == "tenant-123"
+    # The DummySSHClient's `docker inspect` answers Status exited / ExitCode 255 / FinishedAt — the fields that
+    # separate "the workload exited" from "the host lost the container" reach the backend as sent.
+    assert evidence["container"]["container_status"] == "exited"
+    assert evidence["container"]["container_exit_code"] == 255
+    assert evidence["container"]["container_finished_at"] == ssh.container_finished_at
+    assert evidence["container"]["container_missing"] is False
+    # Logs and host context stay in Loki; they are not part of the penalty row.
+    assert "container_logs_tail" not in evidence["container"]
+    assert "container_host_context" not in evidence["container"]
+
+
+def test_a_check_that_clears_the_job_without_naming_itself_is_named_by_the_pipeline():
+    result = CheckResult(passed=False, event=_event("SPEC_CHANGED", None), updates={"clear_verified_job_info": True})
+
+    updates = clear_evidence_for(result, "gpu.validate.spec_change")
+
+    assert updates["clear_verified_job_info"] is True
+    assert updates["clear_verified_job_evidence"] == {"reason_code": "SPEC_CHANGED", "check_id": "gpu.validate.spec_change"}
+    # A check that attached richer evidence keeps it; the pipeline only fills the two names it can know.
+    rich = CheckResult(
+        passed=False,
+        event=_event("POD_NOT_RUNNING", "executor.validate.rented_state"),
+        updates={"clear_verified_job_info": True, "clear_verified_job_evidence": {"container": {"container_exit_code": 2}}},
+    )
+    assert clear_evidence_for(rich, "executor.validate.rented_state")["clear_verified_job_evidence"] == {
+        "container": {"container_exit_code": 2},
+        "reason_code": "POD_NOT_RUNNING",
+        "check_id": "executor.validate.rented_state",
+    }
+
+
+def test_a_check_that_does_not_clear_the_job_adds_no_evidence():
+    result = CheckResult(
+        passed=False, event=_event("EXECUTOR_TRANSPORT_UNREACHABLE", "executor.validate.rented_state"),
+        updates={"default_extra": {"rented": True}},
+    )
+    assert clear_evidence_for(result, "executor.validate.rented_state") == {"default_extra": {"rented": True}}
+
+
+@pytest.mark.asyncio
+async def test_the_publish_splits_names_from_evidence_and_an_empty_evidence_is_none():
+    service = RedisService.__new__(RedisService)
+    service.hset = AsyncMock()
+    service.publish = AsyncMock()
+
+    await service.clear_verified_job_info(
+        miner_hotkey="hk", executor_id="ex-1", prev_info={}, reason=ResetVerifiedJobReason.POD_NOT_RUNNING,
+        evidence={"reason_code": "POD_NOT_RUNNING", "check_id": "executor.validate.rented_state",
+                  "container": {"container_exit_code": 2, "container_oom_killed": False}},
+    )
+    channel, payload = service.publish.await_args.args
+    assert payload["reason"] == ResetVerifiedJobReason.POD_NOT_RUNNING.value
+    assert payload["reason_code"] == "POD_NOT_RUNNING"
+    assert payload["check_id"] == "executor.validate.rented_state"
+    assert payload["evidence"] == {"container": {"container_exit_code": 2, "container_oom_killed": False}}
+    # The compute client rebuilds the request from exactly this payload; the backend's copy of the model has the
+    # same three optional fields, so both directions of a rolling deploy parse.
+    request = ResetVerifiedJobRequest(validator_hotkey="vk", **{k: v for k, v in payload.items()})
+    assert request.evidence == payload["evidence"] and request.reason_code == "POD_NOT_RUNNING"
+    assert json.loads(request.model_dump_json())["check_id"] == "executor.validate.rented_state"
+
+    await service.clear_verified_job_info(miner_hotkey="hk", executor_id="ex-2", prev_info={})
+    _, bare = service.publish.await_args.args
+    assert bare["reason"] == ResetVerifiedJobReason.DEFAULT.value
+    assert bare["reason_code"] is None and bare["check_id"] is None and bare["evidence"] is None
+    assert ResetVerifiedJobRequest(validator_hotkey="vk", **bare).evidence is None


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3386](https://app.notion.com/p/3d7b8bfdbde981068710f95288af1852) · reviewer: @taiberium

**TL;DR** — The reset that flips a rented node inactive reaches the backend as reason 0/1, so the penalty it raises cannot say which check fired or why (165 in 90 d, 11 reverted by hand). Every clearing check now names itself and `POD_NOT_RUNNING` carries the container's death diagnostics; the new wire fields are optional both ways. No check outcome or score changes.

**What changed**
- `updates_with_clear_verified_job_evidence` fills `clear_verified_job_evidence` (`reason_code`, `check_id`) for any check that sets `clear_verified_job_info` (`services/task/pipeline.py`)
- `TenantEnforcementCheck` adds `pod_id`, `container_name` and the container's death diagnostics on `POD_NOT_RUNNING` — strings cut to 256 chars, exit code only as int, flags only as bool (`services/task/checks/rented_machine.py`)
- `clear_verified_job_info(evidence=)` publishes `reason_code`, `check_id`, `evidence` next to `reason` (`services/redis_service.py`, `services/task/result_handler.py`)
- `ResetVerifiedJobRequest` gains optional `reason_code`, `check_id`, `evidence`; the compute client forwards them (`protocol/vc_protocol/validator_requests.py`, `clients/compute_client.py`)

**How to verify**
- `pytest neurons/validators/tests/test_reset_verified_job_evidence.py -q` → 6 passed (diagnostics on the reset; hostile inspect state bounded; an unnamed clearing check is named; transport-unreachable adds nothing; wire shape with and without the new keys; the published payload reaches the backend queue)
- `pytest neurons/validators/tests/test_rented_machine_check.py neurons/validators/tests/test_pipeline_default_scenarios.py -q` → green (existing behaviour)

**Ran it:** `aws_verify.sh lium-io 4eff09c --bundle` full suite → 2223 passed, 2 pre-existing env failures in untouched files (Details) · EC2 20260911T081217Z-t1mc

**Verified by the loop:** Gate: PASS 4eff09c

**Self-review:** clean at 4eff09c (19 checks)

**Parts:** validator ✓ · backend ✓ lium-platform#325 (reads the new fields) · migration n/a — wire fields only · frontend n/a — nothing renter-facing changes here · CLI/SDK n/a — validator-internal · docs ✓ lium-docs#284 · tests ✓ 6 · dashboards n/a — no metric

**Docs:** docs: https://github.com/Datura-ai/lium-docs/pull/284 — `penalties.mdx` documents `evidence.validator`, the field this PR fills

<details><summary>Details</summary>

### Why (lium-ads reports/PENALTY_ACCURACY_20260910.md)

Backend `reset_verified_job` marks the executor inactive and raises `EXECUTOR_INACTIVE_MID_RENTAL` on every `ResetVerifiedJobRequest`; the request carries `reason` ∈ {DEFAULT, POD_NOT_RUNNING}. Spec change, GPU fingerprint, duplicate executor, banned GPU, NVML spoof and rental verification all arrive as DEFAULT. The 11 hand reverts on this path in 90 d were one `POD_NOT_RUNNING` cycle between two `RENTED` cycles (ticket-0292) and renters' own containers exiting (image without `MINER_KEY`, entrypoint exit 2, sglang wedging the kernel) — each needed an SSH to the host to establish. With the diagnostics on the row the backend (DAH-3385) can show them, and the owner can decide a rule on them (DECISION-PENALTY-RENTER-EXIT in lium-ads).

### Compatibility

Publish payload gains three keys; `compute_client` reads them with `.get`, so a validator on this build talking to an older backend sends fields the older `ResetVerifiedJobRequest` model ignores (pydantic default `extra=ignore` on `BaseRequest`), and an older validator's payload parses on the new backend (all three default to None — test 5). `evidence` is a `ResetVerifiedJobEvidence` model (`pod_id`, `container_name`, `container` with the eight `_PENALTY_EVIDENCE_FIELDS`), `extra="allow"` so a key a newer check adds never drops the reset; unanswered fields stay absent on the wire (a `None`-dropping serializer), so the JSON is the redis payload unchanged. Logs and host context stay in Loki (`_PENALTY_EVIDENCE_FIELDS` is the allow-list); every forwarded value is typed and bounded (`_penalty_evidence_from_diagnostics`: strings ≤ `_PENALTY_EVIDENCE_STR_MAX`, exit code int, flags bool) because it is the provider host's `docker inspect` answer and the backend writes it into JSONB and a log line. The backend bounds the whole payload again on receipt (lium-platform#325 `bounded_reset_evidence`).

### Ran it

```
aws_verify: run 20260911T081217Z-t1mc (4eff09c, rebased onto main 7b53a06) validators pytest tests/: 2 failed, 2223 passed, 15 skipped — failures: tests/test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices, tests/test_sshd_bootstrap_script.py::test_adopt_path_hardens_config_for_key_only_auth (files not in this diff)
aws_verify: run 20260910T225326Z-d94n --only tests/test_reset_verified_job_evidence.py tests/test_rented_machine_check.py tests/test_pipeline_default_scenarios.py: 43 passed (the first head, before the rebase)
aws_verify: run 20260910T230648Z-gum3 same targets at the head taiberium approved (before the rebase): 44 passed
```

### Self-review

Verdict `clean` at `4eff09c` · 19 checks · by subagent-r91-1355 · 2026-09-11 08:29Z (tools/pr_self_review.py)

Mechanical notes dismissed: `neurons/validators/src/protocol/vc_protocol/validator_requests.py:143` Medium 1 from 555cf73 is fixed: `_AbsentWhenNone` (extra=allow + `@model_serializer(mode="wrap")` dropping None) is inherited by both evidence models; re-checked on pydantic 2.13 with the same shapes — `model_dump_json()` of the queued request equals the redis payload's evidence key for key, extras (`future_key`, `other_new`) are kept, `0`/`False` are kept, an all-None container serialises as `{}` exactly as `_penalty_evidence_from_diagnostics` publishes it, `evidence: None` at the request level stays `null` (the request model has no serializer), python-mode dump matches, and `model_validate_json` round-trips; the docstring now says what the wire does, including the deliberate-None drop. · `neurons/validators/tests/test_reset_verified_job_evidence.py:243` The wire assertion now uses `request.model_dump_json()` with nothing excluded — the exact call `send_model` makes — and pins it to `payload["evidence"]` and the literal dict, so a regression to per-field nulls or to a dropped key fails the test; the bare case still asserts `plain.evidence is None`. · `neurons/validators/src/services/task/pipeline.py:211` Medium 2 is fixed: merge-base is origin/main 7b53a06f, `git merge-tree --write-tree origin/main 4eff09c8` writes a tree with no conflict, `STEP_SUMMARY_MIN_MS` is gone from the file (main's #1356 removal kept), `updates_with_clear_verified_job_evidence` is defined once (line 211) and used at the single call site (line 290); `git diff origin/main 4eff09c8 --stat` is the PR's own 7 files (+386 −3). · `neurons/validators/src/services/task/pipeline.py:217` Body low carried from 555cf73 (the bullet still names `clear_evidence_for`; How-to-verify `5 passed`, Parts `tests ✓ 5`, Compatibility's `test 4` pointer) — the author fixes these in the body before the push per the brief; not re-flagged. · `neurons/validators/src/clients/compute_client.py:394` Unchanged since 555cf73: pydantic validates the `data.get("evidence")` dict into ResetVerifiedJobEvidence and leaves None as None; nothing else in neurons/ constructs ResetVerifiedJobRequest or reads `.evidence`; result_handler.py:309 passes the Context dict to the publisher. · `neurons/validators/src/services/task/pipeline.py:163` `clear_verified_job_evidence: dict[str, Any] | None` on the Context is a deliberate superset of the wire model (it carries reason_code/check_id that redis_service.py pops into top-level request fields); typing it as ResetVerifiedJobEvidence would be wrong. · `neurons/validators/tests/test_reset_verified_job_evidence.py:191` The CancelledError exit is reliable (BaseException past `except Exception`, `finally` still awaits `pubsub.aclose()` and the test asserts it, `await asyncio.sleep(1)` never reached; same pattern as test_incentive_reasons_payload.py:50); deleting the three `data.get` kwargs fails at `request.reason_code == "POD_NOT_RUNNING"` and at `request.evidence.pod_id`, so the SO §52 gap is guarded. · `neurons/validators/src/protocol/vc_protocol/validator_requests.py:147` `extra="allow"` remains the right trade-off: known keys are named and typed as the reviewer asked, a key a newer check adds flows to the backend's `evidence: dict | None` instead of a ValidationError in the redis loop that would drop the reset and tear the pubsub down for a second; the only publisher is the validator's own bounded `_penalty_evidence_from_diagnostics`, so lax coercion of mistyped known keys is unreachable on this path and the backend re-bounds on receipt (RESET_EVIDENCE_MAX_BYTES=4096).

### Verified

Gate: PASS (4eff09c) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1355)

Gate: not yet run for this head

</details>
