### PR TITLE
DAH-3405 - [P0] validator: no verdict for nodes unreachable in a known image rollout

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -66,6 +66,14 @@ EXPRESS_LANE_TICK_SECONDS=30
 EXPRESS_LANE_MAX_IN_FLIGHT=4
 EXPRESS_LANE_MAX_IN_FLIGHT_PER_MINER=2
 
+# Executor image rollout grace (DAH-3405): for this many validation cycles, counting the one in which the registry digest
+# of EXECUTOR_IMAGE_REF was seen to change, an executor that fails the way a watchtower restart makes it fail (SSH
+# unreachable, scrape failed, ports missing, image not yet the new one) gets no verdict instead of a 0 - nothing is scored
+# or published for it. Default 2 = the cycle the push landed in and the next. Capped at 2: a withheld executor publishes
+# nothing, and the backend marks an executor whose row is not updated for 1 h inactive (EXECUTOR_INACTIVE_MID_RENTAL).
+# 0 turns the window off.
+EXECUTOR_ROLLOUT_GRACE_CYCLES=2
+
 #############################
 # Local Dev                 #
 #############################

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -338,6 +338,16 @@ class Settings(BaseSettings):
     # validation and every OUTDATED executor earns 0. Off until nodes auto-update again
     # (DAH-3419): with Watchtower stalled, 99 executors earned 0 for it in one hour on 11 Sep.
     EXECUTOR_IMAGE_CHECK_ENFORCE: bool = Field(env="EXECUTOR_IMAGE_CHECK_ENFORCE", default=False)
+    # DAH-3405: for this many validation cycles, counting the one in which the registry digest of
+    # EXECUTOR_IMAGE_REF was seen to change, an executor that fails the way a watchtower restart
+    # makes it fail (SSH gone, scrape failed, ports missing, image not yet the new one) gets no
+    # verdict instead of a 0. 2 = the cycle the push landed in and the next (watchtower polls
+    # every 60 s; a node that has not pulled and restarted 15 minutes later is a node whose
+    # watchtower is not working). Cycles are counted as the validator runs them, never by the
+    # clock. Capped at MAX_ROLLOUT_GRACE_CYCLES (2, services/executor_rollout.py): a withheld
+    # executor publishes nothing, and the backend marks an executor inactive (with the
+    # EXECUTOR_INACTIVE_MID_RENTAL penalty) when its row is not updated for 1 h. 0 turns it off.
+    EXECUTOR_ROLLOUT_GRACE_CYCLES: int = Field(env="EXECUTOR_ROLLOUT_GRACE_CYCLES", default=2)
 
     # DAH-2272: when on, raise the asyncssh logger to DEBUG (debug level 2) so the
     # SSH handshake (banner / key exchange / auth) is logged per connection, and

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -22,6 +22,7 @@ from services.executor_rollout import (
     ROLLOUT_GRACE,
     ExecutorRolloutTracker,
     RolloutWindow,
+    WithheldVerdict,
     withhold_rollout_verdicts,
 )
 from services.executor_connectivity.container_runner import ContainerRunner
@@ -537,7 +538,7 @@ class Validator:
                         miner_hotkey
                         for miner_hotkey, results in all_job_results.items()
                         if any(result.is_successful for result in results)
