### PR TITLE
DAH-3439 - [P0] validator: outdated executor image is a warning, not a zero score

### DIFF
--- a/neurons/validators/.env.template
+++ b/neurons/validators/.env.template
@@ -30,6 +30,10 @@ COMPUTE_APP_URI=wss://lium.io/api
 # the verdict; ENFORCEMENT lets a fault zero the score. Both off by default (shadow mode first).
 GPU_FAULT_PROBE_CHECK_ENABLED=false
 GPU_FAULT_PROBE_ENFORCEMENT_ENABLED=false
+# Executor image check (DAH-2701): compares the executor container's image digest with EXECUTOR_IMAGE_REF's. false = an
+# outdated image is logged as a warning with both digests; score and incentive are unchanged. true = an idle outdated
+# executor fails validation and every outdated executor earns 0. Set to true only after nodes auto-update again (DAH-3419).
+EXECUTOR_IMAGE_CHECK_ENFORCE=false
 
 HOST_WALLET_DIR=/home/ubuntu/.bittensor/wallets
 # Cold-sample retry (DAH-2959): re-measure a never-validated node's cold VerifyX download sample once before failing it.

--- a/neurons/validators/src/core/config.py
+++ b/neurons/validators/src/core/config.py
@@ -332,6 +332,12 @@ class Settings(BaseSettings):
         env="EXECUTOR_IMAGE_REF",
         default="daturaai/compute-subnet-executor:latest",
     )
+    # DAH-2701 compares the executor container's image digest with EXECUTOR_IMAGE_REF's.
+    # False (default): an OUTDATED verdict is logged with both digests and the score, the
+    # incentive and the validation result are unchanged. True: an idle OUTDATED executor fails
+    # validation and every OUTDATED executor earns 0. Off until nodes auto-update again
+    # (DAH-3419): with Watchtower stalled, 99 executors earned 0 for it in one hour on 11 Sep.
+    EXECUTOR_IMAGE_CHECK_ENFORCE: bool = Field(env="EXECUTOR_IMAGE_CHECK_ENFORCE", default=False)
 
     # DAH-2272: when on, raise the asyncssh logger to DEBUG (debug level 2) so the
     # SSH handshake (banner / key exchange / auth) is logged per connection, and

--- a/neurons/validators/src/incentive/default.py
+++ b/neurons/validators/src/incentive/default.py
@@ -105,6 +105,13 @@ class DefaultIncentive(BaseIncentive):
 
     @staticmethod
     def _record_outdated_image_reason(result: JobResult) -> bool:
+        """True when an OUTDATED executor image excludes this result from both pools.
+
+        Only when EXECUTOR_IMAGE_CHECK_ENFORCE is on (DAH-2701). Off, the report still
+        travels on the result and its specs, but no reason is recorded and nothing is zeroed.
+        """
+        if not settings.EXECUTOR_IMAGE_CHECK_ENFORCE:
+            return False
         report = result.executor_image_report or {}
         if report.get("status") != "OUTDATED":
             return False

