### PR TITLE
DAH-3394 - [P0] executor: two validator hotkeys; uploaded ssh keys expire in 15 min

### DIFF
--- a/neurons/executor/.env.template
+++ b/neurons/executor/.env.template
@@ -39,3 +39,11 @@ MINER_HOTKEY_SS58_ADDRESS=
 # own clock, in either direction (a 401 that names the skew). Defaults to 300.
 # Keep the host clock NTP-synced rather than widening this.
 # CONTAINER_SIGNATURE_MAX_AGE_SECONDS=300
+
+# (optional) An ssh key the validator installed on this executor and did not
+# remove is removed by the executor this many seconds after the upload.
+# Defaults to 900 (15 minutes). A validator job authenticates with its key for
+# up to ~820 s, so do not set this below 900.
+# EXECUTOR_UPLOADED_KEY_TTL_S=900
+# (optional) How often the executor checks for such keys, in seconds. Defaults to 60.
+# EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S=60

--- a/neurons/executor/README.md
+++ b/neurons/executor/README.md
@@ -187,3 +187,9 @@ sudo systemctl restart docker
 ## The executor image
 
 `Dockerfile` starts from `python:3.11-slim` pinned by digest; the comment above the `FROM` line names the tag and the date the digest was taken. To move to a newer base, resolve the tag (`docker buildx imagetools inspect python:3.11-slim`), put the new digest on that line and rebuild. The build ends with `sshd_setup.sh`: it turns sshd's `PerSourcePenalties` off through `/etc/ssh/sshd_config.d/lium.conf` when the base's OpenSSH knows the directive (9.8 and later), and fails the build when `sshd -T` rejects the rendered configuration.
+
+### Validator hotkeys and uploaded ssh keys
+
+The executor accepts a request signed by the validator hotkey only. The hotkey is compiled into the image (`src/core/config.py`, `VALIDATOR_HOTKEY_SS58`, overridable at build time with `VALIDATOR_HOTKEY_SS58=<ss58> bash docker_build.sh`). During a hotkey rotation the image accepts a second one, `VALIDATOR_NEXT_HOTKEY_SS58` (same file, or `VALIDATOR_NEXT_HOTKEY_SS58=<ss58>` at build time), and a signature by either is valid; with it empty only the first hotkey is accepted. Neither hotkey is read from the environment: the signers an executor trusts are fixed by its image.
+
+An ssh key the validator installs through `/upload_ssh_key` is appended to the container's `~/.ssh/authorized_keys` with a `lium-uploaded-at=<unix time>` comment. The validator removes its key through `/remove_ssh_key` when its job is done; a key still present `EXECUTOR_UPLOADED_KEY_TTL_S` seconds after the upload (default 900) is removed by the executor itself, checked every `EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S` seconds (default 60). Only lines carrying that comment are ever touched; `authorized_keys` lives on the disk reserve (`setup_disk_reserve.sh`), so lines written before this release survive the upgrade unmarked and are not expired.