-                    } | {result_miner_hotkey for result_miner_hotkey, _ in withheld_results}
+                    } | {withheld.miner_hotkey for withheld in withheld_results}
 
                     incentive = IncentiveFactory.create(
                         config=self.incentive,
@@ -651,7 +652,7 @@ class Validator:
                     # DAH-3405: a withheld executor was handled by this cycle too — the express
                     # lane must not treat it as never validated and run a first pass on it.
                     published_executor_ids.extend(
-                        result.executor_info.uuid for _, result in withheld_results
+                        withheld.result.executor_info.uuid for withheld in withheld_results
                     )
 
                     if settings.EXPRESS_LANE_ENABLED:
@@ -814,7 +815,7 @@ class Validator:
         job_block: int,
         job_batch_id: str,
         window_at_cycle_start: RolloutWindow,
-    ) -> tuple[dict[str, list[JobResult]], list[tuple[str, JobResult]]]:
+    ) -> tuple[dict[str, list[JobResult]], list[WithheldVerdict]]:
         """DAH-3405: at cycle end, take the results the rollout explains out of the cycle.
 
         The push that recreates the fleet's containers can land in the middle of a cycle (11 Sep
@@ -824,14 +825,14 @@ class Validator:
         window = await self.observe_executor_rollout(
             await self.fetch_executor_digest_or_none(), job_block, fallback=window_at_cycle_start
         )
-        kept, withheld_results = withhold_rollout_verdicts(all_job_results, window, job_block)
+        standing, withheld_results = withhold_rollout_verdicts(all_job_results, window, job_block)
         await self.record_withheld_verdicts(window, withheld_results, job_batch_id, job_block)
-        return kept, withheld_results
+        return standing, withheld_results
 
     async def record_withheld_verdicts(
         self,
         window: RolloutWindow,
-        withheld_results: list[tuple[str, JobResult]],
+        withheld_results: list[WithheldVerdict],
         job_batch_id: str,
         job_block: int,
     ) -> None:

--- a/neurons/validators/src/core/validator.py
+++ b/neurons/validators/src/core/validator.py
@@ -18,6 +18,12 @@ from services.default_docker_image_digest_service import (
 )
 from services.docker_service import DockerService
 from services.executor_image_policy import build_expected_image_snapshot
+from services.executor_rollout import (
+    ROLLOUT_GRACE,
+    ExecutorRolloutTracker,
+    RolloutWindow,
+    withhold_rollout_verdicts,
+)
 from services.executor_connectivity.container_runner import ContainerRunner
 from services.executor_connectivity.dind_probe import DindProbe, DindVerifier
 from services.executor_connectivity.orchestrator import ConnectivityOrchestrator
@@ -87,6 +93,8 @@ class Validator:
         self.verifyx_validation_service = VerifyXValidationService()
         self.collateral_contract_service = CollateralContractService()
         self.attestation_service = AttestationService(redis_service=self.redis_service)
+        # DAH-3405: remembers the authorized executor digest and when it last changed.
+        self.rollout_tracker = ExecutorRolloutTracker(redis_service=self.redis_service)
 
         # Backend client for API requests
         keypair = settings.get_bittensor_wallet().get_hotkey()
@@ -315,17 +323,7 @@ class Validator:
                         ),
                     )
 
-                try:
-                    executor_digest = await fetch_executor_image_digest()
-                except Exception as exc:
-                    executor_digest = None
-                    logger.error(
-                        _m(
-                            "[sync] executor image digest fetch failed; image check skips this cycle",
-                            extra=get_extra_info({**self.default_extra, "error": str(exc)}),
-                        ),
-                    )
-
+                executor_digest = await self.fetch_executor_digest_or_none()
                 executor_image_snapshot = build_expected_image_snapshot(executor_digest)
 
                 # Fetch all rented executors from backend API
@@ -338,6 +336,11 @@ class Validator:
                         ),
                     )
                     return
+
+                # DAH-3405: a push between two cycles opens the grace window here, after the last
+                # early return and before the first job of this cycle runs against the new digest,
+                # so an aborted iteration does not count as a cycle of the window.
+                rollout_window = await self.observe_executor_rollout(executor_digest, job_block)
 
                 logger.info(
                     _m(
@@ -522,13 +525,19 @@ class Validator:
                         ),
                     )
 
+                    all_job_results, withheld_results = await self.withhold_verdicts_for_rollout(
+                        all_job_results, job_block, job_batch_id, rollout_window
+                    )
+
                     # DAH-2622: a miner whose machine passed validation must keep its UID even
-                    # when it earned nothing this cycle. Overwrite, never accumulate.
+                    # when it earned nothing this cycle. Overwrite, never accumulate. A miner with a
+                    # withheld result (DAH-3405) got no verdict on that executor this cycle, so it
+                    # is treated as active as well.
                     self.active_hotkeys = {
                         miner_hotkey
                         for miner_hotkey, results in all_job_results.items()
                         if any(result.is_successful for result in results)
-                    }
+                    } | {result_miner_hotkey for result_miner_hotkey, _ in withheld_results}
 
                     incentive = IncentiveFactory.create(
                         config=self.incentive,
@@ -639,6 +648,12 @@ class Validator:
                                 if result.executor_info.uuid != FAILED_MINER_EXECUTOR_UUID
                             )
 
+                    # DAH-3405: a withheld executor was handled by this cycle too — the express
+                    # lane must not treat it as never validated and run a first pass on it.
+                    published_executor_ids.extend(
+                        result.executor_info.uuid for _, result in withheld_results
+                    )
+
                     if settings.EXPRESS_LANE_ENABLED:
                         # DAH-2958: everything published by a cycle is "validated" for the
                         # express lane; only what the portal lists beyond this set is new.
@@ -670,6 +685,7 @@ class Validator:
                                     "total_executors": incentive.total_executors,
                                     "successful_executors": incentive.successful_executors,
                                     "failed_executors": incentive.failed_executors,
+                                    "withheld_executors": len(withheld_results),
                                     "completed_cycles_since_start": self.completed_cycles_since_start,
                                 }
                             ),
@@ -738,6 +754,115 @@ class Validator:
                         ),
                     ),
                 )
+
+    async def fetch_executor_digest_or_none(self) -> str | None:
+        """The registry digest of EXECUTOR_IMAGE_REF, or None when it cannot be read.
+
+        None makes the image check skip this cycle and (DAH-3405) leaves the rollout window as it
+        was. Called at cycle start and, since DAH-3405, once more at cycle end; each call is a
+        token GET and a manifest HEAD against Docker Hub, each with a 30-s timeout.
+        """
+        try:
+            return await fetch_executor_image_digest()
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "[sync] executor image digest fetch failed; image check skips this cycle and "
+                    "the rollout window is left as it was",
+                    extra=get_extra_info({**self.default_extra, "error": str(exc)}),
+                ),
+            )
+            return None
+
+    async def observe_executor_rollout(
+        self,
+        executor_digest: str | None,
+        job_block: int,
+        fallback: RolloutWindow | None = None,
+    ) -> RolloutWindow:
+        """DAH-3405: tell the tracker what the registry says now, in cycle `job_block`.
+
+        Called at cycle start (a push between cycles) and again at cycle end (a push during the
+        cycle — the 11 Sep case) with the start's window as `fallback`. When Redis fails the
+        cycle keeps what it already knew; without that, it behaves as before this change: every
+        failure is a verdict.
+        """
+        try:
+            return await self.rollout_tracker.observe(executor_digest, job_block)
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "[rollout-grace] rollout state unreadable; "
+                    + ("the window seen at cycle start stands" if fallback else "every verdict stands this cycle"),
+                    extra=get_extra_info({**self.default_extra, "error": str(exc)}),
+                ),
+            )
+            if fallback is not None:
+                return fallback
+            return RolloutWindow(
+                digest=executor_digest,
+                previous_digest=None,
+                started_at=None,
+                opened_job_block=None,
+                cycles_seen=0,
+                grace_cycles=0,
+            )
+
+    async def withhold_verdicts_for_rollout(
+        self,
+        all_job_results: dict[str, list[JobResult]],
+        job_block: int,
+        job_batch_id: str,
+        window_at_cycle_start: RolloutWindow,
+    ) -> tuple[dict[str, list[JobResult]], list[tuple[str, JobResult]]]:
+        """DAH-3405: at cycle end, take the results the rollout explains out of the cycle.
+
+        The push that recreates the fleet's containers can land in the middle of a cycle (11 Sep
+        07:50Z did), so the registry is read once more here and the window opens on THIS cycle's
+        results, before scoring and publishing see them.
+        """
+        window = await self.observe_executor_rollout(
+            await self.fetch_executor_digest_or_none(), job_block, fallback=window_at_cycle_start
+        )
+        kept, withheld_results = withhold_rollout_verdicts(all_job_results, window, job_block)
+        await self.record_withheld_verdicts(window, withheld_results, job_batch_id, job_block)
+        return kept, withheld_results
+
+    async def record_withheld_verdicts(
+        self,
+        window: RolloutWindow,
+        withheld_results: list[tuple[str, JobResult]],
+        job_batch_id: str,
+        job_block: int,
+    ) -> None:
+        """DAH-3405: one line per cycle inside the window, and the window's running total."""
+        if not window.covers(job_block):
+            return
+        withheld_count = len(withheld_results)
+        logger.warning(
+            _m(
+                "[rollout-grace] cycle inside the executor image rollout window",
+                extra=get_extra_info(
+                    {
+                        **self.default_extra,
+                        "outcome": ROLLOUT_GRACE,
+                        "job_batch_id": job_batch_id,
+                        "job_block": job_block,
+                        "withheld_executors": withheld_count,
+                        **window.as_extra(),
+                    }
+                ),
+            ),
+        )
+        try:
+            await self.rollout_tracker.record_withheld(withheld_count)
+        except Exception as exc:
+            logger.error(
+                _m(
+                    "[rollout-grace] could not record the withheld count",
+                    extra=get_extra_info({**self.default_extra, "error": str(exc)}),
+                ),
+            )
 
     async def start(self):
         logger.info(

--- a/neurons/validators/src/services/executor_rollout.py
+++ b/neurons/validators/src/services/executor_rollout.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 
 from core.config import settings
@@ -85,6 +85,68 @@ _RUN_ENDED_WITHOUT_FAILING = frozenset(
 
 
 @dataclass(frozen=True)
+class RolloutState:
+    """What Redis remembers between cycles, under `ROLLOUT_STATE_KEY`, as one JSON object.
+
+    `opened_job_block` stays None until a digest change opens a window. `cycles_seen` counts the
+    cycles observed since that change, the opening one included, and `last_job_block` is the cycle
+    the last count was made for. `closed` records that the window-end line was logged, so it is
+    logged once.
+    """
+
+    digest: str | None = None
+    previous_digest: str | None = None
+    started_at: datetime | None = None
+    opened_job_block: int | None = None
+    last_job_block: int | None = None
+    cycles_seen: int = 0
+    withheld: int = 0
+    closed: bool = False
+
+    @classmethod
+    def from_json(cls, raw: str | bytes) -> RolloutState:
+        """Raises ValueError or TypeError on anything this class did not write."""
+        fields = json.loads(raw)
+        if not isinstance(fields, dict):
+            raise ValueError("rollout state is not a JSON object")
+        started_at = fields.get("started_at")
+        opened_job_block = fields.get("opened_job_block")
+        last_job_block = fields.get("last_job_block")
+        return cls(
+            digest=fields.get("digest"),
+            previous_digest=fields.get("previous_digest"),
+            started_at=datetime.fromisoformat(started_at) if started_at else None,
+            opened_job_block=int(opened_job_block) if opened_job_block is not None else None,
+            last_job_block=int(last_job_block) if last_job_block is not None else None,
+            cycles_seen=int(fields.get("cycles_seen", 0)),
+            withheld=int(fields.get("withheld", 0)),
+            closed=bool(fields.get("closed", False)),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "digest": self.digest,
+                "previous_digest": self.previous_digest,
+                "started_at": self.started_at.isoformat() if self.started_at else None,
+                "opened_job_block": self.opened_job_block,
+                "last_job_block": self.last_job_block,
+                "cycles_seen": self.cycles_seen,
+                "withheld": self.withheld,
+                "closed": self.closed,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class WithheldVerdict:
+    """One result the rollout took out of the cycle, with the miner that reported it."""
+
+    miner_hotkey: str
+    result: JobResult
+
+
+@dataclass(frozen=True)
 class RolloutWindow:
     """What the validator knows about the current executor image and its last change.
 
@@ -121,25 +183,24 @@ class RolloutWindow:
 class ExecutorRolloutTracker:
     """Remembers the authorized executor digest, and when and in which cycle it last changed.
 
-    State lives in Redis under `ROLLOUT_STATE_KEY` as one JSON object: `digest`, `previous_digest`,
-    `started_at` (ISO-8601), `opened_job_block`, `last_job_block` and `cycles_seen` (the cycles
-    observed since the change, the opening one included), `withheld` (results withheld so far in
-    this window) and `closed` (the window-end line was logged). A Redis error propagates; the caller decides what
-    a cycle without this knowledge does. An unreadable value is treated as no state and re-seeded.
+    State lives in Redis as a `RolloutState`. A Redis error propagates; the caller decides what a
+    cycle without this knowledge does. An unreadable value is treated as no state and re-seeded.
     With `grace_cycles` 0 the digest is still tracked but no window ever covers a cycle and neither
     window line is logged.
     """
 
     def __init__(self, redis_service: RedisService, grace_cycles: int | None = None):
         self.redis_service = redis_service
-        wanted = settings.EXECUTOR_ROLLOUT_GRACE_CYCLES if grace_cycles is None else grace_cycles
-        self.grace_cycles = min(wanted, MAX_ROLLOUT_GRACE_CYCLES)
-        if wanted > MAX_ROLLOUT_GRACE_CYCLES:
+        configured_grace_cycles = (
+            settings.EXECUTOR_ROLLOUT_GRACE_CYCLES if grace_cycles is None else grace_cycles
+        )
+        self.grace_cycles = min(configured_grace_cycles, MAX_ROLLOUT_GRACE_CYCLES)
+        if configured_grace_cycles > MAX_ROLLOUT_GRACE_CYCLES:
             logger.warning(
                 _m(
                     "[rollout-grace] EXECUTOR_ROLLOUT_GRACE_CYCLES capped: more cycles without a "
                     "published row would trip the backend's 1-hour inactive sweep",
-                    extra={"wanted": wanted, "used": self.grace_cycles},
+                    extra={"wanted": configured_grace_cycles, "used": self.grace_cycles},
                 )
             )
 
@@ -159,125 +220,137 @@ class ExecutorRolloutTracker:
         # The same normalisation the image check applies to what the node reports, so the two
         # sides of the comparison in `rollout_grace_reason` are spelled the same way.
         digest = normalize_sha256_digest(digest)
-        state = await self._load()
-        remembered = state.get("digest")
-        if state.get("opened_job_block") is not None and job_block != state.get("last_job_block"):
-            state = {
-                **state,
-                "last_job_block": job_block,
-                "cycles_seen": int(state.get("cycles_seen", 0)) + 1,
-            }
-            await self._save(state)
-
-        if digest is not None and remembered is None:
-            state = {"digest": digest}
-            await self._save(state)
-        elif (
-            digest is not None
-            and digest != remembered
-            and state.get("opened_job_block") is not None
-            and int(state.get("cycles_seen", 0)) < self.grace_cycles + 2
-        ):
-            # A second push (a hotfix, a rollback) while the window is open or before one uncovered
-            # cycle has published: the new digest is what "current" means from here on, but the
-            # window is NOT reopened or extended — withheld cycles would chain, and three in a row
-            # are what trips the backend's 1-hour inactive sweep.
-            state = {**state, "digest": digest, "previous_digest": remembered}
-            await self._save(state)
-            window = self._window(state)
-            if self.grace_cycles > 0:
-                logger.warning(
-                    _m(
-                        "[rollout-grace] executor image changed again before one cycle after the "
-                        "rollout window has published; the window is not reopened",
-                        extra={"outcome": ROLLOUT_GRACE, "job_block": job_block, **window.as_extra()},
-                    )
-                )
-            return window
-        elif digest is not None and digest != remembered:
-            state = {
-                "digest": digest,
-                "previous_digest": remembered,
-                "started_at": now.isoformat(),
-                "opened_job_block": job_block,
-                "last_job_block": job_block,
-                "cycles_seen": 1,
-                "withheld": 0,
-            }
-            await self._save(state)
-            window = self._window(state)
-            if self.grace_cycles > 0:
-                logger.warning(
-                    _m(
-                        "[rollout-grace] executor image rollout detected; verdicts of executors "
-                        "that fail while restarting are withheld while the window is open",
-                        extra={"outcome": ROLLOUT_GRACE, "job_block": job_block, **window.as_extra()},
-                    )
-                )
-            return window
-
-        window = self._window(state)
-        if (
-            self.grace_cycles > 0
-            and window.opened_job_block is not None
-            and not window.covers(job_block)
-            and not state.get("closed")
-        ):
-            state["closed"] = True
-            await self._save(state)
-            logger.warning(
-                _m(
-                    "[rollout-grace] executor image rollout window ended",
-                    extra={
-                        "outcome": ROLLOUT_GRACE,
-                        "job_block": job_block,
-                        "withheld_total": state.get("withheld", 0),
-                        **window.as_extra(),
-                    },
-                )
-            )
-        return window
+        state = await self._count_this_cycle(await self._load(), job_block)
+        if digest is None or digest == state.digest:
+            return await self._close_the_window_when_it_is_over(state, job_block)
+        return await self._react_to_the_changed_digest(state, digest, job_block, now)
 
     async def record_withheld(self, count: int) -> None:
         """Add this cycle's withheld results to the window's running total."""
         if count <= 0:
             return
         state = await self._load()
-        state["withheld"] = int(state.get("withheld", 0)) + count
-        await self._save(state)
+        await self._save(replace(state, withheld=state.withheld + count))
 
-    def _window(self, state: dict) -> RolloutWindow:
-        started_at = state.get("started_at")
-        opened_job_block = state.get("opened_job_block")
+    async def _count_this_cycle(self, state: RolloutState, job_block: int) -> RolloutState:
+        """Count one more cycle of an open window, the first time this job block is observed.
+
+        The cycle-start and the cycle-end observation of one cycle share a job block, so the
+        second of the two counts nothing.
+        """
+        if state.opened_job_block is None or job_block == state.last_job_block:
+            return state
+        counted = replace(state, last_job_block=job_block, cycles_seen=state.cycles_seen + 1)
+        await self._save(counted)
+        return counted
+
+    async def _react_to_the_changed_digest(
+        self, state: RolloutState, digest: str, job_block: int, now: datetime
+    ) -> RolloutWindow:
+        """Seed the first digest ever seen, open a window on a change, or refuse a second push."""
+        if state.digest is None:
+            seeded = RolloutState(digest=digest)
+            await self._save(seeded)
+            return self._window(seeded)
+
+        if self._a_new_window_may_open(state):
+            opened = RolloutState(
+                digest=digest,
+                previous_digest=state.digest,
+                started_at=now,
+                opened_job_block=job_block,
+                last_job_block=job_block,
+                cycles_seen=1,
+            )
+            await self._save(opened)
+            return self._log_window(
+                "[rollout-grace] executor image rollout detected; verdicts of executors "
+                "that fail while restarting are withheld while the window is open",
+                self._window(opened),
+                job_block,
+            )
+
+        # A second push (a hotfix, a rollback) while the window is open or before one uncovered
+        # cycle has published: the new digest is what "current" means from here on, but the
+        # window is NOT reopened or extended — withheld cycles would chain, and three in a row
+        # are what trips the backend's 1-hour inactive sweep.
+        chained = replace(state, digest=digest, previous_digest=state.digest)
+        await self._save(chained)
+        return self._log_window(
+            "[rollout-grace] executor image changed again before one cycle after the "
+            "rollout window has published; the window is not reopened",
+            self._window(chained),
+            job_block,
+        )
+
+    def _a_new_window_may_open(self, state: RolloutState) -> bool:
+        """True when no window was ever opened, or one uncovered cycle has published since."""
+        return state.opened_job_block is None or state.cycles_seen >= self.grace_cycles + 2
+
+    async def _close_the_window_when_it_is_over(
+        self, state: RolloutState, job_block: int
+    ) -> RolloutWindow:
+        """Log the window-end line on the first cycle the window no longer covers, once."""
+        window = self._window(state)
+        if (
+            self.grace_cycles <= 0
+            or state.opened_job_block is None
+            or state.closed
+            or window.covers(job_block)
+        ):
+            return window
+        await self._save(replace(state, closed=True))
+        logger.warning(
+            _m(
+                "[rollout-grace] executor image rollout window ended",
+                extra={
+                    "outcome": ROLLOUT_GRACE,
+                    "job_block": job_block,
+                    "withheld_total": state.withheld,
+                    **window.as_extra(),
+                },
+            )
+        )
+        return window
+
+    def _log_window(self, message: str, window: RolloutWindow, job_block: int) -> RolloutWindow:
+        """Log one window line and give the window back, so a caller can return in one statement."""
+        if self.grace_cycles > 0:
+            logger.warning(
+                _m(
+                    message,
+                    extra={"outcome": ROLLOUT_GRACE, "job_block": job_block, **window.as_extra()},
+                )
+            )
+        return window
+
+    def _window(self, state: RolloutState) -> RolloutWindow:
         return RolloutWindow(
-            digest=state.get("digest"),
-            previous_digest=state.get("previous_digest"),
-            started_at=datetime.fromisoformat(started_at) if started_at else None,
-            opened_job_block=int(opened_job_block) if opened_job_block is not None else None,
-            cycles_seen=int(state.get("cycles_seen", 0)),
+            digest=state.digest,
+            previous_digest=state.previous_digest,
+            started_at=state.started_at,
+            opened_job_block=state.opened_job_block,
+            cycles_seen=state.cycles_seen,
             grace_cycles=self.grace_cycles,
         )
 
-    async def _load(self) -> dict:
+    async def _load(self) -> RolloutState:
         raw = await self.redis_service.get(ROLLOUT_STATE_KEY)
         if not raw:
-            return {}
+            return RolloutState()
         try:
-            state = json.loads(raw)
-        except ValueError:
-            state = None
-        if not isinstance(state, dict):
+            return RolloutState.from_json(raw)
+        except (ValueError, TypeError):
             logger.error(
                 _m(
-                    "[rollout-grace] rollout state is not a JSON object; starting over",
+                    "[rollout-grace] rollout state is unreadable; starting over",
                     extra={"raw": str(raw)[:200]},
                 )
             )
-            return {}
-        return state
+            return RolloutState()
 
-    async def _save(self, state: dict) -> None:
-        await self.redis_service.set(ROLLOUT_STATE_KEY, json.dumps(state))
+    async def _save(self, state: RolloutState) -> None:
+        await self.redis_service.set(ROLLOUT_STATE_KEY, state.to_json())
 
 
 def _observed_digest(result: JobResult) -> str | None:
@@ -321,27 +394,26 @@ def withhold_rollout_verdicts(
     job_results: dict[str, list[JobResult]],
     window: RolloutWindow,
     job_block: int,
-) -> tuple[dict[str, list[JobResult]], list[tuple[str, JobResult]]]:
+) -> tuple[dict[str, list[JobResult]], list[WithheldVerdict]]:
     """Split a cycle's results into the ones that stand and the ones the rollout withholds.
 
-    Returns the standing results per miner and the withheld ones as (miner_hotkey, result). Every
-    withheld result is logged once with its reason, so Loki can count them
-    (`outcome="ROLLOUT_GRACE"`). Outside the window the input is returned as it is and nothing is
-    logged.
+    Returns the standing results per miner and the withheld ones. Every withheld result is logged
+    once with its reason, so Loki can count them (`outcome="ROLLOUT_GRACE"`). Outside the window
+    the input is returned as it is and nothing is logged.
     """
     if not window.covers(job_block):
         return job_results, []
 
-    kept: dict[str, list[JobResult]] = {}
-    withheld: list[tuple[str, JobResult]] = []
+    standing_by_miner: dict[str, list[JobResult]] = {}
+    withheld: list[WithheldVerdict] = []
     for miner_hotkey, results in job_results.items():
-        standing: list[JobResult] = []
+        standing_results: list[JobResult] = []
         for result in results:
             reason = rollout_grace_reason(result, window, job_block)
             if reason is None:
-                standing.append(result)
+                standing_results.append(result)
                 continue
-            withheld.append((miner_hotkey, result))
+            withheld.append(WithheldVerdict(miner_hotkey=miner_hotkey, result=result))
             logger.warning(
                 _m(
                     "[rollout-grace] verdict withheld: the executor failed during a known "
@@ -358,5 +430,5 @@ def withhold_rollout_verdicts(
                     },
                 )
             )
-        kept[miner_hotkey] = standing
-    return kept, withheld
+        standing_by_miner[miner_hotkey] = standing_results
+    return standing_by_miner, withheld

--- a/neurons/validators/src/services/executor_rollout.py
+++ b/neurons/validators/src/services/executor_rollout.py
@@ -52,8 +52,9 @@ ROLLOUT_GRACE = "ROLLOUT_GRACE"
 # an executor's publishes is three cycle periods plus the duration of the next scored cycle minus
 # the duration of the last one: about 2700 + 850 s (JOB_TIME_OUT − 50) = 3550 s while cycles keep
 # their 15-minute cadence (job blocks 75 × 12 s apart) — a lower bound, since a cycle that runs
-# past 900 s delays the next start. A third withheld cycle puts the gap past the hour in every
-# case, and the hourly sweep catches it whenever it runs inside the excess. A new window may open
+# past 900 s delays the next start. A third withheld cycle puts the gap past the hour whenever
+# the next scored cycle is not shorter than the last (3600 s + d_next − d_last), and the hourly
+# sweep catches it whenever it runs inside the excess, so the cap stays at 2. A new window may open
 # only once one uncovered cycle has published (`cycles_seen >= grace_cycles + 2`), so two pushes
 # back to back cannot chain windows either.
 MAX_ROLLOUT_GRACE_CYCLES = 2
@@ -368,7 +369,10 @@ def rollout_grace_reason(result: JobResult, window: RolloutWindow, job_block: in
     it ended without failing — the rented halt or finalize — with score 0 and the image check had
     read OUTDATED: a rented executor's image check passes, so the run halts as RENTED instead of
     failing), and, for every reason but OUTDATED, the executor's observed image is not the new
-    digest. An executor that already runs
+    digest. The OUTDATED-without-failing case counts only while `EXECUTOR_IMAGE_CHECK_ENFORCE` is
+    on: off (the default since DAH-3439), the image check passes an OUTDATED node and leaves its
+    score alone, so a score of 0 under an OUTDATED report came from another gate (price cap, TDX,
+    collateral) and stands. An executor that already runs
     the new image failed for a reason of its own; a rented executor that failed a later check of
     its own (pod not running, filler killed) failed for that reason, OUTDATED or not; and a result
     with a score is never touched.
@@ -378,7 +382,10 @@ def rollout_grace_reason(result: JobResult, window: RolloutWindow, job_block: in
     reason = result.failure_reason_code
     if reason not in ROLLOUT_FAILURE_REASONS:
         ended_without_failing = reason in _RUN_ENDED_WITHOUT_FAILING
-        outdated = (result.executor_image_report or {}).get("status") == ImageVerdict.OUTDATED.value
+        outdated = (
+            settings.EXECUTOR_IMAGE_CHECK_ENFORCE
+            and (result.executor_image_report or {}).get("status") == ImageVerdict.OUTDATED.value
+        )
         if not (ended_without_failing and outdated):
             return None
         reason = _OUTDATED

--- a/neurons/validators/src/services/executor_rollout.py
+++ b/neurons/validators/src/services/executor_rollout.py
@@ -1,0 +1,362 @@
+"""DAH-3405: no verdict for an executor that fails during a known executor-image rollout.
+
+11 Sep 2026, 07:50–08:00Z: executor-v1.126 was pushed to Docker Hub in the middle of a validation
+cycle. Watchtower on every standard node pulled it and recreated the executor container while the
+validator's SSH sessions were inside it. Rustam's cycle log for that cycle: 168 transport-unreachable,
+51 scrape-failed and 50 insufficient-ports rows, plus 70 EXECUTOR_IMAGE_OUTDATED rows against a
+normal background of ~31 (rows, not distinct executors); tsdb prod_executors: 506 of 514 executors
+at 0 against 161 of 517 the cycle before. None of those were verdicts about the machines.
+
+The validator learns about a release from the same place watchtower does: the registry digest of
+EXECUTOR_IMAGE_REF. `ExecutorRolloutTracker` remembers the moment that digest changed and the cycle
+it was seen in (in Redis, so a restart inside the window keeps it). For that cycle and the next
+(`EXECUTOR_ROLLOUT_GRACE_CYCLES`, counted by the cycle's job block, never by the clock)
+`withhold_rollout_verdicts` takes out of the cycle every result whose failure is one a rollout
+produces and whose executor is not yet on the new image. A withheld result is neither scored nor
+published: the backend keeps the previous cycle's row, the weights are computed without it. A
+failure on an executor that already runs the new image, any failure outside the set, and every
+result after the window stand exactly as before.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from core.config import settings
+from core.utils import _m
+from services.executor_image_policy import ImageVerdict, normalize_sha256_digest
+from services.redis_service import RedisService
+from services.task.availability import AvailabilityErrorCode
+from services.task.checks.executor_image import observed_executor_digest
+from services.task.messages import (
+    ExecutorImageMessages,
+    FinalizeMessages,
+    MachineSpecMessages,
+    PortCountMessages,
+    RentalVerificationMessages,
+    TenantEnforcementMessages,
+    UploadFilesMessages,
+)
+from services.task.models import JobResult
+
+logger = logging.getLogger(__name__)
+
+ROLLOUT_STATE_KEY = "executor_image_rollout"
+ROLLOUT_GRACE = "ROLLOUT_GRACE"
+# A withheld executor publishes nothing, and the backend marks an executor inactive (with the
+# EXECUTOR_INACTIVE_MID_RENTAL penalty) when its row was not updated for 1 h (lium-io-backend
+# apps/server/src/worker.py, check_and_update_executors). With two withheld cycles the gap between
+# an executor's publishes is three cycle periods plus the duration of the next scored cycle minus
+# the duration of the last one: about 2700 + 850 s (JOB_TIME_OUT − 50) = 3550 s while cycles keep
+# their 15-minute cadence (job blocks 75 × 12 s apart) — a lower bound, since a cycle that runs
+# past 900 s delays the next start. A third withheld cycle puts the gap past the hour in every
+# case, and the hourly sweep catches it whenever it runs inside the excess. A new window may open
+# only once one uncovered cycle has published (`cycles_seen >= grace_cycles + 2`), so two pushes
+# back to back cannot chain windows either.
+MAX_ROLLOUT_GRACE_CYCLES = 2
+
+# What a watchtower container recreate makes a running validation look like, in the order the
+# pipeline meets them: the connect never opens; the shell dies under the upload, under a check
+# that lets asyncssh raise, or under the filler liveness read; the scrape that ran inside the old
+# container returns nothing; the connectivity probe cannot verify the ports of a container being
+# replaced; and an executor that has not pulled yet (or a validator whose snapshot predates the
+# push) reads OUTDATED.
+ROLLOUT_FAILURE_REASONS = frozenset(
+    {
+        AvailabilityErrorCode.EXECUTOR_SSH_UNREACHABLE.value,
+        UploadFilesMessages.UPLOAD_FAILED.reason,
+        TenantEnforcementMessages.EXECUTOR_TRANSPORT_UNREACHABLE.reason,
+        RentalVerificationMessages.FILLER_TRANSPORT_UNREACHABLE.reason,
+        MachineSpecMessages.SCRAPE_FAILED.reason,
+        PortCountMessages.INSUFFICIENT_PORTS.reason,
+        ExecutorImageMessages.OUTDATED.reason,
+    }
+)
+_OUTDATED = ExecutorImageMessages.OUTDATED.reason
+# The two ways a run ends with score 0 and the OUTDATED report attached instead of failing at the
+# image check: a rented executor's image check passes and the tenant-enforcement halt ends the run
+# (RENTED); a run that reaches finalize ends on VALIDATION_COMPLETED.
+_RUN_ENDED_WITHOUT_FAILING = frozenset(
+    {FinalizeMessages.COMPLETED.reason, TenantEnforcementMessages.ALREADY_RENTED.reason}
+)
+
+
+@dataclass(frozen=True)
+class RolloutWindow:
+    """What the validator knows about the current executor image and its last change.
+
+    `opened_job_block` is the job block of the cycle in which the change was seen; `cycles_seen` is
+    how many distinct cycles (that one included) the tracker has been told about since. The window
+    covers a cycle while `cycles_seen <= grace_cycles`. Cycles are counted as the validator runs
+    them, so a long cycle, a slow clock or a cycle that lands two job blocks later cannot stretch or
+    shorten the window.
+    """
+
+    digest: str | None
+    previous_digest: str | None
+    started_at: datetime | None
+    opened_job_block: int | None
+    cycles_seen: int
+    grace_cycles: int
+
+    def covers(self, job_block: int) -> bool:
+        if self.grace_cycles <= 0 or self.opened_job_block is None:
+            return False
+        return job_block >= self.opened_job_block and 0 < self.cycles_seen <= self.grace_cycles
+
+    def as_extra(self) -> dict[str, object]:
+        return {
+            "rollout_digest": self.digest,
+            "rollout_previous_digest": self.previous_digest,
+            "rollout_started_at": self.started_at.isoformat() if self.started_at else None,
+            "rollout_opened_job_block": self.opened_job_block,
+            "rollout_cycles_seen": self.cycles_seen,
+            "rollout_grace_cycles": self.grace_cycles,
+        }
+
+
+class ExecutorRolloutTracker:
+    """Remembers the authorized executor digest, and when and in which cycle it last changed.
+
+    State lives in Redis under `ROLLOUT_STATE_KEY` as one JSON object: `digest`, `previous_digest`,
+    `started_at` (ISO-8601), `opened_job_block`, `last_job_block` and `cycles_seen` (the cycles
+    observed since the change, the opening one included), `withheld` (results withheld so far in
+    this window) and `closed` (the window-end line was logged). A Redis error propagates; the caller decides what
+    a cycle without this knowledge does. An unreadable value is treated as no state and re-seeded.
+    With `grace_cycles` 0 the digest is still tracked but no window ever covers a cycle and neither
+    window line is logged.
+    """
+
+    def __init__(self, redis_service: RedisService, grace_cycles: int | None = None):
+        self.redis_service = redis_service
+        wanted = settings.EXECUTOR_ROLLOUT_GRACE_CYCLES if grace_cycles is None else grace_cycles
+        self.grace_cycles = min(wanted, MAX_ROLLOUT_GRACE_CYCLES)
+        if wanted > MAX_ROLLOUT_GRACE_CYCLES:
+            logger.warning(
+                _m(
+                    "[rollout-grace] EXECUTOR_ROLLOUT_GRACE_CYCLES capped: more cycles without a "
+                    "published row would trip the backend's 1-hour inactive sweep",
+                    extra={"wanted": wanted, "used": self.grace_cycles},
+                )
+            )
+
+    async def observe(
+        self, digest: str | None, job_block: int, now: datetime | None = None
+    ) -> RolloutWindow:
+        """Compare the digest fetched now with the one remembered; open a window on a change.
+
+        `job_block` is the current cycle's job block (the one its `job_batch_id` was derived from);
+        a job block not seen before counts as one more cycle of an open window. `None` for the
+        digest (the registry could not be read) changes nothing else: the window the validator
+        already knows about stays as it is. The first digest ever seen opens no window —
+        there is nothing to compare it with, and a window on every fresh Redis would grace every
+        failure after a redeploy.
+        """
+        now = now or datetime.now(UTC)
+        # The same normalisation the image check applies to what the node reports, so the two
+        # sides of the comparison in `rollout_grace_reason` are spelled the same way.
+        digest = normalize_sha256_digest(digest)
+        state = await self._load()
+        remembered = state.get("digest")
+        if state.get("opened_job_block") is not None and job_block != state.get("last_job_block"):
+            state = {
+                **state,
+                "last_job_block": job_block,
+                "cycles_seen": int(state.get("cycles_seen", 0)) + 1,
+            }
+            await self._save(state)
+
+        if digest is not None and remembered is None:
+            state = {"digest": digest}
+            await self._save(state)
+        elif (
+            digest is not None
+            and digest != remembered
+            and state.get("opened_job_block") is not None
+            and int(state.get("cycles_seen", 0)) < self.grace_cycles + 2
+        ):
+            # A second push (a hotfix, a rollback) while the window is open or before one uncovered
+            # cycle has published: the new digest is what "current" means from here on, but the
+            # window is NOT reopened or extended — withheld cycles would chain, and three in a row
+            # are what trips the backend's 1-hour inactive sweep.
+            state = {**state, "digest": digest, "previous_digest": remembered}
+            await self._save(state)
+            window = self._window(state)
+            if self.grace_cycles > 0:
+                logger.warning(
+                    _m(
+                        "[rollout-grace] executor image changed again before one cycle after the "
+                        "rollout window has published; the window is not reopened",
+                        extra={"outcome": ROLLOUT_GRACE, "job_block": job_block, **window.as_extra()},
+                    )
+                )
+            return window
+        elif digest is not None and digest != remembered:
+            state = {
+                "digest": digest,
+                "previous_digest": remembered,
+                "started_at": now.isoformat(),
+                "opened_job_block": job_block,
+                "last_job_block": job_block,
+                "cycles_seen": 1,
+                "withheld": 0,
+            }
+            await self._save(state)
+            window = self._window(state)
+            if self.grace_cycles > 0:
+                logger.warning(
+                    _m(
+                        "[rollout-grace] executor image rollout detected; verdicts of executors "
+                        "that fail while restarting are withheld while the window is open",
+                        extra={"outcome": ROLLOUT_GRACE, "job_block": job_block, **window.as_extra()},
+                    )
+                )
+            return window
+
+        window = self._window(state)
+        if (
+            self.grace_cycles > 0
+            and window.opened_job_block is not None
+            and not window.covers(job_block)
+            and not state.get("closed")
+        ):
+            state["closed"] = True
+            await self._save(state)
+            logger.warning(
+                _m(
+                    "[rollout-grace] executor image rollout window ended",
+                    extra={
+                        "outcome": ROLLOUT_GRACE,
+                        "job_block": job_block,
+                        "withheld_total": state.get("withheld", 0),
+                        **window.as_extra(),
+                    },
+                )
+            )
+        return window
+
+    async def record_withheld(self, count: int) -> None:
+        """Add this cycle's withheld results to the window's running total."""
+        if count <= 0:
+            return
+        state = await self._load()
+        state["withheld"] = int(state.get("withheld", 0)) + count
+        await self._save(state)
+
+    def _window(self, state: dict) -> RolloutWindow:
+        started_at = state.get("started_at")
+        opened_job_block = state.get("opened_job_block")
+        return RolloutWindow(
+            digest=state.get("digest"),
+            previous_digest=state.get("previous_digest"),
+            started_at=datetime.fromisoformat(started_at) if started_at else None,
+            opened_job_block=int(opened_job_block) if opened_job_block is not None else None,
+            cycles_seen=int(state.get("cycles_seen", 0)),
+            grace_cycles=self.grace_cycles,
+        )
+
+    async def _load(self) -> dict:
+        raw = await self.redis_service.get(ROLLOUT_STATE_KEY)
+        if not raw:
+            return {}
+        try:
+            state = json.loads(raw)
+        except ValueError:
+            state = None
+        if not isinstance(state, dict):
+            logger.error(
+                _m(
+                    "[rollout-grace] rollout state is not a JSON object; starting over",
+                    extra={"raw": str(raw)[:200]},
+                )
+            )
+            return {}
+        return state
+
+    async def _save(self, state: dict) -> None:
+        await self.redis_service.set(ROLLOUT_STATE_KEY, json.dumps(state))
+
+
+def _observed_digest(result: JobResult) -> str | None:
+    report = result.executor_image_report or {}
+    observed = report.get("observed_digest")
+    if observed:
+        return str(observed)
+    return observed_executor_digest(result.spec or {})
+
+
+def rollout_grace_reason(result: JobResult, window: RolloutWindow, job_block: int) -> str | None:
+    """The reason code this result's verdict is withheld for, or None when the verdict stands.
+
+    Withheld: the window covers this cycle, the run ended on one of `ROLLOUT_FAILURE_REASONS` (or
+    it ended without failing — the rented halt or finalize — with score 0 and the image check had
+    read OUTDATED: a rented executor's image check passes, so the run halts as RENTED instead of
+    failing), and, for every reason but OUTDATED, the executor's observed image is not the new
+    digest. An executor that already runs
+    the new image failed for a reason of its own; a rented executor that failed a later check of
+    its own (pod not running, filler killed) failed for that reason, OUTDATED or not; and a result
+    with a score is never touched.
+    """
+    if not window.covers(job_block) or result.score > 0:
+        return None
+    reason = result.failure_reason_code
+    if reason not in ROLLOUT_FAILURE_REASONS:
+        ended_without_failing = reason in _RUN_ENDED_WITHOUT_FAILING
+        outdated = (result.executor_image_report or {}).get("status") == ImageVerdict.OUTDATED.value
+        if not (ended_without_failing and outdated):
+            return None
+        reason = _OUTDATED
+    # OUTDATED is withheld whatever the observed digest says: old = not pulled yet, new = the
+    # validator's own snapshot predated the push. Every other reason on an executor that already
+    # runs the new image is that executor's own failure.
+    if reason != _OUTDATED and _observed_digest(result) == window.digest:
+        return None
+    return reason
+
+
+def withhold_rollout_verdicts(
+    job_results: dict[str, list[JobResult]],
+    window: RolloutWindow,
+    job_block: int,
+) -> tuple[dict[str, list[JobResult]], list[tuple[str, JobResult]]]:
+    """Split a cycle's results into the ones that stand and the ones the rollout withholds.
+
+    Returns the standing results per miner and the withheld ones as (miner_hotkey, result). Every
+    withheld result is logged once with its reason, so Loki can count them
+    (`outcome="ROLLOUT_GRACE"`). Outside the window the input is returned as it is and nothing is
+    logged.
+    """
+    if not window.covers(job_block):
+        return job_results, []
+
+    kept: dict[str, list[JobResult]] = {}
+    withheld: list[tuple[str, JobResult]] = []
+    for miner_hotkey, results in job_results.items():
+        standing: list[JobResult] = []
+        for result in results:
+            reason = rollout_grace_reason(result, window, job_block)
+            if reason is None:
+                standing.append(result)
+                continue
+            withheld.append((miner_hotkey, result))
+            logger.warning(
+                _m(
+                    "[rollout-grace] verdict withheld: the executor failed during a known "
+                    "executor-image rollout; no score is written this cycle",
+                    extra={
+                        "outcome": ROLLOUT_GRACE,
+                        "miner_hotkey": miner_hotkey,
+                        "executor_uuid": result.executor_info.uuid,
+                        "job_batch_id": result.job_batch_id,
+                        "job_block": job_block,
+                        "reason_code": reason,
+                        "observed_digest": _observed_digest(result),
+                        **window.as_extra(),
+                    },
+                )
+            )
+        kept[miner_hotkey] = standing
+    return kept, withheld

--- a/neurons/validators/src/services/task/models.py
+++ b/neurons/validators/src/services/task/models.py
@@ -79,6 +79,12 @@ class JobResult(BaseModel):
     # rather than re-listing a node nobody tested.
     availability_errors: list[dict[str, Any]] | None = None
 
+    # DAH-3405: the reason code of the event that ended a run without a score (the failed
+    # check's, the finalize or rented halt event's, or EXECUTOR_SSH_UNREACHABLE when the connect
+    # itself failed). None on a scored run and on an error no check produced. Read by the
+    # rollout-grace classifier at the end of the cycle.
+    failure_reason_code: str | None = None
+
     # Incentive relevant fields
     mining_score: float | None = None                   # Score for mining pool for scoring logic
     sysbox_multiplier: float | None = None              # Multiplier for sysbox runtime for scoring logic

--- a/neurons/validators/src/services/task/service.py
+++ b/neurons/validators/src/services/task/service.py
@@ -24,6 +24,7 @@ from core.utils import _m, get_extra_info
 from services.ssh_service import SSHService
 
 from .availability import availability_errors, build_ssh_unreachable_event
+from .messages import TenantEnforcementMessages
 from .models import JobResult
 from .pipeline import PodRecoverer
 from .pipeline_factory import PipelineFactory
@@ -216,9 +217,15 @@ class TaskService:
                 result.availability_errors = [
                     error.model_dump(mode="json") for error in availability_errors(events)
                 ]
+                # DAH-3405: the last event is the one that ended the run — the failed fatal check,
+                # the finalize event of a run that completed without a score, or the rented halt
+                # (success=True, score 0 when the image is OUTDATED).
+                if not success or result.score <= 0:
+                    result.failure_reason_code = last_event.reason_code
                 return result
 
         except Exception as e:
+            failure_reason_code = None
             # DAH-2748: SSH we could not open is an availability error, not a verdict on the
             # machine. One is enough to hide the node until a cycle succeeds.
             if is_opening_ssh_connection and _is_ssh_transport_failure(e):
@@ -230,7 +237,17 @@ class TaskService:
                 )
                 log_text = _m(event.event, extra=event.model_dump())
                 availability_problems = [error.model_dump(mode="json") for error in availability_errors([event])]
+                failure_reason_code = event.reason_code
             else:
+                # DAH-3405: a shell that died under a check that lets asyncssh raise (a watchtower
+                # recreate mid-run) ends here; name it the way the rented-machine check names the
+                # same death so the rollout classifier sees it. Not an availability error: the
+                # connect succeeded, and the code says nothing about the machine's own sshd. Any
+                # OSError after the connect takes the name too (an aiohttp connection error from a
+                # backend call included): inside a rollout window that withholds a verdict for two
+                # cycles at most, outside it the name changes nothing.
+                if has_reached_the_node and _is_ssh_transport_failure(e):
+                    failure_reason_code = TenantEnforcementMessages.EXECUTOR_TRANSPORT_UNREACHABLE.reason
                 log_text = _m(
                     "Pipeline validation error",
                     extra=get_extra_info({
@@ -265,6 +282,7 @@ class TaskService:
                 tee_type=tee_type,
                 gpu_attestation_passed=gpu_attestation_passed,
                 availability_errors=availability_problems,
+                failure_reason_code=failure_reason_code,
             )
 
 

--- a/neurons/validators/tests/test_executor_rollout_grace.py
+++ b/neurons/validators/tests/test_executor_rollout_grace.py
@@ -1,0 +1,664 @@
+"""DAH-3405: an executor that fails during a known executor-image rollout gets no verdict, not a 0.
+
+11 Sep 2026 07:50–08:00Z: executor-v1.126 was pushed mid-cycle, watchtower recreated the executor
+containers under the validator's SSH sessions, and the cycle read the fleet as 168 transport-unreachable,
+51 scrape-failed, 50 insufficient-ports and 70 EXECUTOR_IMAGE_OUTDATED rows (Rustam's cycle log; tsdb:
+506 of 514 executors at 0). Each test below names the regression that would bring one of those zeros back.
+"""
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import asyncssh
+import pytest
+from core.validator import Validator
+from datura.requests.miner_requests import ExecutorSSHInfo
+from payload_models.payloads import MinerJobRequestPayload
+from services.attestation_service import HostPolicyResult
+from services.executor_image_policy import ExecutorImageReport, ImageVerdict
+from services.executor_rollout import (
+    ROLLOUT_STATE_KEY,
+    ExecutorRolloutTracker,
+    RolloutWindow,
+    rollout_grace_reason,
+    withhold_rollout_verdicts,
+)
+from services.task import service as task_service_module
+from services.task.models import JobResult, build_msg
+from services.task.pipeline import ContextState
+from services.task.service import TaskService
+
+from helpers import make_context
+
+OLD = "sha256:" + "a" * 64
+NEW = "sha256:" + "b" * 64
+T0 = datetime(2026, 9, 11, 7, 50, tzinfo=UTC)
+BPC = 75  # blocks per cycle, what BLOCKS_FOR_JOB is in production
+J0 = 7500  # job block of the cycle in which the change is seen
+J1, J2 = J0 + BPC, J0 + 2 * BPC
+
+
+class _FakeRedis:
+    """The two RedisService calls the tracker makes, over a dict that outlives a tracker."""
+
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+
+    async def get(self, key: str) -> str | None:
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str) -> None:
+        self.store[key] = value
+
+
+def _tracker(redis: _FakeRedis, grace_cycles: int = 2) -> ExecutorRolloutTracker:
+    return ExecutorRolloutTracker(redis_service=redis, grace_cycles=grace_cycles)
+
+
+def _open_window(cycles_seen: int = 1, grace_cycles: int = 2) -> RolloutWindow:
+    """The window as the tracker reports it in the cycle the change was seen (cycles_seen=1)."""
+    return RolloutWindow(
+        digest=NEW,
+        previous_digest=OLD,
+        started_at=T0,
+        opened_job_block=J0,
+        cycles_seen=cycles_seen,
+        grace_cycles=grace_cycles,
+    )
+
+
+def _executor(uuid: str) -> ExecutorSSHInfo:
+    return ExecutorSSHInfo(
+        uuid=uuid,
+        address="203.0.113.5",
+        port=8080,
+        ssh_username="root",
+        ssh_port=2200,
+        python_path="/usr/bin/python3",
+        root_dir="/root/app",
+    )
+
+
+def _failed(
+    uuid: str,
+    reason: str | None,
+    *,
+    observed_digest: str | None = None,
+    image_status: str | None = None,
+) -> JobResult:
+    """A result the way TaskService builds one for a run that ended without a score."""
+    spec = None
+    report = None
+    if observed_digest is not None or image_status is not None:
+        spec = {
+            "docker": {
+                "container_id": "c1",
+                "containers": [{"container_id": "c1", "name": "executor-executor-1", "digest": observed_digest}],
+            }
+        }
+    if image_status is not None:
+        report = {
+            "status": image_status,
+            "observed_digest": observed_digest,
+            "expected_ref": "daturaai/compute-subnet-executor:latest",
+            "expected_digest": NEW,
+        }
+    return JobResult(
+        spec=spec,
+        executor_info=_executor(uuid),
+        score=0,
+        job_score=0,
+        job_batch_id="batch-1",
+        log_status="error",
+        log_text="x",
+        failure_reason_code=reason,
+        executor_image_report=report,
+    )
+
+
+def _scored(uuid: str) -> JobResult:
+    return JobResult(
+        spec={},
+        executor_info=_executor(uuid),
+        score=1.0,
+        job_score=1.0,
+        job_batch_id="batch-1",
+        log_status="info",
+        log_text="ok",
+        gpu_model="H100",
+        gpu_count=8,
+    )
+
+
+# --- the tracker: when is a rollout "known"? -------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_digest_change_opens_the_window_and_the_first_digest_does_not() -> None:
+    """Regression: a window on the first digest a fresh Redis sees would grace every failure
+    after each redeploy; no window on a change would zero the fleet again on the next release."""
+    redis = _FakeRedis()
+    tracker = _tracker(redis)
+
+    first = await tracker.observe(OLD, J0 - BPC, now=T0)
+    assert first.covers(J0 - BPC) is False
+    assert first.digest == OLD
+
+    unchanged = await tracker.observe(OLD, J0 - BPC, now=T0 + timedelta(minutes=15))
+    assert unchanged.covers(J0 - BPC) is False
+    assert unchanged.opened_job_block is None
+
+    opened = await tracker.observe(NEW, J0, now=T0 + timedelta(minutes=20))
+    assert opened.digest == NEW
+    assert opened.previous_digest == OLD
+    assert opened.started_at == T0 + timedelta(minutes=20)
+    assert opened.opened_job_block == J0
+    assert opened.covers(J0) is True
+
+
+@pytest.mark.asyncio
+async def test_a_push_during_the_cycle_covers_that_same_cycle() -> None:
+    """The 11 Sep case: the cycle started on the old digest and the push landed while its jobs
+    ran. Regression: a window that opens only at the next cycle start leaves this cycle's
+    failures — the ones the push caused — as zeros."""
+    redis = _FakeRedis()
+    tracker = _tracker(redis)
+    await tracker.observe(OLD, J0 - BPC, now=T0)
+    at_start = await tracker.observe(OLD, J0, now=T0)
+    assert at_start.covers(J0) is False
+
+    at_end = await tracker.observe(NEW, J0, now=T0 + timedelta(minutes=10))
+
+    assert at_end.opened_job_block == J0
+    assert at_end.cycles_seen == 1
+    assert at_end.covers(J0) is True
+
+
+@pytest.mark.asyncio
+async def test_the_window_covers_the_observing_cycle_and_the_next_whatever_the_clock_says() -> None:
+    """Regression: a window measured in seconds at cycle end — a 13-minute cycle after a 2-minute
+    one lands outside it — or in job blocks: a cycle that starts late in its block window and runs
+    long makes the next one land two job blocks later (`sync` starts a cycle on the first 12-s tick
+    at ≥ 75 blocks since the last), and that cycle would fall outside a block-arithmetic window.
+    Cycles are counted as the validator observes them; the third one is not covered, whatever the
+    clock or the block says, because a third withheld cycle trips the backend's 1-hour sweep."""
+    redis = _FakeRedis()
+    await _tracker(redis).observe(OLD, J0 - BPC, now=T0)
+    opened = await _tracker(redis).observe(NEW, J0, now=T0)
+    # the cycle-end observation of the same cycle is the same cycle
+    same_cycle = await _tracker(redis).observe(NEW, J0, now=T0 + timedelta(minutes=14))
+    assert same_cycle.cycles_seen == 1
+
+    after_restart = _tracker(redis)
+    next_cycle = await after_restart.observe(NEW, J2, now=T0 + timedelta(hours=3))  # landed two blocks on
+    assert next_cycle.opened_job_block == J0
+    assert next_cycle.cycles_seen == 2
+    assert next_cycle.covers(J2) is True
+
+    third_cycle = await after_restart.observe(NEW, J2 + BPC, now=T0 + timedelta(minutes=16))
+    assert third_cycle.covers(J2 + BPC) is False
+    assert opened.covers(J0 - BPC) is False  # a cycle before the change is never covered
+    assert json.loads(redis.store[ROLLOUT_STATE_KEY])["closed"] is True
+
+
+@pytest.mark.asyncio
+async def test_a_second_push_inside_the_window_does_not_extend_it() -> None:
+    """Regression: a hotfix or rollback pushed while the fleet is still restarting for the first
+    image reopens the window at the new cycle — three cycles withheld in a row, and the backend's
+    1-hour inactive sweep marks the old-image fleet inactive with EXECUTOR_INACTIVE_MID_RENTAL.
+    The new digest becomes "current"; the window keeps its opening cycle and its count."""
+    hotfix = "sha256:" + "c" * 64
+    redis = _FakeRedis()
+    tracker = _tracker(redis)
+    await tracker.observe(OLD, J0 - BPC, now=T0)
+    await tracker.observe(NEW, J0, now=T0)
+    await tracker.record_withheld(200)
+
+    window = await tracker.observe(hotfix, J1, now=T0 + timedelta(minutes=15))
+    assert window.digest == hotfix
+    assert window.previous_digest == NEW
+    assert window.opened_job_block == J0
+    assert window.covers(J1) is True
+    assert json.loads(redis.store[ROLLOUT_STATE_KEY])["withheld"] == 200
+
+    third_cycle = await tracker.observe(hotfix, J2, now=T0 + timedelta(minutes=30))
+    assert third_cycle.covers(J2) is False
+
+
+@pytest.mark.asyncio
+async def test_a_push_right_after_the_window_closes_does_not_chain_a_second_window() -> None:
+    """Regression: a change seen in the first cycle after the window closed opens a fresh window —
+    an unreachable or OUTDATED executor is withheld four cycles in a row (J0..J3), over an hour
+    without a published row, and the backend's inactive sweep fires. One cycle must publish in
+    between; a change seen one cycle later does open a new window."""
+    hotfix = "sha256:" + "c" * 64
+    redis = _FakeRedis()
+    tracker = _tracker(redis)
+    await tracker.observe(OLD, J0 - BPC, now=T0)
+    await tracker.observe(NEW, J0, now=T0)
+    await tracker.observe(NEW, J1, now=T0)
+    closed = await tracker.observe(NEW, J2, now=T0)
+    assert closed.covers(J2) is False
+
+    too_soon = await tracker.observe(hotfix, J2, now=T0)
+    assert too_soon.digest == hotfix
+    assert too_soon.covers(J2) is False
+
+    late_enough = await tracker.observe("sha256:" + "d" * 64, J2 + BPC, now=T0)
+    assert late_enough.opened_job_block == J2 + BPC
+    assert late_enough.covers(J2 + BPC) is True
+
+
+def test_more_than_two_cycles_are_refused_because_of_the_backend_inactive_sweep() -> None:
+    """Regression: an operator setting 4 cycles — the withheld executors' rows go unrefreshed for
+    more than an hour and lium-io-backend's check_and_update_executors marks them inactive with
+    EXECUTOR_INACTIVE_MID_RENTAL, the penalty the ticket counts."""
+    tracker = ExecutorRolloutTracker(redis_service=_FakeRedis(), grace_cycles=4)
+
+    assert tracker.grace_cycles == 2
+
+
+@pytest.mark.asyncio
+async def test_a_registry_outage_keeps_the_window_as_it_was() -> None:
+    """Regression: reading `None` as "the digest changed" would open a window on every Docker
+    Hub hiccup; reading it as "no rollout" would close a real one halfway."""
+    redis = _FakeRedis()
+    tracker = _tracker(redis)
+    await tracker.observe(OLD, J0 - BPC, now=T0)
+    await tracker.observe(NEW, J0, now=T0)
+
+    window = await tracker.observe(None, J1, now=T0 + timedelta(minutes=15))
+
+    assert window.digest == NEW
+    assert window.opened_job_block == J0
+    assert window.covers(J1) is True
+
+
+@pytest.mark.asyncio
+async def test_the_withheld_total_accumulates_across_the_cycles_of_one_window() -> None:
+    """Regression: a per-cycle count that overwrites the last one makes the window-end line
+    report only the final cycle."""
+    redis = _FakeRedis()
+    tracker = _tracker(redis)
+    await tracker.observe(OLD, J0 - BPC, now=T0)
+    await tracker.observe(NEW, J0, now=T0)
+
+    await tracker.record_withheld(200)
+    await tracker.record_withheld(0)
+    await tracker.record_withheld(39)
+
+    assert json.loads(redis.store[ROLLOUT_STATE_KEY])["withheld"] == 239
+
+
+@pytest.mark.asyncio
+async def test_a_corrupt_redis_value_is_replaced_instead_of_failing_every_cycle() -> None:
+    """Regression: one bad write leaves `json.loads` raising on every observe, so the fail-open
+    path runs forever and no rollout is ever known again until someone deletes the key."""
+    for corrupt in ("{not json", "[1, 2]"):
+        redis = _FakeRedis()
+        redis.store[ROLLOUT_STATE_KEY] = corrupt
+        tracker = _tracker(redis)
+
+        window = await tracker.observe(OLD, J0, now=T0)
+
+        assert window.digest == OLD
+        assert json.loads(redis.store[ROLLOUT_STATE_KEY]) == {"digest": OLD}
+
+
+@pytest.mark.asyncio
+async def test_zero_grace_cycles_never_cover_a_cycle(caplog) -> None:
+    """Regression: the operator's off switch (EXECUTOR_ROLLOUT_GRACE_CYCLES=0) must mean today's
+    behaviour — no cycle covered, not even the observing one, and no window lines in the log
+    that would make an operator look for verdicts that were never withheld."""
+    redis = _FakeRedis()
+    tracker = _tracker(redis, grace_cycles=0)
+    await tracker.observe(OLD, J0 - BPC, now=T0)
+
+    with caplog.at_level("WARNING", logger="services.executor_rollout"):
+        window = await tracker.observe(NEW, J0, now=T0)
+        again = await tracker.observe("sha256:" + "c" * 64, J1, now=T0)
+
+    assert window.opened_job_block == J0
+    assert window.covers(J0) is False
+    assert again.covers(J1) is False
+    assert "[rollout-grace]" not in caplog.text
+
+
+# --- the classifier: which results does a rollout explain? ------------------------------------
+
+
+def test_an_unreachable_executor_inside_the_window_gets_no_verdict() -> None:
+    """The transport-unreachable rows of 11 Sep: the connect failed, nothing about the image is
+    known, the digest just changed — no score is written."""
+    unreachable = _failed("node-1", "EXECUTOR_SSH_UNREACHABLE")
+    healthy = _scored("node-2")
+    window = _open_window()
+
+    kept, withheld = withhold_rollout_verdicts({"5Miner": [unreachable, healthy]}, window, J0)
+
+    assert kept == {"5Miner": [healthy]}
+    assert [(hk, r.executor_info.uuid) for hk, r in withheld] == [("5Miner", "node-1")]
+
+
+def test_the_same_failure_after_the_window_is_a_zero_as_today() -> None:
+    """Regression: a window with no end turns every unreachable node into "no verdict" forever."""
+    unreachable = _failed("node-1", "EXECUTOR_SSH_UNREACHABLE")
+    third_cycle = _open_window(cycles_seen=3)
+
+    kept, withheld = withhold_rollout_verdicts({"5Miner": [unreachable]}, third_cycle, J2)
+
+    assert kept == {"5Miner": [unreachable]}
+    assert withheld == []
+
+
+@pytest.mark.parametrize(
+    "reason",
+    ["EXECUTOR_TRANSPORT_UNREACHABLE", "FILLER_TRANSPORT_UNREACHABLE", "SCRAPE_FAILED", "INSUFFICIENT_PORTS"],
+)
+def test_a_failure_on_an_executor_already_running_the_new_image_is_a_real_failure(reason: str) -> None:
+    """Regression: grace hiding a port-table or SSH failure on a node that has finished
+    restarting — the rollout cannot explain a failure on the image it rolled out."""
+    on_new_image = _failed("node-1", reason, observed_digest=NEW)
+    still_on_old = _failed("node-2", reason, observed_digest=OLD)
+    window = _open_window()
+
+    assert rollout_grace_reason(on_new_image, window, J1) is None
+    assert rollout_grace_reason(still_on_old, window, J1) == reason
+
+
+def test_an_outdated_image_inside_the_window_gets_no_verdict_rented_or_not() -> None:
+    """The 70 EXECUTOR_IMAGE_OUTDATED rows of 11 Sep. Unrented, the fatal check ends the run with
+    that reason; rented, the run completes with score 0 and only the report says OUTDATED. Both
+    are the fleet not having pulled yet (or the validator's snapshot predating the push, in which
+    case the observed digest is already the new one)."""
+    window = _open_window()
+    unrented = _failed("node-1", "EXECUTOR_IMAGE_OUTDATED", observed_digest=OLD, image_status="OUTDATED")
+    rented = _failed("node-2", "RENTED", observed_digest=OLD, image_status="OUTDATED")
+    validator_snapshot_was_stale = _failed(
+        "node-3", "EXECUTOR_IMAGE_OUTDATED", observed_digest=NEW, image_status="OUTDATED"
+    )
+
+    assert rollout_grace_reason(unrented, window, J0) == "EXECUTOR_IMAGE_OUTDATED"
+    assert rollout_grace_reason(rented, window, J0) == "EXECUTOR_IMAGE_OUTDATED"
+    assert rollout_grace_reason(validator_snapshot_was_stale, window, J0) == "EXECUTOR_IMAGE_OUTDATED"
+
+
+def test_a_rented_executor_failing_a_later_check_of_its_own_stands_even_when_outdated() -> None:
+    """Regression: the OUTDATED report riding along on every rented run makes any failure of that
+    run (the pod gone, the filler killed) read as "not pulled yet" and hides it for two cycles."""
+    window = _open_window()
+    pod_gone = _failed("node-1", "POD_NOT_RUNNING", observed_digest=OLD, image_status="OUTDATED")
+
+    assert rollout_grace_reason(pod_gone, window, J0) is None
+
+
+def test_a_failure_the_rollout_does_not_explain_stands() -> None:
+    """Regression: the window becoming a blanket amnesty — too many GPUs or a result with a score
+    has nothing to do with a container restart."""
+    window = _open_window()
+    too_many_gpus = _failed("node-1", "GPU_COUNT_EXCEEDS_MAX")
+    unknown_error = _failed("node-2", None)
+
+    assert rollout_grace_reason(too_many_gpus, window, J0) is None
+    assert rollout_grace_reason(unknown_error, window, J0) is None
+    assert rollout_grace_reason(_scored("node-3"), window, J0) is None
+
+
+def test_no_digest_change_means_unchanged_results() -> None:
+    """Regression: the classifier acting without a rollout — every cycle without a release must
+    hand its results on untouched, the same objects, nothing marked."""
+    unreachable = _failed("node-1", "EXECUTOR_SSH_UNREACHABLE")
+    results = {"5Miner": [unreachable]}
+    no_rollout = RolloutWindow(
+        digest=OLD, previous_digest=None, started_at=None, opened_job_block=None, cycles_seen=0, grace_cycles=2
+    )
+
+    kept, withheld = withhold_rollout_verdicts(results, no_rollout, J0)
+
+    assert kept is results
+    assert withheld == []
+
+
+# --- TaskService hands the classifier the reason a run ended on ---------------------------------
+
+
+def _task_service_that_reaches_the_ssh_connect() -> TaskService:
+    service = TaskService.__new__(TaskService)
+    service.ssh_service = MagicMock()
+    service.ssh_service.decrypt_payload = MagicMock(return_value="decrypted-key")
+    service.attestation_service = MagicMock()
+    service.attestation_service.prepare_host_policy = AsyncMock(return_value=HostPolicyResult())
+    return service
+
+
+def _a_job_for(executor_uuid: str) -> tuple[MinerJobRequestPayload, ExecutorSSHInfo]:
+    miner = MinerJobRequestPayload(
+        job_batch_id="batch-1",
+        miner_hotkey="5Miner",
+        miner_coldkey="5Cold",
+        miner_address="203.0.113.5",
+        miner_port=8080,
+        executors=[],
+    )
+    return miner, _executor(executor_uuid)
+
+
+async def _run_cycle(service: TaskService, miner: MinerJobRequestPayload, executor: ExecutorSSHInfo) -> JobResult:
+    return await service.create_task(
+        miner_info=miner,
+        executor_info=executor,
+        keypair=MagicMock(ss58_address="5Val"),
+        private_key="key",
+        public_key="pub",
+        encrypted_files=MagicMock(),
+        rented_data=MagicMock(),
+        default_docker_image_digests={},
+    )
+
+
+class _ShellThatRefusesToConnect:
+    def __init__(self, **_: object) -> None:
+        pass
+
+    async def __aenter__(self) -> "_ShellThatRefusesToConnect":
+        raise asyncssh.Error(code=1, reason="Connection refused")
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+
+class _ShellThatOpens:
+    async def __aenter__(self) -> "_ShellThatOpens":
+        return self
+
+    async def __aexit__(self, *_: object) -> bool:
+        return False
+
+
+@pytest.mark.asyncio
+async def test_a_refused_connect_records_its_reason_code_for_the_classifier(monkeypatch) -> None:
+    """Regression: the connect failure reaching the cycle end with no reason code — the classifier
+    would let a refused connect stand as a zero inside the window."""
+    monkeypatch.setattr(task_service_module, "InteractiveShellService", _ShellThatRefusesToConnect)
+    miner, executor = _a_job_for("node-9")
+
+    result = await _run_cycle(_task_service_that_reaches_the_ssh_connect(), miner, executor)
+
+    assert result.score == 0
+    assert result.failure_reason_code == "EXECUTOR_SSH_UNREACHABLE"
+    assert rollout_grace_reason(result, _open_window(), J0) == "EXECUTOR_SSH_UNREACHABLE"
+
+
+@pytest.mark.asyncio
+async def test_a_shell_that_dies_under_a_check_records_the_transport_code(monkeypatch) -> None:
+    """The recreate lands after the connect, inside a check that lets asyncssh raise (upload,
+    a `ctx.ssh.run`). Regression: the run ends in the generic error branch with no reason code and
+    the classifier lets it stand as 0 inside the window. A non-transport crash after the connect
+    must stay unnamed — it is not something a rollout explains."""
+    monkeypatch.setattr(task_service_module, "InteractiveShellService", lambda **_: _ShellThatOpens())
+    service = _task_service_that_reaches_the_ssh_connect()
+    service.pipeline_factory = MagicMock()
+    miner, executor = _a_job_for("node-9")
+
+    service.pipeline_factory.build_context = AsyncMock(side_effect=asyncssh.Error(code=1, reason="Connection lost"))
+    died = await _run_cycle(service, miner, executor)
+
+    service.pipeline_factory.build_context = AsyncMock(side_effect=ValueError("a bug of our own"))
+    crashed = await _run_cycle(service, miner, executor)
+
+    assert died.failure_reason_code == "EXECUTOR_TRANSPORT_UNREACHABLE"
+    assert died.availability_errors == []  # the connect succeeded: not an availability error
+    assert rollout_grace_reason(died, _open_window(), J0) == "EXECUTOR_TRANSPORT_UNREACHABLE"
+    assert crashed.failure_reason_code is None
+    assert rollout_grace_reason(crashed, _open_window(), J0) is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_check_records_its_reason_code_and_a_passing_run_records_none(monkeypatch) -> None:
+    """Regression: the reason of the failed fatal check not reaching the result (the 51 scrape
+    failures would stand), or a scored run carrying a reason it did not fail on."""
+    monkeypatch.setattr(task_service_module, "InteractiveShellService", lambda **_: _ShellThatOpens())
+    service = _task_service_that_reaches_the_ssh_connect()
+    # ResultHandler writes the verified-job counters here; the pipeline itself is stubbed.
+    service.redis_service = AsyncMock()
+    service.pipeline_factory = MagicMock()
+    service.pipeline_factory.build_checks = MagicMock(return_value=[])
+    miner, executor = _a_job_for("node-9")
+
+    scrape_failed = build_msg(
+        event="Machine specs scrape failed", reason="SCRAPE_FAILED", severity="error", impact="no score"
+    )
+    failed_ctx = make_context(executor=executor, miner_hotkey=miner.miner_hotkey, score=0.0, success=False)
+    service.pipeline_factory.build_context = AsyncMock(return_value=failed_ctx)
+    service.pipeline_factory.build_pipeline = MagicMock(
+        return_value=MagicMock(run=AsyncMock(return_value=(False, [scrape_failed], failed_ctx)))
+    )
+    failed = await _run_cycle(service, miner, executor)
+
+    finished = build_msg(event="Validation finished", reason="VALIDATION_COMPLETED", severity="info", impact="")
+    passed_ctx = make_context(executor=executor, miner_hotkey=miner.miner_hotkey, score=1.0, success=True)
+    service.pipeline_factory.build_context = AsyncMock(return_value=passed_ctx)
+    service.pipeline_factory.build_pipeline = MagicMock(
+        return_value=MagicMock(run=AsyncMock(return_value=(True, [finished], passed_ctx)))
+    )
+    passed = await _run_cycle(service, miner, executor)
+
+    assert failed.failure_reason_code == "SCRAPE_FAILED"
+    assert passed.failure_reason_code is None
+    assert passed.score == 1.0
+
+
+@pytest.mark.asyncio
+async def test_a_rented_outdated_run_carries_the_rented_halt_as_its_reason(monkeypatch) -> None:
+    """A rented executor's image check passes and TenantEnforcementCheck halts the run with
+    success=True and score 0. Regression: recording a reason only for failed runs leaves this
+    result with none, and the classifier publishes the rented fleet's OUTDATED zeros as today."""
+    monkeypatch.setattr(task_service_module, "InteractiveShellService", lambda **_: _ShellThatOpens())
+    service = _task_service_that_reaches_the_ssh_connect()
+    service.redis_service = AsyncMock()
+    service.pipeline_factory = MagicMock()
+    service.pipeline_factory.build_checks = MagicMock(return_value=[])
+    miner, executor = _a_job_for("node-9")
+    rented_halt = build_msg(event="Executor already rented", reason="RENTED", severity="info", impact="")
+    report = ExecutorImageReport(
+        status=ImageVerdict.OUTDATED, observed_digest=OLD, expected_ref="ref", expected_digest=NEW
+    )
+    rented_ctx = make_context(
+        executor=executor,
+        miner_hotkey=miner.miner_hotkey,
+        state=ContextState(executor_image_report=report),
+        score=0.0,
+        job_score=1.0,
+        rented=True,
+        success=True,
+    )
+    service.pipeline_factory.build_context = AsyncMock(return_value=rented_ctx)
+    service.pipeline_factory.build_pipeline = MagicMock(
+        return_value=MagicMock(run=AsyncMock(return_value=(True, [rented_halt], rented_ctx)))
+    )
+
+    result = await _run_cycle(service, miner, executor)
+
+    assert result.score == 0
+    assert result.failure_reason_code == "RENTED"
+    assert rollout_grace_reason(result, _open_window(), J0) == "EXECUTOR_IMAGE_OUTDATED"
+
+
+# --- the cycle: what happens when the tracker itself cannot be read -----------------------------
+
+
+def _validator_process(tracker: ExecutorRolloutTracker) -> Validator:
+    validator_process = Validator.__new__(Validator)
+    validator_process.default_extra = {}
+    validator_process.rollout_tracker = tracker
+    return validator_process
+
+
+@pytest.mark.asyncio
+async def test_a_redis_error_leaves_every_verdict_standing_instead_of_ending_the_cycle() -> None:
+    """Regression: the tracker's exception reaching `sync` — the whole cycle is lost to the
+    `[sync] Unexpected error` handler (no weights, no publish for anyone) because the grace
+    bookkeeping failed. Without Redis the cycle must run as it did before this change."""
+    broken = ExecutorRolloutTracker(
+        redis_service=MagicMock(get=AsyncMock(side_effect=ConnectionError("down"))), grace_cycles=2
+    )
+    validator_process = _validator_process(broken)
+    unreachable = _failed("node-1", "EXECUTOR_SSH_UNREACHABLE")
+
+    window = await validator_process.observe_executor_rollout(NEW, J0)
+    kept, withheld = withhold_rollout_verdicts({"5Miner": [unreachable]}, window, J0)
+
+    assert window.covers(J0) is False
+    assert kept == {"5Miner": [unreachable]}
+    assert withheld == []
+
+    # Redis was fine at cycle start and died before the cycle-end observation: the cycle keeps
+    # the window it saw at its start instead of dropping every withheld verdict.
+    seen_at_start = _open_window()
+    assert await validator_process.observe_executor_rollout(NEW, J0, fallback=seen_at_start) is seen_at_start
+
+
+@pytest.mark.asyncio
+async def test_the_cycle_end_read_of_the_registry_withholds_this_cycles_results(monkeypatch) -> None:
+    """The 11 Sep case end to end at the cycle level: the cycle started on the old digest, the push
+    landed while its jobs ran. Regression: the cycle-end registry read dropped from `sync` — the
+    window would open at the next cycle and this cycle's failures would publish as zeros."""
+    redis = _FakeRedis()
+    tracker = _tracker(redis)
+    validator_process = _validator_process(tracker)
+    await tracker.observe(OLD, J0 - BPC, now=T0)
+    at_start = await validator_process.observe_executor_rollout(OLD, J0)
+    assert at_start.covers(J0) is False
+    monkeypatch.setattr(validator_process, "fetch_executor_digest_or_none", AsyncMock(return_value=NEW))
+    unreachable = _failed("node-1", "EXECUTOR_SSH_UNREACHABLE")
+    healthy = _scored("node-2")
+
+    kept, withheld = await validator_process.withhold_verdicts_for_rollout(
+        {"5Miner": [unreachable, healthy]}, J0, "batch-1", at_start
+    )
+
+    assert kept == {"5Miner": [healthy]}
+    assert [r.executor_info.uuid for _, r in withheld] == ["node-1"]
+    assert json.loads(redis.store[ROLLOUT_STATE_KEY])["withheld"] == 1
+
+
+@pytest.mark.asyncio
+async def test_the_cycle_adds_its_withheld_count_to_the_window_total_only_inside_the_window() -> None:
+    """Regression: a count written on every cycle — the window-end line would carry cycles the
+    window never covered — or a count never written, leaving the window-end line at 0."""
+    redis = _FakeRedis()
+    tracker = _tracker(redis)
+    await tracker.observe(OLD, J0 - BPC, now=T0)
+    window = await tracker.observe(NEW, J0, now=T0)
+    validator_process = _validator_process(tracker)
+    withheld = [("5Miner", _failed("node-1", "EXECUTOR_SSH_UNREACHABLE"))] * 3
+
+    await validator_process.record_withheld_verdicts(window, withheld, job_batch_id="batch-1", job_block=J1)
+    assert json.loads(redis.store[ROLLOUT_STATE_KEY])["withheld"] == 3
+
+    await tracker.observe(NEW, J1, now=T0)
+    closed = await tracker.observe(NEW, J2, now=T0)
+    assert closed.covers(J2) is False
+    await validator_process.record_withheld_verdicts(closed, withheld, job_batch_id="batch-2", job_block=J2)
+    assert json.loads(redis.store[ROLLOUT_STATE_KEY])["withheld"] == 3

--- a/neurons/validators/tests/test_executor_rollout_grace.py
+++ b/neurons/validators/tests/test_executor_rollout_grace.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import asyncssh
 import pytest
+from core.config import settings
 from core.validator import Validator
 from datura.requests.miner_requests import ExecutorSSHInfo
 from payload_models.payloads import MinerJobRequestPayload
@@ -370,11 +371,13 @@ def test_a_failure_on_an_executor_already_running_the_new_image_is_a_real_failur
     assert rollout_grace_reason(still_on_old, window, J1) == reason
 
 
-def test_an_outdated_image_inside_the_window_gets_no_verdict_rented_or_not() -> None:
-    """The 70 EXECUTOR_IMAGE_OUTDATED rows of 11 Sep. Unrented, the fatal check ends the run with
-    that reason; rented, the run completes with score 0 and only the report says OUTDATED. Both
-    are the fleet not having pulled yet (or the validator's snapshot predating the push, in which
-    case the observed digest is already the new one)."""
+def test_an_outdated_image_inside_the_window_gets_no_verdict_rented_or_not(monkeypatch) -> None:
+    """The 70 EXECUTOR_IMAGE_OUTDATED rows of 11 Sep, with the image check enforced as it was that
+    day. Unrented, the fatal check ends the run with that reason; rented, the run completes with
+    score 0 and only the report says OUTDATED. Both are the fleet not having pulled yet (or the
+    validator's snapshot predating the push, in which case the observed digest is already the new
+    one)."""
+    monkeypatch.setattr(settings, "EXECUTOR_IMAGE_CHECK_ENFORCE", True)
     window = _open_window()
     unrented = _failed("node-1", "EXECUTOR_IMAGE_OUTDATED", observed_digest=OLD, image_status="OUTDATED")
     rented = _failed("node-2", "RENTED", observed_digest=OLD, image_status="OUTDATED")
@@ -385,6 +388,18 @@ def test_an_outdated_image_inside_the_window_gets_no_verdict_rented_or_not() -> 
     assert rollout_grace_reason(unrented, window, J0) == "EXECUTOR_IMAGE_OUTDATED"
     assert rollout_grace_reason(rented, window, J0) == "EXECUTOR_IMAGE_OUTDATED"
     assert rollout_grace_reason(validator_snapshot_was_stale, window, J0) == "EXECUTOR_IMAGE_OUTDATED"
+
+
+def test_a_rented_zero_under_an_unenforced_outdated_report_stands(monkeypatch) -> None:
+    """Regression: with EXECUTOR_IMAGE_CHECK_ENFORCE off (the default since DAH-3439) the image
+    check passes an OUTDATED node and leaves its score alone, so a rented run at score 0 owes its
+    0 to another gate (price cap, TDX, collateral). Reading the OUTDATED report as the cause would
+    withhold that verdict for two cycles and keep the executor's previous scored row."""
+    monkeypatch.setattr(settings, "EXECUTOR_IMAGE_CHECK_ENFORCE", False)
+    window = _open_window()
+    rented_zero_from_another_gate = _failed("node-2", "RENTED", observed_digest=OLD, image_status="OUTDATED")
+
+    assert rollout_grace_reason(rented_zero_from_another_gate, window, J0) is None
 
 
 def test_a_rented_executor_failing_a_later_check_of_its_own_stands_even_when_outdated() -> None:
@@ -557,6 +572,7 @@ async def test_a_rented_outdated_run_carries_the_rented_halt_as_its_reason(monke
     """A rented executor's image check passes and TenantEnforcementCheck halts the run with
     success=True and score 0. Regression: recording a reason only for failed runs leaves this
     result with none, and the classifier publishes the rented fleet's OUTDATED zeros as today."""
+    monkeypatch.setattr(settings, "EXECUTOR_IMAGE_CHECK_ENFORCE", True)
     monkeypatch.setattr(task_service_module, "InteractiveShellService", lambda **_: _ShellThatOpens())
     service = _task_service_that_reaches_the_ssh_connect()
     service.redis_service = AsyncMock()

--- a/neurons/validators/tests/test_executor_rollout_grace.py
+++ b/neurons/validators/tests/test_executor_rollout_grace.py
@@ -21,6 +21,7 @@ from services.executor_rollout import (
     ROLLOUT_STATE_KEY,
     ExecutorRolloutTracker,
     RolloutWindow,
+    WithheldVerdict,
     rollout_grace_reason,
     withhold_rollout_verdicts,
 )
@@ -303,7 +304,9 @@ async def test_a_corrupt_redis_value_is_replaced_instead_of_failing_every_cycle(
         window = await tracker.observe(OLD, J0, now=T0)
 
         assert window.digest == OLD
-        assert json.loads(redis.store[ROLLOUT_STATE_KEY]) == {"digest": OLD}
+        reseeded = json.loads(redis.store[ROLLOUT_STATE_KEY])
+        assert reseeded["digest"] == OLD
+        assert reseeded["opened_job_block"] is None
 
 
 @pytest.mark.asyncio
@@ -338,7 +341,7 @@ def test_an_unreachable_executor_inside_the_window_gets_no_verdict() -> None:
     kept, withheld = withhold_rollout_verdicts({"5Miner": [unreachable, healthy]}, window, J0)
 
     assert kept == {"5Miner": [healthy]}
-    assert [(hk, r.executor_info.uuid) for hk, r in withheld] == [("5Miner", "node-1")]
+    assert [(w.miner_hotkey, w.result.executor_info.uuid) for w in withheld] == [("5Miner", "node-1")]
 
 
 def test_the_same_failure_after_the_window_is_a_zero_as_today() -> None:
@@ -639,7 +642,7 @@ async def test_the_cycle_end_read_of_the_registry_withholds_this_cycles_results(
     )
 
     assert kept == {"5Miner": [healthy]}
-    assert [r.executor_info.uuid for _, r in withheld] == ["node-1"]
+    assert [w.result.executor_info.uuid for w in withheld] == ["node-1"]
     assert json.loads(redis.store[ROLLOUT_STATE_KEY])["withheld"] == 1
 
 
@@ -652,7 +655,7 @@ async def test_the_cycle_adds_its_withheld_count_to_the_window_total_only_inside
     await tracker.observe(OLD, J0 - BPC, now=T0)
     window = await tracker.observe(NEW, J0, now=T0)
     validator_process = _validator_process(tracker)
-    withheld = [("5Miner", _failed("node-1", "EXECUTOR_SSH_UNREACHABLE"))] * 3
+    withheld = [WithheldVerdict("5Miner", _failed("node-1", "EXECUTOR_SSH_UNREACHABLE"))] * 3
 
     await validator_process.record_withheld_verdicts(window, withheld, job_batch_id="batch-1", job_block=J1)
     assert json.loads(redis.store[ROLLOUT_STATE_KEY])["withheld"] == 3


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3405](https://app.notion.com/p/3d8b8bfdbde981ac8c86cf027caa65d8) · reviewer: @taiberium

**TL;DR** — 11 Sep 07:50Z executor-v1.126 went live mid-cycle; watchtower restarts cut the validator's SSH; one cycle read 168 unreachable, 51 scrape-failed, 50 insufficient-ports, 70 OUTDATED rows (tsdb 506/514 at 0). The validator now records the cycle the digest changed in and, for that cycle and the next, withholds those verdicts for executors not yet on the new image: neither scored nor published.

**What changed**
- `ExecutorRolloutTracker`: digest, last change, cycles since (Redis key `executor_image_rollout`; `services/executor_rollout.py`)
- `withhold_rollout_verdicts`: score-0 results ending unreachable / upload or scrape failed / insufficient ports (digest ≠ new) or OUTDATED leave the cycle; one `outcome=ROLLOUT_GRACE` log line each
- digest read at cycle start and end; withheld results leave `all_job_results` before incentive and publish (`core/validator.py`)
- `JobResult.failure_reason_code`: the event a run without a score ended on (`services/task/models.py`, `service.py`)
- `EXECUTOR_ROLLOUT_GRACE_CYCLES` default 2, capped at 2 (backend 1-h sweep), 0 = off; OUTDATED counts only with `EXECUTOR_IMAGE_CHECK_ENFORCE` on (`core/config.py`)
- 25 tests (28 cases), each naming its regression (`tests/test_executor_rollout_grace.py`)

**Risks**
- Changes runtime configuration (`config.py`) on the next deploy, no pod restart — noticed only if a value is wrong — rollback: revert the file and redeploy.

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_executor_rollout_grace.py -q` → 28 passed
- log after a push: `[rollout-grace]` detected → `verdict withheld` per executor → `window ended`

**Verified by the loop:** Gate: PASS a0d7821

**Ran it:** `pdm run pytest tests -q` → 2319 passed, 2 env failures also on main · warm EC2 20260912T142315Z-pjav, this head · no live registry/Redis

**Self-review:** clean at a0d7821 (15 checks, 3 low)

**Parts:** backend ✓ · migration n/a — no schema change · frontend n/a — validator only · CLI/SDK n/a — no command or SDK surface · docs ✓ `.env.template` · tests ✓ 25 · dashboards n/a — Loki `outcome=ROLLOUT_GRACE`

**Docs:** none needed because the only new surface is validator operator config (`EXECUTOR_ROLLOUT_GRACE_CYCLES`, `neurons/validators/.env.template`); a withheld result publishes nothing to providers

<details><summary>Details</summary>

### Numbers and sources

- Rustam's validator cycle log, 11 Sep 2026 07:50–08:00Z (Notion comment 09:39Z): 168 transport-unreachable, 51 scrape-failed, 50 insufficient-ports rows, and 70 `EXECUTOR_IMAGE_OUTDATED` rows against a normal background of 31 (units: log rows in one cycle; they are not summed here because a row is not a distinct executor). The orchestrator's count of zeroed executors in the same log: 239 of 476 (distinct executors, one cycle).
- tsdb `prod_executors` (ticket body): 506 of 514 distinct executors at 0 in that cycle vs 161 of 517 the cycle before (executors per cycle).
- Cause (Rustam, 09:39Z): watchtower recreated the executor container mid-cycle when the new image went live, killing the validator's SSH sessions; OUTDATED rows were the fleet not yet pulled (or the validator's snapshot predating the push). No incentive was lost (09:21Z weights unchanged, sum 5.0000) — the damage was the published cycle score (Grafana dip, 7 inactive marks, 4 `EXECUTOR_INACTIVE_MID_RENTAL` penalties = $113.61, reverts with Mikhail). The money path is lium-platform#325 (DAH-3385), out of scope here.
- Ceiling for the window: lium-io-backend `apps/server/src/worker.py` `check_and_update_executors` marks an executor inactive when its row was not updated for 1 h and applies `EXECUTOR_INACTIVE_MID_RENTAL`. A withheld executor publishes nothing, so at most two consecutive cycles may be withheld: the gap between its publishes is then three cycle periods (job blocks 900 s apart) plus the duration of the next scored cycle minus the duration of the last one — about 2700 + 850 s (`JOB_TIME_OUT − 50`) = 3550 s when cycles start 900 s apart — a lower bound, not a ceiling: a cycle that runs past 900 s delays the next start (`sync` waits for 75 blocks since the previous start), and the row lands after incentive, estimates and the publish loop. A third withheld cycle is past the hour whenever the next scored cycle is not shorter than the last; two are under it only when cycles keep their 15-min cadence. `MAX_ROLLOUT_GRACE_CYCLES = 2` in `executor_rollout.py` caps the setting and logs the cap. Measuring the real publish cadence from `prod_executors.updated_at` and keying the backend sweep to validator cycles (or 75 min) is the durable fix — follow-up below.

### Design

- Source of truth for "a rollout is happening": the registry digest of `EXECUTOR_IMAGE_REF` (`fetch_executor_image_digest`), the same tag watchtower pulls (`neurons/executor/docker-compose.yml`: `nickfedor/watchtower` with `--interval 60 --cleanup --label-enable`). The validator already fetched it once per cycle for `ExecutorImageCheck`; it is now fetched a second time at cycle end, because the 07:50Z push landed mid-cycle and a start-of-cycle read alone would have opened the window one cycle late.
- Decision point is the cycle (`Validator.sync`), not the pipeline: the pipeline cannot know a digest that changed after it started. `withhold_rollout_verdicts` runs after every job returned and before `IncentiveFactory.create`, so withheld results are in neither the incentive nor `publish_machine_specs` nor `silence_availability_errors_on_our_own_outage`. Their miners stay in `active_hotkeys` (DAH-2622: the u16=1 floor that keeps a UID); their ids are added to the express lane's validated set so it does not start a first pass on them.
- The window is counted in cycles as the validator observes them (`cycles_seen`, incremented when `observe` is called with a job block it has not seen; the cycle-start and cycle-end observations of one cycle share the job block), never by the clock or by job-block arithmetic: `sync` starts a cycle on the first 12-s tick at ≥ 75 blocks since the last, so a late-starting long cycle makes the next one land two job blocks later — it is still the next cycle. `RolloutWindow.covers(job_block)` is true while `cycles_seen ≤ 2`. A validator restart inside the window resumes it from Redis.
- Classifier (`rollout_grace_reason`): score > 0 ⇒ stands. Reason ∈ {`EXECUTOR_SSH_UNREACHABLE`, `UPLOAD_FAILED`, `EXECUTOR_TRANSPORT_UNREACHABLE`, `FILLER_TRANSPORT_UNREACHABLE`, `SCRAPE_FAILED`, `INSUFFICIENT_PORTS`, `EXECUTOR_IMAGE_OUTDATED`}, or the run ended without failing (the rented halt `RENTED`, or `VALIDATION_COMPLETED`) with score 0 and the image report says OUTDATED (a rented executor's image check passes, so `TenantEnforcementCheck` halts its run as RENTED with score 0 instead of failing) ⇒ candidate; a rented executor that failed a later check of its own (pod not running, filler killed) stands, OUTDATED or not. For every reason but OUTDATED, an observed digest (`executor_image.observed_executor_digest` over the scraped specs, or the report) equal to the new digest ⇒ a real failure on the rolled-out image ⇒ stands. OUTDATED is withheld regardless of the observed digest: old = not pulled yet, new = the validator's snapshot predated the push.
- `failure_reason_code` is set by `TaskService.create_task`: the last event's reason when the run did not succeed or ended with score 0 (the rented halt included); `EXECUTOR_SSH_UNREACHABLE` when the connect failed; `EXECUTOR_TRANSPORT_UNREACHABLE` when the shell had opened and an `asyncssh.Error`/`OSError` escaped a check (the recreate landing under a `ctx.ssh.run` that a check does not catch) — the name the rented-machine check gives the same death. Any other exception leaves it None and the result stands.
- Redis state (`executor_image_rollout`, JSON: `digest`, `previous_digest`, `started_at`, `opened_job_block`, `last_job_block`, `cycles_seen`, `withheld`, `closed`) survives the validator redeploy that usually accompanies a release. A second digest change while the window is open, or before one uncovered cycle has published (`cycles_seen < grace_cycles + 2`), makes the new digest current but does not reopen the window — withheld cycles would otherwise chain to three or four in a row; that second push gets no grace, and the log says so. A Redis error at cycle start leaves the cycle as it is today (every failure a verdict) and logs `[rollout-grace] rollout state unreadable; every verdict stands this cycle`; a Redis error at cycle end keeps the window seen at cycle start; a value that is not JSON is replaced. A registry error (`fetch_registry_digest` returns None on any HTTP error) changes nothing: a window already open stays open, no window is opened. The first digest a fresh Redis sees opens no window. `EXECUTOR_ROLLOUT_GRACE_CYCLES=0`: the digest is still tracked, no cycle is covered, no window lines are logged.
- Incentive effect: a withheld executor is absent from the cycle, so its miner's mining score for that cycle is what a 0 would have given (nothing) — no scoring formula changes. Accepting the previous digest as CURRENT for the window (ticket option a) would score those nodes normally; that is a scoring change and needs a design note first (PR_PROCESS §1b).

### Known follow-ups

- Watchtower delaying the recreate until the validator's job on the node has finished (brief part 5): the standard stack runs upstream `nickfedor/watchtower`, so the mechanism is a lifecycle pre-update hook in the executor image (label `com.centurylinklabs.watchtower.lifecycle.pre-update`, exit 75 skips this round) that returns non-zero while a validator SSH session / uploaded key is present — an executor image + compose change on every provider, not small; separate PR on this ticket. The in-repo `watchtower/` (CVM `executor-runner`) would take the same check before `container.stop`.
- Pushing `:latest` right after a cycle ends is a release-process rule, not code.
- A provider-facing note on release behaviour ("during an executor image release your node keeps its last cycle's score for up to two cycles") on lium-docs `providers/troubleshooting.md` — on this ticket, if Rustam wants providers told.
- A withheld result's `availability_errors` (DAH-2748) leave the cycle with it: a node that really died during the window is not hidden from the market until its next scored cycle (one or two cycles later). Publishing only the availability part of a withheld result would need the backend to accept a row without a score — follow-up on this ticket if Rustam wants it.
- `RedisService.set_verified_job_info` still counts a withheld run as `failed` (written inside `TaskService.create_task`, before the cycle-level decision). The counter is read by nothing that scores — the branch that acted on it is commented out.
- The second registry read at cycle end is a token GET plus a manifest HEAD against Docker Hub, each with a 30-s timeout (`fetch_registry_digest`), on the path between the last job and the weight computation; an unresponsive Docker Hub costs the cycle up to 60 s there.
- The backend's 1-h sweep vs a 2-cycle window leaves under a minute of margin (numbers above); keying `check_and_update_executors` to validator cycles, or 75 min, is a lium-io-backend follow-up on this ticket.
- The express lane (`core/express_lane.py`) is unchanged: a never-validated executor whose first pass fails during a rollout is still published with score 0 (there is no previous row to keep); the next scored cycle overwrites it.
- No test drives `Validator.sync` end to end (it needs a subtensor, backend, Redis and miner service); the wiring is the `withhold_rollout_verdicts(` call in `core/validator.py` — the rebinding of `all_job_results` before `IncentiveFactory.create` — and the fail-open helpers `observe_executor_rollout` / `record_withheld_verdicts` are tested directly.
- Self-review round 8 finding, fixed in this head: a rented executor's run halts in `TenantEnforcementCheck` with success=True and score 0 (reason `RENTED`), so the reason is now recorded for every score-0 run and the classifier accepts `RENTED` as well as `VALIDATION_COMPLETED`; the rented case is driven through `TaskService.create_task` with the real halt event.
- Self-review round 7 findings, fixed in this head: the OUTDATED fallback applies only to a run that completed (`VALIDATION_COMPLETED`), so a rented executor's own later failure stands; the cycle-end block is `Validator.withhold_verdicts_for_rollout` and tested with the registry stubbed OLD → NEW inside one job block; the tracker normalises the registry digest the way the image check normalises the node's; any `OSError` after the connect is named `EXECUTOR_TRANSPORT_UNREACHABLE` on purpose (stated in `service.py`).
- Self-review round 6 findings, fixed in this head: the grace-0 log guard; the `MAX_ROLLOUT_GRACE_CYCLES` comment now calls 3550 s the lower bound it is; a Redis error at the cycle-end observation falls back to the window seen at cycle start; the cycle-start observation moved below the `rented_executors is None` abort so an aborted iteration is not a cycle of the window; a test for the headline mid-cycle push (OLD at cycle start, NEW at cycle end of the same job block). Open lium-io#1351 adds `JobResult` fields in the adjacent hunk (merge order: either first, trivial conflict).
- lium-platform#325 (DAH-3385, confirm an automatic penalty before charging it): the money path for the first cycle after a push.

### Ran it

EC2 sandbox, warm lium-io box i-0551cd50560a42a0d (c6i.2xlarge, Linux), this head:

```
$ pdm run pytest tests -q                                       # run 20260911T115100Z-jzd0, this head
2 failed, 2240 passed, 15 skipped, 165 warnings in 121.33s (0:02:01)
FAILED tests/test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices
FAILED tests/test_sshd_bootstrap_script.py::test_adopt_path_hardens_config_for_key_only_auth
FAILED tests/test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices
FAILED tests/test_sshd_bootstrap_script.py::test_adopt_path_hardens_config_for_key_only_auth
```

The two failures are the box's (sysfs readable as root; an sshd already running) and appear identically in main runs 20260911T084014Z-pldc, 20260911T070308Z-h5fd, 20260910T172331Z-qqh0. Not run: a live validator against Docker Hub and Redis.

### Self-review

Verdict `clean` at `a0d7821` · 15 checks · by subagent-drain-r125b · 2026-09-12 14:34Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | PROSE-VS-CODE | `RECOVERY/workers/rollout-grace/body.md:43` | Property: the body's Classifier bullet must state the same rule as rollout_grace_reason. The bullet lists the OUTDATED-without-failing arm ('the run ended without failing ... with score 0 and the image report says OUTDATED => candidate') with no mention of EXECUTOR_IMAGE_CHECK_ENFORCE, while executor_rollout.py:386 fires that arm only when the flag is on; the only body sentence that states the condition is the 'What changed' bullet, and it points at core/config.py, where nothing about the rule lives (the flag's comment at config.py:336-340 says nothing about rollout grace). | In the Classifier bullet add 'the OUTDATED-without-failing arm counts only while EXECUTOR_IMAGE_CHECK_ENFORCE is on (off by default since DAH-3439/#1360); off, an OUTDATED node scores normally and a rented 0 under an OUTDATED report stands', and in the 'What changed' bullet point that clause at services/executor_rollout.py rather than core/config.py. |
| low | CODE-QUALITY | `neurons/validators/src/services/task/service.py:222` | Property: a comment that names a condition must name the whole condition. '(success=True, score 0 when the image is OUTDATED)' describes the rented halt, but score_calculator.py:44-50 zeroes the score for OUTDATED only while EXECUTOR_IMAGE_CHECK_ENFORCE is on; with the flag off (main's default) the rented halt carries the run's normal score and this line does not record a reason for it. | Say '(success=True, score 0 when the image is OUTDATED and EXECUTOR_IMAGE_CHECK_ENFORCE is on, or when another gate zeroed the score)'. |
| low | STALE-BODY | `RECOVERY/workers/rollout-grace/body.md:69` | Property: every run id and count in the body must come from one run at the head it describes. The top-level 'Ran it' line renders as run 20260912T142315Z-pjav / 2319 passed (matches aws_run/20260912T142315Z-pjav/job.log, checked out at a0d7821), while the Details 'Ran it' block (body.md:67-75) still says run 20260911T115100Z-jzd0 / 2240 passed 'this head' and lists the two failures twice; the Details 'Self-review' block cites e4335e9 and 1b0831e, neither reachable from a0d7821 (git merge-base --is-ancestor fails for both), and 'Verified' says 'not run at 80a81e4'. | Replace the Details 'Ran it' block with the pjav run (2 failed, 2319 passed, 15 skipped, 128.11 s; same two env failures as on main) and let tools/pr_self_review.py --record --apply replace the Self-review/Verified blocks so only reachable shas remain. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/tests/test_executor_rollout_grace.py:17` Mechanical note: datura.requests.miner_requests resolves. neurons/validators/pyproject.toml:19 installs the sibling package `datura @ file:///${PROJECT_ROOT}/../../datura`, ../../datura/datura/requests/miner_requests.py exists in the worktree, tests/conftest.py:8 imports the same name today, and the EC2 run at this head collected and passed the module (2319 passed). · `neurons/validators/src/services/executor_rollout.py:386` The r125 medium is fixed: `settings` is imported at executor_rollout.py:28 (from core.config import settings, already used for EXECUTOR_ROLLOUT_GRACE_CYCLES), the fallback reads settings.EXECUTOR_IMAGE_CHECK_ENFORCE at classification time, and monkeypatching core.config.settings in the tests reaches the same object. The new test fails without the fix: on 80a81e4 the same input (reason RENTED, report status OUTDATED, score 0) sets ended_without_failing=True and outdated=True, relabels the reason EXECUTOR_IMAGE_OUTDATED and returns it, which is not None. · `neurons/validators/src/services/executor_rollout.py:46` ROLLOUT_FAILURE_REASONS keeps EXECUTOR_IMAGE_OUTDATED without a flag check, but with EXECUTOR_IMAGE_CHECK_ENFORCE off that reason can never be a run's failure_reason_code: checks/executor_image.py:84-98 passes the check with OUTDATED_WARNING, Pipeline.run (pipeline.py:295-301) continues past a passing check, and FinalizeCheck / TenantEnforcementCheck's halt supply the last event, so service.py:224 never records it; the except-block at service.py:227-250 records None or EXECUTOR_TRANSPORT_UNREACHABLE only. Nothing in core/validator.py mentions OUTDATED, and incentive/default.py:110-116 already gates its own OUTDATED exclusion on the flag. · `neurons/validators/tests/test_executor_rollout_grace.py:374` TEST-GAP: the two tests that set the flag True encode the enforced 11 Sep behaviour and their docstrings say so; the unrented arm (reason EXECUTOR_IMAGE_OUTDATED in the set) does not depend on the flag, the rented arm and the create_task-driven rented halt (tests:571) do, and each assertion still fails against a classifier that drops the fallback. 25 test functions plus the 4-way parametrize at tests:359 give the 28 cases the body claims; the local sibling venv is empty, so the run rests on the EC2 log at this head. · `neurons/validators/src/core/validator.py:456` total_gpu_model_count_map is built before withhold_verdicts_for_rollout (validator.py:529), but a withheld unrented result has score 0 and job_score 0 and never enters the map, and a withheld rented result is counted exactly as today's code counts it, so the mining denominator does not move. · `neurons/validators/src/core/validator.py:826` PERF: the cycle-end Docker Hub read (token GET + manifest HEAD, 30-s timeouts) runs even with EXECUTOR_ROLLOUT_GRACE_CYCLES=0 and sits between the last job and the weight computation, not on a request path; it is fail-open (None leaves the window as it was) and the body lists the up-to-60-s cost as a follow-up. · `neurons/validators/src/services/executor_rollout.py:108` SECURITY/CORRECTNESS on the Redis value: from_json is wrapped in except (ValueError, TypeError) at _load, which covers json.loads, int(), datetime.fromisoformat and a non-dict payload, and the corrupt-value test drives both a non-JSON string and a list; the key is written only by this validator. · `neurons/validators/src/services/task/models.py:86` CROSS-PR: open lium-io#1351 (base DAH-2991-reap-unkillable-orphan-container, not main) touches models.py, pipeline.py and result_handler.py but not executor_rollout.py or service.py's except-block; the body states the merge order and the models.py hunk is a field-list merge. #1358 is based on main (merge-base a120dda == GitHub main tip) and GitHub reports MERGEABLE.

### Verified

Gate: PASS (a0d7821) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1358)

**Why Redis, not a stateless tag_last_pushed window (taiberium NIT, 13:29Z):** the window is counted in validator cycles, not seconds, so it must outlive a validator restart in the middle of a rollout: with a stateless comparison a restart at cycle 1 would re-read the registry, see the digest as already current, and score the still-unreachable nodes 0 in cycle 2. The two Redis keys (observed digest, cycles remaining) are the only state; they expire on their own and a flush just means one more grace cycle, never a lost score.

</details>