--- a/neurons/validators/src/incentive/miner_incentive_log.py
+++ b/neurons/validators/src/incentive/miner_incentive_log.py
@@ -242,7 +242,7 @@ class MinerLogLine(BaseModel):
         return MinerLogLine._no_payout(
             result,
             reason=ZeroIncentiveReason.OUTDATED_EXECUTOR_IMAGE,
-            message=outdated_image_remediation(str(expected_ref)),
+            message=outdated_image_remediation(str(expected_ref), enforced=True),
             extra_fields={
                 "executor_image_status": report.get("status"),
                 "observed_digest": report.get("observed_digest"),

--- a/neurons/validators/src/services/executor_image_policy.py
+++ b/neurons/validators/src/services/executor_image_policy.py
@@ -75,12 +75,18 @@ def build_expected_image_snapshot(digest: str | None) -> ExpectedImageSnapshot:
     return ExpectedImageSnapshot(executor=executor, executor_ref=ref)
 
 
-def outdated_image_remediation(expected_ref: str) -> str:
+def outdated_image_remediation(expected_ref: str, *, enforced: bool) -> str:
+    consequence = (
+        "The node earns no incentive until the executor image matches the current release."
+        if enforced
+        else "Incentive is unchanged for now: the image check is a warning until "
+        "EXECUTOR_IMAGE_CHECK_ENFORCE is on."
+    )
     return (
         f"This node is not running the current {expected_ref} image. "
         "On a standard stack, confirm executor-executor-runner-1 and executor-watchtower-1 "
         "are running so Watchtower can pull and redeploy the latest executor automatically. "
         "If auto-update stopped, follow "
         "https://docs.lium.io/providers/nodes/gpu-power-cap#the-standard-stack-which-stopped-updating. "
-        "The node earns no incentive until the executor image matches the current release."
+        f"{consequence}"
     )

--- a/neurons/validators/src/services/task/checks/executor_image.py
+++ b/neurons/validators/src/services/task/checks/executor_image.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Callable
 from dataclasses import replace
 
+from core.config import settings
 from services.executor_image_policy import (
     ImageVerdict,
     normalize_sha256_digest,
@@ -80,6 +81,21 @@ class ExecutorImageCheck:
         if report.status is ImageVerdict.CURRENT:
             event = render_message(Msg.CURRENT, ctx=ctx, check_id=self.check_id, what=what)
             passed = True
+        elif not settings.EXECUTOR_IMAGE_CHECK_ENFORCE:
+            # Warning only (DAH-2701 paused until DAH-3419 restores auto-update): the verdict
+            # and both digests are logged, the check passes, and the score is left alone.
+            passed = True
+            event = render_message(
+                Msg.OUTDATED_WARNING,
+                ctx=ctx,
+                check_id=self.check_id,
+                what=what,
+                remediation=outdated_image_remediation(report.expected_ref, enforced=False),
+                extra={
+                    "executor_image_status": report.status.value,
+                    "executor_image_check_enforced": False,
+                },
+            )
         else:
             rented_data = ctx.state.rented_data
             rented_executor = rented_data.executors.get(ctx.executor.uuid) if rented_data else None
@@ -95,8 +111,11 @@ class ExecutorImageCheck:
                     if is_rented
                     else "Validation failed - executor unavailable for rent until the image is current"
                 ),
-                remediation=outdated_image_remediation(report.expected_ref),
-                extra={"executor_image_status": report.status.value},
+                remediation=outdated_image_remediation(report.expected_ref, enforced=True),
+                extra={
+                    "executor_image_status": report.status.value,
+                    "executor_image_check_enforced": True,
+                },
             )
         return CheckResult(
             passed=passed,

--- a/neurons/validators/src/services/task/messages.py
+++ b/neurons/validators/src/services/task/messages.py
@@ -444,6 +444,14 @@ class ExecutorImageMessages:
         category="policy",
         impact="Score set to 0 until the image is current",
     )
+    # Same reason code as OUTDATED so log queries keep matching; severity says it is not scored.
+    OUTDATED_WARNING = MessageTemplate(
+        event="Executor image is outdated",
+        reason="EXECUTOR_IMAGE_OUTDATED",
+        severity="warning",
+        category="policy",
+        impact="Warning only until EXECUTOR_IMAGE_CHECK_ENFORCE is on: score and incentive unchanged",
+    )
 
 
 class SysboxRequiredMessages:

--- a/neurons/validators/src/services/task/score_calculator.py
+++ b/neurons/validators/src/services/task/score_calculator.py
@@ -39,8 +39,14 @@ def calculate_scores(
     job_score = 1.0
     actual_score = 1.0
 
+    # Outdated executor image (DAH-2701). Enforcement is off by default until nodes
+    # auto-update again (DAH-3419); off, ExecutorImageCheck logs the verdict as a warning.
     image_report = getattr(ctx.state, "executor_image_report", None)
-    if image_report and image_report.status is ImageVerdict.OUTDATED:
+    if (
+        settings.EXECUTOR_IMAGE_CHECK_ENFORCE
+        and image_report
+        and image_report.status is ImageVerdict.OUTDATED
+    ):
         actual_score = 0.0
         job_score = 0.0
         warning_messages.append("Required executor image is outdated")

--- a/neurons/validators/tests/test_executor_image_check.py
+++ b/neurons/validators/tests/test_executor_image_check.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
+from core.config import Settings, settings
 from protocol.vc_protocol.compute_requests import (
     RentedExecutor,
     RentedExecutorsResponse,
@@ -21,6 +22,16 @@ from tests.helpers import build_context_config, build_state, make_context
 
 EXECUTOR_DIGEST = f"sha256:{'a' * 64}"
 STALE_DIGEST = f"sha256:{'c' * 64}"
+
+
+@pytest.fixture
+def enforce(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "EXECUTOR_IMAGE_CHECK_ENFORCE", True)
+
+
+@pytest.fixture
+def warn_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "EXECUTOR_IMAGE_CHECK_ENFORCE", False)
 
 
 def policy() -> ExpectedImageSnapshot:
@@ -94,8 +105,14 @@ def test_observation_returns_none_when_ambiguous():
     )
 
 
+def test_enforcement_is_off_by_default():
+    # Regression: flipping the default back to True zeroes idle pay for every node still on
+    # the old image before DAH-3419 restores auto-update (99 executors on 11 Sep).
+    assert Settings.model_fields["EXECUTOR_IMAGE_CHECK_ENFORCE"].default is False
+
+
 @pytest.mark.asyncio
-async def test_unrented_outdated_executor_fails_validation():
+async def test_unrented_outdated_executor_fails_validation(enforce):
     context = make_context(
         config=build_context_config(executor_image_snapshot=policy()),
         state=build_state(
@@ -109,10 +126,38 @@ async def test_unrented_outdated_executor_fails_validation():
     assert result.passed is False
     assert result.updates["state"].executor_image_report.status is ImageVerdict.OUTDATED
     assert "unavailable for rent" in result.event.impact
+    assert result.event.severity == "error"
+    assert result.event.context["executor_image_check_enforced"] is True
+    assert "earns no incentive" in result.event.remediation
 
 
 @pytest.mark.asyncio
-async def test_rented_outdated_executor_passes_validation():
+async def test_warning_only_unrented_outdated_executor_passes_and_logs_digests(warn_only):
+    context = make_context(
+        config=build_context_config(executor_image_snapshot=policy()),
+        state=build_state(
+            specs=specs(executor_digest=STALE_DIGEST),
+            rented_data=SimpleNamespace(executors={}),
+        ),
+    )
+
+    result = await ExecutorImageCheck().run(context)
+
+    assert result.passed is True
+    assert result.updates["state"].executor_image_report.status is ImageVerdict.OUTDATED
+    assert result.updates["default_extra"]["executor_image_status"] == "OUTDATED"
+    assert result.event.reason_code == "EXECUTOR_IMAGE_OUTDATED"
+    assert result.event.severity == "warning"
+    assert result.event.what_we_saw["observed_digest"] == STALE_DIGEST
+    assert result.event.what_we_saw["expected_digest"] == EXECUTOR_DIGEST
+    assert "EXECUTOR_IMAGE_CHECK_ENFORCE" in result.event.impact
+    assert "EXECUTOR_IMAGE_CHECK_ENFORCE" in result.event.remediation
+    assert "earns no incentive" not in result.event.remediation
+    assert result.event.context["executor_image_check_enforced"] is False
+
+
+@pytest.mark.asyncio
+async def test_rented_outdated_executor_passes_validation(enforce):
     context = make_context(
         config=build_context_config(executor_image_snapshot=policy()),
         state=build_state(
@@ -144,7 +189,7 @@ async def test_current_executor_passes_validation():
 
 
 @pytest.mark.asyncio
-async def test_unobservable_executor_digest_is_outdated():
+async def test_unobservable_executor_digest_is_outdated(enforce):
     context = make_context(
         config=build_context_config(executor_image_snapshot=policy()),
         state=build_state(
@@ -220,6 +265,7 @@ def test_image_check_precedes_tenant_enforcement_in_both_pipelines():
     [(False, 0.0), (True, 1.0)],
 )
 def test_score_calculator_zeroes_outdated_executor(
+    enforce,
     rented: bool,
     expected_job_score: float,
 ):
@@ -237,6 +283,25 @@ def test_score_calculator_zeroes_outdated_executor(
     assert actual_score == 0.0
     assert job_score == expected_job_score
     assert "Required executor image is outdated" in warning
+
+
+@pytest.mark.parametrize("rented", [False, True])
+def test_warning_only_score_calculator_leaves_outdated_executor_scored(warn_only, rented: bool):
+    report = policy().report(STALE_DIGEST)
+    context = make_context(
+        state=build_state(
+            gpu_model="NVIDIA H200",
+            executor_image_report=report,
+            specs={"network": {"ema_verifyx_download_speed": 100.0}},
+        ),
+        collateral_deposited=True,
+    )
+
+    actual_score, job_score, warning = calculate_scores(context, rented)
+
+    assert actual_score == 1.0
+    assert job_score == 1.0
+    assert "outdated" not in warning
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_executor_image_check.py
+++ b/neurons/validators/tests/test_executor_image_check.py
@@ -105,10 +105,30 @@ def test_observation_returns_none_when_ambiguous():
     )
 
 
-def test_enforcement_is_off_by_default():
-    # Regression: flipping the default back to True zeroes idle pay for every node still on
-    # the old image before DAH-3419 restores auto-update (99 executors on 11 Sep).
-    assert Settings.model_fields["EXECUTOR_IMAGE_CHECK_ENFORCE"].default is False
+@pytest.mark.asyncio
+async def test_shipped_default_keeps_an_idle_outdated_executor_validated(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Regression: the default flips back to True before DAH-3419 restores auto-update, and every
+    # idle node on the old image fails validation again (99 executors earned 0 in one hour, 11 Sep).
+    monkeypatch.delenv("EXECUTOR_IMAGE_CHECK_ENFORCE", raising=False)
+    shipped = Settings(_env_file=None)  # no developer .env: the class default only
+    monkeypatch.setattr(
+        settings, "EXECUTOR_IMAGE_CHECK_ENFORCE", shipped.EXECUTOR_IMAGE_CHECK_ENFORCE
+    )
+    context = make_context(
+        config=build_context_config(executor_image_snapshot=policy()),
+        state=build_state(
+            specs=specs(executor_digest=STALE_DIGEST),
+            rented_data=SimpleNamespace(executors={}),
+        ),
+    )
+
+    result = await ExecutorImageCheck().run(context)
+
+    assert result.passed is True
+    assert result.event.severity == "warning"
+    assert result.updates["state"].executor_image_report.status is ImageVerdict.OUTDATED
 
 
 @pytest.mark.asyncio

--- a/neurons/validators/tests/test_executor_image_incentive.py
+++ b/neurons/validators/tests/test_executor_image_incentive.py
@@ -1,12 +1,23 @@
 from unittest.mock import AsyncMock
 
 import pytest
+from core.config import settings
 from datura.requests.miner_requests import ExecutorSSHInfo
 from incentive.config import IncentiveConfig
 from incentive.default import DefaultIncentive
 from incentive.miner_incentive_log import ZeroIncentiveReason
 from incentive.rental_price import RentalPriceIncentive
 from services.task.models import JobResult
+
+
+@pytest.fixture
+def enforce(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "EXECUTOR_IMAGE_CHECK_ENFORCE", True)
+
+
+@pytest.fixture
+def warn_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "EXECUTOR_IMAGE_CHECK_ENFORCE", False)
 
 
 def failed_idle_result() -> JobResult:
@@ -35,7 +46,7 @@ def failed_idle_result() -> JobResult:
 
 
 @pytest.mark.asyncio
-async def test_default_incentive_records_outdated_reason_before_score_early_return():
+async def test_default_incentive_records_outdated_reason_before_score_early_return(enforce):
     result = failed_idle_result()
     incentive = DefaultIncentive(
         IncentiveConfig(),
@@ -53,7 +64,7 @@ async def test_default_incentive_records_outdated_reason_before_score_early_retu
 
 
 @pytest.mark.asyncio
-async def test_rental_price_incentive_records_reason_before_unsuccessful_filter():
+async def test_rental_price_incentive_records_reason_before_unsuccessful_filter(enforce):
     result = failed_idle_result()
     incentive = RentalPriceIncentive(
         IncentiveConfig(),
@@ -70,7 +81,7 @@ async def test_rental_price_incentive_records_reason_before_unsuccessful_filter(
 
 
 @pytest.mark.asyncio
-async def test_rented_outdated_executor_keeps_job_result_but_gets_zero_mining_score():
+async def test_rented_outdated_executor_keeps_job_result_but_gets_zero_mining_score(enforce):
     result = failed_idle_result().model_copy(
         update={
             "job_score": 1.0,
@@ -90,3 +101,75 @@ async def test_rented_outdated_executor_keeps_job_result_but_gets_zero_mining_sc
 
     assert result.mining_score == 0
     assert result.zero_incentive_reasons[0].reason == "outdated_executor_image"
+
+
+def idle_result_on_old_image() -> JobResult:
+    # A validated idle H200 node whose executor container still runs the previous image.
+    return failed_idle_result().model_copy(
+        update={
+            "score": 1.0,
+            "job_score": 1.0,
+            "log_status": "success",
+            "log_text": "ok",
+            "gpu_model": "NVIDIA H200",
+            "gpu_count": 8,
+        }
+    )
+
+
+def redis_with_full_portion() -> AsyncMock:
+    redis = AsyncMock()
+    redis.get_portion_per_gpu_type.return_value = 1.0
+    return redis
+
+
+@pytest.mark.asyncio
+async def test_warning_only_default_incentive_scores_old_image_node(warn_only):
+    # Regression: DAH-2701 zeroed idle pay for ~100 nodes on the old image (11 Sep).
+    result = idle_result_on_old_image()
+    incentive = DefaultIncentive(
+        IncentiveConfig(),
+        redis_with_full_portion(),
+        {"miner": [result]},
+        {"NVIDIA H200": 8},
+    )
+
+    await incentive._pre_process_job_result("miner", result)
+
+    assert result.mining_score > 0
+    assert ZeroIncentiveReason.OUTDATED_EXECUTOR_IMAGE.value not in [
+        reason.reason for reason in result.zero_incentive_reasons
+    ]
+
+
+@pytest.mark.asyncio
+async def test_warning_only_rental_price_incentive_records_no_outdated_reason(warn_only):
+    result = failed_idle_result()
+    incentive = RentalPriceIncentive(
+        IncentiveConfig(),
+        AsyncMock(),
+        {"miner": [result]},
+        {},
+    )
+
+    await incentive._pre_process_job_result("miner", result)
+
+    assert result.zero_incentive_reasons == []
+
+
+@pytest.mark.asyncio
+async def test_warning_only_rented_old_image_executor_keeps_mining_score(warn_only):
+    result = idle_result_on_old_image().model_copy(update={"is_rented": True})
+    incentive = RentalPriceIncentive(
+        IncentiveConfig(),
+        redis_with_full_portion(),
+        {"miner": [result]},
+        {"NVIDIA H200": 8},
+    )
+
+    await incentive._pre_process_job_result("miner", result)
+
+    assert result.mining_score > 0
+    assert ZeroIncentiveReason.OUTDATED_EXECUTOR_IMAGE.value not in [
+        reason.reason for reason in result.zero_incentive_reasons
+    ]


### PR DESCRIPTION
<!-- loop-pr-template v1 -->
Implements [DAH-3439](https://app.notion.com/p/P0-validator-outdated-image-check-is-warning-only-until-nodes-auto-update-again-DAH-2701-zeroed-i-3d8b8bfdbde981f18208c55a5ee438fa) · reviewer: @arhangel66

**TL;DR** — DAH-2701 (#1252) zeroes every executor whose image digest is not the latest, and Watchtower does not update nodes (DAH-3419): 99 executors earned 0 in one hour on 11 Sep. The check now logs `OUTDATED` as a warning and scores nothing unless `EXECUTOR_IMAGE_CHECK_ENFORCE` is on (default off).

**What changed**
- New setting `EXECUTOR_IMAGE_CHECK_ENFORCE`, default `False` (`neurons/validators/src/core/config.py`)
- Off: an `OUTDATED` executor passes the check with a `warning` event carrying both digests (`services/task/checks/executor_image.py`)
- Off: `calculate_scores` leaves `actual_score` and `job_score` alone (`services/task/score_calculator.py`)
- Off: no `outdated_executor_image` reason, `mining_score` unchanged (`incentive/default.py`)
- Remediation text and `OUTDATED_WARNING` template name the setting (`services/executor_image_policy.py`, `services/task/messages.py`)
- 6 new tests; the 7 DAH-2701 tests run with the setting on (`tests/test_executor_image_check.py`, `tests/test_executor_image_incentive.py`)

**How to verify**
- `cd neurons/validators && pdm run pytest tests/test_executor_image_check.py tests/test_executor_image_incentive.py -q` → 23 passed
- Negative control (Details): same files on `main`'s `src` plus the new `Field` → 7 failed, the 6 `warning_only` tests among them
- `pdm run pytest tests/ -q` → 2291 passed, 2 failed that fail the same way on `origin/main` on the box (Details)

**Verified by the loop:** Gate: PASS 0522abd

**Ran it:** `pdm run pytest tests/test_executor_image_*.py tests/test_miner_incentive_log.py tests/test_incentive_flow.py -q` → 96 passed · EC2 warm lium-io box 20260912T001816Z-ut1y at this head

**Self-review:** clean at 0522abd (27 checks, 1 low)

**Parts:** backend ✓ · migration n/a — no schema change · frontend n/a — validator only · CLI/SDK n/a — validator only · docs ✓ `.env.template` + lium-platform#363 · tests ✓ 6 new, 7 adjusted · dashboards n/a — reason code unchanged

**Docs:** `neurons/validators/.env.template` · public: none needed because the setting is operator-only validator config. The troubleshooting rows that described the zero score are corrected in lium-platform#363 (same ticket and reviewer)

<details><summary>Details</summary>

### Why (owner P127, 11 Sep 2026 23:24Z)

> there was some change to unrented incentive recently. Please revert it. Whatever made unrented incentive decrease, and make it a p0 to fix.

The unrented pool formula is unchanged since July (`incentive/rental_price.py` `_calculate_rental_share`, `FIXED_RATIO` in `services/const.py`). The 13 % to 10 % rented-pool change is lium-platform#322, open and not deployed (live `total_burn_emission` 0.87). The decrease is DAH-2701 (#1252, merged 2 Sep 05:43Z): `ExecutorImageCheck` gives an executor whose container digest differs from the latest `compute-subnet-executor` image the verdict `OUTDATED` and incentive 0. Enforcement started with the validator release at 10 Sep 03:11Z. Watchtower does not update nodes (DAH-3419, #1359 open), so the nodes cannot leave that state on their own:

- 99 executors with `incentive 0`, reason `outdated_executor_image`, in the last hour (tsdb, 11 Sep 23:40Z)
- 139 of 493 nodes on the old image earlier on 11 Sep, 106 of them rented
- zero-incentive idle checks rose from 5 % to 17 % (DAH-3418)
- two provider complaints in #providers read this as "idle incentive dropped" (DAH-3418)

DAH-3419 is the precondition to enforce again. #1329 (the owner's parity decision) and #322 are not touched.

### What providers see

Nothing to do on their side. Idle pay for a node on the old image returns on the first cycle after the validator release that carries this change. The validation log still shows `Executor image is outdated` with the observed and expected digests, now at severity `warning`, with the remediation text ending "Incentive is unchanged for now: the image check is a warning until EXECUTOR_IMAGE_CHECK_ENFORCE is on."

### How to enforce again

After DAH-3419 has updated the fleet, set `EXECUTOR_IMAGE_CHECK_ENFORCE=true` in the validator's environment (`neurons/validators/.env.template` lists it next to `GPU_FAULT_PROBE_ENFORCEMENT_ENABLED`) and restart the validator. Behaviour is then exactly #1252: an idle `OUTDATED` executor fails validation, every `OUTDATED` executor earns 0 with reason `outdated_executor_image`.

### The scoring path, line by line

| where the verdict fed the score | on `main` | this PR when the setting is off |
|---|---|---|
| `services/task/checks/executor_image.py` L84-98 | idle `OUTDATED` → `passed=False` (fatal check) | `passed=True`, event `OUTDATED_WARNING` (severity `warning`, same reason code `EXECUTOR_IMAGE_OUTDATED`), `executor_image_check_enforced: false` in the context |
| `services/task/score_calculator.py` L42-49 | `OUTDATED` → `actual_score = job_score = 0` | untouched |
| `incentive/default.py` L108-115 (`_record_outdated_image_reason`, called from `default.py` L164, `rental_price.py` L632 and L911) | records `outdated_executor_image`; the L164 and L911 callers set `mining_score = 0` (L911 also clears `eligible_for_rental_share`), L632 only records | returns `False` before reading the report |

The report itself still travels: `ContextState.executor_image_report`, `JobResult.executor_image_report`, the `executor_image` spec field and the `executor_image_status` default extra are unchanged, so the backend and dashboards keep seeing which nodes are on the old image.

### Cross-PR

- #1358 (DAH-3405, rollout grace) adds a setting to `core/config.py` and a block to `.env.template` in other hunks; no shared symbol, either order merges.
- #1359 (DAH-3419, Watchtower self-update) touches the executor compose only. It is the condition for turning this setting on, not a code dependency.

### Ran it

EC2 warm lium-io box, run 20260912T001816Z-ut1y at this head (c6i.2xlarge, Python 3.11.11, CI's `pdm` venv, lockfile unchanged); runs `20260911T235738Z-cj0y` and `20260911T234159Z-ur8c` at the earlier heads (one comment line and one test differ) gave the same result:

```
validators pytest tests/test_executor_image_check.py tests/test_executor_image_incentive.py tests/test_executor_image_policy.py tests/test_miner_incentive_log.py tests/test_incentive_flow.py tests/test_executor_image_spec_bridge.py: rc=0 in 3 s — 96 passed, 99 warnings in 0.68s
```

Negative control, run `20260911T234349Z-hxh5`: the same two test files with `neurons/validators/src` from `origin/main` plus only the new `Field` (a throwaway commit, not on this branch):

```
validators pytest tests/test_executor_image_check.py tests/test_executor_image_incentive.py: rc=1 in 2 s — 7 failed, 16 passed
FAILED tests/test_executor_image_check.py::test_warning_only_unrented_outdated_executor_passes_and_logs_digests
FAILED tests/test_executor_image_check.py::test_warning_only_score_calculator_leaves_outdated_executor_scored[False]
FAILED tests/test_executor_image_check.py::test_warning_only_score_calculator_leaves_outdated_executor_scored[True]
FAILED tests/test_executor_image_incentive.py::test_warning_only_default_incentive_scores_old_image_node
FAILED tests/test_executor_image_incentive.py::test_warning_only_rental_price_incentive_records_no_outdated_reason
FAILED tests/test_executor_image_incentive.py::test_warning_only_rented_old_image_executor_keeps_mining_score
FAILED tests/test_executor_image_check.py::test_unrented_outdated_executor_fails_validation
```

The seventh failure is the DAH-2701 test that now also asserts the `executor_image_check_enforced` context key.

Full validators suite, run `20260911T234732Z-iise` at the earlier head (this head differs by one comment line in `core/config.py` and one test in `test_executor_image_check.py`; `pdm run pytest tests/`, 2 min 1 s):

```
2 failed, 2291 passed, 15 skipped, 162 warnings in 121.13s
FAILED tests/test_scrape_infiniband.py::test_an_unreadable_sysfs_tree_is_not_reported_as_no_devices
FAILED tests/test_sshd_bootstrap_script.py::test_adopt_path_hardens_config_for_key_only_auth
```

Both failures are the box's environment, not this change: `origin/main` (`b9fa381`) run `20260912T000533Z-yowi` on the same box fails the same two tests (2 failed, 24 passed in those two files) (root reads the "unreadable" sysfs tree; a live sshd on the box). Neither test file is touched here.

### Tests and the regression each one names

| test | fails when |
|---|---|
| `test_shipped_default_keeps_an_idle_outdated_executor_validated` (a fresh `Settings(_env_file=None)` with the env var unset drives the real check) | the default flips to `True` before DAH-3419 |
| `test_warning_only_unrented_outdated_executor_passes_and_logs_digests` | an idle node on the old image fails validation, or the log loses a digest or the severity |
| `test_warning_only_score_calculator_leaves_outdated_executor_scored[False/True]` | `calculate_scores` zeroes an `OUTDATED` report with the setting off |
| `test_warning_only_default_incentive_scores_old_image_node` | `DefaultIncentive` gives a validated idle H200 on the old image `mining_score 0` or the `outdated_executor_image` reason |
| `test_warning_only_rental_price_incentive_records_no_outdated_reason` | `RentalPriceIncentive._pre_process_job_result` records the reason with the setting off |
| `test_warning_only_rented_old_image_executor_keeps_mining_score` | a rented node on the old image loses its mining score with the setting off |
| the 7 DAH-2701 tests (8 cases), now under the `enforce` fixture | the setting on does not restore #1252's behaviour |

### Known follow-ups

- The `ruff format` diff in `tests/test_executor_image_check.py` (one `RentedPod(...)` line) predates this PR; CI's format job is report-only.
- Self-review round 1 (2 medium, 4 low, all body or docs): the negative-control step and the Docs line above were rewritten, the docs rows got their own PR, `core/config.py`'s comment now carries the measured number. Round 2 (2 medium, 2 low, body and docs wording): fixed, round 3 clean. The gate then flagged the Field-default assertion as a constant restatement; it became `test_shipped_default_keeps_an_idle_outdated_executor_validated`.

### Self-review

Verdict `clean` at `0522abd` · 27 checks · by subagent-unrented-revert-r5 · 2026-09-12 00:22Z (tools/pr_self_review.py)

| severity | class | where | what | fix |
|---|---|---|---|---|
| low | PROSE-VS-CODE | `RECOVERY/workers/unrented-revert/body.md:104` | The tests table still describes the new test as 'a fresh `Settings()` with the env unset'; the code now builds `Settings(_env_file=None)`, which also excludes a developer `.env` — the sentence is true but under-states the isolation the round-4 fix added. | Write 'a fresh `Settings(_env_file=None)` with the env var unset (no `.env` either)'. |

Low items above are known nits left for the human reviewer to accept or ask for (PR_PROCESS §7).

Mechanical notes dismissed: `neurons/validators/tests/test_executor_image_check.py:115` Round-4 medium resolved: `shipped = Settings(_env_file=None)` disables the dotenv source per instance, `delenv` removes the OS var, so the copied value is the class default only; the setattr is on two lines as ruff formats it; the only change since 953c644 (git diff --stat: 1 file, +2 −1). · `RECOVERY/workers/unrented-revert/body.md:16` Round-4 low resolved: the negative-control bullet now says '7 failed at the time … (the default test added later fails there too)', which is what hxh5's log shows and what the new test does on main's src. · `RECOVERY/workers/unrented-revert/body.md:27` Round-4 low resolved: the Docs line is two sentences — the setting is operator-only (true: env flag in core/config.py, nothing provider-facing) and the troubleshooting rows are corrected in lium-platform#363 (open, head 4ee7d36). · `RECOVERY/aws_run/20260912T001816Z-ut1y/out/summary.txt:2` Run id verified: tree_hash commit 0522abd (this head), rc=0, the six named files, 96 passed, 99 warnings in 0.70s; body's 'Ran it' says 96 passed at this head, and the glob `tests/test_executor_image_*.py` expands to the same six-file set. · `RECOVERY/workers/unrented-revert/body.md:69` 'runs cj0y and ur8c at the earlier heads (one comment line and one test differ) gave the same result' remains true: both logged 96 passed, 99 warnings. · `neurons/validators/src/core/config.py:340` No source change since 9f39450; rounds 1-4 code analysis stands; SECURITY properties do not apply.

### Verified

Gate: PASS (0522abd) on EC2 sandbox Linux x86_64 (aws_run gate-lium-io-1360)

### Re-enable condition, corrected (Mikhail via his agent, 12 Sep 01:15Z)
Host diagnostics show 70 of 74 stale nodes sit behind Docker Hub mirrors that serve an old `runner:latest`. So the watchtower fix (DAH-3419, #1359) is not the condition for setting `EXECUTOR_IMAGE_CHECK_ENFORCE=true`; the mirror path has to be fixed first (nodes must pull the current digest, e.g. pin by digest or bypass the mirror). Until then the setting stays off.

</details>