--- a/neurons/executor/docker_build.sh
+++ b/neurons/executor/docker_build.sh
@@ -77,7 +77,7 @@ if [[ ${#missing[@]} -gt 0 ]]; then
     echo -e "    ${RED}•  ${var}${RESET}" >&2
   done
   echo -e "\n${YELLOW}  Usage example:${RESET}"
-  echo -e "  ${DIM}TAG=latest [VALIDATOR_HOTKEY_SS58=<hotkey>] bash docker_build.sh${RESET}\n"
+  echo -e "  ${DIM}TAG=latest [VALIDATOR_HOTKEY_SS58=<hotkey>] [VALIDATOR_NEXT_HOTKEY_SS58=<hotkey>] bash docker_build.sh${RESET}\n"
   exit 1
 fi
 
@@ -89,17 +89,27 @@ IMAGE_NAME="daturaai/compute-subnet-executor:${TAG}"
 # ── Optionally generate config_override.py ────────────────────────────────────
 log_step "Validator hotkey configuration"
 
-if [[ -n "${VALIDATOR_HOTKEY_SS58:-}" ]]; then
-  log_info "VALIDATOR_HOTKEY_SS58 is set — generating config_override.py"
-  echo "_VALIDATOR_HOTKEY_SS58 = \"${VALIDATOR_HOTKEY_SS58}\"" > "${CONFIG_OVERRIDE_FILE}"
+# DAH-3394: VALIDATOR_NEXT_HOTKEY_SS58 is the hotkey the validator rotates to; the image accepts
+# both while it is set. Either variable alone is enough to write the override (the unset one keeps
+# the default from config.py).
+if [[ -n "${VALIDATOR_HOTKEY_SS58:-}" || -n "${VALIDATOR_NEXT_HOTKEY_SS58:-}" ]]; then
+  log_info "VALIDATOR_HOTKEY_SS58 / VALIDATOR_NEXT_HOTKEY_SS58 set — generating config_override.py"
+  : > "${CONFIG_OVERRIDE_FILE}"
+  if [[ -n "${VALIDATOR_HOTKEY_SS58:-}" ]]; then
+    echo "_VALIDATOR_HOTKEY_SS58 = \"${VALIDATOR_HOTKEY_SS58}\"" >> "${CONFIG_OVERRIDE_FILE}"
+    log_kv "Validator hotkey:" "${VALIDATOR_HOTKEY_SS58}"
+  fi
+  if [[ -n "${VALIDATOR_NEXT_HOTKEY_SS58:-}" ]]; then
+    echo "_VALIDATOR_NEXT_HOTKEY_SS58 = \"${VALIDATOR_NEXT_HOTKEY_SS58}\"" >> "${CONFIG_OVERRIDE_FILE}"
+    log_kv "Next validator hotkey:" "${VALIDATOR_NEXT_HOTKEY_SS58}"
+  fi
   log_success "Generated: ${CONFIG_OVERRIDE_FILE}"
-  log_kv "Validator hotkey:" "${VALIDATOR_HOTKEY_SS58}"
 else
-  log_warn "VALIDATOR_HOTKEY_SS58 not set — skipping config_override.py generation"
+  log_warn "Neither VALIDATOR_HOTKEY_SS58 nor VALIDATOR_NEXT_HOTKEY_SS58 is set — skipping config_override.py generation"
   if [[ -f "${CONFIG_OVERRIDE_FILE}" ]]; then
-    existing_hotkey=$(python3 -c "import ast, sys; tree=ast.parse(open('${CONFIG_OVERRIDE_FILE}').read()); [sys.stdout.write(n.value.s) for n in ast.walk(tree) if isinstance(n, ast.Assign)]" 2>/dev/null || true)
+    existing_hotkeys=$(python3 -c "import ast, sys; tree=ast.parse(open('${CONFIG_OVERRIDE_FILE}').read()); [sys.stdout.write(n.targets[0].id.strip('_') + '=' + n.value.value + ' ') for n in ast.walk(tree) if isinstance(n, ast.Assign)]" 2>/dev/null || true)
     log_info "Using existing config_override.py"
-    [[ -n "$existing_hotkey" ]] && log_kv "Validator hotkey:" "${existing_hotkey}"
+    [[ -n "$existing_hotkeys" ]] && log_kv "Validator hotkeys:" "${existing_hotkeys}"
   else
     log_info "No config_override.py found — will use hardcoded default in config.py"
   fi

--- a/neurons/executor/src/core/config.py
+++ b/neurons/executor/src/core/config.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from bittensor_wallet import Keypair
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -11,6 +12,40 @@ try:
     VALIDATOR_HOTKEY_SS58 = _VALIDATOR_HOTKEY_SS58
 except Exception:
     pass
+
+# DAH-3394: the validator hotkey is being rotated. A release that trusts only the new hotkey
+# would be refused by every executor that has not restarted onto it yet, so this release accepts
+# two: `current` (above) and `next`, the hotkey the validator swaps to. `next` is empty until the
+# new hotkey exists; it is then set here or in config_override at build time — like `current`,
+# never from the environment: the set of signers an executor trusts is fixed by the image, not by
+# whoever writes its .env. With `next` empty the executor behaves exactly as before.
+VALIDATOR_NEXT_HOTKEY_SS58 = ""
+try:
+    from core.config_override import _VALIDATOR_NEXT_HOTKEY_SS58
+    VALIDATOR_NEXT_HOTKEY_SS58 = _VALIDATOR_NEXT_HOTKEY_SS58
+except ImportError:
+    # no override module (the default build) or one that names only `current`
+    pass
+
+
+def _validator_hotkeys(current: str, next_: str) -> dict[str, str]:
+    """Key id -> ss58 of every hotkey whose signature the executor accepts, `current` first.
+
+    Each address is parsed here, at import: a mistyped `next` must stop the executor (and CI) now,
+    not surface as a 401 on the first request after the chain swap.
+    """
+    hotkeys = {"current": current}
+    if next_.strip() and next_.strip() != current:
+        hotkeys["next"] = next_.strip()
+    for key_id, ss58 in hotkeys.items():
+        try:
+            Keypair(ss58_address=ss58)
+        except ValueError as exc:
+            raise ValueError(f"the {key_id} validator hotkey is not a valid ss58 address") from exc
+    return hotkeys
+
+
+VALIDATOR_HOTKEYS_SS58: dict[str, str] = _validator_hotkeys(VALIDATOR_HOTKEY_SS58, VALIDATOR_NEXT_HOTKEY_SS58)
 
 class Settings(BaseSettings):
     model_config = SettingsConfigDict(env_file=".env", extra="ignore")
@@ -65,6 +100,16 @@ class Settings(BaseSettings):
     # refused, so a captured one cannot be replayed for the life of the container. Symmetric so a
     # host clock that runs ahead is treated like one that runs behind; wide enough for NTP drift.
     CONTAINER_SIGNATURE_MAX_AGE_SECONDS: int = Field(env="CONTAINER_SIGNATURE_MAX_AGE_SECONDS", default=300)
+    # DAH-3394: an ssh key the validator installed through /upload_ssh_key is removed by the
+    # executor itself this many seconds after the upload when no /remove_ssh_key came for it,
+    # so a leaked or forgotten upload is worth at most this window. The validator's own flows fit:
+    # a verification job authenticates with its key for up to ~820 s (tasks capped at
+    # JOB_TIME_OUT - 120 s, the RoCE sweep up to JOB_TIME_OUT - 80 s) and removes it right
+    # after; a rental create keeps ONE established ssh session for the image pull, which sshd
+    # does not re-check against authorized_keys. Do not set below 900.
+    EXECUTOR_UPLOADED_KEY_TTL_S: int = Field(env="EXECUTOR_UPLOADED_KEY_TTL_S", default=900, ge=1)
+    # How often the purge looks at authorized_keys; a key lives at most TTL + this.
+    EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S: int = Field(env="EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S", default=60, ge=1)
 
 
 settings = Settings()

--- a/neurons/executor/src/dependencies/auth.py
+++ b/neurons/executor/src/dependencies/auth.py
@@ -2,11 +2,26 @@ from fastapi import HTTPException
 import bittensor
 import json
 import time
-from core.config import VALIDATOR_HOTKEY_SS58, settings
+from core.config import VALIDATOR_HOTKEYS_SS58, settings
 from core.logger import get_logger
 from payloads.backend import SignaturePayload, HardwareUtilizationPayload, PingPayload, ContainerUtilizationPayload
 
 logger = get_logger(__name__)
+
+
+def match_validator_hotkey(message: str | bytes, signature: str) -> str | None:
+    """The id (`current` / `next`) of the configured validator hotkey that signed `message`, or None.
+
+    Every validator-signature check in the executor goes through here, so the hotkey rotation
+    (DAH-3394) is one list: VALIDATOR_HOTKEYS_SS58, tried in order. Malformed signatures raise
+    as they did before; the caller decides the status code.
+    """
+    for key_id, ss58 in VALIDATOR_HOTKEYS_SS58.items():
+        if bittensor.Keypair(ss58_address=ss58).verify(message, signature):
+            # the id only: which key is in use is operational information, the key itself is not
+            logger.debug("validator signature verified with the %s hotkey", key_id)
+            return key_id
+    return None
 
 
 async def verify_signature(payload: SignaturePayload, message: str) -> None:
@@ -24,21 +39,16 @@ async def verify_signature(payload: SignaturePayload, message: str) -> None:
         HTTPException: If signature verification fails
     """
     try:
-        # Create keypair from the allowed hotkey SS58 address
-        keypair = bittensor.Keypair(ss58_address=VALIDATOR_HOTKEY_SS58)
-
         # Normalize signature format - Bittensor expects 0x prefix
         signature = payload.signature
         if not signature.startswith('0x'):
             signature = '0x' + signature
 
-        # Verify the signature against the message
-        is_valid = keypair.verify(message, signature)
-
-        if not is_valid:
+        # Verify the signature against the message with each configured validator hotkey
+        if match_validator_hotkey(message, signature) is None:
             raise HTTPException(
                 status_code=401,
-                detail=f"Invalid signature from allowed hotkey {VALIDATOR_HOTKEY_SS58}"
+                detail="Invalid signature: not signed by a configured validator hotkey"
             )
 
     except HTTPException:

--- a/neurons/executor/src/executor.py
+++ b/neurons/executor/src/executor.py
@@ -12,6 +12,7 @@ from core.logger import get_logger
 from middlewares.miner import MinerMiddleware
 from routes.apis import apis_router
 from services.cache_template_service import run_cache_template_prefetch
+from services.ssh_service import run_uploaded_key_purge
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -38,16 +39,19 @@ async def lifespan(app: FastAPI):
     # Start pulling this host's cache template image as soon as the executor
     # boots, and keep it fresh in the background, without blocking startup.
     prefetch_task = asyncio.create_task(run_cache_template_prefetch())
+    # DAH-3394: ssh keys the validator uploaded and never removed expire (EXECUTOR_UPLOADED_KEY_TTL_S)
+    key_purge_task = asyncio.create_task(run_uploaded_key_purge())
     try:
         yield
     finally:
-        prefetch_task.cancel()
-        try:
-            await prefetch_task
-        except asyncio.CancelledError:
-            pass
-        except Exception as e:
-            logger.warning(f"cache template pre-pull task ended with error: {e}")
+        for name, task in (("cache template pre-pull", prefetch_task), ("uploaded ssh key purge", key_purge_task)):
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                logger.warning(f"{name} task ended with error: {e}")
 
 
 app = FastAPI(

--- a/neurons/executor/src/routes/apis.py
+++ b/neurons/executor/src/routes/apis.py
@@ -10,7 +10,6 @@ from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeout
 from pathlib import Path
 from typing import Annotated, Any, Optional
 
-import bittensor
 import docker
 from datura.requests.validator_requests import ssh_pubkey_signing_blob
 from fastapi import APIRouter, Depends, Query, Header, HTTPException
@@ -18,11 +17,17 @@ from fastapi.responses import StreamingResponse
 from services.miner_service import MinerService
 from services.pod_log_service import PodLogService
 from services.hardware_service import get_system_metrics, get_container_metrics
-from core.config import VALIDATOR_HOTKEY_SS58, settings
+from core.config import settings
 
 from payloads.miner import UploadSShKeyPayload, GetPodLogsPaylod
 from payloads.backend import ContainerUtilizationPayload
-from dependencies.auth import verify_allowed_hotkey_signature, verify_ping_signature, verify_container_signature, verify_container_logs_signature
+from dependencies.auth import (
+    match_validator_hotkey,
+    verify_allowed_hotkey_signature,
+    verify_ping_signature,
+    verify_container_signature,
+    verify_container_logs_signature,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +47,10 @@ _container_log_stream_executor = ThreadPoolExecutor(
 _active_follow_log_streams = 0
 _active_follow_log_streams_lock = asyncio.Lock()
 
+# Upper bound on a peer-supplied authorized_keys line (the purge re-reads the file every minute):
+# 8192 less the 32 bytes the expiry marker takes (services/ssh_service.py). A real key is far
+# smaller — an ed25519 line is ~100 bytes, an rsa-4096 one ~750.
+MAX_PUBLIC_KEY_BYTES = 8192 - 32
 METRICS_MAX_CONCURRENT = 3
 METRICS_TIMEOUT_SECONDS = 8.0
 CONTAINER_LOOKUP_TIMEOUT_SECONDS = 5.0
@@ -202,6 +211,15 @@ def _validate_ssh_key_consistency(payload: UploadSShKeyPayload) -> None:
             f"public_key length={len(pk_normalized)}, data_to_sign length={len(dts_normalized)}"
         )
         raise HTTPException(status_code=400, detail="Public key mismatch")
+    # DAH-3394: the key is appended as one authorized_keys line with an expiry marker; a second
+    # line inside it would be a second key without the marker, and so without the expiry
+    if "\n" in pk_normalized or "\r" in pk_normalized:
+        logger.warning("Rejecting a public_key that spans more than one line")
+        raise HTTPException(status_code=400, detail="Public key must be a single line")
+    # bounded input: the line goes into a file the purge re-reads every minute
+    if len(pk_normalized.encode()) > MAX_PUBLIC_KEY_BYTES:
+        logger.warning("Rejecting a public_key of %d bytes", len(pk_normalized.encode()))
+        raise HTTPException(status_code=400, detail=f"Public key longer than {MAX_PUBLIC_KEY_BYTES} bytes")
 
 
 def _validate_validator_signature(payload: UploadSShKeyPayload, require_nonce: bool = False) -> None:
@@ -217,9 +235,8 @@ def _validate_validator_signature(payload: UploadSShKeyPayload, require_nonce: b
         logger.warning("Rejecting SSH-key upload without an attestation nonce (enforcement on)")
         raise HTTPException(status_code=401, detail="Attestation nonce required")
     try:
-        keypair = bittensor.Keypair(ss58_address=VALIDATOR_HOTKEY_SS58)
         signed_blob = ssh_pubkey_signing_blob(payload.public_key, payload.nonce)
-        if not keypair.verify(signed_blob, payload.validator_signature):
+        if match_validator_hotkey(signed_blob, payload.validator_signature) is None:
             raise HTTPException(status_code=401, detail="Invalid validator signature")
         logger.info("Validator signature verification successful")
     except HTTPException:

--- a/neurons/executor/src/services/ssh_service.py
+++ b/neurons/executor/src/services/ssh_service.py
@@ -1,27 +1,154 @@
+import asyncio
 import getpass
 import logging
 import os
+import tempfile
+import threading
+import time
+from collections.abc import Callable
 
 from core.config import settings
 
 logger = logging.getLogger(__name__)
 
+# DAH-3394: every key /upload_ssh_key appends carries this trailing comment token with the upload
+# time, so the purge below can tell the validator's keys from lines written by anything else (a
+# template's key, a key the provider added by hand) and never touches the latter. sshd treats
+# everything after the key material as a comment, so the token changes nothing for logins.
+UPLOADED_KEY_MARKER = b"lium-uploaded-at="
+
+# The routes and the purge task all run on the event loop thread and do their file work
+# synchronously, so today nothing contends for this lock; it is what keeps an append from landing
+# on an inode the purge is replacing if any of them ever moves to a worker thread.
+_authorized_keys_lock = threading.Lock()
+
+
+def authorized_keys_path() -> str:
+    return os.path.expanduser("~/.ssh/authorized_keys")
+
+
+def _lacks_trailing_newline(path: str) -> bool:
+    """True when the file exists, is not empty and its last byte is not a newline."""
+    try:
+        with open(path, "rb") as file:
+            file.seek(0, os.SEEK_END)
+            if file.tell() == 0:
+                return False
+            file.seek(-1, os.SEEK_END)
+            return file.read(1) != b"\n"
+    except FileNotFoundError:
+        return False
+
+
+def _split_marker(line: bytes) -> tuple[bytes, bytes | None]:
+    """(key without the marker, the marker's value) — value is None on an unmarked line.
+
+    The marker is the line's last whitespace-separated token; plain splits, no regex, so a
+    hostile line (the key text is peer-supplied) costs linear time on every purge tick. Bytes
+    throughout: one non-UTF-8 byte anywhere in the file must not stop the purge or a removal.
+    """
+    stripped = line.strip()
+    parts = stripped.rsplit(None, 1)
+    if len(parts) != 2 or not parts[1].startswith(UPLOADED_KEY_MARKER):
+        return stripped, None
+    return parts[0], parts[1][len(UPLOADED_KEY_MARKER):]
+
+
+def _rewrite_authorized_keys(path: str, keep: Callable[[bytes], bool]) -> int:
+    """Rewrite `path` keeping the lines `keep(line)` accepts byte-for-byte; returns lines dropped.
+
+    Written next to the file and moved into place, so a crash mid-write leaves the old file
+    whole rather than an empty authorized_keys that locks the validator out.
+    """
+    with open(path, "rb") as file:
+        lines = file.readlines()
+    kept = [line for line in lines if keep(line)]
+    dropped = len(lines) - len(kept)
+    if dropped == 0:
+        return 0
+    mode = os.stat(path).st_mode & 0o777
+    fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(path), prefix=".authorized_keys.")
+    try:
+        with os.fdopen(fd, "wb") as file:
+            file.writelines(kept)
+        os.chmod(tmp_path, mode)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+    return dropped
+
+
+def purge_expired_uploaded_keys(ttl_s: int, now: float | None = None) -> int:
+    """Drop every marked key uploaded more than `ttl_s` seconds ago; returns how many.
+
+    Only lines carrying UPLOADED_KEY_MARKER are candidates; every other line is kept unchanged.
+    A marked line whose timestamp cannot be read, or lies more than `ttl_s` in the future (the
+    host clock was stepped back after the upload), is dropped too: the marker is ours, so an age
+    we cannot bound is a key we cannot bound. Every marked key therefore lives at most 2 × ttl_s.
+    """
+    now = time.time() if now is None else now
+    path = authorized_keys_path()
+
+    def keep(line: bytes) -> bool:
+        _, uploaded_at = _split_marker(line)
+        if uploaded_at is None:
+            return True
+        try:
+            return abs(now - int(uploaded_at)) <= ttl_s
+        except ValueError:
+            return False
+
+    with _authorized_keys_lock:
+        try:
+            return _rewrite_authorized_keys(path, keep)
+        except FileNotFoundError:
+            return 0
+
+
+async def run_uploaded_key_purge() -> None:
+    """Background loop: every EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S remove the expired uploads."""
+    ttl_s = settings.EXECUTOR_UPLOADED_KEY_TTL_S
+    interval_s = settings.EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S
+    logger.info("uploaded ssh keys expire after %ss (checked every %ss)", ttl_s, interval_s)
+    while True:
+        try:
+            removed = purge_expired_uploaded_keys(ttl_s)
+            if removed:
+                # the count only: a key still present after its TTL is what this line reports
+                logger.warning("removed %d uploaded ssh key(s) older than %ss", removed, ttl_s)
+        except Exception:
+            logger.exception("uploaded ssh key purge failed; retrying next interval")
+        await asyncio.sleep(interval_s)
+
 
 class SSHService:
     def add_pubkey_to_host(self, pub_key: str):
-        with open(os.path.expanduser("~/.ssh/authorized_keys"), "a") as file:
-            file.write(pub_key + "\n")
+        pub_key = pub_key.strip()
+        if "\n" in pub_key or "\r" in pub_key:
+            # a second line would be a second, unmarked key that no TTL reaches
+            raise ValueError("an authorized_keys entry is one line")
+        line = pub_key.encode() + b" " + UPLOADED_KEY_MARKER + str(int(time.time())).encode() + b"\n"
+        with _authorized_keys_lock:
+            path = authorized_keys_path()
+            # a last line without its newline would merge with this one, and the merged line —
+            # marked — would take the other key with it at the purge
+            if _lacks_trailing_newline(path):
+                line = b"\n" + line
+            with open(path, "ab") as file:
+                file.write(line)
 
     def remove_pubkey_from_host(self, pub_key: str):
-        authorized_keys_path = os.path.expanduser("~/.ssh/authorized_keys")
-
-        with open(authorized_keys_path, "r") as file:
-            lines = file.readlines()
-
-        with open(authorized_keys_path, "w") as file:
-            for line in lines:
-                if line.strip() != pub_key:
-                    file.write(line)
+        wanted = pub_key.strip().encode()
+        # a key uploaded by this release carries the marker; one uploaded by the previous
+        # release does not — both must go when the validator asks
+        with _authorized_keys_lock:
+            _rewrite_authorized_keys(
+                authorized_keys_path(), lambda line: _split_marker(line)[0] != wanted
+            )
 
     def get_current_os_user(self) -> str:
         return getpass.getuser()

--- a/neurons/executor/tests/test_attestation_nonce_and_gpu.py
+++ b/neurons/executor/tests/test_attestation_nonce_and_gpu.py
@@ -52,7 +52,9 @@ def miner_keypair():
 def client(validator_keypair, miner_keypair, monkeypatch):
     monkeypatch.setattr(settings, "MINER_HOTKEY_SS58_ADDRESS", miner_keypair.ss58_address)
     monkeypatch.setattr(settings, "DEFAULT_MINER_HOTKEY", miner_keypair.ss58_address)
-    monkeypatch.setattr("routes.apis.VALIDATOR_HOTKEY_SS58", validator_keypair.ss58_address)
+    monkeypatch.setattr(
+        "dependencies.auth.VALIDATOR_HOTKEYS_SS58", {"current": validator_keypair.ss58_address}
+    )
 
     app = FastAPI()
     app.add_middleware(MinerMiddleware)

--- a/neurons/executor/tests/test_container_signature_freshness.py
+++ b/neurons/executor/tests/test_container_signature_freshness.py
@@ -32,7 +32,7 @@ def validator_keypair():
 
 @pytest.fixture(autouse=True)
 def trust_the_test_validator(validator_keypair, monkeypatch):
-    monkeypatch.setattr(auth, "VALIDATOR_HOTKEY_SS58", validator_keypair.ss58_address)
+    monkeypatch.setattr(auth, "VALIDATOR_HOTKEYS_SS58", {"current": validator_keypair.ss58_address})
     monkeypatch.setattr(settings, "CONTAINER_SIGNATURE_MAX_AGE_SECONDS", WINDOW)
 
 

--- a/neurons/executor/tests/test_upload_ssh_key_auth.py
+++ b/neurons/executor/tests/test_upload_ssh_key_auth.py
@@ -73,7 +73,7 @@ def client(validator_keypair, miner_keypair, monkeypatch):
       - settings.MINER_HOTKEY_SS58_ADDRESS → test miner's ss58 address
       - settings.DEFAULT_MINER_HOTKEY      → same (prevents accidental match
                                              via the fallback hotkey)
-      - routes.apis.VALIDATOR_HOTKEY_SS58  → test validator's ss58 address
+      - dependencies.auth.VALIDATOR_HOTKEYS_SS58 → {"current": test validator's ss58 address}
 
     MinerService is overridden so no real SSH or TDX operations occur.
     """
@@ -84,7 +84,9 @@ def client(validator_keypair, miner_keypair, monkeypatch):
     monkeypatch.setattr(settings, "DEFAULT_MINER_HOTKEY", miner_keypair.ss58_address)
 
     # --- patch validator auth ---
-    monkeypatch.setattr("routes.apis.VALIDATOR_HOTKEY_SS58", validator_keypair.ss58_address)
+    monkeypatch.setattr(
+        "dependencies.auth.VALIDATOR_HOTKEYS_SS58", {"current": validator_keypair.ss58_address}
+    )
 
     # --- build minimal app ---
     app = FastAPI()

--- a/neurons/executor/tests/test_uploaded_key_expiry.py
+++ b/neurons/executor/tests/test_uploaded_key_expiry.py
@@ -1,0 +1,269 @@
+"""DAH-3394: an ssh key installed through /upload_ssh_key expires unless the validator removes it.
+
+The validator uploads a fresh keypair per job and removes it afterwards; a key that is still in the
+executor's authorized_keys after EXECUTOR_UPLOADED_KEY_TTL_S is a leak (I-78: keys planted through a
+validator-hotkey-signed upload stayed for months). The executor now appends every upload with a marker
+carrying the upload time and purges marked lines past the TTL. Everything else in the file — a template's
+key, a key the provider added by hand, comments, blank lines — is never touched.
+"""
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+import services.ssh_service as ssh_service
+from services.ssh_service import SSHService, purge_expired_uploaded_keys
+
+TTL = 900
+NOW = 1_800_000_000  # a fixed clock: the tests never read time.time() for the ages they assert on
+
+RENTER_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIRenterOwnKeyNotOursToTouch renter@laptop\n"
+TEMPLATE_KEY = 'command="/usr/bin/tunnel",no-pty ssh-rsa AAAAB3NzaC1yc2ETemplateKey template\n'
+COMMENT = "# keys below this line were installed by the image\n"
+ODDLY_SPACED = "ssh-ed25519   AAAAC3NzaC1lZDI1NTE5AAAAIKeyWithTabsAndSpaces\t  \n"
+# a CRLF line and a comment that is not UTF-8 (a key pasted from a Windows box, a latin-1 name)
+FOREIGN_BYTES = b"ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIWindowsPastedKey user@pc\r\n# Jos\xe9's key\n"
+
+
+MARKER = ssh_service.UPLOADED_KEY_MARKER.decode()
+
+
+def _marked(key: str, uploaded_at) -> str:
+    return f"{key} {MARKER}{uploaded_at}\n"
+
+
+@pytest.fixture()
+def authorized_keys(tmp_path, monkeypatch):
+    """A private HOME so ~/.ssh/authorized_keys is a temp file; returns its path."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir(mode=0o700)
+    path = ssh_dir / "authorized_keys"
+    path.write_text("")
+    path.chmod(0o600)
+    return path
+
+
+def test_purge_removes_a_marked_key_past_the_ttl_and_keeps_a_fresh_one(authorized_keys):
+    # regression: off-by-one or unit error on the age (ms vs s, TTL compared to the timestamp
+    # instead of the age) removes a key the validator is still using, or never removes any
+    stale = _marked("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIStaleValidatorJobKey", NOW - TTL - 1)
+    fresh = _marked("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFreshValidatorJobKey", NOW - TTL)
+    authorized_keys.write_text(stale + fresh)
+
+    removed = purge_expired_uploaded_keys(TTL, now=NOW)
+
+    assert removed == 1
+    assert authorized_keys.read_text() == fresh
+
+
+def test_purge_keeps_every_unmarked_line_byte_for_byte(authorized_keys):
+    # regression: the purge re-serialises the file (strip(), split/join, dropped comments or
+    # blank lines) and a renter's or template's key is altered or lost with the stale one
+    stale = _marked("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIStaleValidatorJobKey", NOW - 2 * TTL)
+    untouchable = (RENTER_KEY + COMMENT + "\n").encode() + FOREIGN_BYTES + (TEMPLATE_KEY + ODDLY_SPACED).encode()
+    authorized_keys.write_bytes(
+        (RENTER_KEY + COMMENT + stale + "\n").encode() + FOREIGN_BYTES + (TEMPLATE_KEY + ODDLY_SPACED).encode()
+    )
+    before_mode = authorized_keys.stat().st_mode
+
+    removed = purge_expired_uploaded_keys(TTL, now=NOW)
+
+    assert removed == 1
+    assert authorized_keys.read_bytes() == untouchable
+    assert authorized_keys.stat().st_mode == before_mode
+
+
+def test_purge_drops_a_marked_key_whose_timestamp_it_cannot_read(authorized_keys):
+    # regression: a marker the purge cannot parse is skipped as "not ours", and a key with a
+    # garbled timestamp becomes the one permanent upload
+    garbled = _marked("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGarbledMarkerKey", "yesterday")
+    authorized_keys.write_text(RENTER_KEY + garbled)
+
+    assert purge_expired_uploaded_keys(TTL, now=NOW) == 1
+    assert authorized_keys.read_text() == RENTER_KEY
+
+
+def test_purge_drops_a_marked_key_dated_more_than_ttl_in_the_future(authorized_keys):
+    # regression: a negative age reads as "fresh", so a key uploaded while the host clock ran ahead
+    # (then stepped back) lives until that future date — unbounded, like an unparsable marker
+    far_future = _marked("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIClockSteppedBackKey", NOW + TTL + 1)
+    slightly_ahead = _marked("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINtpSlewKey", NOW + 5)
+    authorized_keys.write_text(far_future + slightly_ahead)
+
+    assert purge_expired_uploaded_keys(TTL, now=NOW) == 1
+    assert authorized_keys.read_text() == slightly_ahead
+
+
+def test_purge_leaves_the_file_alone_when_nothing_expired(authorized_keys):
+    # regression: a rewrite every interval on an unchanged file (mtime churn, a truncated file
+    # if the process dies mid-write) where no rewrite was needed
+    fresh = _marked("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFreshValidatorJobKey", NOW - 1)
+    authorized_keys.write_text(RENTER_KEY + fresh)
+    inode = authorized_keys.stat().st_ino
+
+    assert purge_expired_uploaded_keys(TTL, now=NOW) == 0
+    assert authorized_keys.stat().st_ino == inode
+    assert authorized_keys.read_text() == RENTER_KEY + fresh
+
+
+def test_purge_without_an_authorized_keys_file_is_a_no_op(authorized_keys):
+    # regression: the loop dies on its first tick on an executor that has had no upload yet
+    authorized_keys.unlink()
+
+    assert purge_expired_uploaded_keys(TTL, now=NOW) == 0
+
+
+def test_purge_and_removal_survive_a_non_utf8_byte_elsewhere_in_the_file(authorized_keys):
+    # regression: text-mode reads raise UnicodeDecodeError on one latin-1 byte in someone else's
+    # comment, so on that executor no upload ever expires and /remove_ssh_key is a 500
+    stale = _marked("ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIStaleValidatorJobKey", NOW - 2 * TTL)
+    fresh_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFreshValidatorJobKey validator@lium"
+    authorized_keys.write_bytes(FOREIGN_BYTES + (stale + _marked(fresh_key, NOW)).encode())
+
+    assert purge_expired_uploaded_keys(TTL, now=NOW) == 1
+    SSHService().remove_pubkey_from_host(fresh_key)
+
+    assert authorized_keys.read_bytes() == FOREIGN_BYTES
+
+
+def test_the_purge_loop_survives_one_failing_tick_and_logs_what_it_removed(monkeypatch, caplog):
+    # regression: a narrowed `except`, or none, ends the loop on its first transient error (a
+    # read-only filesystem moment, a permissions blip) and nothing expires until the next restart
+    ticks = []
+
+    def purge(ttl_s):
+        ticks.append(ttl_s)
+        if len(ticks) == 1:
+            raise OSError("authorized_keys busy")
+        if len(ticks) == 2:
+            return 1
+        raise asyncio.CancelledError  # the lifespan's cancel, on the third tick
+
+    monkeypatch.setattr(ssh_service, "purge_expired_uploaded_keys", purge)
+    monkeypatch.setattr(ssh_service.settings, "EXECUTOR_UPLOADED_KEY_TTL_S", 7)
+    monkeypatch.setattr(ssh_service.settings, "EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S", 0)
+
+    with caplog.at_level(logging.WARNING, logger="services.ssh_service"):
+        with pytest.raises(asyncio.CancelledError):
+            asyncio.run(ssh_service.run_uploaded_key_purge())
+
+    assert ticks == [7, 7, 7]
+    assert "uploaded ssh key purge failed" in caplog.text
+    assert "removed 1 uploaded ssh key(s) older than 7s" in caplog.text
+
+
+# --- through the real writer -----------------------------------------------------------------------
+
+
+def test_an_uploaded_key_expires_after_the_ttl_and_not_before(authorized_keys):
+    # regression: the writer and the purge disagree on the marker (format, position, units) —
+    # uploads are written but never recognised, so nothing ever expires
+    key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIUploadedThroughTheRoute validator@lium"
+    uploaded_at = time.time()
+    SSHService().add_pubkey_to_host(key)
+    assert authorized_keys.read_text().startswith(key + " ")
+
+    assert purge_expired_uploaded_keys(TTL, now=uploaded_at + TTL - 5) == 0
+    assert authorized_keys.read_text().startswith(key + " ")
+
+    assert purge_expired_uploaded_keys(TTL, now=uploaded_at + TTL + 5) == 1
+    assert authorized_keys.read_text() == ""
+
+
+def test_an_upload_onto_a_file_without_a_trailing_newline_does_not_merge_with_the_last_line(authorized_keys):
+    # regression: the upload is appended straight after a provider key that has no newline; the
+    # merged line carries the marker and the purge deletes the provider's key with ours
+    authorized_keys.write_text(RENTER_KEY.rstrip("\n"))
+    key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIUploadedAfterNoNewline validator@lium"
+
+    SSHService().add_pubkey_to_host(key)
+    assert authorized_keys.read_text().startswith(RENTER_KEY + key + " ")
+
+    assert purge_expired_uploaded_keys(TTL, now=time.time() + TTL + 5) == 1
+    assert authorized_keys.read_text() == RENTER_KEY
+
+
+def test_remove_ssh_key_still_removes_a_key_uploaded_with_the_marker(authorized_keys):
+    # regression: /remove_ssh_key compares the whole line to the bare key, so a marked line is
+    # never matched and every validator key stays until the TTL — 15 minutes of access it did
+    # not ask for, on every job
+    key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIValidatorJobKey validator@lium"
+    authorized_keys.write_text(RENTER_KEY)
+    service = SSHService()
+    service.add_pubkey_to_host(key)
+
+    service.remove_pubkey_from_host(key)
+
+    assert authorized_keys.read_text() == RENTER_KEY
+
+
+def test_remove_ssh_key_removes_a_key_the_previous_release_wrote_without_a_marker(authorized_keys):
+    # regression: authorized_keys lives on the disk reserve (setup_disk_reserve.sh mount_ssh) and
+    # survives the restart onto this release, so a key the previous release appended (no marker)
+    # is still there when the validator asks to remove it
+    key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKeyFromTheOldRelease validator@lium"
+    authorized_keys.write_text(RENTER_KEY + key + "\n")
+
+    SSHService().remove_pubkey_from_host(key)
+
+    assert authorized_keys.read_text() == RENTER_KEY
+
+
+def test_a_public_key_with_an_embedded_newline_is_refused_by_the_writer(authorized_keys):
+    # regression: "key-a\nkey-b" appended verbatim puts key-b on its own unmarked line — a
+    # permanent key smuggled past the TTL by whoever holds the validator hotkey
+    with pytest.raises(ValueError):
+        SSHService().add_pubkey_to_host("ssh-ed25519 AAAAFirst a\nssh-ed25519 AAAASecond b")
+
+    assert authorized_keys.read_text() == ""
+
+
+def _signed_upload(monkeypatch, public_key: str):
+    """POST /upload_ssh_key through the real app (middleware + route + real SSHService) with real signatures."""
+    import bittensor
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from middlewares.miner import MinerMiddleware
+    from routes.apis import apis_router
+
+    import dependencies.auth as auth
+    from core.config import settings
+
+    miner = bittensor.Keypair.create_from_uri("//LiumExpiryMiner")
+    validator = bittensor.Keypair.create_from_uri("//LiumExpiryValidator")
+    monkeypatch.setattr(settings, "MINER_HOTKEY_SS58_ADDRESS", miner.ss58_address)
+    monkeypatch.setattr(settings, "DEFAULT_MINER_HOTKEY", miner.ss58_address)
+    monkeypatch.setattr(auth, "VALIDATOR_HOTKEYS_SS58", {"current": validator.ss58_address})
+    app = FastAPI()
+    app.add_middleware(MinerMiddleware)
+    app.include_router(apis_router)
+    return TestClient(app).post(
+        "/upload_ssh_key",
+        json={
+            "public_key": public_key,
+            "data_to_sign": public_key,
+            "signature": "0x" + miner.sign(public_key).hex(),
+            "validator_signature": "0x" + validator.sign(public_key).hex(),
+        },
+    )
+
+
+def test_upload_ssh_key_route_refuses_a_public_key_spanning_two_lines(authorized_keys, monkeypatch):
+    # the same property at the door: a correctly signed two-line key is a 400, not a 500 from
+    # the writer and not two lines in authorized_keys
+    response = _signed_upload(monkeypatch, "ssh-ed25519 AAAAFirst a\nssh-ed25519 AAAASecond b")
+
+    assert response.status_code == 400
+    assert authorized_keys.read_text() == ""
+
+
+def test_upload_ssh_key_route_refuses_a_public_key_over_the_line_bound(authorized_keys, monkeypatch):
+    # regression: a correctly signed multi-megabyte "key" lands in authorized_keys, and the purge
+    # re-reads the file every minute for as long as it lives
+    response = _signed_upload(monkeypatch, "ssh-ed25519 " + "A" * 8192)
+
+    assert response.status_code == 400
+    assert authorized_keys.read_text() == ""

--- a/neurons/executor/tests/test_validator_hotkeys.py
+++ b/neurons/executor/tests/test_validator_hotkeys.py
@@ -1,0 +1,212 @@
+"""DAH-3394: the executor accepts a signature from either of two configured validator hotkeys.
+
+The validator hotkey is rotated in two releases: this one trusts `current` and `next`, the one after
+drops `current`. Every test names the regression it guards; signatures are real (ephemeral keypairs),
+shaped exactly as the miner relays them, and go through the routes, not the helper.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import AsyncMock, MagicMock
+
+import bittensor
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from middlewares.miner import MinerMiddleware
+from routes.apis import apis_router
+from services.miner_service import MinerService
+
+import dependencies.auth as auth
+from core.config import settings
+
+_SSH_KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAITestKey123456789abcdef validator@lium"
+
+
+@pytest.fixture(scope="module")
+def current_validator():
+    return bittensor.Keypair.create_from_uri("//LiumRotationCurrent")
+
+
+@pytest.fixture(scope="module")
+def next_validator():
+    return bittensor.Keypair.create_from_uri("//LiumRotationNext")
+
+
+@pytest.fixture(scope="module")
+def miner_keypair():
+    return bittensor.Keypair.create_from_uri("//LiumRotationMiner")
+
+
+@pytest.fixture()
+def client(miner_keypair, monkeypatch):
+    monkeypatch.setattr(settings, "MINER_HOTKEY_SS58_ADDRESS", miner_keypair.ss58_address)
+    monkeypatch.setattr(settings, "DEFAULT_MINER_HOTKEY", miner_keypair.ss58_address)
+    app = FastAPI()
+    app.add_middleware(MinerMiddleware)
+    app.include_router(apis_router)
+    service = MagicMock()
+    service.upload_ssh_key = AsyncMock(return_value={"ssh_username": "root", "ssh_port": 2200})
+    service.remove_ssh_key = AsyncMock(return_value=None)
+    app.dependency_overrides[MinerService] = lambda: service
+    return TestClient(app)
+
+
+def _trust(monkeypatch, **hotkeys: bittensor.Keypair) -> None:
+    monkeypatch.setattr(
+        auth, "VALIDATOR_HOTKEYS_SS58", {key_id: kp.ss58_address for key_id, kp in hotkeys.items()}
+    )
+
+
+def _upload_payload(miner_kp, validator_kp) -> dict:
+    # miners/services/executor_service.py:send_pubkey_to_executor, no nonce
+    return {
+        "public_key": _SSH_KEY,
+        "data_to_sign": _SSH_KEY,
+        "signature": "0x" + miner_kp.sign(_SSH_KEY).hex(),
+        "validator_signature": "0x" + validator_kp.sign(_SSH_KEY).hex(),
+    }
+
+
+def _ping_payload(validator_kp) -> dict:
+    return {"signature": validator_kp.sign("ping_request").hex()}
+
+
+# --- /upload_ssh_key ------------------------------------------------------------------------------
+
+
+def test_upload_signed_by_the_current_hotkey_is_accepted_when_next_is_configured(
+    client, miner_keypair, current_validator, next_validator, monkeypatch
+):
+    # regression: configuring `next` replaces `current` instead of adding to it — the live
+    # validator is refused by every executor that restarts onto the release
+    _trust(monkeypatch, current=current_validator, next=next_validator)
+
+    response = client.post("/upload_ssh_key", json=_upload_payload(miner_keypair, current_validator))
+
+    assert response.status_code == 200
+
+
+def test_upload_signed_by_the_next_hotkey_is_accepted_when_configured(
+    client, miner_keypair, current_validator, next_validator, monkeypatch
+):
+    # regression: the verifier reads only the first configured hotkey, so the chain swap
+    # (phase 2) is fleet-wide downtime
+    _trust(monkeypatch, current=current_validator, next=next_validator)
+
+    response = client.post("/upload_ssh_key", json=_upload_payload(miner_keypair, next_validator))
+
+    assert response.status_code == 200
+
+
+def test_upload_signed_by_a_third_hotkey_is_rejected_with_two_configured(
+    client, miner_keypair, current_validator, next_validator, monkeypatch
+):
+    # regression: a loop that returns the last comparison's result, or one that treats "no key
+    # raised" as verified, accepts any signer once more than one hotkey is configured
+    _trust(monkeypatch, current=current_validator, next=next_validator)
+    stranger = bittensor.Keypair.create_from_uri("//LiumRotationStranger")
+
+    response = client.post("/upload_ssh_key", json=_upload_payload(miner_keypair, stranger))
+
+    assert response.status_code == 401
+
+
+def test_upload_signed_by_the_next_hotkey_is_rejected_while_only_current_is_configured(
+    client, miner_keypair, current_validator, next_validator, monkeypatch
+):
+    # regression: `next` accepted before the release that names it — exactly today's behaviour
+    # must hold for a single configured key
+    _trust(monkeypatch, current=current_validator)
+
+    response = client.post("/upload_ssh_key", json=_upload_payload(miner_keypair, next_validator))
+
+    assert response.status_code == 401
+
+
+# --- the dependencies/auth.py verifiers (ping, hardware, containers) ------------------------------
+
+
+def test_ping_signed_by_the_next_hotkey_is_accepted_when_configured(
+    client, current_validator, next_validator, monkeypatch
+):
+    # regression: the rotation reaches _validate_validator_signature (ssh key uploads) but not
+    # dependencies.auth.verify_signature, so /ping, /hardware_utilization and /containers/*
+    # go dark after the chain swap while rentals still work
+    _trust(monkeypatch, current=current_validator, next=next_validator)
+
+    response = client.post("/ping", json=_ping_payload(next_validator))
+
+    assert response.status_code == 200
+
+
+def test_ping_signed_by_a_third_hotkey_is_rejected_with_two_configured(
+    client, current_validator, next_validator, monkeypatch
+):
+    # regression: verify_signature's error path (a raised or False verify on the first key) is
+    # read as "verified" once a second key is in the loop
+    _trust(monkeypatch, current=current_validator, next=next_validator)
+    stranger = bittensor.Keypair.create_from_uri("//LiumRotationStranger")
+
+    response = client.post("/ping", json=_ping_payload(stranger))
+
+    assert response.status_code == 401
+
+
+# --- core/config.py: where the two hotkeys come from ----------------------------------------------
+
+
+def _load_config_with_override(monkeypatch, next_hotkey: str | None):
+    # a fresh module object from core/config.py with `core.config_override` standing in as
+    # docker_build.sh would have written it (next only; `current` keeps the code default). Reloading
+    # sys.modules["core.config"] instead would hand every other test a second `settings` object.
+    if next_hotkey is None:
+        monkeypatch.delitem(sys.modules, "core.config_override", raising=False)
+    else:
+        monkeypatch.setitem(
+            sys.modules, "core.config_override", types.SimpleNamespace(_VALIDATOR_NEXT_HOTKEY_SS58=next_hotkey)
+        )
+    # the executor must never take a hotkey from its environment; set it to prove it is ignored
+    monkeypatch.setenv("VALIDATOR_NEXT_HOTKEY_SS58", bittensor.Keypair.create_from_uri("//FromEnv").ss58_address)
+    path = os.path.join(os.path.dirname(__file__), "..", "src", "core", "config.py")
+    spec = importlib.util.spec_from_file_location("config_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_without_an_override_only_the_current_hotkey_is_configured(monkeypatch):
+    # regression: an empty `next` becomes a second entry ("" or a duplicate of current), or the
+    # environment variable of the same name is honoured — the fleet as deployed today must see
+    # exactly one hotkey, and a provider's .env must not add a signer
+    config = _load_config_with_override(monkeypatch, next_hotkey=None)
+
+    assert config.VALIDATOR_HOTKEYS_SS58 == {"current": config.VALIDATOR_HOTKEY_SS58}
+
+
+def test_the_build_time_override_adds_the_next_hotkey_after_current(monkeypatch, next_validator):
+    # regression: the override is read but never reaches the dict (or lands first, so the log
+    # says `current` for the new key), or surrounding whitespace is kept
+    config = _load_config_with_override(monkeypatch, next_hotkey=f" {next_validator.ss58_address} ")
+
+    assert list(config.VALIDATOR_HOTKEYS_SS58.items()) == [
+        ("current", config.VALIDATOR_HOTKEY_SS58),
+        ("next", next_validator.ss58_address),
+    ]
+
+
+def test_a_next_hotkey_equal_to_current_is_not_listed_twice(monkeypatch):
+    # regression: the same key verified twice, and a log line claiming `next` is in use
+    current = _load_config_with_override(monkeypatch, next_hotkey=None).VALIDATOR_HOTKEY_SS58
+    config = _load_config_with_override(monkeypatch, next_hotkey=current)
+
+    assert config.VALIDATOR_HOTKEYS_SS58 == {"current": current}
+
+
+def test_a_next_hotkey_that_is_not_an_ss58_address_stops_the_executor_at_import(monkeypatch):
+    # regression: a mistyped `next` is discovered by the first 401 after the chain swap, on the
+    # whole fleet, instead of by CI on this PR
+    with pytest.raises(ValueError, match="next validator hotkey"):
+        _load_config_with_override(monkeypatch, next_hotkey="5F7X5UpKSr26KU3jKfpLmT8kuKtBNyHhEnfS8xtxPCqCb13q")


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3394](https://app.notion.com/p/3d8b8bfdbde98156a5b5ee7790982645) · reviewer: @taiberium

**TL;DR** — I-78: a foreign ssh key is re-planted through hotkey-signed `/upload_ssh_key` calls; the hotkey is being rotated. The executor accepts `current` and `next`; uploaded keys expire after 900 s, and keys left by the previous release are stamped once at start.

**What changed**
- `core/config.py`: `VALIDATOR_HOTKEYS_SS58 = {current, next}`; `next` from a constant or build-time override, never the environment
- `dependencies/auth.py:match_validator_hotkey` tries each hotkey; every verifier uses it
- `services/ssh_service.py`: uploads get `lium-uploaded-at=<unix time>`; the purge drops marked lines past the TTL (900 s)
- `ssh_service.py:stamp_legacy_uploaded_keys`: once, at first start, every unmarked key line gets the marker; log `legacy keys stamped: N`
- `routes/apis.py`: a two-line or > 8160-byte `public_key` is a 400
- 33 tests; `README.md`; `docker_build.sh` refuses `next` without `current`

**Risks**
- Changes runtime configuration (`config.py`) on the next deploy, no pod restart — noticed only if a value is wrong — rollback: revert the file and redeploy.
- Data rewrite at the first start: every unmarked key line in the executor container's `/root/.ssh/authorized_keys` gets the marker and is gone 15 min later unless re-uploaded. The file is the container's (`reserve_data` volume, bound over `/root/.ssh` by `setup_disk_reserve.sh`), not the provider's host file — a hand key a provider put in the container goes too — rollback: re-add it; the validator uploads a fresh key per job.

**How to verify**
- `cd neurons/executor && pdm run pytest tests/ -q` → 250 passed
- two unmarked lines in `~/.ssh/authorized_keys`, TTL 5 s → `legacy keys stamped: 2`, file empty 7 s later; second start changes nothing

**Verified by the loop:** 11 Sep 2026 · targeted 25/25 · Result: PASS · Gate: PASS eaec880

**Ran it:** `python src/executor.py` on macOS (TTL 5 s): upload by `next` → 200, marked line · third key → 401 · … +1 under Details

**Self-review:** clean at eaec880 (15 checks, 2 low)

**Parts:** backend ✓ · migration n/a — no schema · frontend n/a — executor only · CLI/SDK n/a — executor only · docs ✓ `neurons/executor/README.md` · tests ✓ 33 · dashboards n/a — purge WARNING is the signal

**Docs:** none needed because the container's `authorized_keys` is internal to the image; see `neurons/executor/README.md`

<details><summary>Details</summary>

Implements [DAH-3394](https://app.notion.com/p/3d8b8bfdbde98156a5b5ee7790982645) · reviewer: @taiberium

Origin: I-78 (LIUM_ISSUES.md) — an ssh key nobody on the team recognises sits in ≥ 23 renters' pods on 14 providers and is re-planted 2–3×/day through a root session into executor containers; the only credential an executor accepts for that is a signature of the validator hotkey. Owner 11 Sep 05:56Z: the hotkey is treated as compromised → rotation plan `RECOVERY/workers/pod-key-identify/ROTATION_PLAN.md` §0.2 and §1. This PR is phase 1 (executor release N+1); nothing here changes the hotkey itself.

### Design

**Two hotkeys.** `core/config.py` builds `VALIDATOR_HOTKEYS_SS58: dict[str, str]` — `{"current": VALIDATOR_HOTKEY_SS58}` plus `"next": VALIDATOR_NEXT_HOTKEY_SS58` when that is non-empty and differs from `current`. `next` is a code constant (empty in this PR — the owner supplies the new ss58 in this thread, it goes into the constant before the image is published), overridable by `core/config_override._VALIDATOR_NEXT_HOTKEY_SS58` (`docker_build.sh` writes the override from `VALIDATOR_HOTKEY_SS58` and `VALIDATOR_NEXT_HOTKEY_SS58` at build time and exits 1 when only `next` is set: since DAH-3114 (#1301, on main) `config.py` reads `_VALIDATOR_HOTKEY_SS58` from any override it finds, so a rotation build passes both). Neither hotkey is read from the environment: the brief asked for an env var, the fresh self-review flagged it (SECURITY, medium) — in the CVM deployment the image is attested and the operator is untrusted, so a signer added through `.env` would let the provider into the attested container — and the constant + build-time override already cover staging (`VALIDATOR_NEXT_HOTKEY_SS58=<ss58> bash docker_build.sh`). `test_without_an_override_only_the_current_hotkey_is_configured` sets the env var and asserts it is ignored. `dependencies/auth.py:match_validator_hotkey(message, signature)` tries each configured hotkey in order and returns the id that verified (`current` / `next`, logged at DEBUG — the id only) or `None`. Both existing verifiers call it: `routes/apis.py:_validate_validator_signature` (`/upload_ssh_key`, `/remove_ssh_key`, via `ssh_pubkey_signing_blob`) and `dependencies/auth.py:verify_signature` (`/ping`, `/hardware_utilization`, `/containers/{name}`, `/containers/{name}/logs`). `middlewares/miner.py` verifies the miner's hotkey, not the validator's, and is unchanged. Each configured address is parsed with `bittensor_wallet.Keypair` at import, so a mistyped `next` stops the executor and CI rather than surfacing as the fleet's first 401 after the swap. With `next` empty the dict has one entry and every path behaves as before (`test_without_an_override_only_the_current_hotkey_is_configured`, `test_upload_signed_by_the_next_hotkey_is_rejected_while_only_current_is_configured`).

**Uploaded keys expire.** `services/ssh_service.py:SSHService.add_pubkey_to_host` appends `<key> lium-uploaded-at=<unix time>` (a trailing comment; sshd ignores it). `purge_expired_uploaded_keys(ttl_s, now)` rewrites `~/.ssh/authorized_keys` keeping every line without the marker unchanged and every marked line whose age is ≤ TTL; a marked line whose timestamp does not parse, or lies more than TTL in the future (host clock stepped back after the upload), is dropped (the marker is ours; an age we cannot bound is a key we cannot bound) — so every marked key lives at most 2 × TTL by the executor's clock. The rewrite goes to a temp file in the same directory, keeps the mode, `os.replace`s — and is skipped entirely when nothing expired (no mtime churn, no truncation window). `run_uploaded_key_purge()` is a lifespan task in `executor.py` next to the cache pre-pull: every `EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S` (60) it purges with `EXECUTOR_UPLOADED_KEY_TTL_S` (900) and logs a WARNING with the count when it removed anything. `remove_pubkey_from_host` matches a line with or without the marker: `authorized_keys` lives on the disk reserve (`setup_disk_reserve.sh:mount_ssh`, "keys now survive container recreation"), so a key the previous release appended is still there after the restart onto this one and the validator's removal must find it. For the same reason every line present at upgrade time — the previous release's uploads, I-78's leftovers among them — carries no marker; `stamp_legacy_uploaded_keys()` runs once before the purge loop's first tick and gives every unmarked key line `lium-uploaded-at=<start time>` (blank lines and `#` comments skipped, marked lines keep their own time), so they expire on the purge's normal path 900 s after the start. It writes `~/.ssh/.lium-uploaded-keys-stamped` next to `authorized_keys` (same reserve mount) after the rewrite and does nothing on a later start that finds that file; a start that dies between rewrite and done-file stamps again and finds nothing unmarked. A failing stamp is logged and the purge loop still starts. The log line is `legacy keys stamped: N` (WARNING when N > 0). The file is the executor container's `/root/.ssh/authorized_keys`: `docker-compose.app.yml` mounts only the `reserve_data` volume and `setup_disk_reserve.sh:mount_ssh` binds `$MNT/ssh` over `/root/.ssh` inside the container; the provider's host file is not involved. Asked for by @taiberium's review of 14 Sep 09:54Z (640 unmarked two-field lines on the staging executor). The file is read and written as bytes (a latin-1 byte in someone else's comment must not stop the purge; CRLF lines stay CRLF), and an upload onto a last line without its newline gets a newline first. A `threading.Lock` around append / remove / purge never contends today (all run on the event-loop thread) and is there for the day one of them moves to a worker thread. `_validate_ssh_key_consistency` refuses (400) a `public_key` containing `\n` or `\r`: appended verbatim, the second line would be a second key without the marker and so without the expiry; the writer raises on the same input as a second door. A `public_key` over `MAX_PUBLIC_KEY_BYTES` (8160 = 8192 minus the marker's 32 bytes; an ed25519 line is ~100 bytes, rsa-4096 ~750) is a 400 too — bounded input for a line the purge re-reads every minute; this is new behaviour, not a formalised no-op. The marker is found with `str.rsplit`, not a regex, so a hostile key text costs the purge linear time.

**Parts:** backend ✓ (executor) · migration n/a — no schema · frontend n/a — executor image only · CLI/SDK n/a — no command change · docs ✓ `neurons/executor/README.md`, `.env.template` · tests ✓ 33 · dashboards n/a — the purge WARNING is the signal.

**Not in this PR:** the new hotkey's ss58 (owner), the image publish (`daturaai/compute-subnet-executor:latest`, Rustam), the chain swap, release N+2 that drops `current`, the pod sweep (ROTATION_PLAN §2).

### Key lifetime behind the 900 s default

Measured in `neurons/validators/src` at `0460574`:
- **Verification job** (`services/miner_service.py:367` WebSocket, `:1996` REST): `generate_ssh_key` → `SSHPubKeySubmitRequest` → wait ≤ `JOB_LENGTH` = 30 s for the miner's accept → `task_service.create_task` per executor under `asyncio.wait_for(…, timeout=settings.JOB_TIME_OUT - 120)` = 780 s (`core/config.py:108`, 15 min) → `SSHPubKeyRemoveRequest` in `finally` (`:501`). The outer cycle waits `JOB_TIME_OUT - 50` = 850 s (`core/validator.py:414`). The RoCE sweep authenticates with the same key as late as `JOB_TIME_OUT - 50 - 30` = 820 s (`services/roce_link_probe.py:314`). Longest legitimate life of a job key before its removal: ≈ 820 s; the purge removes it at 900–960 s. Margin ≈ 80 s.
- **Rental create / container ops** (`:1063`, `:2207`): the key is uploaded, ONE asyncssh connection (`docker_service.py:4502`, keepalive 30 s × 4) and ONE Docker-SDK-over-ssh client (`:4512`, paramiko) are opened and used for the whole flow — image pull included, which `rental_docker_sdk.py:19` allows up to `3 * 60 * 60` s — then the key is removed — on the success path. The WebSocket branches for `BackupContainerRequest` / `RestoreContainerRequest` / `CancelStorageOperationRequest` (`:1276–1281`) return without a `SSHPubKeyRemoveRequest`, and every container op that raises leaves its key too (`except` at `:2432` on the REST path); today those keys are permanent and this purge is their only bound. sshd checks `authorized_keys` at authentication only, so an established session outlives the purge; the pull is not interrupted. What changes: after minute 15 a *transport drop* can no longer be recovered by re-authenticating with the same key (docker-py's `SSHHTTPAdapter` reconnects on a dead transport; the create then fails where today it would retry). Today that retry exists only for a pull that was already interrupted, so the flow fails in both cases unless the retry itself succeeds; I kept 900 s and name this in the open questions.
- **`add_debug_ssh_key`** (`:1465` WebSocket, `:2559` REST): uploads a key and never removes it — by design a long-lived debug door. With this PR it lives 15 minutes. No `AddDebugSshKeyRequest` has been seen since 13 Aug (I-78 notes). Open question below.
- **Executor image sshd:** OpenSSH 10.0 (`Dockerfile` base `python:3.11-slim-trixie`), so `expiry-time="…"` in authorized_keys would also work as a native second guard; not used here because a malformed option makes sshd reject the whole line, and a purge is what §0.2 asked for.

### Security properties (PR_PROCESS §5)

- *fail closed*: an unparsable marker timestamp is removed, not kept; a `public_key` with an embedded newline is a 400 before any write, and `add_pubkey_to_host` raises on it independently (`test_a_public_key_with_an_embedded_newline_is_refused_by_the_writer`, `test_upload_ssh_key_route_refuses_a_public_key_spanning_two_lines`).
- *every door*: the two verifiers (`_validate_validator_signature`, `verify_signature`) share one helper; a hotkey added in one place is added in both (`test_ping_signed_by_the_next_hotkey_is_accepted_when_configured` guards the second door).
- *no secrets*: only ss58 public addresses appear in code, tests and this body; the log line names the key id (`current`/`next`), never the key. Tests use ephemeral `Keypair.create_from_uri` keys.
- *no signer from the environment*: both hotkeys come from the image (constant or build-time `config_override`); a provider's `.env` cannot add one (`test_without_an_override_only_the_current_hotkey_is_configured` sets `VALIDATOR_NEXT_HOTKEY_SS58` in the environment and asserts it is ignored).
- *no rewrite without need*: the purge does not touch the file when nothing expired (`test_purge_leaves_the_file_alone_when_nothing_expired`); when it does, unmarked lines are kept byte-for-byte and the mode is preserved (`test_purge_keeps_every_unmarked_line_byte_for_byte`).

### Tests (each names the regression it guards in its comment)

`tests/test_validator_hotkeys.py` (10): current accepted with next configured (next replacing current); next accepted when configured (verifier reads only the first key); third key rejected with two configured (loop returning the last comparison / "no key raised" = verified); next rejected while only current configured (today's behaviour with one key); `/ping` by next accepted (rotation reaching one verifier but not `dependencies/auth.py`); `/ping` by a third key rejected; no override → `{"current": …}` only, with the env var set and ignored; the build-time override adds `next` after `current` (trimmed); `next == current` listed once; a `next` that is not an ss58 address raises at import (a typo found by CI, not by the fleet's first 401 after the swap).
`tests/test_uploaded_key_expiry.py` (15): stale marked key removed at TTL+1 s, fresh one kept at exactly TTL (off-by-one / unit error); unmarked renter, template, comment, blank, CRLF, non-UTF-8 and oddly-spaced lines byte-for-byte unchanged and mode preserved (re-serialisation, universal newlines); purge and removal work with a latin-1 byte elsewhere in the file (text-mode `UnicodeDecodeError` = nothing expires on that executor); the purge loop survives a failing tick and logs the count (a narrowed `except` ends it on the first blip); an upload onto a file whose last line has no newline gets its own line (a merged, marked line would take the provider's key with it); garbled marker timestamp removed (skipped as "not ours"); a marker dated more than TTL in the future removed, one 5 s ahead kept (negative age read as fresh = unbounded after a clock step); no rewrite when nothing expired (churn / truncation window); no file → no-op (loop dies on first tick); an upload through the real writer expires after TTL and not before (writer/purge marker disagreement); `/remove_ssh_key` removes a marked key (whole-line comparison misses the marker → every job key lives 15 min); removes an unmarked key from the previous release; two-line key refused by the writer; two-line key refused by the route with 400 and nothing written; a key over 8160 bytes refused by the route with 400 (the purge would re-read it every minute).

`tests/test_legacy_uploaded_key_stamp.py` (8): first start stamps every unmarked key line, comments/blank/CRLF/non-UTF-8 included, mode kept (a shape check that skips some lines leaves the access open); marked lines keep their own time and no rewrite happens with nothing to stamp; a second start stamps nothing even when a new unmarked line appeared ("once" implemented as "while unmarked lines exist"); the purge removes stamped lines at TTL+1 s and not at TTL (unit error / unbounded); the done-file is written only after a successful rewrite (a crash mid-rewrite recorded as done); no file → done recorded, file not created; the lifespan task stamps at start and logs `legacy keys stamped: 2`; an `OSError` in the stamp does not stop the purge loop.
Negative control (not committed): with `match_validator_hotkey` mutated to always return `"current"`, 3 of the hotkey tests fail (the two third-key rejections and next-while-only-current).

### Ran it

The real app (`src/executor.py`, uvicorn, `ENV=prod`) on the Mac with a private `HOME`, a `core.config_override` carrying `_VALIDATOR_NEXT_HOTKEY_SS58 = <ephemeral //RanItNextValidator ss58>` (injected through a `sitecustomize.py` on `PYTHONPATH`, a next-only module, as the branch's `config.py` reads it; on main merged, an override also needs `_VALIDATOR_HOTKEY_SS58`, see Design), `EXECUTOR_UPLOADED_KEY_TTL_S=5`, `EXECUTOR_UPLOADED_KEY_PURGE_INTERVAL_S=1`, `COMPUTE_REST_API_URL=` (pre-pull off); driver `RECOVERY/workers/executor-dual-hotkey/ranit/ranit.py`, full output `ranit.out`. Real sr25519 signatures shaped as `miners/services/executor_service.py:send_pubkey_to_executor` sends them.

```
$ POST /upload_ssh_key  (key A, signed by the `next` hotkey from core.config_override)
  -> 200 {"ssh_username":"c","ssh_port":2200,...
--- authorized_keys after upload (2 lines):
    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIProviderOwnKeyLeftAlone provider@host
    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIRanItKeyAAAA... ranit-a lium-uploaded-at=1789110440
$ POST /upload_ssh_key  (key B, signed by a third keypair)
  -> 401 {"detail":"Invalid validator signature"}
$ POST /ping  (signed by the `next` hotkey)
  -> 200 {"status":"pong"}
$ POST /ping  (signed by a third keypair)
  -> 401 {"detail":"Invalid signature: not signed by a configured validator hotkey"}
$ POST /upload_ssh_key (key B, `next`) then POST /remove_ssh_key (key B)
  upload -> 200 / remove -> 200 → authorized_keys back to provider key + key A
--- authorized_keys 7.5s after the upload (1 lines):
    ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIProviderOwnKeyLeftAlone provider@host
    INFO:services.ssh_service:uploaded ssh keys expire after 5s (checked every 1s)
    WARNING:services.ssh_service:removed 1 uploaded ssh key(s) older than 5s
```

Not run: the Docker image build (`docker_build.sh`; `bash -n` passes and the `ast` one-liner was run on a two-line override) and a real sshd login against a marked line — the marker is a trailing comment, which the authorized_keys format defines as free text after the key; Rustam's image publish is the first real-sshd run. The Mac ran the suite because it is mock-only (docker is a `MagicMock` in `tests/conftest.py`) and finishes in 81 s with no heavy dependency; no EC2 spend.


**Stamp at start (Mac, executor venv, 2ed7bca; TTL 5 s, purge 1 s):** `run_uploaded_key_purge()` as the lifespan task runs it, `~/.ssh/authorized_keys` holding two unmarked lines and one marked line:

```
--- before:
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOldReleaseUploadOne
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOldReleaseUploadTwo
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFreshUpload lium-uploaded-at=1789379993
INFO services.ssh_service: uploaded ssh keys expire after 5s (checked every 1s)
WARNING services.ssh_service: legacy keys stamped: 2
--- 0.5 s after start:
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOldReleaseUploadOne lium-uploaded-at=1789379993
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOldReleaseUploadTwo lium-uploaded-at=1789379993
ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIFreshUpload lium-uploaded-at=1789379993
--- done-file: 1789379993 2
WARNING services.ssh_service: removed 3 uploaded ssh key(s) older than 5s
--- 7 s after start:
''
--- second start:
INFO services.ssh_service: uploaded ssh keys expire after 5s (checked every 1s)
```

### Verification

**Re-verified after the CI fix (Mac, executor venv, Python 3.11.11):** the merged tree (`git merge-tree origin/main HEAD`, conflict-free) `pytest tests/ -q` → 264 passed at eaec880 · branch `test_validator_hotkeys.py` 10/10 · `TAG=x VALIDATOR_NEXT_HOTKEY_SS58=<ss58> bash docker_build.sh` → exit 1 with the both-hotkeys message, no override written · Result: PASS eaec880 · Gate: not run

**Re-verified after the stamp round (Mac, executor venv, Python 3.11.11):** `cd neurons/executor && pytest tests/ -q` → 250 passed (242 + 8 new) at 2ed7bca · targeted 33/33 (`test_validator_hotkeys.py test_uploaded_key_expiry.py test_legacy_uploaded_key_stamp.py`) · stamp run: see Ran it · Result: PASS 2ed7bca · Gate: not run

**Verified by the loop on 11 Sep 2026 (Mac, executor venv, Python 3.11.11):** `cd neurons/executor && pytest tests/ -q` → 242 passed (217 before this PR + 25 new) at 75fc128 · targeted 25/25 (`test_validator_hotkeys.py test_uploaded_key_expiry.py`) · app run: see Ran it · Result: PASS 75fc128 · Gate: not run

### Rollout (ROTATION_PLAN §1)

1. Owner generates the new hotkey offline (`btcli wallet new_hotkey`) and posts its **ss58 only** in this thread; it goes into `VALIDATOR_NEXT_HOTKEY_SS58` in `core/config.py` (one-line follow-up commit on this PR).
2. Merge → Rustam publishes `daturaai/compute-subnet-executor:latest` (executor CD). The fleet restarts onto it on its own (`entrypoint.sh`: `docker compose up --pull always --force-recreate`; the Aug and 10 Sep waves show ≤ 1 day). From the first restart, every uploaded key on that executor expires after 15 min.
3. Once the new ss58 is in the image: a signed `/ping` with the NEW hotkey against one executor reporting `CURRENT` proves the fleet accepts it before anything touches the chain. Wait for `executor_image_report.status = CURRENT` ≥ 99 % (validator `incentive.utils` lines in Loki, or `executor.specs->executor_image` in prod).
4. Phase 2 (separate GO, owner + Rustam): `swap_hotkey` on netuid 51 → Pulumi secret → validator/connector restart → backend `executor.validator_hotkey` rows (Mikhail). Rollback at any point before N+2: a second `swap_hotkey`; the executors accept both.
5. Phase 3: release N+2 removes `current`; then the pod sweep (§2) and the renter notices.

### Cross-PR

lium-io#1339 and #1348 (DAH-2834, `POST /verify` / `POST /rent`) edit the same import hunk of `routes/apis.py` and their tests monkeypatch `dependencies.auth.VALIDATOR_HOTKEY_SS58`, a name this PR removes. This PR lands first (P0); their rebase patches `dependencies.auth.VALIDATOR_HOTKEYS_SS58 = {"current": …}` instead — their routes already verify through `verify_signature`, so they pick up both hotkeys with no further change.

### Open questions for @taiberium

1. `add_debug_ssh_key` uploads a key the validator never removes; with this PR it expires in 15 min like every other upload. Fine as the new contract, or does the debug path need its own (longer) TTL or a `no-expiry` flag signed by the validator?
2. Rental create: a pull longer than 15 min followed by an ssh transport drop can no longer re-authenticate (the established session is unaffected). Keep 900 s, or raise `EXECUTOR_UPLOADED_KEY_TTL_S` to, say, 1800 for margin? A larger TTL is a larger window for a leaked upload.
3. The brief asked for `next` to be readable from the environment; I dropped that on the self-review's SECURITY finding (attested CVM image, untrusted operator) and kept constant + build-time override. Say so if you want the env path back.
4. Answered by @taiberium's review (14 Sep 09:54Z): option (c). Done at 2ed7bca — `stamp_legacy_uploaded_keys()` marks every unmarked line once at the first start; the TTL purge removes them 15 min later (see Design).

### Self-review

Verdict `findings` at `eaec880` · 15 checks · by subagent-fresh-r135c · 2026-09-14 10:37Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | STALE-BODY | `review-wave/readability/overrides/lium-io-1357.json:0` | Property: every sha in the body is reachable on the pushed branch; the new Verification paragraph says '264 passed at 7968ae9 … Result: PASS 7968ae9', but 7968ae9 was amended into eaec880 and will not exist on the remote (the tested code is byte-identical apart from two comment/usage strings, so the result itself holds). | Write 'at eaec880' in both places of that paragraph (or 'at eaec880, run before the comment-only amend') before pushing. |
| low | STALE-BODY | `review-wave/readability/overrides/lium-io-1357.json:0` | Carried: the summary rows 'Self-review: clean at 2ed7bca (15 checks, 2 low)', 'Verified by the loop: 11 Sep 2026 · targeted 25/25 · Result: PASS · Gate: PASS 2ed7bca' and the '### Self-review' section (r135b at 2ed7bca) describe the previous head; Verification says 'Gate: not run' at 2ed7bca while '### Verified' says 'Gate: PASS (2ed7bca)'. | Handled by `tools/pr_self_review.py … --record` at eaec880 (replace the Self-review row and section with this verdict) and one edit making the two Gate statements agree on the sha the gate ran at. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/executor/src/services/ssh_service.py:63` `os.stat(path).st_mode & 0o777` is a read mask preserving the original mode on the mkstemp temp file before os.replace; nothing is set to 0o777; unchanged since 2ed7bca. · `neurons/executor/src/core/config.py:24` `core.config_override` is the optional, gitignored build-time module; on the branch the import is in `try: … except ImportError: pass`, on the merged tree main's resolver takes the built-in when find_spec returns None — both suites run without the file (264 passed merged, previous round).

### Verified

Gate: PASS (eaec880) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1357)

</details>
